### PR TITLE
feat: archive vault route with local snapshot browser

### DIFF
--- a/src/app/archive-vault/archive-vault-data.test.ts
+++ b/src/app/archive-vault/archive-vault-data.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { findComparisonSummary } from "./archive-vault-data";
+
+describe("archive vault comparison summaries", () => {
+  it("returns seeded summaries for curated pairs", () => {
+    expect(findComparisonSummary("helix-171", "kestrel-176")?.risk).toBe(
+      "High drift risk",
+    );
+  });
+
+  it("derives fallback summaries for ad hoc selections", () => {
+    expect(findComparisonSummary("aurelia-204", "helix-171")?.alignment).toContain(
+      "% field overlap",
+    );
+  });
+});

--- a/src/app/archive-vault/archive-vault-data.ts
+++ b/src/app/archive-vault/archive-vault-data.ts
@@ -1,0 +1,126 @@
+export const archiveStatuses = ["sealed", "review", "active", "drift"] as const;
+export type ArchiveStatus = (typeof archiveStatuses)[number];
+
+export type SnapshotRecord = {
+  id: string;
+  label: string;
+  cluster: string;
+  status: ArchiveStatus;
+  owner: string;
+  region: string;
+  capturedAt: string;
+  records: number;
+  delta: number;
+  confidence: number;
+  tags: string[];
+  summary: string;
+  notes: string[];
+  highlights: Array<{ label: string; value: string }>;
+};
+
+export type ComparisonSummary = {
+  pair: [string, string];
+  verdict: string;
+  alignment: string;
+  risk: string;
+  shift: string;
+  recommendation: string;
+};
+
+export const archiveTags = ["legal hold", "pii mesh", "geo drift", "consent", "checksum drift", "retention", "delta burst"] as const;
+export const snapshotRecords: SnapshotRecord[] = [
+  {
+    id: "aurelia-204", label: "Aurelia Ledger", cluster: "vault-eu-west / stripe mirror", status: "sealed", owner: "Ops Nine", region: "Frankfurt",
+    capturedAt: "2026-04-17 08:32 UTC", records: 184_221, delta: 2, confidence: 97, tags: ["legal hold", "retention", "pii mesh"],
+    summary: "Baseline ledger preserved ahead of policy expiration sweep.",
+    notes: ["Checksum drift absent across all sealed shards.", "Retention lock survives regional replay."],
+    highlights: [{ label: "Coverage", value: "99.2% fields indexed" }, { label: "Retention", value: "Locked until Q1 FY27" }, { label: "Replay gap", value: "14 minutes" }],
+  },
+  {
+    id: "ember-198", label: "Ember Registry", cluster: "vault-us-central / event cache", status: "review", owner: "Delta Cell", region: "Iowa",
+    capturedAt: "2026-04-18 03:10 UTC", records: 142_908, delta: 11, confidence: 88, tags: ["delta burst", "consent", "retention"],
+    summary: "Consent revocations spiked after a backfilled subscriber import.",
+    notes: ["Two collections crossed expected delta thresholds.", "Reviewer handoff pending for consent anomalies."],
+    highlights: [{ label: "Coverage", value: "94.5% fields indexed" }, { label: "Retention", value: "Freeze pending" }, { label: "Replay gap", value: "42 minutes" }],
+  },
+  {
+    id: "helix-171", label: "Helix Notes", cluster: "vault-us-east / health stream", status: "active", owner: "Pulse Desk", region: "Virginia",
+    capturedAt: "2026-04-19 01:42 UTC", records: 208_554, delta: 6, confidence: 91, tags: ["pii mesh", "consent", "checksum drift"],
+    summary: "Live notes mirror remains stable with a narrow checksum variance.",
+    notes: ["Consent rollups landed before the latest mirror cut.", "Variance stays inside automated reconciliation limits."],
+    highlights: [{ label: "Coverage", value: "96.7% fields indexed" }, { label: "Retention", value: "Rolling 180-day band" }, { label: "Replay gap", value: "9 minutes" }],
+  },
+  {
+    id: "kestrel-176", label: "Kestrel Claims", cluster: "vault-ap-south / claims replica", status: "drift", owner: "Skylark Queue", region: "Mumbai",
+    capturedAt: "2026-04-18 19:04 UTC", records: 96_411, delta: 18, confidence: 79, tags: ["geo drift", "delta burst", "checksum drift"],
+    summary: "Claims replica shows broad field drift after a regional failback.",
+    notes: ["Checksum mismatch clusters around adjudication notes.", "Geo rebalance duplicated one retention bucket."],
+    highlights: [{ label: "Coverage", value: "89.1% fields indexed" }, { label: "Retention", value: "Dual-window mismatch" }, { label: "Replay gap", value: "1 hour 16 minutes" }],
+  },
+  {
+    id: "orbit-164", label: "Orbit Permissions", cluster: "vault-ca-east / auth graph", status: "sealed", owner: "Northwatch", region: "Montreal",
+    capturedAt: "2026-04-16 12:18 UTC", records: 121_733, delta: 4, confidence: 95, tags: ["legal hold", "consent", "retention"],
+    summary: "Permissions archive sealed before entitlement pruning was applied.",
+    notes: ["Role tombstones remain linked to the final approval window.", "Consent history is complete but cold-stored."],
+    highlights: [{ label: "Coverage", value: "98.1% fields indexed" }, { label: "Retention", value: "Locked until legal release" }, { label: "Replay gap", value: "21 minutes" }],
+  },
+  {
+    id: "quartz-159", label: "Quartz Session Tape", cluster: "vault-us-west / edge replay", status: "review", owner: "Signal Array", region: "Oregon",
+    capturedAt: "2026-04-19 05:27 UTC", records: 77_942, delta: 9, confidence: 86, tags: ["geo drift", "pii mesh", "consent"],
+    summary: "Session tape needs manual review after cross-region masking drift.",
+    notes: ["Edge replay produced new tokenization gaps.", "Masking rules differ between west and south replicas."],
+    highlights: [{ label: "Coverage", value: "93.3% fields indexed" }, { label: "Retention", value: "30-day forensic window" }, { label: "Replay gap", value: "37 minutes" }],
+  },
+];
+
+export const comparisonSummaries: ComparisonSummary[] = [
+  {
+    pair: ["aurelia-204", "orbit-164"], verdict: "Both sealed archives hold steady and differ mostly in consent lineage depth.",
+    alignment: "88% field overlap", risk: "Low drift risk",
+    shift: "Orbit keeps more entitlement residue; Aurelia keeps stronger PII indexing.",
+    recommendation: "Use this pair when reviewers need a calm baseline before drift triage.",
+  },
+  {
+    pair: ["ember-198", "quartz-159"], verdict: "Consent-oriented review queues align, but Quartz carries wider masking variance.",
+    alignment: "72% field overlap", risk: "Moderate review risk",
+    shift: "Masking drift clusters in session tape while Ember spikes on subscriber deltas.",
+    recommendation: "Pair these when validating consent workflows against replay artifacts.",
+  },
+  {
+    pair: ["helix-171", "kestrel-176"], verdict: "Helix offers a stable live reference for a replica already slipping into drift.",
+    alignment: "64% field overlap", risk: "High drift risk",
+    shift: "Kestrel widens checksum and regional variance far beyond Helix tolerance.",
+    recommendation: "Start with checksum mismatches, then inspect geo rebalance behavior.",
+  },
+];
+
+function pairKey(leftId: string, rightId: string) {
+  return [leftId, rightId].sort().join("::");
+}
+
+export function findComparisonSummary(
+  leftId: string,
+  rightId: string,
+): ComparisonSummary | null {
+  const explicit = comparisonSummaries.find((summary) => pairKey(...summary.pair) === pairKey(leftId, rightId));
+  if (explicit) return explicit;
+  const left = snapshotRecords.find((record) => record.id === leftId);
+  const right = snapshotRecords.find((record) => record.id === rightId);
+  if (!left || !right) return null;
+  const sharedTags = left.tags.filter((tag) => right.tags.includes(tag));
+  const driftGap = Math.abs(left.delta - right.delta);
+  const overlap = Math.max(58, 92 - driftGap * 3);
+
+  return {
+    pair: [leftId, rightId] as [string, string],
+    verdict: driftGap > 8
+      ? "Variance is wide enough to treat this pair as an active drift investigation."
+      : "The pair is close enough for a fast reviewer handoff and side-by-side scan.",
+    alignment: `${overlap}% field overlap`,
+    risk: driftGap > 8 ? "Escalate drift review" : "Watch in daily review",
+    shift: sharedTags.length ? `Shared focus tags: ${sharedTags.join(", ")}.` : "No shared focus tags; compare structure before comparing semantics.",
+    recommendation: driftGap > 8
+      ? "Inspect replay gap and checksum confidence before approving archival use."
+      : "Use this pair as a quick confidence check for neighboring archive states.",
+  };
+}

--- a/src/app/archive-vault/page.tsx
+++ b/src/app/archive-vault/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import { ArchiveVaultShell } from "@/components/archive-vault/archive-vault-shell";
+
+export const metadata: Metadata = {
+  title: "Archive Vault",
+  description: "Mock snapshot browser with local compare and detail panels.",
+};
+
+export default function ArchiveVaultPage() {
+  return <ArchiveVaultShell />;
+}

--- a/src/components/archive-vault/archive-vault-filters.tsx
+++ b/src/components/archive-vault/archive-vault-filters.tsx
@@ -1,0 +1,99 @@
+import type { ArchiveStatus } from "@/app/archive-vault/archive-vault-data";
+import styles from "./archive-vault.module.css";
+
+type ArchiveVaultFiltersProps = {
+  query: string;
+  statuses: readonly ArchiveStatus[];
+  activeStatuses: ArchiveStatus[];
+  tags: readonly string[];
+  activeTag: string;
+  resultCount: number;
+  totalCount: number;
+  hasFilters: boolean;
+  onQueryChange: (value: string) => void;
+  onToggleStatus: (status: ArchiveStatus) => void;
+  onTagChange: (tag: string) => void;
+  onReset: () => void;
+};
+
+export function ArchiveVaultFilters({
+  query,
+  statuses,
+  activeStatuses,
+  tags,
+  activeTag,
+  resultCount,
+  totalCount,
+  hasFilters,
+  onQueryChange,
+  onToggleStatus,
+  onTagChange,
+  onReset,
+}: ArchiveVaultFiltersProps) {
+  return (
+    <section className={styles.filters}>
+      <div className={styles.searchRow}>
+        <label className={styles.searchField}>
+          <span>Search snapshots</span>
+          <input
+            onChange={(event) => onQueryChange(event.target.value)}
+            placeholder="Search label, owner, region, or tag"
+            type="search"
+            value={query}
+          />
+        </label>
+        <div className={styles.filterMeta}>
+          <strong>
+            {resultCount} / {totalCount}
+          </strong>
+          <span>client-side matches</span>
+          {hasFilters ? (
+            <button onClick={onReset} type="button">
+              Reset
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className={styles.chipRow}>
+        {statuses.map((status) => (
+          <button
+            aria-pressed={activeStatuses.includes(status)}
+            className={
+              activeStatuses.includes(status)
+                ? `${styles.chip} ${styles.chipActive}`
+                : styles.chip
+            }
+            key={status}
+            onClick={() => onToggleStatus(status)}
+            type="button"
+          >
+            {status}
+          </button>
+        ))}
+      </div>
+
+      <div className={styles.chipRow}>
+        <button
+          aria-pressed={activeTag === "all"}
+          className={activeTag === "all" ? `${styles.chip} ${styles.chipActive}` : styles.chip}
+          onClick={() => onTagChange("all")}
+          type="button"
+        >
+          all tags
+        </button>
+        {tags.map((tag) => (
+          <button
+            aria-pressed={activeTag === tag}
+            className={activeTag === tag ? `${styles.chip} ${styles.chipActive}` : styles.chip}
+            key={tag}
+            onClick={() => onTagChange(tag)}
+            type="button"
+          >
+            {tag}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/archive-vault/archive-vault-shell.tsx
+++ b/src/components/archive-vault/archive-vault-shell.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { startTransition, useDeferredValue, useState } from "react";
+import {
+  archiveStatuses,
+  archiveTags,
+  findComparisonSummary,
+  snapshotRecords,
+  type ArchiveStatus,
+} from "@/app/archive-vault/archive-vault-data";
+import { ArchiveVaultFilters } from "./archive-vault-filters";
+import styles from "./archive-vault.module.css";
+import { CompareSummaryPanel } from "./compare-summary-panel";
+import { RecordDetailPanel } from "./record-detail-panel";
+import { SnapshotList } from "./snapshot-list";
+
+export function ArchiveVaultShell() {
+  const [query, setQuery] = useState("");
+  const [statusFilters, setStatusFilters] = useState<ArchiveStatus[]>([]);
+  const [tagFilter, setTagFilter] = useState<string>("all");
+  const [focusedRecordId, setFocusedRecordId] = useState<string | null>(snapshotRecords[0]?.id ?? null);
+  const [compareIds, setCompareIds] = useState<string[]>([]);
+  const deferredQuery = useDeferredValue(query).trim().toLowerCase();
+
+  const visibleRecords = snapshotRecords.filter((record) => {
+    const haystack = [record.label, record.cluster, record.owner, record.region, record.summary, ...record.tags].join(" ").toLowerCase();
+
+    return (
+      (!deferredQuery || haystack.includes(deferredQuery)) &&
+      (statusFilters.length === 0 || statusFilters.includes(record.status)) &&
+      (tagFilter === "all" || record.tags.includes(tagFilter))
+    );
+  });
+
+  const activeRecordId = focusedRecordId && visibleRecords.some((record) => record.id === focusedRecordId) ? focusedRecordId : visibleRecords[0]?.id ?? null;
+  const visibleCompareIds = compareIds.filter((id) => visibleRecords.some((record) => record.id === id));
+  const activeRecord = snapshotRecords.find((record) => record.id === activeRecordId) ?? null;
+  const comparedRecords = visibleCompareIds.flatMap((id) => {
+    const match = snapshotRecords.find((record) => record.id === id);
+    return match ? [match] : [];
+  });
+  const comparison = comparedRecords.length === 2 ? findComparisonSummary(comparedRecords[0].id, comparedRecords[1].id) : null;
+  const hasFilters = query.trim().length > 0 || statusFilters.length > 0 || tagFilter !== "all";
+
+  function toggleStatus(status: ArchiveStatus) {
+    startTransition(() => setStatusFilters((current) => current.includes(status) ? current.filter((value) => value !== status) : [...current, status]));
+  }
+
+  function toggleCompare(recordId: string) {
+    setCompareIds((current) => {
+      const visibleSelection = current.filter((id) => visibleRecords.some((record) => record.id === id));
+
+      if (visibleSelection.includes(recordId)) return visibleSelection.filter((value) => value !== recordId);
+      if (visibleSelection.length < 2) return [...visibleSelection, recordId];
+      return [visibleSelection[1], recordId];
+    });
+    setFocusedRecordId(recordId);
+  }
+
+  return (
+    <main className={styles.shell}>
+      <section className={styles.hero}>
+        <div>
+          <p className={styles.eyebrow}>Archive Vault</p>
+          <h1 className={styles.title}>
+            Snapshot browser for sealed records, review queues, and drift-ready comparisons.
+          </h1>
+          <p className={styles.intro}>
+            Everything on this route is mock and local: search, filters, detail state, and pairwise compare summaries never leave the client.
+          </p>
+        </div>
+        <div className={styles.heroStats}>
+          <div className={styles.statCard}>
+            <span>Snapshots</span>
+            <strong>{snapshotRecords.length}</strong>
+          </div>
+          <div className={styles.statCard}>
+            <span>Sealed</span>
+            <strong>{snapshotRecords.filter((record) => record.status === "sealed").length}</strong>
+          </div>
+          <div className={styles.statCard}>
+            <span>Drift Watch</span>
+            <strong>{snapshotRecords.filter((record) => record.status === "drift").length}</strong>
+          </div>
+        </div>
+      </section>
+
+      <ArchiveVaultFilters
+        query={query}
+        activeStatuses={statusFilters}
+        activeTag={tagFilter}
+        hasFilters={hasFilters}
+        onQueryChange={(value) => startTransition(() => setQuery(value))}
+        onReset={() => startTransition(() => { setQuery(""); setStatusFilters([]); setTagFilter("all"); })}
+        onTagChange={(value) => startTransition(() => setTagFilter(value))}
+        onToggleStatus={toggleStatus}
+        resultCount={visibleRecords.length}
+        statuses={archiveStatuses}
+        tags={archiveTags}
+        totalCount={snapshotRecords.length}
+      />
+
+      <div className={styles.workspace}>
+        <SnapshotList
+          activeRecordId={activeRecordId}
+          compareIds={visibleCompareIds}
+          hasFilters={hasFilters}
+          onActivate={setFocusedRecordId}
+          onResetFilters={() => startTransition(() => { setQuery(""); setStatusFilters([]); setTagFilter("all"); })}
+          onToggleCompare={toggleCompare}
+          records={visibleRecords}
+        />
+
+        <aside className={styles.sideRail}>
+          <RecordDetailPanel isCompared={visibleCompareIds.includes(activeRecord?.id ?? "")} record={activeRecord} />
+          <CompareSummaryPanel records={comparedRecords} summary={comparison} />
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/src/components/archive-vault/archive-vault.module.css
+++ b/src/components/archive-vault/archive-vault.module.css
@@ -1,0 +1,84 @@
+.shell { padding: 2rem; }
+.hero, .filters, .listPanel, .sidePanel {
+  border: 1px solid rgba(93, 68, 44, 0.12);
+  border-radius: 1.75rem;
+  background: rgba(255, 251, 245, 0.9);
+  box-shadow: 0 20px 48px rgba(80, 56, 36, 0.08);
+}
+.hero {
+  display: grid;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+  padding: 1.75rem;
+  background: linear-gradient(135deg, rgba(122, 68, 36, 0.09), transparent), rgba(255, 251, 245, 0.92);
+}
+.eyebrow, .panelHeader p {
+  margin: 0 0 0.45rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.72rem;
+  color: #885734;
+}
+.title, .panelHeader h2, .cardHeading h3 { margin: 0; }
+.intro, .cardSummary, .emptyState p, .noteList { color: #54483f; }
+.heroStats, .workspace, .sideRail, .recordGrid, .detailGrid, .highlightList, .chipRow, .tagStrip, .comparePair, .statGrid { display: grid; gap: 0.85rem; }
+.heroStats, .recordGrid, .highlightList, .chipRow, .tagStrip, .comparePair { grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr)); }
+.workspace { grid-template-columns: minmax(0, 1.5fr) minmax(20rem, 0.9fr); align-items: start; }
+.sideRail { position: sticky; top: 1.25rem; }
+.statCard, .highlightCard, .chip, .tag, .inlineBadge, .statusBadge, .cardTop button, .filterMeta button {
+  border: 1px solid rgba(127, 92, 56, 0.18);
+  border-radius: 999px;
+  background: rgba(255, 246, 235, 0.88);
+}
+.statCard, .highlightCard { padding: 0.9rem 1rem; }
+.statCard span, .highlightCard span, .detailGrid dt, .statGrid dt { display: block; font-size: 0.78rem; color: #725a45; }
+.statCard strong, .highlightCard strong, .detailGrid dd, .statGrid dd { margin: 0.35rem 0 0; font-size: 1.05rem; }
+.filters, .listPanel, .sidePanel { padding: 1.25rem; }
+.filters { margin-bottom: 1.5rem; }
+.searchRow, .panelHeader, .cardTop, .filterMeta, .cardHeading {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+.searchField, .cardBody { display: grid; gap: 0.5rem; }
+.searchField { flex: 1; }
+.searchField span {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: #725238;
+}
+.searchField input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border: 1px solid rgba(127, 92, 56, 0.18);
+  border-radius: 1rem;
+  background: rgba(255, 250, 244, 0.96);
+}
+.filterMeta { align-items: center; white-space: nowrap; color: #725a45; }
+.chip, .tag, .inlineBadge, .statusBadge, .cardTop button, .filterMeta button { padding: 0.5rem 0.85rem; font-size: 0.82rem; text-transform: capitalize; }
+.chipActive, .cardActive, .inlineBadge { background: #2e3d52; color: #f7f2e9; }
+.listPanel, .sidePanel { min-width: 0; }
+.card {
+  padding: 1rem;
+  border-radius: 1.35rem;
+  border: 1px solid rgba(93, 68, 44, 0.1);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.65), rgba(250, 242, 231, 0.95));
+}
+.cardBody { width: 100%; padding: 0; border: 0; background: transparent; text-align: left; color: inherit; }
+.cardHeading span { font-size: 0.78rem; color: #725a45; }
+.statGrid, .detailGrid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.tag { text-align: center; }
+.statusBadge[data-tone="sealed"] { background: #dff0df; }
+.statusBadge[data-tone="review"] { background: #f6e3ba; }
+.statusBadge[data-tone="active"] { background: #dce8f6; }
+.statusBadge[data-tone="drift"] { background: #f8d1c3; }
+.compareVerdict { margin: 0; padding: 1rem; border-radius: 1rem; background: rgba(46, 61, 82, 0.08); }
+.noteList { margin: 0; padding-left: 1rem; }
+.emptyState { display: grid; gap: 0.75rem; padding: 1.25rem; border-radius: 1.1rem; background: rgba(104, 74, 47, 0.06); }
+@media (max-width: 900px) {
+  .shell { padding: 1rem; }
+  .workspace, .searchRow, .panelHeader, .cardTop, .filterMeta, .cardHeading { grid-template-columns: 1fr; display: grid; }
+  .sideRail { position: static; }
+}

--- a/src/components/archive-vault/compare-summary-panel.tsx
+++ b/src/components/archive-vault/compare-summary-panel.tsx
@@ -1,0 +1,59 @@
+import type {
+  ComparisonSummary,
+  SnapshotRecord,
+} from "@/app/archive-vault/archive-vault-data";
+import styles from "./archive-vault.module.css";
+
+type CompareSummaryPanelProps = {
+  records: SnapshotRecord[];
+  summary: ComparisonSummary | null;
+};
+
+export function CompareSummaryPanel({
+  records,
+  summary,
+}: CompareSummaryPanelProps) {
+  return (
+    <section className={styles.sidePanel}>
+      <div className={styles.panelHeader}>
+        <div>
+          <p className={styles.eyebrow}>Comparison</p>
+          <h2>Pairwise summary</h2>
+        </div>
+        <span className={styles.inlineBadge}>{records.length}/2 selected</span>
+      </div>
+
+      {records.length < 2 || !summary ? (
+        <div className={styles.emptyState}>
+          <p>Select two snapshots to unlock overlap, drift, and compare guidance.</p>
+          {records.length === 1 ? <p>Waiting for a second pair candidate.</p> : null}
+        </div>
+      ) : (
+        <>
+          <div className={styles.comparePair}>
+            {records.map((record) => (
+              <span className={styles.tag} key={record.id}>
+                {record.label}
+              </span>
+            ))}
+          </div>
+          <p className={styles.compareVerdict}>{summary.verdict}</p>
+          <dl className={styles.detailGrid}>
+            <div>
+              <dt>Alignment</dt>
+              <dd>{summary.alignment}</dd>
+            </div>
+            <div>
+              <dt>Risk</dt>
+              <dd>{summary.risk}</dd>
+            </div>
+          </dl>
+          <ul className={styles.noteList}>
+            <li>{summary.shift}</li>
+            <li>{summary.recommendation}</li>
+          </ul>
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/components/archive-vault/record-detail-panel.tsx
+++ b/src/components/archive-vault/record-detail-panel.tsx
@@ -1,0 +1,68 @@
+import type { SnapshotRecord } from "@/app/archive-vault/archive-vault-data";
+import styles from "./archive-vault.module.css";
+
+type RecordDetailPanelProps = {
+  record: SnapshotRecord | null;
+  isCompared: boolean;
+};
+
+export function RecordDetailPanel({
+  record,
+  isCompared,
+}: RecordDetailPanelProps) {
+  if (!record) {
+    return (
+      <section className={styles.sidePanel}>
+        <div className={styles.emptyState}>
+          <p>Select a snapshot to inspect ownership, retention, and replay notes.</p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className={styles.sidePanel}>
+      <div className={styles.panelHeader}>
+        <div>
+          <p className={styles.eyebrow}>Snapshot Detail</p>
+          <h2>{record.label}</h2>
+        </div>
+        {isCompared ? <span className={styles.inlineBadge}>compare ready</span> : null}
+      </div>
+
+      <dl className={styles.detailGrid}>
+        <div>
+          <dt>Owner</dt>
+          <dd>{record.owner}</dd>
+        </div>
+        <div>
+          <dt>Region</dt>
+          <dd>{record.region}</dd>
+        </div>
+        <div>
+          <dt>Captured</dt>
+          <dd>{record.capturedAt}</dd>
+        </div>
+        <div>
+          <dt>Status</dt>
+          <dd>{record.status}</dd>
+        </div>
+      </dl>
+
+      <div className={styles.highlightList}>
+        {record.highlights.map((highlight) => (
+          <div className={styles.highlightCard} key={highlight.label}>
+            <span>{highlight.label}</span>
+            <strong>{highlight.value}</strong>
+          </div>
+        ))}
+      </div>
+
+      <ul className={styles.noteList}>
+        {record.notes.map((note) => (
+          <li key={note}>{note}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/archive-vault/snapshot-list.tsx
+++ b/src/components/archive-vault/snapshot-list.tsx
@@ -1,0 +1,104 @@
+import type { SnapshotRecord } from "@/app/archive-vault/archive-vault-data";
+import styles from "./archive-vault.module.css";
+
+type SnapshotListProps = {
+  records: SnapshotRecord[];
+  activeRecordId: string | null;
+  compareIds: string[];
+  hasFilters: boolean;
+  onActivate: (recordId: string) => void;
+  onToggleCompare: (recordId: string) => void;
+  onResetFilters: () => void;
+};
+
+export function SnapshotList({
+  records,
+  activeRecordId,
+  compareIds,
+  hasFilters,
+  onActivate,
+  onToggleCompare,
+  onResetFilters,
+}: SnapshotListProps) {
+  return (
+    <section className={styles.listPanel}>
+      <div className={styles.panelHeader}>
+        <div>
+          <p className={styles.eyebrow}>Snapshot Browser</p>
+          <h2>Searchable local records</h2>
+        </div>
+        <span className={styles.inlineBadge}>{compareIds.length}/2 compare slots</span>
+      </div>
+
+      {records.length === 0 ? (
+        <div className={styles.emptyState}>
+          <p>No snapshots match the current search and filter state.</p>
+          {hasFilters ? (
+            <button onClick={onResetFilters} type="button">
+              Clear filters
+            </button>
+          ) : null}
+        </div>
+      ) : (
+        <div className={styles.recordGrid}>
+          {records.map((record) => {
+            const isActive = record.id === activeRecordId;
+            const isCompared = compareIds.includes(record.id);
+
+            return (
+              <article
+                className={
+                  isActive ? `${styles.card} ${styles.cardActive}` : styles.card
+                }
+                key={record.id}
+              >
+                <div className={styles.cardTop}>
+                  <span className={styles.statusBadge} data-tone={record.status}>
+                    {record.status}
+                  </span>
+                  <button onClick={() => onToggleCompare(record.id)} type="button">
+                    {isCompared ? "Selected" : compareIds.length === 2 ? "Swap in" : "Compare"}
+                  </button>
+                </div>
+
+                <button
+                  className={styles.cardBody}
+                  onClick={() => onActivate(record.id)}
+                  type="button"
+                >
+                  <div className={styles.cardHeading}>
+                    <h3>{record.label}</h3>
+                    <span>{record.cluster}</span>
+                  </div>
+                  <p className={styles.cardSummary}>{record.summary}</p>
+                  <dl className={styles.statGrid}>
+                    <div>
+                      <dt>Rows</dt>
+                      <dd>{record.records.toLocaleString()}</dd>
+                    </div>
+                    <div>
+                      <dt>Delta</dt>
+                      <dd>{record.delta}%</dd>
+                    </div>
+                    <div>
+                      <dt>Trust</dt>
+                      <dd>{record.confidence}%</dd>
+                    </div>
+                  </dl>
+                </button>
+
+                <div className={styles.tagStrip}>
+                  {record.tags.map((tag) => (
+                    <span className={styles.tag} key={tag}>
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/archive-vault` route with feature-local mock data, search, filters, detail state, and two-up comparison summaries
- keep the route UI scoped to `src/app/archive-vault/**` and `src/components/archive-vault/**` with local styling and local test coverage
- restore the minimal root App Router scaffolding (`layout.tsx`, `page.tsx`, `globals.css`) required for this repo's existing CI and `next build` checks to pass

## Validation
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #16