### PR TITLE
feat: add isolated signal lab route

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "API Test",
+  description: "Isolated route experiments built with the Next.js App Router.",
+};
+
+type RootLayoutProps = {
+  children: ReactNode;
+};
+
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,19 @@
+export default function HomePage() {
+  return (
+    <main className="min-h-screen bg-slate-950 px-6 py-16 text-slate-100">
+      <div className="mx-auto max-w-3xl rounded-[2rem] border border-white/10 bg-white/5 p-8 shadow-[0_24px_80px_rgba(15,23,42,0.55)] backdrop-blur">
+        <p className="text-xs uppercase tracking-[0.4em] text-cyan-300">
+          API Test
+        </p>
+        <h1 className="mt-4 text-4xl font-semibold tracking-tight text-white">
+          Shared routes stay intentionally minimal in this branch.
+        </h1>
+        <p className="mt-4 max-w-2xl text-base leading-7 text-slate-300">
+          Dedicated issue work lives in isolated App Router segments. This
+          placeholder keeps the repository&apos;s required root entrypoint intact
+          without introducing navigation or shared UI for feature routes.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/app/signal-lab/page.tsx
+++ b/src/app/signal-lab/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+import { SignalLabWorkspace } from "@/components/signal-lab/signal-lab-workspace";
+
+export const metadata: Metadata = {
+  title: "Signal Lab",
+  description:
+    "Synthetic monitoring workspace with stream cards, anomaly markers, and inspector panels.",
+};
+
+export default function SignalLabPage() {
+  return <SignalLabWorkspace />;
+}

--- a/src/components/signal-lab/anomaly-list.tsx
+++ b/src/components/signal-lab/anomaly-list.tsx
@@ -1,0 +1,108 @@
+import type { SignalAnomaly } from "./mock-data";
+
+const severityClasses = {
+  low: "border-sky-400/30 bg-sky-400/10 text-sky-200",
+  medium: "border-amber-400/30 bg-amber-400/10 text-amber-200",
+  high: "border-rose-400/30 bg-rose-400/10 text-rose-200",
+};
+
+type AnomalyListProps = {
+  anomalies: SignalAnomaly[];
+  acknowledgedIds: string[];
+  showDismissed: boolean;
+  onToggleAcknowledged: (anomalyId: string) => void;
+  onToggleDismissed: (anomalyId: string) => void;
+  onToggleDismissedView: () => void;
+  onSelectStream: (streamId: string) => void;
+};
+export function AnomalyList({
+  anomalies,
+  acknowledgedIds,
+  showDismissed,
+  onToggleAcknowledged,
+  onToggleDismissed,
+  onToggleDismissedView,
+  onSelectStream,
+}: AnomalyListProps) {
+  return (
+    <section
+      aria-label="Anomaly feed"
+      className="rounded-[1.75rem] border border-white/10 bg-slate-950/75 p-5 backdrop-blur"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-[0.35em] text-slate-400">Anomaly Feed</p>
+          <h2 className="mt-2 text-xl font-semibold text-white">Synthetic incidents</h2>
+        </div>
+        <button
+          className="rounded-full border border-white/10 px-4 py-2 text-sm text-slate-200 transition hover:border-white/20 hover:bg-white/5"
+          onClick={onToggleDismissedView}
+          type="button"
+        >
+          {showDismissed ? "Hide dismissed" : "Show dismissed"}
+        </button>
+      </div>
+      <div className="mt-5 space-y-3">
+        {anomalies.length === 0 ? (
+          <div className="rounded-[1.5rem] border border-dashed border-white/10 px-5 py-8 text-sm text-slate-400">
+            No anomalies match the current view. Restore dismissed items or clear stream focus to widen the sweep.
+          </div>
+        ) : null}
+        {anomalies.map((anomaly) => {
+          const isTracked = acknowledgedIds.includes(anomaly.id);
+          const dismissLabel = `Dismiss ${anomaly.title}`;
+          const trackLabel = `${isTracked ? "Release" : "Track"} ${anomaly.title}`;
+          return (
+            <article
+              key={anomaly.id}
+              className="rounded-[1.5rem] border border-white/10 bg-white/[0.03] p-4"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="max-w-2xl">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className={`rounded-full border px-3 py-1 text-xs uppercase tracking-[0.25em] ${severityClasses[anomaly.severity]}`}>
+                      {anomaly.severity}
+                    </span>
+                    <span className="text-xs uppercase tracking-[0.2em] text-slate-500">{anomaly.detectedAt}</span>
+                  </div>
+                  <h3 className="mt-3 text-lg font-medium text-white">{anomaly.title}</h3>
+                  <p className="mt-2 text-sm leading-6 text-slate-300">{anomaly.summary}</p>
+                </div>
+                <div className="text-right">
+                  <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Delta</p>
+                  <p className="mt-2 text-lg font-medium text-white">{anomaly.delta}</p>
+                </div>
+              </div>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <button
+                  className="rounded-full border border-cyan-400/20 bg-cyan-400/10 px-4 py-2 text-sm text-cyan-100 transition hover:border-cyan-300/40"
+                  onClick={() => onSelectStream(anomaly.streamId)}
+                  type="button"
+                >
+                  Jump to stream
+                </button>
+                <button
+                  aria-label={trackLabel}
+                  className="rounded-full border border-white/10 px-4 py-2 text-sm text-slate-100 transition hover:border-white/20 hover:bg-white/5"
+                  onClick={() => onToggleAcknowledged(anomaly.id)}
+                  type="button"
+                >
+                  {isTracked ? "Tracked" : "Track"}
+                </button>
+                <button
+                  aria-label={dismissLabel}
+                  className="rounded-full border border-white/10 px-4 py-2 text-sm text-slate-100 transition hover:border-white/20 hover:bg-white/5"
+                  onClick={() => onToggleDismissed(anomaly.id)}
+                  type="button"
+                >
+                  Dismiss
+                </button>
+              </div>
+              <p className="mt-3 text-sm text-slate-400">{anomaly.recommendation}</p>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/signal-lab/inspector-panel.tsx
+++ b/src/components/signal-lab/inspector-panel.tsx
@@ -1,0 +1,124 @@
+import type { SignalStream } from "./mock-data";
+
+const toneClasses = {
+  steady: "text-emerald-200",
+  watch: "text-amber-200",
+  alert: "text-rose-200",
+};
+
+type InspectorPanelProps = {
+  stream: SignalStream | null;
+  anomalyCount: number;
+  isFocused: boolean;
+  isMuted: boolean;
+  isPaused: boolean;
+  onClearSelection: () => void;
+  onToggleFocus: () => void;
+  onToggleMute: () => void;
+  onTogglePause: () => void;
+};
+
+export function InspectorPanel({
+  stream,
+  anomalyCount,
+  isFocused,
+  isMuted,
+  isPaused,
+  onClearSelection,
+  onToggleFocus,
+  onToggleMute,
+  onTogglePause,
+}: InspectorPanelProps) {
+  const controls = [
+    { active: isPaused, activeClasses: "border-amber-400/30 bg-amber-400/10 text-amber-100", idleLabel: "Pause stream", activeLabel: "Resume stream", onClick: onTogglePause },
+    { active: isMuted, activeClasses: "border-slate-400/30 bg-slate-400/10 text-slate-100", idleLabel: "Mute stream", activeLabel: "Unmute stream", onClick: onToggleMute },
+    { active: isFocused, activeClasses: "border-cyan-400/30 bg-cyan-400/10 text-cyan-100", idleLabel: "Focus stream", activeLabel: "Release focus", onClick: onToggleFocus },
+  ];
+
+  if (!stream) {
+    return (
+      <aside
+        aria-label="Inspector panel"
+        className="rounded-[1.75rem] border border-dashed border-white/10 bg-slate-950/75 p-6 text-slate-300 backdrop-blur"
+      >
+        <p className="text-xs uppercase tracking-[0.35em] text-slate-500">
+          Inspector Panel
+        </p>
+        <h2 className="mt-4 text-2xl font-semibold text-white">No stream selected</h2>
+        <p className="mt-3 text-sm leading-6 text-slate-400">
+          Select a stream card to inspect the synthetic readings, recent markers, and local controls. Selecting the same card again clears the workspace back to this idle state.
+        </p>
+      </aside>
+    );
+  }
+
+  return (
+    <aside
+      aria-label="Inspector panel"
+      className="rounded-[1.75rem] border border-white/10 bg-slate-950/80 p-6 backdrop-blur"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-[0.35em] text-slate-400">Inspector Panel</p>
+          <h2 className="mt-3 text-2xl font-semibold text-white">{stream.name}</h2>
+          <p className="mt-2 text-sm text-slate-400">
+            {stream.channel} / {stream.region}
+          </p>
+        </div>
+        <button
+          className="rounded-full border border-white/10 px-4 py-2 text-sm text-slate-100 transition hover:border-white/20 hover:bg-white/5"
+          onClick={onClearSelection}
+          type="button"
+        >
+          Clear selection
+        </button>
+      </div>
+      <div className="mt-5 grid gap-3 sm:grid-cols-2">
+        {[["Cadence", stream.cadence], ["Open anomalies", String(anomalyCount)]].map(([label, value]) => (
+          <div key={label} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-500">{label}</p>
+            <p className="mt-2 text-lg font-medium text-white">{value}</p>
+          </div>
+        ))}
+      </div>
+      <div className="mt-5 grid gap-3 sm:grid-cols-3">
+        {controls.map((control) => (
+          <button
+            key={control.idleLabel}
+            className={`rounded-2xl border px-4 py-3 text-left text-sm transition ${control.active ? control.activeClasses : "border-white/10 bg-white/[0.03] text-slate-100 hover:border-white/20"}`}
+            onClick={control.onClick}
+            type="button"
+          >
+            {control.active ? control.activeLabel : control.idleLabel}
+          </button>
+        ))}
+      </div>
+      <div className="mt-6">
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Inspector reads</p>
+        <div className="mt-3 grid gap-3 sm:grid-cols-3">
+          {stream.readings.map((reading) => (
+            <div key={reading.label} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+              <p className="text-sm text-slate-400">{reading.label}</p>
+              <p className="mt-2 text-xl font-medium text-white">{reading.value}</p>
+              <p className={`mt-2 text-sm ${toneClasses[reading.tone]}`}>{reading.trend}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="mt-6">
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Marker trail</p>
+        <div className="mt-3 space-y-3">
+          {stream.markers.map((marker) => (
+            <div key={`${marker.label}-${marker.time}`} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+              <div className="flex items-center justify-between gap-3">
+                <p className="font-medium text-white">{marker.label}</p>
+                <p className="text-sm text-slate-500">{marker.time}</p>
+              </div>
+              <p className="mt-2 text-sm text-slate-400">{marker.detail}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/signal-lab/mock-data.ts
+++ b/src/components/signal-lab/mock-data.ts
@@ -1,0 +1,83 @@
+export type StreamStatus = "stable" | "drifting" | "critical";
+export type Severity = "low" | "medium" | "high";
+export type ReadingTone = "steady" | "watch" | "alert";
+
+export type StreamReading = { label: string; value: string; trend: string; tone: ReadingTone };
+export type StreamMarker = { label: string; time: string; detail: string };
+export type SignalStream = {
+  id: string;
+  name: string;
+  channel: string;
+  status: StreamStatus;
+  owner: string;
+  throughput: string;
+  cadence: string;
+  noiseFloor: string;
+  syncWindow: string;
+  region: string;
+  readings: StreamReading[];
+  markers: StreamMarker[];
+};
+
+export type SignalAnomaly = {
+  id: string;
+  streamId: SignalStream["id"];
+  title: string;
+  severity: Severity;
+  summary: string;
+  detectedAt: string;
+  delta: string;
+  recommendation: string;
+};
+
+export const heartbeatSeed = "2026-04-19T09:30:00.000Z";
+const reading = (label: string, value: string, trend: string, tone: ReadingTone): StreamReading => ({ label, value, trend, tone });
+const marker = (label: string, time: string, detail: string): StreamMarker => ({ label, time, detail });
+export const signalStreams: SignalStream[] = [
+  {
+    id: "ion-trace-07", name: "Ion Trace 07", channel: "Substrate relay", status: "stable", owner: "Console North",
+    throughput: "184 kHz", cadence: "4.2 ms jitter", noiseFloor: "-72 dB", syncWindow: "94.8%", region: "Delta Shelf",
+    readings: [reading("Phase lock", "0.91", "+0.02", "steady"), reading("Return gain", "8.4 dB", "-0.1", "steady"), reading("Echo spill", "3.7%", "+0.4", "watch")],
+    markers: [marker("Bootstrap", "09:24:12", "Loop seal closed"), marker("Sweep", "09:27:40", "Noise gate normalized"), marker("Pulse", "09:29:58", "Signal plateau retained")],
+  },
+  {
+    id: "phase-array-12", name: "Phase Array 12", channel: "Synthetic mirror", status: "drifting", owner: "Vector Room",
+    throughput: "236 kHz", cadence: "9.6 ms jitter", noiseFloor: "-61 dB", syncWindow: "87.2%", region: "North Basin",
+    readings: [reading("Phase lock", "0.74", "-0.11", "watch"), reading("Return gain", "6.1 dB", "-0.8", "watch"), reading("Echo spill", "9.8%", "+2.1", "alert")],
+    markers: [marker("Offset", "09:18:09", "Mirror lane diverged"), marker("Drift", "09:26:41", "Threshold crossed"), marker("Clamp", "09:29:22", "Recovery bias applied")],
+  },
+  {
+    id: "lattice-echo-03", name: "Lattice Echo 03", channel: "Null cage", status: "critical", owner: "Archive West",
+    throughput: "117 kHz", cadence: "14.8 ms jitter", noiseFloor: "-54 dB", syncWindow: "72.4%", region: "Quiet Fringe",
+    readings: [reading("Phase lock", "0.41", "-0.23", "alert"), reading("Return gain", "3.3 dB", "-1.9", "alert"), reading("Echo spill", "18.4%", "+4.7", "alert")],
+    markers: [marker("Fault", "09:15:38", "Carrier split detected"), marker("Spike", "09:21:03", "Synthetic bloom flared"), marker("Hold", "09:28:11", "Operator froze relay")],
+  },
+  {
+    id: "harbor-sim-21", name: "Harbor Sim 21", channel: "Coastal sampler", status: "stable", owner: "Dock Array",
+    throughput: "201 kHz", cadence: "5.7 ms jitter", noiseFloor: "-69 dB", syncWindow: "92.1%", region: "South Break",
+    readings: [reading("Phase lock", "0.88", "+0.01", "steady"), reading("Return gain", "7.6 dB", "+0.2", "steady"), reading("Echo spill", "4.4%", "-0.3", "steady")],
+    markers: [marker("Anchor", "09:17:20", "Baseline restored"), marker("Trim", "09:25:33", "Channel weight balanced"), marker("Pulse", "09:29:44", "Heartbeat confirmed")],
+  },
+];
+export const signalAnomalies: SignalAnomaly[] = [
+  {
+    id: "phase-drift-envelope", streamId: "phase-array-12", title: "Phase drift beyond synthetic envelope", severity: "high",
+    summary: "Mirror channel yaw is widening faster than the auto-clamp can recover.", detectedAt: "09:28:45", delta: "+14.2%",
+    recommendation: "Focus the stream and watch the next recovery pass.",
+  },
+  {
+    id: "echo-bloom-flare", streamId: "lattice-echo-03", title: "Echo bloom flare on null cage return", severity: "high",
+    summary: "The return path shows a repeated flare every third pulse packet.", detectedAt: "09:26:58", delta: "+22.9%",
+    recommendation: "Pause the stream before the relay saturates.",
+  },
+  {
+    id: "noise-gate-slip", streamId: "ion-trace-07", title: "Noise gate slip near bootstrap marker", severity: "medium",
+    summary: "A brief gate slip appeared after the last bootstrap cycle.", detectedAt: "09:24:13", delta: "+6.1%",
+    recommendation: "Track the anomaly to compare with the next heartbeat.",
+  },
+  {
+    id: "cadence-shear", streamId: "harbor-sim-21", title: "Cadence shear resolved but still reportable", severity: "low",
+    summary: "A resolved cadence shear remains within the historical watch range.", detectedAt: "09:19:05", delta: "+2.3%",
+    recommendation: "Dismiss after operator review if the channel stays steady.",
+  },
+];

--- a/src/components/signal-lab/signal-lab-header.tsx
+++ b/src/components/signal-lab/signal-lab-header.tsx
@@ -1,0 +1,56 @@
+type SignalLabHeaderProps = {
+  heartbeat: string;
+  labState: string;
+  activeStreams: number;
+  openAnomalies: number;
+  mutedStreams: number;
+  pausedStreams: number;
+  focusedStream: string | null;
+};
+
+export function SignalLabHeader({
+  heartbeat,
+  labState,
+  activeStreams,
+  openAnomalies,
+  mutedStreams,
+  pausedStreams,
+  focusedStream,
+}: SignalLabHeaderProps) {
+  const panels = [
+    { label: "Lab State", value: labState, detail: `Heartbeat ${heartbeat}` },
+    { label: "Active Sweep", value: `${activeStreams} streams / ${openAnomalies} anomalies`, detail: `Paused ${pausedStreams} / Muted ${mutedStreams}` },
+    { label: "Focus Lock", value: focusedStream ?? "No stream focused", detail: "Select a card again to clear the inspector.", span: true },
+  ];
+
+  return (
+    <header className="rounded-[2rem] border border-cyan-400/20 bg-slate-950/80 p-6 shadow-[0_24px_90px_rgba(8,145,178,0.18)] backdrop-blur">
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+        <div className="max-w-2xl">
+          <p className="text-xs uppercase tracking-[0.45em] text-cyan-300">
+            Signal Lab
+          </p>
+          <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+            Synthetic streams with local controls and live inspector state.
+          </h1>
+          <p className="mt-3 text-sm leading-6 text-slate-300 sm:text-base">
+            The workspace stays client-side: stream focus, anomaly triage, and
+            operator toggles all update locally without server calls.
+          </p>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {panels.map((panel) => (
+            <div
+              key={panel.label}
+              className={`rounded-2xl border border-white/10 bg-white/5 px-4 py-3 ${panel.span ? "sm:col-span-2 xl:col-span-1" : ""}`}
+            >
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-400">{panel.label}</p>
+              <p className="mt-2 text-lg font-medium text-white">{panel.value}</p>
+              <p className="mt-1 text-sm text-slate-400">{panel.detail}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/signal-lab/signal-lab-workspace.test.tsx
+++ b/src/components/signal-lab/signal-lab-workspace.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SignalLabWorkspace } from "./signal-lab-workspace";
+
+describe("SignalLabWorkspace", () => {
+  it("updates the inspector when a new stream is selected", () => {
+    render(<SignalLabWorkspace />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Phase Array 12/i }));
+
+    const inspector = screen.getByLabelText(/Inspector panel/i);
+    expect(within(inspector).getByText(/Phase Array 12/i)).toBeInTheDocument();
+    expect(within(inspector).getByText(/North Basin/i)).toBeInTheDocument();
+  });
+
+  it("handles anomaly dismissal and restore locally", () => {
+    render(<SignalLabWorkspace />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Dismiss Phase drift beyond synthetic envelope/i }),
+    );
+    expect(screen.queryByText(/Phase drift beyond synthetic envelope/i)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Show dismissed/i }));
+    expect(screen.getByText(/Phase drift beyond synthetic envelope/i)).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: /Track Phase drift beyond synthetic envelope/i }),
+    );
+    expect(screen.getByText("Tracked")).toBeInTheDocument();
+  });
+});

--- a/src/components/signal-lab/signal-lab-workspace.tsx
+++ b/src/components/signal-lab/signal-lab-workspace.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { startTransition, useEffect, useEffectEvent, useState } from "react";
+
+import {
+  heartbeatSeed,
+  signalAnomalies,
+  signalStreams,
+} from "./mock-data";
+import { AnomalyList } from "./anomaly-list";
+import { InspectorPanel } from "./inspector-panel";
+import { SignalLabHeader } from "./signal-lab-header";
+import { StreamGrid } from "./stream-grid";
+
+const heartbeatFormatter = new Intl.DateTimeFormat("en-US", {
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+});
+const heartbeatStepMs = 5000;
+
+function toggleId(items: string[], id: string) {
+  return items.includes(id) ? items.filter((item) => item !== id) : [...items, id];
+}
+export function SignalLabWorkspace() {
+  const [selectedStreamId, setSelectedStreamId] = useState<string | null>(signalStreams[0]?.id ?? null);
+  const [dismissedIds, setDismissedIds] = useState<string[]>([]);
+  const [acknowledgedIds, setAcknowledgedIds] = useState<string[]>([]);
+  const [mutedIds, setMutedIds] = useState<string[]>([]);
+  const [pausedIds, setPausedIds] = useState<string[]>([]);
+  const [focusedStreamId, setFocusedStreamId] = useState<string | null>(null);
+  const [showDismissed, setShowDismissed] = useState(false);
+  const [heartbeatTick, setHeartbeatTick] = useState(0);
+  const tickHeartbeat = useEffectEvent(() => {
+    setHeartbeatTick((value) => value + 1);
+  });
+  useEffect(() => {
+    const timerId = window.setInterval(() => tickHeartbeat(), heartbeatStepMs);
+    return () => window.clearInterval(timerId);
+  }, []);
+  const selectedStream = signalStreams.find((stream) => stream.id === selectedStreamId) ?? null;
+  const focusedStream = signalStreams.find((stream) => stream.id === focusedStreamId) ?? null;
+  const visibleStreams = focusedStreamId ? signalStreams.filter((stream) => stream.id === focusedStreamId) : signalStreams;
+  const openAnomalies = signalAnomalies.filter((anomaly) => !dismissedIds.includes(anomaly.id));
+  const visibleAnomalies = signalAnomalies.filter((anomaly) => {
+    if (focusedStreamId && anomaly.streamId !== focusedStreamId) return false;
+    return showDismissed || !dismissedIds.includes(anomaly.id);
+  });
+  const selectedStreamAnomalies = selectedStream ? openAnomalies.filter((anomaly) => anomaly.streamId === selectedStream.id) : [];
+  const heartbeat = heartbeatFormatter.format(new Date(new Date(heartbeatSeed).getTime() + heartbeatTick * heartbeatStepMs));
+  const activeStreams = signalStreams.length - pausedIds.length;
+  const labState = focusedStreamId
+    ? "Focused capture"
+    : openAnomalies.some((anomaly) => anomaly.severity === "high")
+      ? "Critical watch"
+      : pausedIds.length > 0
+        ? "Partial hold"
+        : "Nominal sweep";
+  const handleSelectStream = (streamId: string) => {
+    startTransition(() => {
+      const nextStreamId = selectedStreamId === streamId ? null : streamId;
+      setSelectedStreamId(nextStreamId);
+      if (nextStreamId === null && focusedStreamId === streamId) {
+        setFocusedStreamId(null);
+      }
+    });
+  };
+  const handleClearSelection = () => {
+    startTransition(() => {
+      setSelectedStreamId(null);
+      setFocusedStreamId(null);
+    });
+  };
+  const handleTogglePause = () => {
+    if (!selectedStreamId) return;
+    setPausedIds((items) => toggleId(items, selectedStreamId));
+  };
+  const handleToggleMute = () => {
+    if (!selectedStreamId) return;
+    setMutedIds((items) => toggleId(items, selectedStreamId));
+  };
+  const handleToggleFocus = () => {
+    if (!selectedStreamId) return;
+    setFocusedStreamId((current) => (current === selectedStreamId ? null : selectedStreamId));
+  };
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(34,211,238,0.18),_transparent_35%),linear-gradient(135deg,_#020617_0%,_#111827_45%,_#020617_100%)] px-4 py-6 text-slate-100 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl">
+        <SignalLabHeader
+          activeStreams={activeStreams}
+          focusedStream={focusedStream?.name ?? null}
+          heartbeat={heartbeat}
+          labState={labState}
+          mutedStreams={mutedIds.length}
+          openAnomalies={openAnomalies.length}
+          pausedStreams={pausedIds.length}
+        />
+
+        <div className="mt-6 grid gap-6 xl:grid-cols-[minmax(0,1.55fr)_minmax(320px,0.95fr)]">
+          <div className="space-y-6">
+            <StreamGrid
+              focusedStreamId={focusedStreamId}
+              mutedIds={mutedIds}
+              onSelectStream={handleSelectStream}
+              pausedIds={pausedIds}
+              selectedStreamId={selectedStreamId}
+              streams={visibleStreams}
+            />
+            <AnomalyList
+              acknowledgedIds={acknowledgedIds}
+              anomalies={visibleAnomalies}
+              onSelectStream={(streamId) => startTransition(() => setSelectedStreamId(streamId))}
+              onToggleAcknowledged={(anomalyId) => setAcknowledgedIds((items) => toggleId(items, anomalyId))}
+              onToggleDismissed={(anomalyId) => setDismissedIds((items) => toggleId(items, anomalyId))}
+              onToggleDismissedView={() => setShowDismissed((value) => !value)}
+              showDismissed={showDismissed}
+            />
+          </div>
+
+          <InspectorPanel
+            anomalyCount={selectedStreamAnomalies.length}
+            isFocused={selectedStream ? focusedStreamId === selectedStream.id : false}
+            isMuted={selectedStream ? mutedIds.includes(selectedStream.id) : false}
+            isPaused={selectedStream ? pausedIds.includes(selectedStream.id) : false}
+            onClearSelection={handleClearSelection}
+            onToggleFocus={handleToggleFocus}
+            onToggleMute={handleToggleMute}
+            onTogglePause={handleTogglePause}
+            stream={selectedStream}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/signal-lab/stream-grid.tsx
+++ b/src/components/signal-lab/stream-grid.tsx
@@ -1,0 +1,95 @@
+import type { SignalStream, StreamStatus } from "./mock-data";
+
+const statusClasses: Record<StreamStatus, string> = {
+  stable: "border-emerald-400/30 bg-emerald-400/10 text-emerald-200",
+  drifting: "border-amber-400/30 bg-amber-400/10 text-amber-200",
+  critical: "border-rose-400/30 bg-rose-400/10 text-rose-200",
+};
+
+type StreamGridProps = {
+  streams: SignalStream[];
+  selectedStreamId: string | null;
+  focusedStreamId: string | null;
+  mutedIds: string[];
+  pausedIds: string[];
+  onSelectStream: (streamId: string) => void;
+};
+
+export function StreamGrid({
+  streams,
+  selectedStreamId,
+  focusedStreamId,
+  mutedIds,
+  pausedIds,
+  onSelectStream,
+}: StreamGridProps) {
+  return (
+    <section
+      aria-label="Stream grid"
+      className="rounded-[1.75rem] border border-white/10 bg-slate-950/75 p-5 backdrop-blur"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-[0.35em] text-slate-400">
+            Stream Cards
+          </p>
+          <h2 className="mt-2 text-xl font-semibold text-white">
+            Channel sweep
+          </h2>
+        </div>
+        <p className="text-sm text-slate-400">{streams.length} visible</p>
+      </div>
+
+      <div className="mt-5 grid gap-4 md:grid-cols-2">
+        {streams.map((stream) => {
+          const isSelected = selectedStreamId === stream.id;
+          const isFocused = focusedStreamId === stream.id;
+          const isMuted = mutedIds.includes(stream.id);
+          const isPaused = pausedIds.includes(stream.id);
+          const stats = [
+            ["Throughput", stream.throughput],
+            ["Sync Window", stream.syncWindow],
+            ["Noise Floor", stream.noiseFloor],
+            ["Owner", stream.owner],
+          ];
+
+          return (
+            <button
+              key={stream.id}
+              className={`rounded-[1.5rem] border p-5 text-left transition hover:-translate-y-0.5 ${
+                isSelected
+                  ? "border-cyan-300/50 bg-cyan-400/10 shadow-[0_18px_50px_rgba(34,211,238,0.14)]"
+                  : "border-white/10 bg-white/[0.03] hover:border-white/20"
+              }`}
+              onClick={() => onSelectStream(stream.id)}
+              type="button"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="text-lg font-semibold text-white">{stream.name}</p>
+                  <p className="mt-1 text-sm text-slate-400">{stream.channel}</p>
+                </div>
+                <span className={`rounded-full border px-3 py-1 text-xs uppercase tracking-[0.25em] ${statusClasses[stream.status]}`}>
+                  {stream.status}
+                </span>
+              </div>
+              <div className="mt-4 grid grid-cols-2 gap-3 text-sm text-slate-300">
+                {stats.map(([label, value]) => (
+                  <div key={label}>
+                    <p className="text-slate-500">{label}</p>
+                    <p className="mt-1 text-white">{value}</p>
+                  </div>
+                ))}
+              </div>
+              <div className="mt-4 flex flex-wrap gap-2 text-xs uppercase tracking-[0.2em]">
+                {isFocused ? <span className="rounded-full border border-cyan-400/30 bg-cyan-400/10 px-3 py-1 text-cyan-200">Focused</span> : null}
+                {isPaused ? <span className="rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-1 text-amber-200">Paused</span> : null}
+                {isMuted ? <span className="rounded-full border border-slate-400/30 bg-slate-400/10 px-3 py-1 text-slate-200">Muted</span> : null}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add the isolated `/signal-lab` route with a synthetic monitoring workspace, local mock data, and client-side inspector/anomaly interactions
- keep the feature split across dedicated `src/components/signal-lab/*` components with a focused interaction test
- add the minimum root App Router scaffold required for this branch to satisfy the repository build checks without introducing navigation to the feature

## Testing
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #15