### PR TITLE
feat: add projects portfolio with filtering & detail modals

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,64 +1,10 @@
-import Image from "next/image";
+import { ProjectsSection } from "@/components/ProjectsSection";
 
 export default function Home() {
   return (
-    <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            To get started, edit the page.tsx file.
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            Looking for a starting point or more instructions? Head over to{" "}
-            <a
-              href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Templates
-            </a>{" "}
-            or the{" "}
-            <a
-              href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-              className="font-medium text-zinc-950 dark:text-zinc-50"
-            >
-              Learning
-            </a>{" "}
-            center.
-          </p>
-        </div>
-        <div className="flex flex-col gap-4 text-base font-medium sm:flex-row">
-          <a
-            className="flex h-12 w-full items-center justify-center gap-2 rounded-full bg-foreground px-5 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc] md:w-[158px]"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={16}
-              height={16}
-            />
-            Deploy Now
-          </a>
-          <a
-            className="flex h-12 w-full items-center justify-center rounded-full border border-solid border-black/[.08] px-5 transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a] md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Documentation
-          </a>
-        </div>
+    <div className="flex flex-1 flex-col items-center bg-zinc-50 font-sans dark:bg-black">
+      <main className="w-full max-w-6xl px-4 py-16 sm:px-6 lg:px-8">
+        <ProjectsSection />
       </main>
     </div>
   );

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import type { FilterCategory } from "@/types/project";
+
+const categories: readonly FilterCategory[] = [
+  "All",
+  "Frontend",
+  "Backend",
+  "Full Stack",
+  "DevOps",
+];
+
+interface FilterBarProps {
+  readonly activeCategory: FilterCategory;
+  readonly activeTech: string | null;
+  readonly allTechs: readonly string[];
+  readonly onCategoryChange: (category: FilterCategory) => void;
+  readonly onTechChange: (tech: string | null) => void;
+}
+
+export function FilterBar({
+  activeCategory,
+  activeTech,
+  allTechs,
+  onCategoryChange,
+  onTechChange,
+}: FilterBarProps) {
+  return (
+    <div className="mb-8 space-y-4">
+      <div className="flex flex-wrap gap-2">
+        {categories.map((category) => (
+          <button
+            key={category}
+            onClick={() => {
+              onCategoryChange(category);
+              onTechChange(null);
+            }}
+            className={`rounded-full px-4 py-2 text-sm font-medium transition-colors ${
+              activeCategory === category && activeTech === null
+                ? "bg-foreground text-background"
+                : "bg-zinc-100 text-zinc-700 hover:bg-zinc-200 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
+            }`}
+          >
+            {category}
+          </button>
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {allTechs.map((tech) => (
+          <button
+            key={tech}
+            onClick={() => {
+              onTechChange(activeTech === tech ? null : tech);
+              onCategoryChange("All");
+            }}
+            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+              activeTech === tech
+                ? "bg-blue-600 text-white"
+                : "bg-blue-50 text-blue-700 hover:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-300 dark:hover:bg-blue-900/50"
+            }`}
+          >
+            {tech}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import type { Project } from "@/types/project";
+
+interface ProjectCardProps {
+  readonly project: Project;
+  readonly onTagClick: (tech: string) => void;
+  readonly onOpenModal: (project: Project) => void;
+}
+
+export function ProjectCard({ project, onTagClick, onOpenModal }: ProjectCardProps) {
+  return (
+    <div className="group flex flex-col overflow-hidden rounded-xl border border-zinc-200 bg-white transition-shadow hover:shadow-lg dark:border-zinc-800 dark:bg-zinc-900">
+      <button
+        type="button"
+        onClick={() => onOpenModal(project)}
+        className="flex h-48 items-center justify-center bg-gradient-to-br from-zinc-100 to-zinc-200 text-sm text-zinc-400 dark:from-zinc-800 dark:to-zinc-900 dark:text-zinc-600"
+      >
+        {project.imageAlt}
+      </button>
+
+      <div className="flex flex-1 flex-col p-5">
+        <div className="mb-2 flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+            {project.title}
+          </h3>
+          <span className="rounded-full bg-zinc-100 px-2.5 py-0.5 text-xs font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+            {project.category}
+          </span>
+        </div>
+
+        <p className="mb-3 text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">
+          {project.description}
+        </p>
+
+        <p className="mb-4 text-xs text-zinc-500 dark:text-zinc-500">{project.stats}</p>
+
+        <div className="mb-4 flex flex-wrap gap-1.5">
+          {project.techStack.map((tech) => (
+            <button
+              key={tech}
+              onClick={(e) => {
+                e.stopPropagation();
+                onTagClick(tech);
+              }}
+              className="rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-700 transition-colors hover:bg-blue-100 dark:bg-blue-900/30 dark:text-blue-300 dark:hover:bg-blue-900/50"
+            >
+              {tech}
+            </button>
+          ))}
+        </div>
+
+        <div className="mt-auto flex gap-3">
+          <a
+            href={project.githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-medium text-zinc-700 underline-offset-4 hover:underline dark:text-zinc-300"
+          >
+            GitHub
+          </a>
+          {project.liveUrl && (
+            <a
+              href={project.liveUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm font-medium text-blue-600 underline-offset-4 hover:underline dark:text-blue-400"
+            >
+              Live Demo
+            </a>
+          )}
+          <button
+            onClick={() => onOpenModal(project)}
+            className="ml-auto text-sm font-medium text-zinc-500 underline-offset-4 hover:underline dark:text-zinc-400"
+          >
+            Details
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProjectModal.tsx
+++ b/src/components/ProjectModal.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import type { Project } from "@/types/project";
+
+interface ProjectModalProps {
+  readonly project: Project | null;
+  readonly onClose: () => void;
+}
+
+export function ProjectModal({ project, onClose }: ProjectModalProps) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    if (!project) return;
+    document.addEventListener("keydown", handleKeyDown);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [project, handleKeyDown]);
+
+  if (!project) return null;
+
+  return (
+    <div
+      ref={overlayRef}
+      onClick={(e) => {
+        if (e.target === overlayRef.current) onClose();
+      }}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm animate-in fade-in duration-200 sm:p-6"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${project.title} project details`}
+    >
+      <div className="relative max-h-[90vh] w-full max-w-2xl overflow-y-auto rounded-2xl bg-white p-6 shadow-2xl animate-in zoom-in-95 duration-200 dark:bg-zinc-900 sm:p-8 max-sm:max-h-full max-sm:rounded-none">
+        <button
+          onClick={onClose}
+          className="absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-full text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+          aria-label="Close modal"
+        >
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <path
+              d="M4 4l8 8M12 4l-8 8"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+
+        <div className="mb-4 flex items-center gap-3">
+          <h2 className="text-2xl font-bold text-zinc-900 dark:text-zinc-100">{project.title}</h2>
+          <span className="rounded-full bg-zinc-100 px-3 py-1 text-xs font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400">
+            {project.category}
+          </span>
+        </div>
+
+        <p className="mb-6 text-sm leading-relaxed text-zinc-500 dark:text-zinc-500">
+          {project.stats}
+        </p>
+
+        <p className="mb-6 leading-relaxed text-zinc-700 dark:text-zinc-300">
+          {project.fullDescription}
+        </p>
+
+        <div className="mb-6">
+          <h3 className="mb-3 text-sm font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+            Features
+          </h3>
+          <ul className="space-y-2">
+            {project.features.map((feature) => (
+              <li
+                key={feature}
+                className="flex items-start gap-2 text-sm text-zinc-700 dark:text-zinc-300"
+              >
+                <span className="mt-1.5 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-blue-500" />
+                {feature}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="mb-6">
+          <h3 className="mb-3 text-sm font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+            Tech Stack
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            {project.techStack.map((tech) => (
+              <span
+                key={tech}
+                className="rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
+              >
+                {tech}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className="mb-6">
+          <h3 className="mb-3 text-sm font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
+            Challenges
+          </h3>
+          <p className="text-sm leading-relaxed text-zinc-700 dark:text-zinc-300">
+            {project.challenges}
+          </p>
+        </div>
+
+        <div className="flex gap-4 border-t border-zinc-200 pt-6 dark:border-zinc-800">
+          <a
+            href={project.githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-full bg-foreground px-5 py-2 text-sm font-medium text-background transition-colors hover:bg-zinc-700 dark:hover:bg-zinc-300"
+          >
+            View on GitHub
+          </a>
+          {project.liveUrl && (
+            <a
+              href={project.liveUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-full border border-zinc-200 px-5 py-2 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+            >
+              Live Demo
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { FilterCategory, Project } from "@/types/project";
+import { projects } from "@/data/projects";
+import { FilterBar } from "@/components/FilterBar";
+import { ProjectCard } from "@/components/ProjectCard";
+import { ProjectModal } from "@/components/ProjectModal";
+
+export function ProjectsSection() {
+  const [activeCategory, setActiveCategory] = useState<FilterCategory>("All");
+  const [activeTech, setActiveTech] = useState<string | null>(null);
+  const [selectedProject, setSelectedProject] = useState<Project | null>(null);
+
+  const allTechs = useMemo(() => {
+    const techSet = new Set<string>();
+    for (const project of projects) {
+      for (const tech of project.techStack) {
+        techSet.add(tech);
+      }
+    }
+    return Array.from(techSet).sort();
+  }, []);
+
+  const filteredProjects = useMemo(() => {
+    return projects.filter((project) => {
+      if (activeTech) {
+        return project.techStack.includes(activeTech);
+      }
+      if (activeCategory === "All") return true;
+      return project.category === activeCategory;
+    });
+  }, [activeCategory, activeTech]);
+
+  const handleTagClick = (tech: string) => {
+    setActiveTech(activeTech === tech ? null : tech);
+    setActiveCategory("All");
+  };
+
+  return (
+    <section className="w-full">
+      <div className="mb-8 text-center">
+        <h2 className="mb-2 text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-100">
+          Projects
+        </h2>
+        <p className="text-zinc-600 dark:text-zinc-400">
+          A selection of projects I&apos;ve built and contributed to
+        </p>
+      </div>
+
+      <FilterBar
+        activeCategory={activeCategory}
+        activeTech={activeTech}
+        allTechs={allTechs}
+        onCategoryChange={setActiveCategory}
+        onTechChange={setActiveTech}
+      />
+
+      <div className="grid grid-cols-1 gap-6 transition-all duration-300 sm:grid-cols-2 lg:grid-cols-3">
+        {filteredProjects.map((project) => (
+          <ProjectCard
+            key={project.id}
+            project={project}
+            onTagClick={handleTagClick}
+            onOpenModal={setSelectedProject}
+          />
+        ))}
+      </div>
+
+      {filteredProjects.length === 0 && (
+        <p className="py-12 text-center text-zinc-500 dark:text-zinc-400">
+          No projects match the selected filter.
+        </p>
+      )}
+
+      <ProjectModal project={selectedProject} onClose={() => setSelectedProject(null)} />
+    </section>
+  );
+}

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,146 @@
+import type { Project } from "@/types/project";
+
+export const projects: readonly Project[] = [
+  {
+    id: "taskflow",
+    title: "TaskFlow",
+    category: "Full Stack",
+    description:
+      "Real-time project management tool with drag-and-drop Kanban boards, team collaboration, and automated workflows.",
+    fullDescription:
+      "TaskFlow is a comprehensive project management platform designed for modern teams. It features real-time Kanban boards with drag-and-drop functionality, enabling seamless task organization. The platform supports team collaboration with live cursors, comments, and notifications. Automated workflows allow teams to define triggers and actions that streamline their processes.",
+    features: [
+      "Drag-and-drop Kanban boards with real-time sync",
+      "Team collaboration with live presence indicators",
+      "Automated workflow engine with custom triggers",
+      "WebSocket-based live updates across all clients",
+      "Role-based access control and team management",
+      "Activity timeline and audit logging",
+    ],
+    techStack: ["Next.js", "Socket.io", "PostgreSQL", "Redis", "TypeScript", "Tailwind CSS"],
+    challenges:
+      "Implementing conflict-free real-time collaboration required designing a CRDT-based sync engine to handle concurrent edits from multiple users without data loss.",
+    githubUrl: "https://github.com/example/taskflow",
+    liveUrl: "https://taskflow.example.com",
+    imageAlt: "TaskFlow Kanban board interface",
+    stats: "WebSocket-based live updates",
+  },
+  {
+    id: "cloudvault",
+    title: "CloudVault",
+    category: "Backend",
+    description:
+      "Secure file storage and sharing platform with end-to-end encryption, file versioning, and team workspaces.",
+    fullDescription:
+      "CloudVault provides enterprise-grade file storage with a focus on security and collaboration. Files are encrypted end-to-end using AES-256, ensuring only authorized users can access content. The versioning system maintains a complete history of changes, and team workspaces enable organized file sharing with granular permissions.",
+    features: [
+      "End-to-end AES-256 encryption for all files",
+      "Complete file versioning with diff viewer",
+      "Team workspaces with granular permissions",
+      "Chunked upload system for large files",
+      "Real-time sync across devices",
+      "REST API for third-party integrations",
+    ],
+    techStack: ["Node.js", "AWS S3", "MongoDB", "Redis", "Express", "TypeScript"],
+    challenges:
+      "Building a chunked upload system that handles 10K+ concurrent uploads required implementing a custom queue with Redis-backed job management and S3 multipart uploads.",
+    githubUrl: "https://github.com/example/cloudvault",
+    imageAlt: "CloudVault file management dashboard",
+    stats: "Handles 10K+ concurrent uploads",
+  },
+  {
+    id: "pixelcraft",
+    title: "PixelCraft",
+    category: "Frontend",
+    description:
+      "Browser-based image editor with layers, filters, and export options. Uses Web Workers for heavy processing.",
+    fullDescription:
+      "PixelCraft is a powerful image editing application that runs entirely in the browser. It supports multiple layers, blend modes, and a comprehensive set of filters. Heavy image processing tasks are offloaded to Web Workers to keep the UI responsive. Local saves use IndexedDB, allowing users to resume editing sessions without server dependency.",
+    features: [
+      "Multi-layer canvas editing with blend modes",
+      "30+ built-in filters with real-time preview",
+      "Web Workers for non-blocking image processing",
+      "IndexedDB-based local project saves",
+      "Export to PNG, JPEG, WebP, and SVG",
+      "Keyboard shortcuts and customizable toolbar",
+    ],
+    techStack: ["React", "Canvas API", "Web Workers", "IndexedDB", "TypeScript", "Tailwind CSS"],
+    challenges:
+      "Achieving smooth performance with large images required implementing a tile-based rendering system and offloading filter computations to a pool of Web Workers.",
+    githubUrl: "https://github.com/example/pixelcraft",
+    liveUrl: "https://pixelcraft.example.com",
+    imageAlt: "PixelCraft image editing interface",
+    stats: "50K+ users",
+  },
+  {
+    id: "deploypilot",
+    title: "DeployPilot",
+    category: "DevOps",
+    description:
+      "One-click deployment platform for containerized apps. Go CLI + React dashboard with Kubernetes integration.",
+    fullDescription:
+      "DeployPilot simplifies container deployments with a unified CLI and web dashboard. Teams can deploy, rollback, and monitor containerized applications with a single command or click. The platform integrates with GitHub Actions for CI/CD pipelines and uses Terraform for infrastructure provisioning.",
+    features: [
+      "One-click deployments with automatic rollback",
+      "Go CLI for terminal-based workflows",
+      "Real-time deployment logs and health monitoring",
+      "GitHub Actions integration for CI/CD",
+      "Terraform-managed infrastructure provisioning",
+      "Multi-environment support (staging, production)",
+    ],
+    techStack: ["Go", "React", "Docker", "Kubernetes", "Terraform", "GitHub Actions"],
+    challenges:
+      "Designing a reliable rollback mechanism required implementing health checks at each deployment stage and maintaining snapshot states for instant recovery.",
+    githubUrl: "https://github.com/example/deploypilot",
+    imageAlt: "DeployPilot deployment dashboard",
+    stats: "Used by 20+ teams internally",
+  },
+  {
+    id: "datapulse",
+    title: "DataPulse",
+    category: "Full Stack",
+    description:
+      "Real-time analytics dashboard with customizable widgets, data streaming, and alerting system.",
+    fullDescription:
+      "DataPulse is a high-performance analytics platform that processes and visualizes data streams in real time. Users can create custom dashboards with drag-and-drop widgets, set up alerts based on metric thresholds, and export reports. The streaming pipeline handles millions of events daily with minimal latency.",
+    features: [
+      "Customizable dashboard with drag-and-drop widgets",
+      "Real-time data streaming via Apache Kafka",
+      "Threshold-based alerting with notification channels",
+      "Interactive D3.js visualizations and charts",
+      "Historical data queries with TimescaleDB",
+      "Scheduled report generation and export",
+    ],
+    techStack: ["Next.js", "D3.js", "Apache Kafka", "TimescaleDB", "TypeScript", "Tailwind CSS"],
+    challenges:
+      "Processing 1M+ events/day with sub-second dashboard updates required implementing a windowed aggregation pipeline with Kafka Streams and an efficient caching layer.",
+    githubUrl: "https://github.com/example/datapulse",
+    liveUrl: "https://datapulse.example.com",
+    imageAlt: "DataPulse analytics dashboard",
+    stats: "Processes 1M+ events/day",
+  },
+  {
+    id: "opencontrib",
+    title: "OpenContrib",
+    category: "Frontend",
+    description:
+      "GitHub contribution visualizer and open-source portfolio generator. Featured on Hacker News.",
+    fullDescription:
+      "OpenContrib transforms GitHub activity into beautiful, shareable portfolio pages. It pulls contribution data via the GitHub API, generates interactive visualizations using Chart.js, and creates a polished portfolio page that developers can share. The tool highlights open-source impact with metrics like PRs merged, issues closed, and repositories contributed to.",
+    features: [
+      "GitHub API integration for contribution data",
+      "Interactive contribution charts and graphs",
+      "Auto-generated portfolio pages with custom themes",
+      "Contribution streak tracking and statistics",
+      "Shareable portfolio links with OG image generation",
+      "Dark mode and multiple theme options",
+    ],
+    techStack: ["React", "GitHub API", "Chart.js", "Tailwind CSS", "TypeScript", "Vercel"],
+    challenges:
+      "Handling GitHub API rate limits required implementing a smart caching strategy with stale-while-revalidate patterns and incremental data fetching.",
+    githubUrl: "https://github.com/example/opencontrib",
+    liveUrl: "https://opencontrib.example.com",
+    imageAlt: "OpenContrib portfolio visualization",
+    stats: "Featured on Hacker News",
+  },
+] as const satisfies readonly Project[];

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -1,0 +1,18 @@
+export interface Project {
+  readonly id: string;
+  readonly title: string;
+  readonly category: ProjectCategory;
+  readonly description: string;
+  readonly fullDescription: string;
+  readonly features: readonly string[];
+  readonly techStack: readonly string[];
+  readonly challenges: string;
+  readonly githubUrl: string;
+  readonly liveUrl?: string;
+  readonly imageAlt: string;
+  readonly stats: string;
+}
+
+export type ProjectCategory = "Frontend" | "Backend" | "Full Stack" | "DevOps";
+
+export type FilterCategory = "All" | ProjectCategory;


### PR DESCRIPTION
## Summary
- Add 6 detailed project entries (TaskFlow, CloudVault, PixelCraft, DeployPilot, DataPulse, OpenContrib) with full metadata, tech stacks, and descriptions
- Implement filterable project grid with category buttons (All, Frontend, Backend, Full Stack, DevOps) and technology tag filtering
- Add project detail modal with features list, tech stack, challenges, and action links — closes on backdrop click and Escape key
- Responsive layout: 3-column grid on desktop, single column on mobile with full-screen modal

Closes #3

## Test plan
- [ ] Verify all 6 projects render correctly in the grid layout
- [ ] Test category filter buttons correctly filter projects
- [ ] Test clicking technology tags filters projects by that tech
- [ ] Verify project detail modal opens with smooth animation
- [ ] Verify modal closes on backdrop click and Escape key
- [ ] Test mobile responsiveness: single column cards, full-screen modal
- [ ] Verify all project data is properly typed with TypeScript

🤖 Generated with [Claude Code](https://claude.com/claude-code)