### PR TITLE
feat: add experimental control room dashboard

### DIFF
--- a/src/app/control-room/page.tsx
+++ b/src/app/control-room/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+
+import { ControlRoomDashboard } from "@/components/control-room/ControlRoomDashboard";
+import { createControlRoomSnapshot } from "@/components/control-room/control-room-data";
+
+export const metadata: Metadata = {
+  title: "Control Room",
+  description: "Experimental mock operations dashboard.",
+};
+
+export default function ControlRoomPage() {
+  return (
+    <main className="min-h-screen bg-slate-950 px-4 py-6 text-slate-100 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl">
+        <ControlRoomDashboard initialSnapshot={createControlRoomSnapshot()} />
+      </div>
+    </main>
+  );
+}

--- a/src/components/control-room/ActivityFeed.tsx
+++ b/src/components/control-room/ActivityFeed.tsx
@@ -1,0 +1,153 @@
+import type { ActivityFilter, ActivityItem } from "./control-room-data";
+
+const categoryStyles = {
+  Deployments: "bg-emerald-400/15 text-emerald-100",
+  Incidents: "bg-rose-400/15 text-rose-100",
+  Jobs: "bg-amber-400/15 text-amber-100",
+  Notes: "bg-slate-400/15 text-slate-100",
+};
+
+type ActivityFeedProps = {
+  activities: ActivityItem[];
+  expandedIds: string[];
+  filter: ActivityFilter;
+  filters: ActivityFilter[];
+  onFilterChange: (nextFilter: ActivityFilter) => void;
+  onToggle: (activityId: string) => void;
+};
+
+export function ActivityFeed({
+  activities,
+  expandedIds,
+  filter,
+  filters,
+  onFilterChange,
+  onToggle,
+}: Readonly<ActivityFeedProps>) {
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-900/65 shadow-[0_22px_80px_rgba(2,6,23,0.34)] backdrop-blur">
+      <div className="border-b border-white/8 px-6 py-6">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-400">
+              Activity Feed
+            </p>
+            <h2 className="mt-2 text-2xl font-semibold text-white">
+              Operator events and rehearsal traffic
+            </h2>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-300">
+              Filter the mock feed by lane, then expand any entry to inspect more context for the
+              current drill.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            {filters.map((entry) => {
+              const isActive = entry === filter;
+
+              return (
+                <button
+                  key={entry}
+                  type="button"
+                  onClick={() => onFilterChange(entry)}
+                  aria-pressed={isActive}
+                  className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                    isActive
+                      ? "bg-cyan-300 text-slate-950"
+                      : "border border-white/10 bg-white/5 text-slate-200 hover:bg-white/10"
+                  }`}
+                >
+                  {entry}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {activities.length === 0 ? (
+        <div className="px-6 py-10">
+          <div className="rounded-2xl border border-dashed border-white/12 bg-slate-950/45 px-5 py-8 text-center">
+            <p className="text-sm font-semibold uppercase tracking-[0.26em] text-slate-500">
+              Nothing queued
+            </p>
+            <h3 className="mt-3 text-xl font-semibold text-white">
+              No {filter.toLowerCase()} activity in this rehearsal window
+            </h3>
+            <p className="mt-3 text-sm leading-6 text-slate-300">
+              This view is backed by local mock events only. Switch back to another filter or hit
+              refresh to rotate the fake timeline.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <ul className="divide-y divide-white/8">
+          {activities.map((activity) => {
+            const isExpanded = expandedIds.includes(activity.id);
+
+            return (
+              <li key={activity.id} className="px-6 py-5">
+                <button
+                  type="button"
+                  onClick={() => onToggle(activity.id)}
+                  aria-expanded={isExpanded}
+                  className="flex w-full flex-col gap-4 text-left"
+                >
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span
+                          className={`rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${categoryStyles[activity.category]}`}
+                        >
+                          {activity.category}
+                        </span>
+                        <span className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                          {activity.service}
+                        </span>
+                      </div>
+                      <h3 className="mt-3 text-lg font-semibold text-white">{activity.title}</h3>
+                      <p className="mt-2 text-sm text-slate-300">{activity.status}</p>
+                    </div>
+
+                    <div className="shrink-0 text-right">
+                      <p className="text-sm font-medium text-slate-200">{activity.happenedAtLabel}</p>
+                      <p className="mt-2 text-xs uppercase tracking-[0.2em] text-slate-500">
+                        {isExpanded ? "Hide detail" : "Show detail"}
+                      </p>
+                    </div>
+                  </div>
+                </button>
+
+                {isExpanded ? (
+                  <div className="mt-4 rounded-2xl border border-white/8 bg-slate-950/50 p-4">
+                    <p className="text-sm leading-6 text-slate-200">{activity.detail}</p>
+                    <dl className="mt-4 flex flex-wrap gap-x-6 gap-y-3 text-sm text-slate-300">
+                      <div>
+                        <dt className="text-xs uppercase tracking-[0.22em] text-slate-500">
+                          Actor
+                        </dt>
+                        <dd className="mt-1">{activity.actor}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs uppercase tracking-[0.22em] text-slate-500">
+                          Service
+                        </dt>
+                        <dd className="mt-1">{activity.service}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs uppercase tracking-[0.22em] text-slate-500">
+                          Status
+                        </dt>
+                        <dd className="mt-1">{activity.status}</dd>
+                      </div>
+                    </dl>
+                  </div>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/control-room/AlertList.tsx
+++ b/src/components/control-room/AlertList.tsx
@@ -1,0 +1,68 @@
+import type { AlertItem } from "./control-room-data";
+
+const severityStyles = {
+  info: "border-sky-400/20 bg-sky-400/8",
+  warning: "border-amber-400/20 bg-amber-400/8",
+  critical: "border-rose-400/25 bg-rose-400/10",
+};
+
+const severityBadgeStyles = {
+  info: "bg-sky-400/15 text-sky-100",
+  warning: "bg-amber-400/15 text-amber-100",
+  critical: "bg-rose-400/15 text-rose-100",
+};
+
+type AlertListProps = {
+  alerts: AlertItem[];
+};
+
+export function AlertList({ alerts }: Readonly<AlertListProps>) {
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-900/65 p-6 shadow-[0_22px_80px_rgba(2,6,23,0.34)] backdrop-blur">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-400">
+            Alert Rail
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">Live rehearsal alerts</h2>
+        </div>
+        <span className="rounded-full border border-white/10 px-3 py-1 text-xs font-medium text-slate-300">
+          {alerts.length} active
+        </span>
+      </div>
+
+      <ul className="mt-6 space-y-3">
+        {alerts.map((alert) => (
+          <li
+            key={alert.id}
+            className={`rounded-2xl border p-4 ${severityStyles[alert.severity]}`}
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <span
+                  className={`inline-flex rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${severityBadgeStyles[alert.severity]}`}
+                >
+                  {alert.severity}
+                </span>
+                <h3 className="mt-3 text-base font-semibold text-white">{alert.title}</h3>
+              </div>
+              <span className="text-xs text-slate-400">{alert.raisedAtLabel}</span>
+            </div>
+
+            <p className="mt-3 text-sm leading-6 text-slate-200">{alert.message}</p>
+            <dl className="mt-4 grid gap-3 text-sm text-slate-300 sm:grid-cols-2">
+              <div>
+                <dt className="text-xs uppercase tracking-[0.22em] text-slate-500">Service</dt>
+                <dd className="mt-1">{alert.service}</dd>
+              </div>
+              <div>
+                <dt className="text-xs uppercase tracking-[0.22em] text-slate-500">Owner</dt>
+                <dd className="mt-1">{alert.owner}</dd>
+              </div>
+            </dl>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/control-room/ControlRoomDashboard.tsx
+++ b/src/components/control-room/ControlRoomDashboard.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+import { ActivityFeed } from "./ActivityFeed";
+import { AlertList } from "./AlertList";
+import { MetricCard } from "./MetricCard";
+import { QuickActions } from "./QuickActions";
+import {
+  activityFilters,
+  createControlRoomSnapshot,
+  quickActions,
+  type ActivityFilter,
+  type ControlRoomSnapshot,
+} from "./control-room-data";
+
+type ControlRoomDashboardProps = {
+  initialSnapshot: ControlRoomSnapshot;
+};
+
+export function ControlRoomDashboard({
+  initialSnapshot,
+}: Readonly<ControlRoomDashboardProps>) {
+  const [snapshot, setSnapshot] = useState(initialSnapshot);
+  const [filter, setFilter] = useState<ActivityFilter>("All");
+  const [expandedIds, setExpandedIds] = useState<string[]>([]);
+  const [activeActionId, setActiveActionId] = useState<string | null>(null);
+  const [actionMessage, setActionMessage] = useState(
+    "Choose any dry-run control to simulate an operator action inside this mock room.",
+  );
+  const [isPending, startTransition] = useTransition();
+
+  const filteredActivities =
+    filter === "All"
+      ? snapshot.activities
+      : snapshot.activities.filter((activity) => activity.category === filter);
+
+  const criticalAlerts = snapshot.alerts.filter(
+    (alert) => alert.severity === "critical",
+  ).length;
+
+  function handleRefresh() {
+    startTransition(() => {
+      const nextSnapshot = createControlRoomSnapshot(snapshot.revision + 1);
+
+      setSnapshot(nextSnapshot);
+      setExpandedIds([]);
+      setActionMessage(`Telemetry refreshed at ${nextSnapshot.lastUpdatedLabel}.`);
+    });
+  }
+
+  function handleToggleActivity(activityId: string) {
+    setExpandedIds((currentIds) =>
+      currentIds.includes(activityId)
+        ? currentIds.filter((id) => id !== activityId)
+        : [...currentIds, activityId],
+    );
+  }
+
+  function handleAction(actionId: string) {
+    const action = quickActions.find((entry) => entry.id === actionId);
+
+    if (!action) {
+      return;
+    }
+
+    setActiveActionId(actionId);
+    setActionMessage(`${action.response} No live infrastructure was touched.`);
+  }
+
+  return (
+    <div className="relative isolate overflow-hidden rounded-[2rem] border border-white/10 bg-slate-950/80 p-4 shadow-[0_30px_140px_rgba(2,6,23,0.55)] sm:p-6">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute inset-x-0 top-0 h-56 bg-[radial-gradient(circle_at_top,_rgba(34,211,238,0.22),_transparent_55%)]" />
+        <div className="absolute -left-16 top-24 h-52 w-52 rounded-full bg-emerald-400/12 blur-3xl" />
+        <div className="absolute bottom-8 right-0 h-48 w-48 rounded-full bg-rose-400/10 blur-3xl" />
+      </div>
+
+      <div className="relative space-y-6">
+        <section className="rounded-3xl border border-white/10 bg-slate-900/70 p-6 backdrop-blur">
+          <div className="flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
+            <div className="max-w-3xl">
+              <span className="inline-flex rounded-full border border-cyan-300/20 bg-cyan-300/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.26em] text-cyan-100">
+                {snapshot.environmentLabel}
+              </span>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+                Control Room
+              </h1>
+              <p className="mt-4 max-w-2xl text-sm leading-7 text-slate-300 sm:text-base">
+                A self-contained rehearsal dashboard for deployments, incidents, and background
+                jobs. Everything on this page is local mock data with client-side state only.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-end">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="rounded-2xl border border-white/8 bg-slate-950/55 px-4 py-3">
+                  <p className="text-xs uppercase tracking-[0.22em] text-slate-500">Last updated</p>
+                  <p className="mt-2 text-sm font-medium text-white">{snapshot.lastUpdatedLabel}</p>
+                </div>
+                <div className="rounded-2xl border border-white/8 bg-slate-950/55 px-4 py-3">
+                  <p className="text-xs uppercase tracking-[0.22em] text-slate-500">Critical alerts</p>
+                  <p className="mt-2 text-sm font-medium text-white">
+                    {criticalAlerts} requiring review
+                  </p>
+                </div>
+              </div>
+
+              <button
+                type="button"
+                onClick={handleRefresh}
+                className="rounded-2xl bg-cyan-300 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-200"
+              >
+                {isPending ? "Refreshing..." : "Refresh telemetry"}
+              </button>
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          {snapshot.metrics.map((metric) => (
+            <MetricCard key={metric.id} metric={metric} />
+          ))}
+        </section>
+
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.9fr)]">
+          <ActivityFeed
+            activities={filteredActivities}
+            expandedIds={expandedIds}
+            filter={filter}
+            filters={activityFilters}
+            onFilterChange={setFilter}
+            onToggle={handleToggleActivity}
+          />
+
+          <div className="space-y-6">
+            <AlertList alerts={snapshot.alerts} />
+            <QuickActions
+              actions={quickActions}
+              activeActionId={activeActionId}
+              message={actionMessage}
+              onAction={handleAction}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/control-room/MetricCard.tsx
+++ b/src/components/control-room/MetricCard.tsx
@@ -1,0 +1,48 @@
+import type { MetricSnapshot } from "./control-room-data";
+
+const toneStyles = {
+  good: "border-emerald-400/20 bg-emerald-400/8",
+  watch: "border-amber-400/20 bg-amber-400/8",
+  hot: "border-rose-400/20 bg-rose-400/8",
+};
+
+const toneBadgeStyles = {
+  good: "bg-emerald-400/15 text-emerald-200 ring-1 ring-emerald-300/20",
+  watch: "bg-amber-400/15 text-amber-100 ring-1 ring-amber-300/20",
+  hot: "bg-rose-400/15 text-rose-100 ring-1 ring-rose-300/20",
+};
+
+type MetricCardProps = {
+  metric: MetricSnapshot;
+};
+
+export function MetricCard({ metric }: Readonly<MetricCardProps>) {
+  return (
+    <article
+      className={`rounded-2xl border p-5 shadow-[0_18px_60px_rgba(2,6,23,0.28)] ${toneStyles[metric.tone]}`}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium text-slate-200">{metric.label}</p>
+          <p className="mt-1 text-xs uppercase tracking-[0.24em] text-slate-400">
+            {metric.supportLabel}
+          </p>
+        </div>
+        <span
+          className={`rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${toneBadgeStyles[metric.tone]}`}
+        >
+          {metric.stateLabel}
+        </span>
+      </div>
+
+      <p className="mt-8 text-4xl font-semibold tracking-tight text-white">
+        {metric.displayValue}
+      </p>
+      <p className="mt-2 text-sm leading-6 text-slate-300">{metric.caption}</p>
+
+      <div className="mt-5 rounded-xl border border-white/8 bg-slate-950/55 px-3 py-2 text-sm text-slate-200">
+        {metric.deltaLabel}
+      </div>
+    </article>
+  );
+}

--- a/src/components/control-room/QuickActions.tsx
+++ b/src/components/control-room/QuickActions.tsx
@@ -1,0 +1,67 @@
+import type { QuickAction } from "./control-room-data";
+
+const actionToneStyles = {
+  teal: "border-cyan-300/20 bg-cyan-300/8 hover:bg-cyan-300/12",
+  amber: "border-amber-300/20 bg-amber-300/8 hover:bg-amber-300/12",
+  rose: "border-rose-300/20 bg-rose-300/8 hover:bg-rose-300/12",
+  sky: "border-sky-300/20 bg-sky-300/8 hover:bg-sky-300/12",
+  slate: "border-white/12 bg-white/5 hover:bg-white/8",
+};
+
+type QuickActionsProps = {
+  actions: QuickAction[];
+  activeActionId: string | null;
+  message: string;
+  onAction: (actionId: string) => void;
+};
+
+export function QuickActions({
+  actions,
+  activeActionId,
+  message,
+  onAction,
+}: Readonly<QuickActionsProps>) {
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-900/65 p-6 shadow-[0_22px_80px_rgba(2,6,23,0.34)] backdrop-blur">
+      <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-400">
+        Quick Actions
+      </p>
+      <h2 className="mt-2 text-2xl font-semibold text-white">Dry-run controls</h2>
+      <p className="mt-2 text-sm leading-6 text-slate-300">
+        These buttons do not call external systems. They only update this isolated mock control
+        surface.
+      </p>
+
+      <div className="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+        {actions.map((action) => {
+          const isActive = action.id === activeActionId;
+
+          return (
+            <button
+              key={action.id}
+              type="button"
+              onClick={() => onAction(action.id)}
+              aria-pressed={isActive}
+              className={`rounded-2xl border p-4 text-left transition ${actionToneStyles[action.tone]} ${
+                isActive ? "ring-1 ring-cyan-200/45" : ""
+              }`}
+            >
+              <span className="block text-base font-semibold text-white">{action.label}</span>
+              <span className="mt-2 block text-sm leading-6 text-slate-300">
+                {action.description}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        role="status"
+        aria-live="polite"
+        className="mt-6 rounded-2xl border border-cyan-300/15 bg-cyan-300/8 px-4 py-3 text-sm leading-6 text-cyan-50"
+      >
+        {message}
+      </div>
+    </section>
+  );
+}

--- a/src/components/control-room/control-room-data.ts
+++ b/src/components/control-room/control-room-data.ts
@@ -1,0 +1,216 @@
+export type ActivityCategory = "Deployments" | "Incidents" | "Jobs" | "Notes";
+export type ActivityFilter = "All" | ActivityCategory;
+export type AlertSeverity = "info" | "warning" | "critical";
+export type MetricTone = "good" | "watch" | "hot";
+export type QuickActionTone = "teal" | "amber" | "rose" | "sky" | "slate";
+
+export type MetricSnapshot = {
+  id: string;
+  label: string;
+  displayValue: string;
+  deltaLabel: string;
+  caption: string;
+  supportLabel: string;
+  stateLabel: string;
+  tone: MetricTone;
+};
+
+export type AlertItem = {
+  id: string;
+  title: string;
+  message: string;
+  severity: AlertSeverity;
+  service: string;
+  owner: string;
+  raisedAtLabel: string;
+};
+
+export type ActivityItem = {
+  id: string;
+  category: ActivityCategory;
+  title: string;
+  detail: string;
+  status: string;
+  actor: string;
+  service: string;
+  happenedAtLabel: string;
+};
+
+export type QuickAction = {
+  id: string;
+  label: string;
+  description: string;
+  response: string;
+  tone: QuickActionTone;
+};
+
+export type ControlRoomSnapshot = {
+  environmentLabel: string;
+  lastUpdatedLabel: string;
+  metrics: MetricSnapshot[];
+  alerts: AlertItem[];
+  activities: ActivityItem[];
+  revision: number;
+};
+
+type MetricBlueprint = {
+  id: string;
+  label: string;
+  base: number;
+  swing: number;
+  step: number;
+  precision: number;
+  suffix: string;
+  deltaStep: number;
+  deltaPrecision: number;
+  deltaSuffix: string;
+  caption: string;
+  supportLabel: string;
+  stateLabel: string;
+  tone: MetricTone;
+};
+
+type AlertBlueprint = [
+  id: string,
+  severity: AlertSeverity,
+  title: string,
+  message: string,
+  service: string,
+  owner: string,
+  offsetMinutes: number,
+];
+
+type ActivityBlueprint = [
+  id: string,
+  category: ActivityCategory,
+  title: string,
+  detail: string,
+  status: string,
+  actor: string,
+  service: string,
+  offsetMinutes: number,
+];
+
+type QuickActionBlueprint = [
+  id: string,
+  label: string,
+  description: string,
+  response: string,
+  tone: QuickActionTone,
+];
+
+const dateTimeFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+  hour12: false,
+});
+
+export const activityFilters: ActivityFilter[] = ["All", "Deployments", "Incidents", "Jobs", "Notes"];
+
+const metricBlueprints: MetricBlueprint[] = [
+  { id: "throughput", label: "Global throughput", base: 842, swing: 148, step: 17, precision: 0, suffix: " req/s", deltaStep: 14, deltaPrecision: 0, deltaSuffix: " req/s", caption: "Ingress across the mock edge fleet", supportLabel: "Target 800 req/s", stateLabel: "Nominal", tone: "good" },
+  { id: "latency", label: "Edge latency p95", base: 186, swing: 44, step: 5, precision: 0, suffix: " ms", deltaStep: 4, deltaPrecision: 0, deltaSuffix: " ms", caption: "Public request latency at the 95th percentile", supportLabel: "Budget 200 ms", stateLabel: "Watch", tone: "watch" },
+  { id: "success-rate", label: "Success rate", base: 99.82, swing: 0.18, step: 0.03, precision: 2, suffix: "%", deltaStep: 0.04, deltaPrecision: 2, deltaSuffix: "%", caption: "Healthy responses returned by core APIs", supportLabel: "Error budget 0.25%", stateLabel: "Stable", tone: "good" },
+  { id: "queue-depth", label: "Queue depth", base: 38, swing: 24, step: 4, precision: 0, suffix: " jobs", deltaStep: 3, deltaPrecision: 0, deltaSuffix: " jobs", caption: "Outstanding background work in mock schedulers", supportLabel: "Comfort zone < 50", stateLabel: "Rising", tone: "watch" },
+  { id: "saturation", label: "Worker saturation", base: 68, swing: 22, step: 3, precision: 0, suffix: "%", deltaStep: 2, deltaPrecision: 0, deltaSuffix: "%", caption: "Average load across batch workers", supportLabel: "Headroom 20%", stateLabel: "Buffered", tone: "good" },
+  { id: "incidents", label: "Open incidents", base: 2, swing: 4, step: 1, precision: 0, suffix: "", deltaStep: 1, deltaPrecision: 0, deltaSuffix: "", caption: "Active response threads requiring operator attention", supportLabel: "Resolved target 0", stateLabel: "Escalated", tone: "hot" },
+  { id: "deployments", label: "Deployments today", base: 14, swing: 8, step: 2, precision: 0, suffix: "", deltaStep: 1, deltaPrecision: 0, deltaSuffix: "", caption: "Synthetic rollouts promoted across regions", supportLabel: "Canary ratio 2:1", stateLabel: "Active", tone: "good" },
+  { id: "coverage", label: "Runbook coverage", base: 83, swing: 10, step: 2, precision: 0, suffix: "%", deltaStep: 1, deltaPrecision: 0, deltaSuffix: "%", caption: "Mock services linked to a documented response path", supportLabel: "Next target 90%", stateLabel: "Improving", tone: "watch" },
+];
+
+const alertBlueprints: AlertBlueprint[] = [
+  ["alert-control-api", "critical", "Control API retries breached the high-water mark", "Retry volume in sandbox region 2 is 2.3x above the rehearsal baseline.", "control-api", "On-call backend", 6],
+  ["alert-scheduler", "warning", "Background queue lag is trending upward", "Scheduler lane B is averaging 18% slower completion than the last refresh window.", "scheduler", "Jobs desk", 14],
+  ["alert-observability", "info", "Synthetic probe pack rotated to rehearsal mode", "Latency probes now target the upcoming canary template for pre-release comparison.", "observability", "Platform ops", 23],
+];
+
+const activityBlueprints: ActivityBlueprint[] = [
+  ["act-rollout-eu", "Deployments", "Release cr-77 promoted to 50% in eu-west-1", "Synthetic checks stayed green long enough to widen the Europe canary from 15% to 50%.", "Canary widened", "release-bot", "control-api", 4],
+  ["act-incident-cache", "Incidents", "Operator opened incident thread for cache stampede drill", "The response cell tagged the issue as rehearsal-only after cache churn crossed the mock threshold three times in a row.", "Incident bridged", "maya.k", "edge-cache", 9],
+  ["act-job-replay", "Jobs", "Replay batch kicked off for failed settlement jobs", "Seventeen sandbox jobs were queued for replay so the worker pool could validate the retry policy under moderate load.", "Replay running", "scheduler", "job-runner", 13],
+  ["act-rollout-us", "Deployments", "US rehearsal lane pinned to fallback image", "Operators rolled the traffic slice back to the fallback image to compare memory pressure before another deploy attempt.", "Fallback pinned", "nina.p", "worker-api", 18],
+  ["act-job-import", "Jobs", "Ingest cleanup completed on archive partition", "The cleanup job reclaimed headroom in the archive partition and cut the simulated backlog by twelve percent.", "Cleanup done", "janitor-bot", "storage-ops", 24],
+  ["act-incident-auth", "Incidents", "Auth throttling rehearsal escalated to paging stage", "The drill advanced after the mock rate limiter exceeded its error budget and triggered the paging branch of the runbook.", "Paging staged", "ila.s", "identity-gateway", 31],
+  ["act-rollout-apac", "Deployments", "APAC config bundle validated against standby nodes", "A dry-run of the next control-plane config passed on standby nodes and cleared the region for tomorrow's rehearsal.", "Bundle cleared", "config-bot", "control-plane", 37],
+  ["act-job-backfill", "Jobs", "Billing backfill throttled to protect worker headroom", "The scheduler reduced concurrency from 16 to 10 to keep the simulated backlog under the saturation threshold.", "Throttle applied", "scheduling-rule", "billing-jobs", 43],
+  ["act-incident-db", "Incidents", "Database failover drill cleared after replica catch-up", "Replica lag returned to range, so the team closed the drill and marked the failover path ready for another rehearsal.", "Drill resolved", "on-call db", "replica-cluster", 52],
+  ["act-job-audit", "Jobs", "Nightly audit pack queued for integrity verification", "The verification pack will compare checksum drift across archived snapshots before the next synthetic deploy.", "Audit queued", "audit-bot", "artifact-vault", 66],
+  ["act-rollout-canary", "Deployments", "Canary scorecard published for shift handoff", "The release scorecard captured latency, rollback triggers, and error rate so the next operator can continue the drill cleanly.", "Handoff posted", "shift-lead", "release-ops", 73],
+];
+
+const quickActionBlueprints: QuickActionBlueprint[] = [
+  ["queue-canary", "Queue canary", "Simulate a staged rollout across two rehearsal regions.", "Canary simulation queued for the sandbox release lane.", "teal"],
+  ["pause-workers", "Pause workers", "Dry-run a pause on the secondary batch pool.", "Secondary worker pool marked as paused in the mock control plane.", "amber"],
+  ["dispatch-oncall", "Dispatch on-call", "Open a rehearsal escalation thread for the active critical alert.", "Escalation thread drafted and routed to the simulated on-call rotation.", "rose"],
+  ["export-briefing", "Export briefing", "Generate a dummy handoff summary for the next operator.", "Shift briefing assembled with the current dashboard snapshot.", "sky"],
+  ["run-diagnostics", "Run diagnostics", "Trigger a fake cross-service health sweep.", "Diagnostic sweep started across the rehearsal service graph.", "slate"],
+];
+
+export const quickActions: QuickAction[] = quickActionBlueprints.map(
+  ([id, label, description, response, tone]) => ({ id, label, description, response, tone }),
+);
+
+function formatMetricValue(value: number, precision: number, suffix: string) {
+  return `${value.toLocaleString("en-US", { minimumFractionDigits: precision, maximumFractionDigits: precision })}${suffix}`;
+}
+
+function formatDeltaLabel(value: number, precision: number, suffix: string) {
+  const formatted = Math.abs(value).toLocaleString("en-US", {
+    minimumFractionDigits: precision,
+    maximumFractionDigits: precision,
+  });
+  return `${value >= 0 ? "+" : "-"}${formatted}${suffix} vs last refresh`;
+}
+
+function formatDateLabel(date: Date) {
+  return dateTimeFormatter.format(date);
+}
+
+export function createControlRoomSnapshot(revision = 0): ControlRoomSnapshot {
+  const now = new Date();
+
+  return {
+    environmentLabel: "Experimental Sandbox",
+    lastUpdatedLabel: formatDateLabel(now),
+    revision,
+    metrics: metricBlueprints.map((metric, index) => {
+      const wave = ((revision + 1) * metric.step + index * 7) % metric.swing;
+      const value = Number((metric.base + wave - metric.swing / 2).toFixed(metric.precision));
+      const delta = Number(((((revision + index) % 5) - 2) * metric.deltaStep).toFixed(metric.deltaPrecision));
+      return {
+        id: metric.id,
+        label: metric.label,
+        displayValue: formatMetricValue(value, metric.precision, metric.suffix),
+        deltaLabel: formatDeltaLabel(delta, metric.deltaPrecision, metric.deltaSuffix),
+        caption: metric.caption,
+        supportLabel: metric.supportLabel,
+        stateLabel: metric.stateLabel,
+        tone: metric.tone,
+      };
+    }),
+    alerts: alertBlueprints.map(([id, severity, title, message, service, owner, offsetMinutes], index) => ({
+      id,
+      severity,
+      title,
+      message,
+      service,
+      owner,
+      raisedAtLabel: formatDateLabel(new Date(now.getTime() - (offsetMinutes + revision + index) * 60_000)),
+    })),
+    activities: activityBlueprints.map(([id, category, title, detail, status, actor, service, offsetMinutes], index) => ({
+      id,
+      category,
+      title,
+      detail,
+      status,
+      actor,
+      service,
+      happenedAtLabel: formatDateLabel(
+        new Date(now.getTime() - (offsetMinutes + revision * (index % 2 === 0 ? 1 : 2)) * 60_000),
+      ),
+    })),
+  };
+}


### PR DESCRIPTION
## Summary
- add an isolated `/control-room` App Router page with a mock control room surface
- add local KPI, alerts, activity, and quick-action components backed only by feature-local mock data
- support client-side refresh, activity filtering, expandable feed rows, and an empty state without touching the homepage

## Verification
- npm run lint
- npm run build

Closes #7