### PR TITLE
feat: add isolated control room dashboard

### DIFF
--- a/src/app/control-room/mock-data.ts
+++ b/src/app/control-room/mock-data.ts
@@ -1,0 +1,138 @@
+export type MetricState = "healthy" | "warning" | "critical";
+export type AlertSeverity = "info" | "warning" | "critical";
+export type ActivityCategory = "deployments" | "incidents" | "traffic" | "automation";
+export type ActivityFilter = ActivityCategory | "all";
+
+type MetricDefinition = {
+  id: string; label: string; description: string; base: number; step: number;
+  precision: number; suffix: string; deltaPrecision: number; deltaSuffix: string;
+  higherBetter: boolean; attention: number; critical: number;
+};
+type TemplateValue = string | ((cycle: number) => string);
+type AlertTemplate = {
+  id: string; title: string; detail: string; severity: AlertSeverity;
+  owner: string; impact: string; minutesAgo: number;
+};
+type FeedTemplate = {
+  id: string; title: string; summary: string; category: ActivityCategory;
+  actor: string; system: string; minutesAgo: number;
+  details: { label: string; value: TemplateValue }[];
+};
+
+export type MetricCard = { id: string; label: string; description: string; value: string; delta: string; state: MetricState };
+export type AlertItem = { id: string; title: string; detail: string; severity: AlertSeverity; owner: string; impact: string; ageLabel: string };
+export type FeedDetail = { label: string; value: string };
+export type FeedItem = { id: string; title: string; summary: string; category: ActivityCategory; actor: string; system: string; ageLabel: string; details: FeedDetail[] };
+export type ControlRoomSnapshot = { environment: string; lastUpdated: string; metrics: MetricCard[]; alerts: AlertItem[]; feed: FeedItem[] };
+
+export const activityFilters = [
+  { id: "all", label: "All" },
+  { id: "deployments", label: "Deployments" },
+  { id: "incidents", label: "Incidents" },
+  { id: "traffic", label: "Traffic" },
+  { id: "automation", label: "Automation" },
+] satisfies { id: ActivityFilter; label: string }[];
+
+const metricDefinitions: MetricDefinition[] = [
+  { id: "availability", label: "Availability", description: "Successful edge responses across the primary mesh.", base: 99.982, step: 0.008, precision: 3, suffix: "%", deltaPrecision: 3, deltaSuffix: "%", higherBetter: true, attention: 99.975, critical: 99.96 },
+  { id: "latency", label: "P95 latency", description: "Application edge to origin response time.", base: 184, step: 7, precision: 0, suffix: "ms", deltaPrecision: 0, deltaSuffix: "ms", higherBetter: false, attention: 195, critical: 208 },
+  { id: "burn", label: "Error budget burn", description: "Rolling burn rate over the last 60 minutes.", base: 21, step: 3.5, precision: 1, suffix: "%", deltaPrecision: 1, deltaSuffix: "%", higherBetter: false, attention: 25, critical: 31 },
+  { id: "queue", label: "Queue depth", description: "Buffered background jobs waiting on worker capacity.", base: 412, step: 36, precision: 0, suffix: "", deltaPrecision: 0, deltaSuffix: "", higherBetter: false, attention: 460, critical: 520 },
+  { id: "replicas", label: "Replica coverage", description: "Healthy replicas participating in regional failover.", base: 97.4, step: 0.5, precision: 1, suffix: "%", deltaPrecision: 1, deltaSuffix: "%", higherBetter: true, attention: 96, critical: 94.5 },
+  { id: "cadence", label: "Deploy cadence", description: "Production changes cleared through the release lane.", base: 6.4, step: 0.4, precision: 1, suffix: "/hr", deltaPrecision: 1, deltaSuffix: "/hr", higherBetter: true, attention: 5.8, critical: 5.2 },
+  { id: "automation", label: "Automation success", description: "Guardrail tasks completing without intervention.", base: 94.6, step: 0.7, precision: 1, suffix: "%", deltaPrecision: 1, deltaSuffix: "%", higherBetter: true, attention: 92, critical: 89 },
+  { id: "notifications", label: "Notification lag", description: "Median time for paging and timeline fan-out.", base: 42, step: 4, precision: 0, suffix: "s", deltaPrecision: 0, deltaSuffix: "s", higherBetter: false, attention: 48, critical: 56 },
+];
+
+const alertTemplates: AlertTemplate[] = [
+  { id: "replica-drift", title: "Replica drift exceeds guardrail", detail: "Database follower in us-east-2 is 12s behind after a storage rebalance.", severity: "critical", owner: "Storage Ops", impact: "Write protection may arm if drift keeps climbing.", minutesAgo: 4 },
+  { id: "queue-surge", title: "Background queue rising in canary lane", detail: "Worker saturation is pushing fan-out jobs above their comfort band.", severity: "warning", owner: "Workflow Control", impact: "Customer notifications could slip by one processing window.", minutesAgo: 9 },
+  { id: "synthetic-drill", title: "Synthetic failover drill opens in 12 minutes", detail: "Dry-run policies are preloaded and waiting for operator confirmation.", severity: "info", owner: "Resilience Team", impact: "Status banners will switch to drill mode during the exercise.", minutesAgo: 15 },
+  { id: "tls-window", title: "Certificate rotation overlap narrows", detail: "Two edge clusters are within the final renewal grace period.", severity: "warning", owner: "Edge Platform", impact: "Regional handshakes may degrade if renewal is delayed.", minutesAgo: 21 },
+  { id: "audit-note", title: "Runbook audit snapshot published", detail: "Shift handoff notes were attached to the incident ledger.", severity: "info", owner: "Control Desk", impact: "Operators can cross-check the latest mitigation notes locally.", minutesAgo: 28 },
+];
+
+const feedTemplates: FeedTemplate[] = [
+  {
+    id: "deploy-wave", title: "Canary wave 09 advanced to 20% traffic",
+    summary: "Release control widened exposure after the guardrail sweep stayed green.", category: "deployments",
+    actor: "Release control", system: "Deploy lane", minutesAgo: 3,
+    details: [{ label: "Change set", value: (cycle) => `cfg-${912 + cycle}` }, { label: "Target", value: "payments-api" }, { label: "Next gate", value: "40% traffic after 2 healthy intervals" }],
+  },
+  {
+    id: "incident-escalation", title: "Runbook 7 escalated to platform on-call",
+    summary: "Operator requested manual review after replica drift crossed the paging threshold.", category: "incidents",
+    actor: "Shift lead", system: "Incident desk", minutesAgo: 8,
+    details: [{ label: "Escalation", value: "SEV-2 review bridge opened" }, { label: "Primary on-call", value: "P. Alvarez" }, { label: "Mitigation", value: "Follower restart held pending storage snapshot" }],
+  },
+  {
+    id: "traffic-policy", title: "Routing policy widened on eu-west ingress",
+    summary: "Traffic steering compensated for regional cold starts after cache churn.", category: "traffic",
+    actor: "Auto-balancer", system: "Global ingress", minutesAgo: 12,
+    details: [{ label: "Region", value: "eu-west-1" }, { label: "Shift", value: (cycle) => `${6 + cycle}% to standby pool` }, { label: "Observation", value: "Tail latency recovered within one interval" }],
+  },
+  {
+    id: "rollback-sim", title: "Rollback simulator cleared dry-run guardrails",
+    summary: "Automation replay validated recovery steps without changing production state.", category: "automation",
+    actor: "Control bot", system: "Runbook simulator", minutesAgo: 17,
+    details: [{ label: "Scenario", value: "Canary rollback with queue drain" }, { label: "Execution", value: (cycle) => `dry-run-${305 + cycle}` }, { label: "Result", value: "No blocking checks found" }],
+  },
+  {
+    id: "signing-bundle", title: "Configuration bundle signed for edge batch B14",
+    summary: "Edge policies were packaged for the next promotion window.", category: "deployments",
+    actor: "Release signer", system: "Policy vault", minutesAgo: 22,
+    details: [{ label: "Bundle", value: (cycle) => `edge-b14-r${cycle + 1}` }, { label: "Approvers", value: "2 of 2 collected" }, { label: "Window", value: "Next handoff at 10:30 UTC" }],
+  },
+  {
+    id: "replay-trace", title: "Trace replay trimmed duplicate notifications",
+    summary: "Automation de-duped timeline noise after the queue surge warning.", category: "automation",
+    actor: "Signal reducer", system: "Timeline fan-out", minutesAgo: 29,
+    details: [{ label: "Muted events", value: (cycle) => `${18 + cycle}` }, { label: "Scope", value: "warning-only duplicate bursts" }, { label: "Retention", value: "Raw trace preserved for audit" }],
+  },
+];
+
+const timestampFormatter = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit", hour12: false, timeZone: "UTC" });
+const rotate = <T,>(items: T[], cycle: number) => [...items.slice(cycle % items.length), ...items.slice(0, cycle % items.length)];
+const formatAge = (minutes: number) => (minutes < 60 ? `${minutes}m ago` : `${Math.floor(minutes / 60)}h ago`);
+
+function getMetricState(definition: MetricDefinition, value: number): MetricState {
+  if (definition.higherBetter) return value <= definition.critical ? "critical" : value <= definition.attention ? "warning" : "healthy";
+  return value >= definition.critical ? "critical" : value >= definition.attention ? "warning" : "healthy";
+}
+
+export const formatLastUpdated = (timestamp: string) => `${timestampFormatter.format(new Date(timestamp))} UTC`;
+
+export function buildControlRoomSnapshot(cycle: number, referenceTime = new Date()): ControlRoomSnapshot {
+  const updatedAt = new Date(referenceTime.getTime() + cycle * 45_000);
+
+  return {
+    environment: "production / canary lane",
+    lastUpdated: updatedAt.toISOString(),
+    metrics: metricDefinitions.map((definition, index) => {
+      const swing = ((cycle + index * 2) % 5) - 2;
+      const value = definition.base + swing * definition.step;
+      const delta = swing * definition.step;
+      const signedDelta = `${delta > 0 ? "+" : ""}${delta.toFixed(definition.deltaPrecision)}${definition.deltaSuffix} vs baseline`;
+
+      return {
+        id: definition.id,
+        label: definition.label,
+        description: definition.description,
+        value: `${value.toFixed(definition.precision)}${definition.suffix}`,
+        delta: signedDelta,
+        state: getMetricState(definition, value),
+      };
+    }),
+    alerts: rotate(alertTemplates, cycle).map((alert, index) => ({ ...alert, ageLabel: formatAge(alert.minutesAgo + index * 2 + cycle) })),
+    feed: rotate(feedTemplates, cycle).map((entry, index) => ({
+      id: entry.id,
+      title: entry.title,
+      summary: entry.summary,
+      category: entry.category,
+      actor: entry.actor,
+      system: entry.system,
+      ageLabel: formatAge(entry.minutesAgo + index * 2 + cycle),
+      details: entry.details.map((detail) => ({ label: detail.label, value: typeof detail.value === "function" ? detail.value(cycle) : detail.value })),
+    })),
+  };
+}

--- a/src/app/control-room/page.tsx
+++ b/src/app/control-room/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { buildControlRoomSnapshot } from "./mock-data";
+import { ControlRoomDashboard } from "@/components/control-room/control-room-dashboard";
+
+export const metadata: Metadata = {
+  title: "Control Room",
+  description: "Mock operations dashboard with local metrics, alerts, and feed data.",
+};
+
+export default function ControlRoomPage() {
+  return (
+    <ControlRoomDashboard
+      initialSnapshot={buildControlRoomSnapshot(0, new Date())}
+    />
+  );
+}

--- a/src/components/control-room/activity-feed.tsx
+++ b/src/components/control-room/activity-feed.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState } from "react";
+import {
+  activityFilters,
+  type ActivityFilter,
+  type FeedItem,
+} from "@/app/control-room/mock-data";
+
+const categoryClasses = {
+  deployments: "bg-cyan-300/12 text-cyan-100 border-cyan-300/20",
+  incidents: "bg-rose-500/12 text-rose-100 border-rose-400/25",
+  traffic: "bg-violet-400/12 text-violet-100 border-violet-300/25",
+  automation: "bg-emerald-400/12 text-emerald-100 border-emerald-300/20",
+};
+
+type ActivityFeedProps = {
+  items: FeedItem[];
+};
+
+export function ActivityFeed({ items }: ActivityFeedProps) {
+  const [activeFilter, setActiveFilter] = useState<ActivityFilter>("all");
+  const [expandedId, setExpandedId] = useState<string | null>(items[0]?.id ?? null);
+
+  const visibleItems = items.filter(
+    (item) => activeFilter === "all" || item.category === activeFilter,
+  );
+
+  return (
+    <section className="rounded-[2rem] border border-white/10 bg-slate-950/65 p-6 backdrop-blur sm:p-8">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.24em] text-cyan-200/70">
+            Activity Feed
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">
+            Operator timeline
+          </h2>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {activityFilters.map((filter) => {
+            const isActive = activeFilter === filter.id;
+
+            return (
+              <button
+                aria-pressed={isActive}
+                className={`rounded-full border px-4 py-2 text-sm transition ${
+                  isActive
+                    ? "border-cyan-200 bg-cyan-200 text-slate-950"
+                    : "border-white/12 bg-white/[0.04] text-slate-300 hover:border-white/20 hover:text-white"
+                }`}
+                key={filter.id}
+                onClick={() => setActiveFilter(filter.id)}
+                type="button"
+              >
+                {filter.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <ol className="mt-6 space-y-3">
+        {visibleItems.map((item) => {
+          const isExpanded = expandedId === item.id;
+
+          return (
+            <li
+              className="overflow-hidden rounded-[1.5rem] border border-white/8 bg-white/[0.04]"
+              key={item.id}
+            >
+              <button
+                aria-expanded={isExpanded}
+                className="w-full px-5 py-4 text-left"
+                onClick={() =>
+                  setExpandedId(isExpanded ? null : item.id)
+                }
+                type="button"
+              >
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <span
+                      className={`inline-flex rounded-full border px-3 py-1 text-xs uppercase tracking-[0.22em] ${categoryClasses[item.category]}`}
+                    >
+                      {item.category}
+                    </span>
+                    <h3 className="mt-3 text-lg font-medium text-white">
+                      {item.title}
+                    </h3>
+                    <p className="mt-2 text-sm leading-6 text-slate-300">
+                      {item.summary}
+                    </p>
+                  </div>
+                  <div className="text-sm text-slate-400 sm:text-right">
+                    <p>{item.ageLabel}</p>
+                    <p className="mt-1">{item.system}</p>
+                    <p className="mt-1 text-slate-500">{item.actor}</p>
+                  </div>
+                </div>
+              </button>
+              {isExpanded ? (
+                <div className="grid gap-3 border-t border-white/8 px-5 py-4 text-sm sm:grid-cols-3">
+                  {item.details.map((detail) => (
+                    <div
+                      className="rounded-2xl border border-white/8 bg-slate-950/55 p-3"
+                      key={`${item.id}-${detail.label}`}
+                    >
+                      <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                        {detail.label}
+                      </p>
+                      <p className="mt-2 text-slate-200">{detail.value}</p>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}

--- a/src/components/control-room/alert-list.tsx
+++ b/src/components/control-room/alert-list.tsx
@@ -1,0 +1,58 @@
+import type { AlertItem } from "@/app/control-room/mock-data";
+
+const severityClasses = {
+  info: "border-sky-300/20 bg-sky-400/10 text-sky-100",
+  warning: "border-amber-300/25 bg-amber-400/10 text-amber-100",
+  critical: "border-rose-400/25 bg-rose-500/10 text-rose-100",
+};
+
+type AlertListProps = {
+  alerts: AlertItem[];
+};
+
+export function AlertList({ alerts }: AlertListProps) {
+  return (
+    <section className="rounded-[2rem] border border-white/10 bg-slate-950/65 p-6 backdrop-blur sm:p-8">
+      <div className="flex items-end justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-[0.24em] text-cyan-200/70">
+            Alerts
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">
+            Priority queue
+          </h2>
+        </div>
+        <p className="text-sm text-slate-400">{alerts.length} active items</p>
+      </div>
+      <ol className="mt-6 space-y-3">
+        {alerts.map((alert) => (
+          <li
+            className="rounded-[1.5rem] border border-white/8 bg-white/[0.04] p-4"
+            key={alert.id}
+          >
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <span
+                className={`rounded-full border px-3 py-1 text-xs uppercase tracking-[0.22em] ${severityClasses[alert.severity]}`}
+              >
+                {alert.severity}
+              </span>
+              <span className="text-xs uppercase tracking-[0.18em] text-slate-400">
+                {alert.ageLabel}
+              </span>
+            </div>
+            <h3 className="mt-4 text-lg font-medium text-white">{alert.title}</h3>
+            <p className="mt-2 text-sm leading-6 text-slate-300">{alert.detail}</p>
+            <div className="mt-4 grid gap-3 text-sm text-slate-400 sm:grid-cols-2">
+              <p>
+                <span className="text-slate-200">Owner:</span> {alert.owner}
+              </p>
+              <p>
+                <span className="text-slate-200">Impact:</span> {alert.impact}
+              </p>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/src/components/control-room/control-room-dashboard.tsx
+++ b/src/components/control-room/control-room-dashboard.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+  buildControlRoomSnapshot,
+  type ControlRoomSnapshot,
+} from "@/app/control-room/mock-data";
+import { AlertList } from "./alert-list";
+import { ActivityFeed } from "./activity-feed";
+import { ControlRoomHeader } from "./control-room-header";
+import { MetricsGrid } from "./metrics-grid";
+import { QuickActions } from "./quick-actions";
+
+type ControlRoomDashboardProps = {
+  initialSnapshot: ControlRoomSnapshot;
+};
+
+export function ControlRoomDashboard({
+  initialSnapshot,
+}: ControlRoomDashboardProps) {
+  const [snapshot, setSnapshot] = useState(initialSnapshot);
+  const [cycle, setCycle] = useState(0);
+  const [isRefreshing, startTransition] = useTransition();
+
+  const warningCount = snapshot.alerts.filter(
+    (alert) => alert.severity === "warning",
+  ).length;
+  const criticalCount = snapshot.alerts.filter(
+    (alert) => alert.severity === "critical",
+  ).length;
+
+  function refreshSnapshot() {
+    const nextCycle = cycle + 1;
+
+    startTransition(() => {
+      setCycle(nextCycle);
+      setSnapshot(buildControlRoomSnapshot(nextCycle, new Date()));
+    });
+  }
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(6,95,70,0.18),transparent_32%),linear-gradient(180deg,#021014_0%,#031a21_55%,#01070c_100%)] px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <ControlRoomHeader
+          criticalCount={criticalCount}
+          environment={snapshot.environment}
+          isRefreshing={isRefreshing}
+          lastUpdated={snapshot.lastUpdated}
+          warningCount={warningCount}
+          onRefresh={refreshSnapshot}
+        />
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.75fr)_minmax(320px,0.95fr)]">
+          <div className="space-y-6">
+            <MetricsGrid metrics={snapshot.metrics} />
+            <ActivityFeed items={snapshot.feed} />
+          </div>
+          <div className="space-y-6">
+            <AlertList alerts={snapshot.alerts} />
+            <QuickActions />
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/control-room/control-room-header.tsx
+++ b/src/components/control-room/control-room-header.tsx
@@ -1,0 +1,68 @@
+import { formatLastUpdated } from "@/app/control-room/mock-data";
+
+type ControlRoomHeaderProps = {
+  criticalCount: number;
+  environment: string;
+  isRefreshing: boolean;
+  lastUpdated: string;
+  warningCount: number;
+  onRefresh: () => void;
+};
+
+export function ControlRoomHeader({
+  criticalCount,
+  environment,
+  isRefreshing,
+  lastUpdated,
+  warningCount,
+  onRefresh,
+}: ControlRoomHeaderProps) {
+  return (
+    <header className="rounded-[2rem] border border-white/10 bg-slate-950/70 p-6 shadow-[0_30px_100px_rgba(0,0,0,0.38)] backdrop-blur sm:p-8">
+      <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <div className="flex flex-wrap gap-3 text-xs uppercase tracking-[0.24em] text-slate-300">
+            <span className="rounded-full border border-emerald-400/30 bg-emerald-400/12 px-4 py-2 text-emerald-200">
+              {environment}
+            </span>
+            <span className="rounded-full border border-amber-300/25 bg-amber-300/10 px-4 py-2 text-amber-100">
+              local mock telemetry
+            </span>
+          </div>
+          <h1 className="mt-5 text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+            Control Room
+          </h1>
+          <p className="mt-4 max-w-3xl text-sm leading-6 text-slate-300 sm:text-base">
+            Isolated operations dashboard for route-level testing. Metrics,
+            alerts, and activity feed entries refresh in place with no server
+            calls or shared dependencies.
+          </p>
+        </div>
+        <div className="space-y-3 lg:text-right">
+          <p className="text-sm text-slate-300">
+            Last updated{" "}
+            <span className="font-medium text-white">
+              {formatLastUpdated(lastUpdated)}
+            </span>
+          </p>
+          <div className="flex flex-wrap gap-3 lg:justify-end">
+            <span className="rounded-full border border-rose-400/25 bg-rose-500/12 px-4 py-2 text-sm text-rose-100">
+              {criticalCount} critical
+            </span>
+            <span className="rounded-full border border-amber-300/25 bg-amber-400/12 px-4 py-2 text-sm text-amber-100">
+              {warningCount} warning
+            </span>
+            <button
+              className="rounded-full bg-cyan-300 px-5 py-2.5 text-sm font-semibold text-slate-950 transition hover:bg-cyan-200 disabled:cursor-wait disabled:bg-cyan-100"
+              disabled={isRefreshing}
+              onClick={onRefresh}
+              type="button"
+            >
+              {isRefreshing ? "Refreshing..." : "Refresh mock metrics"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/control-room/control-room.test.tsx
+++ b/src/components/control-room/control-room.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { buildControlRoomSnapshot } from "@/app/control-room/mock-data";
+import { ActivityFeed } from "./activity-feed";
+
+describe("control room feature", () => {
+  it("rotates snapshot values across refresh cycles", () => {
+    const referenceTime = new Date("2026-04-19T10:00:00.000Z");
+    const first = buildControlRoomSnapshot(0, referenceTime);
+    const second = buildControlRoomSnapshot(1, referenceTime);
+
+    expect(first.lastUpdated).not.toBe(second.lastUpdated);
+    expect(first.metrics[0]?.value).not.toBe(second.metrics[0]?.value);
+    expect(first.alerts[0]?.title).not.toBe(second.alerts[0]?.title);
+  });
+
+  it("filters and expands activity rows on the client", () => {
+    const snapshot = buildControlRoomSnapshot(
+      0,
+      new Date("2026-04-19T10:00:00.000Z"),
+    );
+
+    render(<ActivityFeed items={snapshot.feed} />);
+
+    expect(
+      screen.getByText("Routing policy widened on eu-west ingress"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Incidents" }));
+
+    expect(
+      screen.queryByText("Routing policy widened on eu-west ingress"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Runbook 7 escalated to platform on-call/i }),
+    );
+
+    expect(screen.getByText("Primary on-call")).toBeInTheDocument();
+  });
+});

--- a/src/components/control-room/metrics-grid.tsx
+++ b/src/components/control-room/metrics-grid.tsx
@@ -1,0 +1,56 @@
+import type { MetricCard } from "@/app/control-room/mock-data";
+
+const toneClasses = {
+  healthy: "border-emerald-400/20 bg-emerald-500/10 text-emerald-100",
+  warning: "border-amber-300/25 bg-amber-400/10 text-amber-100",
+  critical: "border-rose-400/25 bg-rose-500/10 text-rose-100",
+};
+
+type MetricsGridProps = {
+  metrics: MetricCard[];
+};
+
+export function MetricsGrid({ metrics }: MetricsGridProps) {
+  return (
+    <section className="rounded-[2rem] border border-white/10 bg-slate-950/65 p-6 backdrop-blur sm:p-8">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.24em] text-cyan-200/70">
+            Metrics Grid
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">
+            Eight live mock signals
+          </h2>
+        </div>
+        <p className="max-w-xl text-sm text-slate-300">
+          Signals rotate on manual refresh to simulate a busy operations desk
+          without leaving the route.
+        </p>
+      </div>
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 2xl:grid-cols-4">
+        {metrics.map((metric) => (
+          <article
+            className="rounded-[1.6rem] border border-white/8 bg-white/[0.04] p-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]"
+            key={metric.id}
+          >
+            <div
+              className={`inline-flex rounded-full border px-3 py-1 text-xs uppercase tracking-[0.24em] ${toneClasses[metric.state]}`}
+            >
+              {metric.state}
+            </div>
+            <h3 className="mt-4 text-sm uppercase tracking-[0.16em] text-slate-300">
+              {metric.label}
+            </h3>
+            <p className="mt-3 text-3xl font-semibold text-white">
+              {metric.value}
+            </p>
+            <p className="mt-2 text-sm text-cyan-100">{metric.delta}</p>
+            <p className="mt-4 text-sm leading-6 text-slate-400">
+              {metric.description}
+            </p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/control-room/quick-actions.tsx
+++ b/src/components/control-room/quick-actions.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+
+const postureOptions = ["monitor", "contain", "escalate"] as const;
+const clock = new Intl.DateTimeFormat("en-US", {
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+
+export function QuickActions() {
+  const [freezeDeploys, setFreezeDeploys] = useState(true);
+  const [divertWorkers, setDivertWorkers] = useState(false);
+  const [samplingRate, setSamplingRate] = useState(72);
+  const [posture, setPosture] = useState<(typeof postureOptions)[number]>("contain");
+  const [lastAction, setLastAction] = useState("Awaiting operator input. Controls are browser-only.");
+
+  function stageAction(label: string) {
+    setLastAction(`${label} staged at ${clock.format(new Date())}. No request sent.`);
+  }
+
+  return (
+    <section className="rounded-[2rem] border border-white/10 bg-slate-950/65 p-6 backdrop-blur sm:p-8">
+      <p className="text-xs uppercase tracking-[0.24em] text-cyan-200/70">Quick Actions</p>
+      <h2 className="mt-2 text-2xl font-semibold text-white">Drill controls</h2>
+      <p className="mt-3 text-sm leading-6 text-slate-300">Dummy controls for staging operator intent. State stays local to this panel.</p>
+
+      <div className="mt-6 grid gap-3 sm:grid-cols-2">
+        <button
+          aria-pressed={freezeDeploys}
+          className={`rounded-[1.4rem] border px-4 py-4 text-left text-sm transition ${freezeDeploys ? "border-amber-300/30 bg-amber-400/12 text-amber-100" : "border-white/10 bg-white/[0.04] text-slate-300"}`}
+          onClick={() => setFreezeDeploys((value) => !value)}
+          type="button"
+        >
+          Freeze deploy lane
+        </button>
+        <button
+          aria-pressed={divertWorkers}
+          className={`rounded-[1.4rem] border px-4 py-4 text-left text-sm transition ${divertWorkers ? "border-emerald-300/25 bg-emerald-400/12 text-emerald-100" : "border-white/10 bg-white/[0.04] text-slate-300"}`}
+          onClick={() => setDivertWorkers((value) => !value)}
+          type="button"
+        >
+          Divert background workers
+        </button>
+      </div>
+
+      <div className="mt-6">
+        <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Incident posture</p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {postureOptions.map((option) => {
+            const isActive = posture === option;
+
+            return (
+              <button
+                aria-pressed={isActive}
+                className={`rounded-full border px-4 py-2 text-sm capitalize ${isActive ? "border-cyan-200 bg-cyan-200 text-slate-950" : "border-white/10 bg-white/[0.04] text-slate-300"}`}
+                key={option}
+                onClick={() => setPosture(option)}
+                type="button"
+              >
+                {option}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <label className="mt-6 block text-sm text-slate-300">
+        Event sampling: <span className="text-white">{samplingRate}%</span>
+        <input
+          className="mt-3 w-full accent-cyan-300"
+          max={100}
+          min={10}
+          onChange={(event) => setSamplingRate(Number(event.target.value))}
+          type="range"
+          value={samplingRate}
+        />
+      </label>
+
+      <div className="mt-6 flex flex-wrap gap-3">
+        <button
+          className="rounded-full bg-cyan-300 px-5 py-2.5 text-sm font-semibold text-slate-950"
+          onClick={() => stageAction("Dry failover")}
+          type="button"
+        >
+          Run dry failover
+        </button>
+        <button
+          className="rounded-full border border-white/12 bg-white/[0.04] px-5 py-2.5 text-sm font-semibold text-slate-200"
+          onClick={() => stageAction("Info alert silence")}
+          type="button"
+        >
+          Silence info alerts
+        </button>
+      </div>
+
+      <div className="mt-6 rounded-[1.5rem] border border-white/8 bg-white/[0.04] p-4">
+        <div className="flex flex-wrap gap-2 text-xs uppercase tracking-[0.18em]">
+          <span className="rounded-full border border-white/10 px-3 py-1 text-slate-300">{freezeDeploys ? "deploys frozen" : "deploys open"}</span>
+          <span className="rounded-full border border-white/10 px-3 py-1 text-slate-300">{divertWorkers ? "workers diverted" : "workers normal"}</span>
+          <span className="rounded-full border border-white/10 px-3 py-1 text-slate-300">posture {posture}</span>
+        </div>
+        <p className="mt-4 text-sm leading-6 text-slate-300">{lastAction}</p>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/control-room` dashboard with local mock metrics, alerts, activity feed, and quick actions
- implement client-side refresh, feed filtering, and expandable activity rows with feature-local data only
- add the minimal root App Router scaffold and a focused feature test so the repo builds and CI can exercise the route

## Verification
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #13