### PR TITLE
feat: add isolated field guide route

### DIFF
--- a/src/app/field-guide/page.tsx
+++ b/src/app/field-guide/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from "next";
+
+import {
+  procedures,
+  procedureTags,
+} from "@/components/field-guide/field-guide-data";
+import FieldGuideShell from "@/components/field-guide/field-guide-shell";
+
+export const metadata: Metadata = {
+  title: "Field Guide | API Test",
+  description: "Search and review mock procedures with local checklist state.",
+};
+
+export default function FieldGuidePage() {
+  return (
+    <main className="min-h-screen px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mx-auto flex max-w-7xl flex-col gap-6">
+        <section className="overflow-hidden rounded-[2rem] border border-slate-200/70 bg-white/90 shadow-xl shadow-slate-200/60 backdrop-blur">
+          <div className="grid gap-6 px-6 py-8 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,0.7fr)] lg:px-8">
+            <div className="space-y-4">
+              <p className="text-sm font-semibold uppercase tracking-[0.35em] text-sky-700">
+                Field Guide
+              </p>
+              <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
+                Searchable mock procedures for field drills and rapid-response
+                rehearsals.
+              </h1>
+              <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
+                Review isolated mock runbooks, narrow them by team or readiness,
+                and walk through each checklist without leaving this route.
+              </p>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
+              <div className="rounded-3xl bg-slate-950 px-5 py-4 text-slate-50">
+                <p className="text-sm text-slate-300">Procedures</p>
+                <p className="mt-2 text-3xl font-semibold">{procedures.length}</p>
+              </div>
+              <div className="rounded-3xl bg-sky-100 px-5 py-4 text-sky-950">
+                <p className="text-sm text-sky-700">Local tags</p>
+                <p className="mt-2 text-3xl font-semibold">
+                  {procedureTags.length}
+                </p>
+              </div>
+              <div className="rounded-3xl bg-amber-100 px-5 py-4 text-amber-950">
+                <p className="text-sm text-amber-700">Checklist mode</p>
+                <p className="mt-2 text-lg font-semibold">Session-local only</p>
+              </div>
+            </div>
+          </div>
+        </section>
+        <FieldGuideShell />
+      </div>
+    </main>
+  );
+}

--- a/src/components/field-guide/field-guide-data.ts
+++ b/src/components/field-guide/field-guide-data.ts
@@ -1,0 +1,156 @@
+export const procedureTeams = [
+  "Network Ops",
+  "Facilities",
+  "Operations",
+  "Platform",
+  "Lab",
+] as const;
+
+export const procedureDifficulties = [
+  "Beginner",
+  "Intermediate",
+  "Advanced",
+] as const;
+
+export const procedureStatuses = ["Ready", "In Review", "Draft"] as const;
+
+export const procedureTags = [
+  "handoff",
+  "safety",
+  "cold-chain",
+  "networking",
+  "maintenance",
+  "response",
+  "rollback",
+  "telemetry",
+] as const;
+
+export type ProcedureTeam = (typeof procedureTeams)[number];
+export type ProcedureDifficulty = (typeof procedureDifficulties)[number];
+export type ProcedureStatus = (typeof procedureStatuses)[number];
+
+export type ProcedureStep = {
+  id: string;
+  label: string;
+  detail: string;
+};
+
+export type Procedure = {
+  id: string;
+  title: string;
+  summary: string;
+  team: ProcedureTeam;
+  difficulty: ProcedureDifficulty;
+  status: ProcedureStatus;
+  duration: string;
+  cadence: string;
+  location: string;
+  lastUpdated: string;
+  notes: string;
+  tags: readonly string[];
+  tools: readonly string[];
+  checklist: readonly ProcedureStep[];
+};
+
+export const procedures: readonly Procedure[] = [
+  {
+    id: "fiber-uplink-recovery",
+    title: "Fiber Uplink Recovery",
+    summary: "Restore the rooftop uplink after packet loss spikes without dropping the backup path.",
+    team: "Network Ops",
+    difficulty: "Advanced",
+    status: "Ready",
+    duration: "22 min",
+    cadence: "Weekly drill",
+    location: "Roof access cabinet B2",
+    lastUpdated: "April 12, 2026",
+    notes: "Keep the microwave failover online until the final packet capture review is complete.",
+    tags: ["networking", "response", "rollback"],
+    tools: ["Loopback tester", "Patch labels", "Spare SFP kit"],
+    checklist: [
+      { id: "confirm-alert-window", label: "Confirm alert window", detail: "Cross-check NOC timestamps with the edge switch log." },
+      { id: "inspect-fiber-tray", label: "Inspect tray and jumper seating", detail: "Verify strain relief and reseat any mismatched jumper pair." },
+      { id: "validate-primary-return", label: "Validate the primary return", detail: "Capture five clean minutes of traffic before retiring failover." },
+    ],
+  },
+  {
+    id: "cold-chain-isolation",
+    title: "Cold Chain Isolation",
+    summary: "Stabilize the vaccine storage loop during a compressor fault without warming bay inventory.",
+    team: "Facilities",
+    difficulty: "Intermediate",
+    status: "In Review",
+    duration: "18 min",
+    cadence: "Biweekly",
+    location: "Lower level refrigeration plant",
+    lastUpdated: "April 9, 2026",
+    notes: "Record ambient readings at each checkpoint so maintenance can compare drift later.",
+    tags: ["cold-chain", "safety", "maintenance"],
+    tools: ["Thermal probe", "Valve key", "Insulated tags"],
+    checklist: [
+      { id: "isolate-compressor-bank", label: "Isolate the flagged compressor bank", detail: "Close the bypass pair in sequence to prevent pressure rebound." },
+      { id: "stage-portable-cooling", label: "Stage portable cooling", detail: "Keep a clear aisle so inventory carts can still rotate through receiving." },
+      { id: "handoff-maintenance", label: "Handoff to maintenance", detail: "Attach the alarm code and your temperature notes to the ticket." },
+    ],
+  },
+  {
+    id: "dock-safety-sweep",
+    title: "Dock Safety Sweep",
+    summary: "Run the opening safety sweep before inbound trailers are released to the dock.",
+    team: "Operations",
+    difficulty: "Beginner",
+    status: "Ready",
+    duration: "12 min",
+    cadence: "Daily open",
+    location: "North receiving dock",
+    lastUpdated: "April 15, 2026",
+    notes: "Treat blocked egress and cracked wheel stops as no-go findings until cleared.",
+    tags: ["safety", "handoff"],
+    tools: ["Flashlight", "Barrier cones", "Dock checklist card"],
+    checklist: [
+      { id: "inspect-lane-markings", label: "Inspect lane markings", detail: "Replace any missing cone set before opening a lane to a carrier." },
+      { id: "verify-egress-paths", label: "Verify egress paths", detail: "Clear staged pallets that drifted into the pedestrian route overnight." },
+      { id: "log-first-shift-brief", label: "Log the first-shift brief", detail: "Call out restricted lanes so dispatch does not assign them." },
+    ],
+  },
+  {
+    id: "sensor-mast-hot-swap",
+    title: "Sensor Mast Hot Swap",
+    summary: "Replace a weather mast payload while keeping the remote feed online for command.",
+    team: "Platform",
+    difficulty: "Advanced",
+    status: "Ready",
+    duration: "26 min",
+    cadence: "Monthly",
+    location: "Training lot mast array",
+    lastUpdated: "April 11, 2026",
+    notes: "If the backup pod takes more than two minutes to register, abort and roll back.",
+    tags: ["telemetry", "maintenance", "rollback"],
+    tools: ["Harness", "Spare pod", "Weather cap"],
+    checklist: [
+      { id: "inspect-seal", label: "Inspect mast seal and tether line", detail: "Confirm the tether has no fraying before releasing the payload bracket." },
+      { id: "promote-backup-feed", label: "Promote the backup feed", detail: "Wait for two healthy telemetry pings before the physical swap." },
+      { id: "verify-calibration", label: "Verify live calibration", detail: "Compare readings to the nearby control mast for one minute." },
+    ],
+  },
+  {
+    id: "intake-downtime-handoff",
+    title: "Intake Downtime Handoff",
+    summary: "Move specimen intake to a paper queue during LIS downtime and preserve custody notes.",
+    team: "Lab",
+    difficulty: "Intermediate",
+    status: "Draft",
+    duration: "16 min",
+    cadence: "Quarterly rehearsal",
+    location: "Specimen intake window",
+    lastUpdated: "April 8, 2026",
+    notes: "Flag controlled samples separately so they receive immediate reconciliation after recovery.",
+    tags: ["handoff", "response"],
+    tools: ["Downtime packet", "Barcode labels", "Custody seals"],
+    checklist: [
+      { id: "start-paper-log", label: "Start the paper accession log", detail: "Record the downtime start time before first intake." },
+      { id: "tag-priority-samples", label: "Tag STAT and controlled samples", detail: "Use red seals so the catch-up team can separate them quickly." },
+      { id: "handoff-recovery-sheet", label: "Handoff the reconciliation sheet", detail: "Pair each paper row with the matching downtime barcode." },
+    ],
+  },
+];

--- a/src/components/field-guide/field-guide-shell.test.tsx
+++ b/src/components/field-guide/field-guide-shell.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import FieldGuideShell from "@/components/field-guide/field-guide-shell";
+
+describe("FieldGuideShell", () => {
+  it("filters procedures by title or summary", () => {
+    render(<FieldGuideShell />);
+
+    fireEvent.change(screen.getByLabelText("Search procedures"), {
+      target: { value: "weather mast" },
+    });
+
+    expect(
+      screen.getByRole("button", { name: "Open procedure: Sensor Mast Hot Swap" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Open procedure: Dock Safety Sweep" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows an empty state when filters remove every procedure", () => {
+    render(<FieldGuideShell />);
+
+    fireEvent.change(screen.getByLabelText("Search procedures"), {
+      target: { value: "does-not-exist" },
+    });
+
+    expect(
+      screen.getByText("No procedures match the current search or filters."),
+    ).toBeInTheDocument();
+  });
+
+  it("tracks checklist completion for the active procedure", () => {
+    render(<FieldGuideShell />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open procedure: Sensor Mast Hot Swap" }),
+    );
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: "Inspect mast seal and tether line",
+    });
+
+    fireEvent.click(checkbox);
+
+    expect(checkbox).toBeChecked();
+    expect(screen.getAllByText("1 of 3 steps complete")).toHaveLength(2);
+  });
+});

--- a/src/components/field-guide/field-guide-shell.tsx
+++ b/src/components/field-guide/field-guide-shell.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { startTransition, useDeferredValue, useState } from "react";
+
+import {
+  procedureDifficulties,
+  procedures,
+  procedureStatuses,
+  procedureTeams,
+} from "@/components/field-guide/field-guide-data";
+import GuideFilters from "@/components/field-guide/guide-filters";
+import GuideSearch from "@/components/field-guide/guide-search";
+import ProcedureCard from "@/components/field-guide/procedure-card";
+import ProcedureDrawer from "@/components/field-guide/procedure-drawer";
+
+type ChecklistState = Record<string, Record<string, boolean>>;
+
+export default function FieldGuideShell() {
+  const [query, setQuery] = useState("");
+  const [selectedTeam, setSelectedTeam] = useState("all");
+  const [selectedDifficulty, setSelectedDifficulty] = useState("all");
+  const [selectedStatus, setSelectedStatus] = useState("all");
+  const [selectedProcedureId, setSelectedProcedureId] = useState<string | null>(
+    procedures[0]?.id ?? null,
+  );
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [checklistState, setChecklistState] = useState<ChecklistState>({});
+
+  const deferredQuery = useDeferredValue(query);
+  const normalizedQuery = deferredQuery.trim().toLowerCase();
+
+  const filteredProcedures = procedures.filter((procedure) => {
+    const matchesQuery =
+      normalizedQuery.length === 0 ||
+      procedure.title.toLowerCase().includes(normalizedQuery) ||
+      procedure.summary.toLowerCase().includes(normalizedQuery);
+    const matchesTeam =
+      selectedTeam === "all" || procedure.team === selectedTeam;
+    const matchesDifficulty =
+      selectedDifficulty === "all" || procedure.difficulty === selectedDifficulty;
+    const matchesStatus =
+      selectedStatus === "all" || procedure.status === selectedStatus;
+
+    return matchesQuery && matchesTeam && matchesDifficulty && matchesStatus;
+  });
+
+  const activeProcedureId = filteredProcedures.some(
+    (procedure) => procedure.id === selectedProcedureId,
+  )
+    ? selectedProcedureId
+    : (filteredProcedures[0]?.id ?? null);
+
+  const activeProcedure =
+    filteredProcedures.find((procedure) => procedure.id === activeProcedureId) ??
+    null;
+  const drawerIsOpen =
+    isDrawerOpen && selectedProcedureId === activeProcedureId && activeProcedure !== null;
+
+  const hasActiveFilters =
+    query.length > 0 ||
+    selectedTeam !== "all" ||
+    selectedDifficulty !== "all" ||
+    selectedStatus !== "all";
+
+  const handleSelectProcedure = (procedureId: string) => {
+    startTransition(() => {
+      setSelectedProcedureId(procedureId);
+      setIsDrawerOpen(true);
+    });
+  };
+
+  const handleToggleStep = (procedureId: string, stepId: string) => {
+    startTransition(() => {
+      setChecklistState((currentState) => ({
+        ...currentState,
+        [procedureId]: {
+          ...currentState[procedureId],
+          [stepId]: !currentState[procedureId]?.[stepId],
+        },
+      }));
+    });
+  };
+
+  const handleClearFilters = () => {
+    setQuery("");
+    setSelectedTeam("all");
+    setSelectedDifficulty("all");
+    setSelectedStatus("all");
+  };
+
+  return (
+    <section className="grid gap-6 lg:grid-cols-[minmax(0,1.15fr)_minmax(22rem,0.85fr)]">
+      <div className="space-y-5">
+        <GuideSearch
+          onQueryChange={setQuery}
+          query={query}
+          resultCount={filteredProcedures.length}
+          totalCount={procedures.length}
+        />
+        <GuideFilters
+          difficulties={procedureDifficulties}
+          hasActiveFilters={hasActiveFilters}
+          onClear={handleClearFilters}
+          onDifficultyChange={setSelectedDifficulty}
+          onStatusChange={setSelectedStatus}
+          onTeamChange={setSelectedTeam}
+          selectedDifficulty={selectedDifficulty}
+          selectedStatus={selectedStatus}
+          selectedTeam={selectedTeam}
+          statuses={procedureStatuses}
+          teams={procedureTeams}
+        />
+        {filteredProcedures.length > 0 ? (
+          <div className="grid gap-4 md:grid-cols-2">
+            {filteredProcedures.map((procedure) => {
+              const completedCount = procedure.checklist.filter(
+                (step) => checklistState[procedure.id]?.[step.id],
+              ).length;
+
+              return (
+                <ProcedureCard
+                  completedCount={completedCount}
+                  isSelected={procedure.id === activeProcedureId}
+                  key={procedure.id}
+                  onSelect={handleSelectProcedure}
+                  procedure={procedure}
+                />
+              );
+            })}
+          </div>
+        ) : (
+          <div className="rounded-[1.75rem] border border-dashed border-slate-300 bg-white/80 p-8 text-center shadow-lg shadow-slate-200/40">
+            <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">
+              No results
+            </p>
+            <h2 className="mt-3 text-2xl font-semibold text-slate-950">
+              No procedures match the current search or filters.
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              Clear one or more filters to reopen the mock library and restore
+              the checklist drawer.
+            </p>
+          </div>
+        )}
+      </div>
+      <ProcedureDrawer
+        completedSteps={
+          activeProcedure ? checklistState[activeProcedure.id] : undefined
+        }
+        isOpen={drawerIsOpen}
+        onClose={() => setIsDrawerOpen(false)}
+        onToggleStep={handleToggleStep}
+        procedure={activeProcedure}
+      />
+    </section>
+  );
+}

--- a/src/components/field-guide/guide-filters.tsx
+++ b/src/components/field-guide/guide-filters.tsx
@@ -1,0 +1,108 @@
+type GuideFiltersProps = {
+  teams: readonly string[];
+  difficulties: readonly string[];
+  statuses: readonly string[];
+  selectedTeam: string;
+  selectedDifficulty: string;
+  selectedStatus: string;
+  hasActiveFilters: boolean;
+  onTeamChange: (value: string) => void;
+  onDifficultyChange: (value: string) => void;
+  onStatusChange: (value: string) => void;
+  onClear: () => void;
+};
+
+type FilterSelectProps = {
+  id: string;
+  label: string;
+  options: readonly string[];
+  value: string;
+  onChange: (value: string) => void;
+};
+
+function FilterSelect({
+  id,
+  label,
+  options,
+  value,
+  onChange,
+}: FilterSelectProps) {
+  return (
+    <label className="space-y-2" htmlFor={id}>
+      <span className="text-sm font-medium text-slate-700">{label}</span>
+      <select
+        className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-sky-500 focus:ring-4 focus:ring-sky-100"
+        id={id}
+        onChange={(event) => onChange(event.target.value)}
+        value={value}
+      >
+        <option value="all">All {label.toLowerCase()}</option>
+        {options.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+export default function GuideFilters({
+  teams,
+  difficulties,
+  statuses,
+  selectedTeam,
+  selectedDifficulty,
+  selectedStatus,
+  hasActiveFilters,
+  onTeamChange,
+  onDifficultyChange,
+  onStatusChange,
+  onClear,
+}: GuideFiltersProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-slate-200/70 bg-slate-950 p-5 text-slate-50 shadow-lg shadow-slate-300/50">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-400">
+            Filters
+          </p>
+          <p className="mt-2 text-sm text-slate-300">
+            Narrow the library without changing routes or requesting new data.
+          </p>
+        </div>
+        <button
+          className="rounded-full border border-white/20 px-4 py-2 text-sm font-medium text-white transition hover:border-white/40 hover:bg-white/10 disabled:cursor-not-allowed disabled:border-white/10 disabled:text-slate-500"
+          disabled={!hasActiveFilters}
+          onClick={onClear}
+          type="button"
+        >
+          Clear all
+        </button>
+      </div>
+      <div className="mt-5 grid gap-4 md:grid-cols-3">
+        <FilterSelect
+          id="team-filter"
+          label="Teams"
+          onChange={onTeamChange}
+          options={teams}
+          value={selectedTeam}
+        />
+        <FilterSelect
+          id="difficulty-filter"
+          label="Difficulty"
+          onChange={onDifficultyChange}
+          options={difficulties}
+          value={selectedDifficulty}
+        />
+        <FilterSelect
+          id="status-filter"
+          label="Status"
+          onChange={onStatusChange}
+          options={statuses}
+          value={selectedStatus}
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/components/field-guide/guide-search.tsx
+++ b/src/components/field-guide/guide-search.tsx
@@ -1,0 +1,41 @@
+type GuideSearchProps = {
+  query: string;
+  resultCount: number;
+  totalCount: number;
+  onQueryChange: (value: string) => void;
+};
+
+export default function GuideSearch({
+  query,
+  resultCount,
+  totalCount,
+  onQueryChange,
+}: GuideSearchProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-slate-200/70 bg-white/90 p-5 shadow-lg shadow-slate-200/50">
+      <label
+        className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500"
+        htmlFor="field-guide-search"
+      >
+        Search procedures
+      </label>
+      <div className="mt-3 flex flex-col gap-3 lg:flex-row lg:items-center">
+        <input
+          id="field-guide-search"
+          className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-sky-500 focus:bg-white focus:ring-4 focus:ring-sky-100"
+          onChange={(event) => onQueryChange(event.target.value)}
+          placeholder="Try uplink, downtime, dock, or telemetry"
+          type="search"
+          value={query}
+        />
+        <p className="text-sm text-slate-600 lg:min-w-max">
+          Showing {resultCount} of {totalCount} mock procedures
+        </p>
+      </div>
+      <p className="mt-3 text-sm leading-6 text-slate-500">
+        Search checks titles and summaries only, while team, difficulty, and
+        status filters stay entirely client-side.
+      </p>
+    </section>
+  );
+}

--- a/src/components/field-guide/procedure-card.tsx
+++ b/src/components/field-guide/procedure-card.tsx
@@ -1,0 +1,70 @@
+import type { Procedure } from "@/components/field-guide/field-guide-data";
+
+type ProcedureCardProps = {
+  procedure: Procedure;
+  completedCount: number;
+  isSelected: boolean;
+  onSelect: (procedureId: string) => void;
+};
+
+const statusClasses = {
+  Ready: "bg-emerald-100 text-emerald-800",
+  "In Review": "bg-amber-100 text-amber-800",
+  Draft: "bg-slate-200 text-slate-700",
+} as const;
+
+export default function ProcedureCard({
+  procedure,
+  completedCount,
+  isSelected,
+  onSelect,
+}: ProcedureCardProps) {
+  return (
+    <button
+      aria-label={`Open procedure: ${procedure.title}`}
+      className={`w-full rounded-[1.75rem] border p-5 text-left shadow-lg transition ${
+        isSelected
+          ? "border-sky-400 bg-sky-50 shadow-sky-100"
+          : "border-slate-200/70 bg-white/90 shadow-slate-200/40 hover:-translate-y-0.5 hover:border-slate-300"
+      }`}
+      onClick={() => onSelect(procedure.id)}
+      type="button"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="rounded-full bg-slate-950 px-3 py-1 text-xs font-semibold text-slate-50">
+          {procedure.team}
+        </span>
+        <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
+          {procedure.difficulty}
+        </span>
+        <span
+          className={`rounded-full px-3 py-1 text-xs font-semibold ${statusClasses[procedure.status]}`}
+        >
+          {procedure.status}
+        </span>
+      </div>
+      <h2 className="mt-4 text-2xl font-semibold tracking-tight text-slate-950">
+        {procedure.title}
+      </h2>
+      <p className="mt-3 text-sm leading-6 text-slate-600">
+        {procedure.summary}
+      </p>
+      <div className="mt-4 flex flex-wrap gap-2">
+        {procedure.tags.map((tag) => (
+          <span
+            key={tag}
+            className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600"
+          >
+            #{tag}
+          </span>
+        ))}
+      </div>
+      <div className="mt-5 flex flex-wrap items-center justify-between gap-3 text-sm text-slate-500">
+        <span>{procedure.duration}</span>
+        <span>
+          {completedCount} of {procedure.checklist.length} steps complete
+        </span>
+      </div>
+    </button>
+  );
+}

--- a/src/components/field-guide/procedure-checklist.tsx
+++ b/src/components/field-guide/procedure-checklist.tsx
@@ -1,0 +1,65 @@
+import type { ProcedureStep } from "@/components/field-guide/field-guide-data";
+
+type ProcedureChecklistProps = {
+  procedureId: string;
+  steps: readonly ProcedureStep[];
+  completedSteps: Record<string, boolean> | undefined;
+  onToggleStep: (procedureId: string, stepId: string) => void;
+};
+
+export default function ProcedureChecklist({
+  procedureId,
+  steps,
+  completedSteps,
+  onToggleStep,
+}: ProcedureChecklistProps) {
+  const completedCount = steps.filter((step) => completedSteps?.[step.id]).length;
+
+  return (
+    <section className="rounded-[1.5rem] border border-slate-200/70 bg-slate-50 p-5">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">
+            Checklist
+          </p>
+          <p className="mt-2 text-sm text-slate-600">
+            {completedCount} of {steps.length} steps complete
+          </p>
+        </div>
+        <div className="h-2 w-24 overflow-hidden rounded-full bg-slate-200">
+          <div
+            className="h-full rounded-full bg-sky-500 transition-[width]"
+            style={{ width: `${(completedCount / steps.length) * 100}%` }}
+          />
+        </div>
+      </div>
+      <ol className="mt-5 space-y-3">
+        {steps.map((step, index) => {
+          const checked = completedSteps?.[step.id] ?? false;
+
+          return (
+            <li key={step.id}>
+              <label className="flex gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+                <input
+                  aria-label={step.label}
+                  checked={checked}
+                  className="mt-1 h-4 w-4 rounded border-slate-300 text-sky-600 focus:ring-sky-500"
+                  onChange={() => onToggleStep(procedureId, step.id)}
+                  type="checkbox"
+                />
+                <span className="space-y-1">
+                  <span className="block text-sm font-semibold text-slate-900">
+                    {index + 1}. {step.label}
+                  </span>
+                  <span className="block text-sm leading-6 text-slate-600">
+                    {step.detail}
+                  </span>
+                </span>
+              </label>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}

--- a/src/components/field-guide/procedure-drawer.tsx
+++ b/src/components/field-guide/procedure-drawer.tsx
@@ -1,0 +1,148 @@
+import type { Procedure } from "@/components/field-guide/field-guide-data";
+import ProcedureChecklist from "@/components/field-guide/procedure-checklist";
+
+type ProcedureDrawerProps = {
+  procedure: Procedure | null;
+  completedSteps: Record<string, boolean> | undefined;
+  isOpen: boolean;
+  onClose: () => void;
+  onToggleStep: (procedureId: string, stepId: string) => void;
+};
+
+const statusClasses = {
+  Ready: "bg-emerald-100 text-emerald-800",
+  "In Review": "bg-amber-100 text-amber-800",
+  Draft: "bg-slate-200 text-slate-700",
+} as const;
+
+export default function ProcedureDrawer({
+  procedure,
+  completedSteps,
+  isOpen,
+  onClose,
+  onToggleStep,
+}: ProcedureDrawerProps) {
+  const mobileOpen = isOpen && procedure !== null;
+
+  return (
+    <>
+      {mobileOpen ? (
+        <button
+          aria-label="Close active procedure"
+          className="fixed inset-0 z-30 bg-slate-950/40 md:hidden"
+          onClick={onClose}
+          type="button"
+        />
+      ) : null}
+      <aside
+        className={`fixed inset-y-0 right-0 z-40 w-full max-w-xl overflow-y-auto border-l border-slate-200 bg-white px-4 py-6 shadow-2xl transition-transform md:static md:max-w-none md:rounded-[1.75rem] md:border md:px-6 md:shadow-lg ${
+          mobileOpen ? "translate-x-0" : "translate-x-full md:translate-x-0"
+        }`}
+        data-testid="procedure-drawer"
+      >
+        {procedure ? (
+          <div className="space-y-6">
+            <div className="flex items-start justify-between gap-4">
+              <div className="space-y-3">
+                <div className="flex flex-wrap gap-2">
+                  <span className="rounded-full bg-slate-950 px-3 py-1 text-xs font-semibold text-slate-50">
+                    {procedure.team}
+                  </span>
+                  <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
+                    {procedure.difficulty}
+                  </span>
+                  <span
+                    className={`rounded-full px-3 py-1 text-xs font-semibold ${statusClasses[procedure.status]}`}
+                  >
+                    {procedure.status}
+                  </span>
+                </div>
+                <div>
+                  <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">
+                    Active procedure
+                  </p>
+                  <h2 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">
+                    {procedure.title}
+                  </h2>
+                </div>
+              </div>
+              <button
+                className="rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 md:hidden"
+                onClick={onClose}
+                type="button"
+              >
+                Close
+              </button>
+            </div>
+            <p className="text-sm leading-7 text-slate-600">{procedure.summary}</p>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="rounded-2xl bg-slate-50 p-4">
+                <p className="text-sm text-slate-500">Duration</p>
+                <p className="mt-2 text-lg font-semibold text-slate-950">
+                  {procedure.duration}
+                </p>
+              </div>
+              <div className="rounded-2xl bg-slate-50 p-4">
+                <p className="text-sm text-slate-500">Cadence</p>
+                <p className="mt-2 text-lg font-semibold text-slate-950">
+                  {procedure.cadence}
+                </p>
+              </div>
+              <div className="rounded-2xl bg-slate-50 p-4">
+                <p className="text-sm text-slate-500">Location</p>
+                <p className="mt-2 text-lg font-semibold text-slate-950">
+                  {procedure.location}
+                </p>
+              </div>
+              <div className="rounded-2xl bg-slate-50 p-4">
+                <p className="text-sm text-slate-500">Last updated</p>
+                <p className="mt-2 text-lg font-semibold text-slate-950">
+                  {procedure.lastUpdated}
+                </p>
+              </div>
+            </div>
+            <section className="rounded-[1.5rem] border border-slate-200/70 bg-white p-5">
+              <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">
+                Notes and tools
+              </p>
+              <p className="mt-3 text-sm leading-6 text-slate-600">
+                {procedure.notes}
+              </p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                {procedure.tools.map((tool) => (
+                  <span
+                    key={tool}
+                    className="rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-900"
+                  >
+                    {tool}
+                  </span>
+                ))}
+              </div>
+            </section>
+            <ProcedureChecklist
+              completedSteps={completedSteps}
+              onToggleStep={onToggleStep}
+              procedureId={procedure.id}
+              steps={procedure.checklist}
+            />
+          </div>
+        ) : (
+          <div className="flex h-full min-h-80 items-center justify-center rounded-[1.75rem] border border-dashed border-slate-300 bg-slate-50 p-8 text-center">
+            <div className="max-w-sm">
+              <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">
+                Procedure drawer
+              </p>
+              <h2 className="mt-3 text-2xl font-semibold text-slate-950">
+                Select a procedure to review the local checklist.
+              </h2>
+              <p className="mt-3 text-sm leading-6 text-slate-600">
+                The detail panel stays within this route and keeps checklist
+                progress only for the current browser session.
+              </p>
+            </div>
+          </div>
+        )}
+      </aside>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a fully isolated `/field-guide` route with feature-local mock data, search/filter controls, procedure cards, a responsive detail drawer, and session-local checklist state
- keep the interactive UI inside `src/components/field-guide/**` with focused client-side tests for search, empty-state, and checklist behavior
- restore the minimal root App Router scaffold currently missing on `main` so the app still builds without adding any navigation into the new feature

## Testing
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #14