### PR TITLE
Add mission briefing workspace route

### DIFF
--- a/src/app/mission-briefing/layout.tsx
+++ b/src/app/mission-briefing/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+import styles from "./mission-briefing.module.css";
+
+export const metadata: Metadata = {
+  title: "Mission Briefing",
+  description:
+    "Mock scenario planning workspace with timeline phases, readiness indicators, and local decision notes.",
+};
+
+export default function MissionBriefingLayout({
+  children,
+}: Readonly<{
+  children: ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body className={styles.body}>{children}</body>
+    </html>
+  );
+}

--- a/src/app/mission-briefing/layout.tsx
+++ b/src/app/mission-briefing/layout.tsx
@@ -14,9 +14,5 @@ export default function MissionBriefingLayout({
 }: Readonly<{
   children: ReactNode;
 }>) {
-  return (
-    <html lang="en">
-      <body className={styles.body}>{children}</body>
-    </html>
-  );
+  return <div className={styles.body}>{children}</div>;
 }

--- a/src/app/mission-briefing/mission-briefing.module.css
+++ b/src/app/mission-briefing/mission-briefing.module.css
@@ -1,0 +1,49 @@
+.body { margin: 0; background: radial-gradient(circle at top left, rgba(247, 198, 107, 0.25), transparent 26%), radial-gradient(circle at bottom right, rgba(101, 173, 152, 0.2), transparent 30%), linear-gradient(180deg, #091317, #11242c 48%, #122730); color: #edf5ef; font: 16px/1.5 "Avenir Next", "Trebuchet MS", "Segoe UI", sans-serif; }
+.page { min-height: 100vh; max-width: 1380px; margin: 0 auto; padding: 24px; display: grid; gap: 20px; }
+.hero, .workspace, .grid { display: grid; gap: 18px; }
+.hero { grid-template-columns: 1.35fr 0.9fr; }
+.workspace { grid-template-columns: 320px 1fr; align-items: start; }
+.grid { grid-template-columns: 1.05fr 0.95fr; }
+.grid > :last-child { grid-column: 1 / -1; }
+.panel { border: 1px solid rgba(192, 214, 205, 0.14); border-radius: 24px; background: rgba(8, 19, 24, 0.76); box-shadow: 0 20px 44px rgba(0, 0, 0, 0.24); backdrop-filter: blur(16px); padding: 20px; }
+.lead, .stats, .rail, .content, .spotlight, .section { display: grid; gap: 16px; }
+.lead { align-content: start; }
+.eyebrow, .small { margin: 0; color: #9bbab0; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.14em; }
+.title, .cardTitle, .sectionTitle { margin: 0; letter-spacing: -0.04em; }
+.title { font-size: clamp(2.3rem, 5vw, 4rem); line-height: 0.95; }
+.cardTitle { font-size: 1.35rem; }
+.copy, .muted, .empty p, .item p { margin: 0; color: #cfe0d9; }
+.muted, .meta, .empty p { color: #9bbab0; }
+.badges, .filters, .chips, .meta { display: flex; flex-wrap: wrap; gap: 10px; }
+.tag, .status, .chip, .button { border-radius: 999px; font: inherit; }
+.tag, .button { border: 1px solid rgba(190, 210, 202, 0.14); background: rgba(15, 30, 36, 0.86); color: #d9e8e2; padding: 8px 12px; }
+.statsGrid, .list { display: grid; gap: 12px; }
+.metric, .card, .empty { border-radius: 20px; border: 1px solid rgba(190, 210, 202, 0.12); background: rgba(12, 25, 31, 0.92); padding: 16px; }
+.value { font-size: 1.95rem; font-weight: 700; letter-spacing: -0.05em; }
+.label { color: #9bbab0; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.12em; }
+.field { width: 100%; border: 1px solid rgba(190, 210, 202, 0.14); border-radius: 16px; background: rgba(9, 23, 29, 0.92); color: inherit; font: inherit; padding: 12px 14px; }
+.field::placeholder { color: rgba(155, 186, 176, 0.72); }
+.button { cursor: pointer; }
+.button[data-active="true"], .marker[aria-pressed="true"] { border-color: rgba(247, 198, 107, 0.42); background: linear-gradient(180deg, rgba(95, 75, 25, 0.76), rgba(58, 44, 10, 0.74)); }
+.cardButton { width: 100%; border-radius: 20px; border: 1px solid rgba(190, 210, 202, 0.12); background: rgba(12, 25, 31, 0.92); padding: 16px; color: inherit; text-align: left; cursor: pointer; display: grid; gap: 12px; }
+.cardButton[data-active="true"] { border-color: rgba(247, 198, 107, 0.42); background: radial-gradient(circle at top right, rgba(247, 198, 107, 0.14), transparent 32%), rgba(14, 29, 35, 0.96); }
+.head { display: flex; justify-content: space-between; gap: 12px; align-items: flex-start; }
+.status, .chip { display: inline-flex; align-items: center; padding: 6px 10px; font-size: 0.72rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
+.status[data-state="ready"] { background: rgba(50, 141, 108, 0.18); color: #8bd8b6; }
+.status[data-state="watch"] { background: rgba(223, 176, 79, 0.18); color: #efc974; }
+.status[data-state="blocked"] { background: rgba(185, 87, 71, 0.2); color: #ffad9a; }
+.chip[data-severity="low"] { color: #9adabf; background: rgba(40, 116, 82, 0.16); }
+.chip[data-severity="medium"] { color: #efcd88; background: rgba(126, 96, 36, 0.2); }
+.chip[data-severity="high"] { color: #ffb7aa; background: rgba(139, 60, 47, 0.2); }
+.spotlightGrid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+.item { display: grid; gap: 10px; }
+.item strong { color: #f4f8f6; }
+.confidence { height: 10px; border-radius: 999px; background: rgba(190, 210, 202, 0.12); overflow: hidden; }
+.fill { display: block; height: 100%; background: linear-gradient(90deg, #5fa68e, #efc974); }
+.note { min-height: 132px; resize: vertical; }
+.marker { border: 1px solid rgba(190, 210, 202, 0.12); border-radius: 18px; background: rgba(14, 29, 35, 0.86); color: inherit; padding: 12px 14px; text-align: left; cursor: pointer; }
+.marker strong { display: block; margin-bottom: 4px; color: #f4f8f6; }
+.empty { border-style: dashed; }
+.cardButton:focus-visible, .button:focus-visible, .field:focus-visible, .marker:focus-visible { outline: 2px solid #efc974; outline-offset: 3px; }
+@media (max-width: 1080px) { .hero, .workspace, .grid, .spotlightGrid { grid-template-columns: 1fr; } }
+@media (max-width: 720px) { .page { padding: 16px; } .head { flex-direction: column; } .title { font-size: 2.35rem; } }

--- a/src/app/mission-briefing/mission-data.ts
+++ b/src/app/mission-briefing/mission-data.ts
@@ -1,0 +1,100 @@
+export type Severity = "low" | "medium" | "high";
+export type MissionStatus = "ready" | "watch" | "blocked";
+export type MissionRisk = { label: string; severity: Severity };
+export type MissionPhase = { id: string; label: string; window: string; owner: string; objective: string; status: MissionStatus; blockers: MissionRisk[] };
+export type MissionTeam = { id: string; name: string; lead: string; readiness: MissionStatus; confidence: string; focus: string };
+export type MissionDecision = { id: string; label: string; rationale: string };
+export type MissionScenario = {
+  id: string;
+  callsign: string;
+  theater: string;
+  horizon: string;
+  summary: string;
+  lead: string;
+  status: MissionStatus;
+  alert: string;
+  blockers: MissionRisk[];
+  timeline: MissionPhase[];
+  readiness: MissionTeam[];
+  decisions: MissionDecision[];
+};
+
+export const statusLabels: Record<MissionStatus, string> = { ready: "Ready", watch: "Watch", blocked: "Blocked" };
+
+export const missionScenarios: MissionScenario[] = [
+  {
+    id: "northern-line",
+    callsign: "Northern Line",
+    theater: "Arctic relay corridor",
+    horizon: "18h window",
+    summary: "Escort corridor with a weather shelf after phase two.",
+    lead: "S. Flores",
+    status: "ready",
+    alert: "Route holds if the offset refuel plan is approved before convoy merge.",
+    blockers: [{ label: "Fuel variance", severity: "medium" }, { label: "Dock queue", severity: "low" }],
+    timeline: [
+      { id: "nl-1", label: "Recon sweep", window: "18:00", owner: "Signals", objective: "Validate relay health before corridor entry.", status: "ready", blockers: [{ label: "Cloud drift", severity: "low" }] },
+      { id: "nl-2", label: "Convoy merge", window: "18:40", owner: "Ops", objective: "Merge escorts before the shelf compresses.", status: "watch", blockers: [{ label: "Refuel pacing", severity: "medium" }] },
+      { id: "nl-3", label: "Harbor handoff", window: "20:10", owner: "Harbor", objective: "Transfer cargo without blocking berth seven.", status: "ready", blockers: [] },
+    ],
+    readiness: [
+      { id: "nl-r1", name: "Flight wing", lead: "R. Singh", readiness: "ready", confidence: "87%", focus: "Hold escort spacing through the shelf." },
+      { id: "nl-r2", name: "Signals desk", lead: "M. Hart", readiness: "ready", confidence: "81%", focus: "Preserve relay quality in the north band." },
+      { id: "nl-r3", name: "Fuel control", lead: "I. Moreno", readiness: "watch", confidence: "68%", focus: "Trim reserve mismatch before merge." },
+    ],
+    decisions: [
+      { id: "nl-d1", label: "Approve offset tanking", rationale: "Adds reserve margin if weather closes early." },
+      { id: "nl-d2", label: "Hold reserve escort", rationale: "Keeps an extraction option for the final leg." },
+    ],
+  },
+  {
+    id: "harbor-echo",
+    callsign: "Harbor Echo",
+    theater: "Littoral staging arc",
+    horizon: "9h window",
+    summary: "Coastal logistics rehearsal with contested pier access.",
+    lead: "A. Rhee",
+    status: "watch",
+    alert: "Cargo timing is healthy, but pier access stays fragile until the patrol overlap clears.",
+    blockers: [{ label: "Pier access", severity: "high" }, { label: "Drone overlap", severity: "medium" }],
+    timeline: [
+      { id: "he-1", label: "Harbor scan", window: "13:10", owner: "Recon", objective: "Map congestion around delta approach.", status: "watch", blockers: [{ label: "Blind spot", severity: "medium" }] },
+      { id: "he-2", label: "Cargo staging", window: "13:40", owner: "Logistics", objective: "Stage priority pallets by reload order.", status: "ready", blockers: [] },
+      { id: "he-3", label: "Pier insertion", window: "14:20", owner: "Harbor", objective: "Thread the convoy into pier delta.", status: "blocked", blockers: [{ label: "Patrol overlap", severity: "high" }] },
+    ],
+    readiness: [
+      { id: "he-r1", name: "Harbor cell", lead: "L. Zhou", readiness: "blocked", confidence: "41%", focus: "Protect the insertion window at pier delta." },
+      { id: "he-r2", name: "Cargo staging", lead: "F. Clarke", readiness: "ready", confidence: "84%", focus: "Keep pallets aligned with the reroute model." },
+      { id: "he-r3", name: "Counter-drone desk", lead: "N. Kim", readiness: "watch", confidence: "63%", focus: "Track low-altitude interruptions above delta." },
+    ],
+    decisions: [
+      { id: "he-d1", label: "Trigger berth gamma fallback", rationale: "Prevents the drill from slipping into the evening cycle." },
+      { id: "he-d2", label: "Delay pier insertion", rationale: "Trades schedule for a cleaner safety margin." },
+    ],
+  },
+  {
+    id: "polar-relay",
+    callsign: "Polar Relay",
+    theater: "Sub-orbital comms chain",
+    horizon: "27h window",
+    summary: "Relay recovery with a degraded node and a crew rotation gap.",
+    lead: "T. Osei",
+    status: "blocked",
+    alert: "Restoration is paused until node six stabilizes or the crew gap is closed.",
+    blockers: [{ label: "Node six drift", severity: "high" }, { label: "Crew gap", severity: "high" }],
+    timeline: [
+      { id: "pr-1", label: "Node isolation", window: "07:00", owner: "Systems", objective: "Strip node six from the mesh and contain loss.", status: "blocked", blockers: [{ label: "Handshake failures", severity: "high" }] },
+      { id: "pr-2", label: "Cold restart", window: "07:35", owner: "Power", objective: "Attempt a staged restart on drifted hardware.", status: "watch", blockers: [{ label: "Power sag", severity: "medium" }] },
+      { id: "pr-3", label: "Network restore", window: "08:40", owner: "Command net", objective: "Reintroduce node six only after drift falls.", status: "watch", blockers: [{ label: "Tolerance mismatch", severity: "medium" }] },
+    ],
+    readiness: [
+      { id: "pr-r1", name: "Systems recovery", lead: "J. Patel", readiness: "blocked", confidence: "34%", focus: "Keep drift contained while restart is validated." },
+      { id: "pr-r2", name: "Power desk", lead: "C. Nwosu", readiness: "watch", confidence: "55%", focus: "Prevent another sag during the restart cycle." },
+      { id: "pr-r3", name: "Crew rotations", lead: "D. Mercer", readiness: "blocked", confidence: "29%", focus: "Backfill the vacant operator seat quickly." },
+    ],
+    decisions: [
+      { id: "pr-d1", label: "Keep node six isolated", rationale: "Avoids a broader mesh regression." },
+      { id: "pr-d2", label: "Activate reserve controller", rationale: "Closes the rotation gap before the next checkpoint." },
+    ],
+  },
+];

--- a/src/app/mission-briefing/page.tsx
+++ b/src/app/mission-briefing/page.tsx
@@ -1,0 +1,7 @@
+import { MissionBriefingShell } from "@/components/mission-briefing/MissionBriefingShell";
+
+import { missionScenarios } from "./mission-data";
+
+export default function MissionBriefingPage() {
+  return <MissionBriefingShell scenarios={missionScenarios} />;
+}

--- a/src/components/mission-briefing/DecisionDesk.tsx
+++ b/src/components/mission-briefing/DecisionDesk.tsx
@@ -1,0 +1,63 @@
+import styles from "@/app/mission-briefing/mission-briefing.module.css";
+import type { MissionScenario } from "@/app/mission-briefing/mission-data";
+
+export function DecisionDesk({
+  markers,
+  note,
+  onNoteChange,
+  onToggleMarker,
+  scenario,
+}: Readonly<{
+  markers: Record<string, boolean>;
+  note: string;
+  onNoteChange: (nextNote: string) => void;
+  onToggleMarker: (decisionId: string) => void;
+  scenario: MissionScenario | null;
+}>) {
+  const activeCount = scenario
+    ? scenario.decisions.filter((decision) => markers[decision.id]).length
+    : 0;
+
+  return (
+    <section className={`${styles.panel} ${styles.section}`}>
+      <div className={styles.head}>
+        <div>
+          <p className={styles.eyebrow}>Decision Desk</p>
+          <h2 className={styles.sectionTitle}>Local session notes</h2>
+        </div>
+        <span className={styles.tag}>Client state only</span>
+      </div>
+      {!scenario ? (
+        <div className={styles.empty}>
+          <strong>Nothing pinned yet.</strong>
+          <p>Select a scenario card to mark decisions and capture briefing notes.</p>
+        </div>
+      ) : (
+        <>
+          <div className={styles.badges}>
+            <span className={styles.tag}>{activeCount} active marker{activeCount === 1 ? "" : "s"}</span>
+            <span className={styles.tag}>{scenario.horizon}</span>
+          </div>
+          <div className={styles.list}>
+            {scenario.decisions.map((decision) => (
+              <button aria-pressed={Boolean(markers[decision.id])} className={styles.marker} key={decision.id} onClick={() => onToggleMarker(decision.id)} type="button">
+                <strong>{decision.label}</strong>
+                {decision.rationale}
+              </button>
+            ))}
+          </div>
+          <div className={styles.item}>
+            <label className={styles.small} htmlFor="mission-note-field">Decision notes</label>
+            <textarea
+              className={`${styles.field} ${styles.note}`}
+              id="mission-note-field"
+              onChange={(event) => onNoteChange(event.target.value)}
+              placeholder="Capture operator notes, go/no-go language, or next review triggers."
+              value={note}
+            />
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/components/mission-briefing/MissionBriefingShell.test.tsx
+++ b/src/components/mission-briefing/MissionBriefingShell.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { missionScenarios } from "@/app/mission-briefing/mission-data";
+
+import { MissionBriefingShell } from "./MissionBriefingShell";
+
+describe("MissionBriefingShell", () => {
+  it("updates the selected scenario and keeps notes in local state", () => {
+    render(<MissionBriefingShell scenarios={missionScenarios} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /harbor echo/i }));
+    expect(
+      screen.getByText(/Cargo timing is healthy, but pier access stays fragile/i),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/decision notes/i), {
+      target: { value: "Delay insertion until the patrol overlap clears." },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /polar relay/i }));
+    fireEvent.click(screen.getByRole("button", { name: /harbor echo/i }));
+
+    expect(screen.getByLabelText(/decision notes/i)).toHaveValue(
+      "Delay insertion until the patrol overlap clears.",
+    );
+  });
+
+  it("shows empty-state copy for filtered and deselected views", () => {
+    render(<MissionBriefingShell scenarios={missionScenarios} />);
+
+    fireEvent.change(screen.getByLabelText(/search scenarios/i), {
+      target: { value: "zz-no-match" },
+    });
+
+    expect(
+      screen.getByText(/No scenarios match this filter\./i),
+    ).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/search scenarios/i), {
+      target: { value: "" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /clear focus/i }));
+
+    expect(
+      screen.getByText(/Select a scenario card to populate the briefing workspace\./i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/mission-briefing/MissionBriefingShell.tsx
+++ b/src/components/mission-briefing/MissionBriefingShell.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useDeferredValue, useState } from "react";
+
+import styles from "@/app/mission-briefing/mission-briefing.module.css";
+import type { MissionScenario, MissionStatus } from "@/app/mission-briefing/mission-data";
+import { statusLabels } from "@/app/mission-briefing/mission-data";
+
+import { DecisionDesk } from "./DecisionDesk";
+import { MissionTimeline } from "./MissionTimeline";
+import { ReadinessMatrix } from "./ReadinessMatrix";
+import { ScenarioRail } from "./ScenarioRail";
+
+type ScenarioFilter = "all" | MissionStatus;
+
+export function MissionBriefingShell({
+  scenarios,
+}: Readonly<{
+  scenarios: MissionScenario[];
+}>) {
+  const [statusFilter, setStatusFilter] = useState<ScenarioFilter>("all");
+  const [query, setQuery] = useState("");
+  const [selectedScenarioId, setSelectedScenarioId] = useState<string | null>(
+    scenarios[0]?.id ?? null,
+  );
+  const [notesByScenario, setNotesByScenario] = useState<Record<string, string>>({});
+  const [markersByScenario, setMarkersByScenario] = useState<Record<string, Record<string, boolean>>>({});
+  const deferredQuery = useDeferredValue(query.trim().toLowerCase());
+  const visibleScenarios = scenarios.filter((scenario) => {
+    const matchesFilter =
+      statusFilter === "all" ? true : scenario.status === statusFilter;
+    const searchable = `${scenario.callsign} ${scenario.lead} ${scenario.theater}`.toLowerCase();
+    const matchesQuery =
+      deferredQuery.length === 0 ? true : searchable.includes(deferredQuery);
+
+    return matchesFilter && matchesQuery;
+  });
+
+  const selectedScenario =
+    visibleScenarios.find((scenario) => scenario.id === selectedScenarioId) ??
+    null;
+
+  const visibleTeams = visibleScenarios.flatMap((scenario) => scenario.readiness);
+  const visibleRisks = visibleScenarios.flatMap((scenario) => [
+    ...scenario.blockers,
+    ...scenario.timeline.flatMap((phase) => phase.blockers),
+  ]);
+
+  const note = selectedScenario ? notesByScenario[selectedScenario.id] ?? "" : "";
+  const markers = selectedScenario
+    ? markersByScenario[selectedScenario.id] ?? {}
+    : {};
+
+  const clearMessage = visibleScenarios.length === 0
+    ? "No briefing is in focus because the current filter rail is empty."
+    : "Select a scenario card to populate the briefing workspace.";
+
+  return (
+    <main className={styles.page}>
+      <section className={styles.hero}>
+        <section className={`${styles.panel} ${styles.lead}`}>
+          <p className={styles.eyebrow}>Mission Briefing Route</p>
+          <h1 className={styles.title}>Scenario planning under active constraints.</h1>
+          <p className={styles.copy}>This workspace keeps mission cards, phase timing, readiness posture, and notes isolated to a single route and a single client session.</p>
+          <div className={styles.badges}>
+            <span className={styles.tag}>/mission-briefing</span>
+            <span className={styles.tag}>Independent route shell</span>
+            <span className={styles.tag}>Local state only</span>
+          </div>
+        </section>
+
+        <section className={`${styles.panel} ${styles.stats}`}>
+          <p className={styles.eyebrow}>Readiness Snapshot</p>
+          <div className={styles.statsGrid}>
+            <article className={styles.metric}>
+              <span className={styles.value}>{visibleScenarios.length}</span>
+              <span className={styles.label}>Visible scenarios</span>
+            </article>
+            <article className={styles.metric}>
+              <span className={styles.value}>{visibleTeams.filter((team) => team.readiness === "ready").length}</span>
+              <span className={styles.label}>Teams ready</span>
+            </article>
+            <article className={styles.metric}>
+              <span className={styles.value}>{visibleRisks.filter((risk) => risk.severity === "high").length}</span>
+              <span className={styles.label}>High blockers</span>
+            </article>
+          </div>
+        </section>
+      </section>
+
+      <section className={styles.workspace}>
+        <ScenarioRail
+          activeScenarioId={selectedScenarioId}
+          isPending={false}
+          onFilterChange={setStatusFilter}
+          onQueryChange={setQuery}
+          onSelect={setSelectedScenarioId}
+          query={query}
+          scenarios={visibleScenarios}
+          statusFilter={statusFilter}
+        />
+
+        <div className={styles.content}>
+          <section className={`${styles.panel} ${styles.spotlight}`}>
+            {selectedScenario ? (
+              <>
+                <div className={styles.head}>
+                  <div>
+                    <p className={styles.eyebrow}>Focused Briefing</p>
+                    <h2 className={styles.cardTitle}>{selectedScenario.callsign}</h2>
+                  </div>
+                  <div className={styles.badges}>
+                    <span className={styles.status} data-state={selectedScenario.status}>{statusLabels[selectedScenario.status]}</span>
+                    <button className={styles.button} onClick={() => setSelectedScenarioId(null)} type="button">Clear focus</button>
+                  </div>
+                </div>
+                <p className={styles.copy}>{selectedScenario.alert}</p>
+                <div className={styles.meta}>
+                  <span className={styles.tag}>{selectedScenario.theater}</span>
+                  <span className={styles.tag}>{selectedScenario.horizon}</span>
+                  <span className={styles.tag}>{selectedScenario.lead}</span>
+                </div>
+                <div className={styles.spotlightGrid}>
+                  <article className={styles.card}><p className={styles.small}>Mission summary</p><p className={styles.copy}>{selectedScenario.summary}</p></article>
+                  <article className={styles.card}><p className={styles.small}>Open blockers</p><div className={styles.chips}>{selectedScenario.blockers.map((blocker) => <span className={styles.chip} data-severity={blocker.severity} key={blocker.label}>{blocker.label}</span>)}</div></article>
+                </div>
+              </>
+            ) : (
+              <div className={styles.empty}>
+                <strong>Briefing focus cleared.</strong>
+                <p>{clearMessage}</p>
+              </div>
+            )}
+          </section>
+          <div className={styles.grid}>
+            <MissionTimeline scenario={selectedScenario} />
+            <ReadinessMatrix scenario={selectedScenario} />
+            <DecisionDesk
+              markers={markers}
+              note={note}
+              onNoteChange={(nextNote) => selectedScenario && setNotesByScenario((currentNotes) => ({ ...currentNotes, [selectedScenario.id]: nextNote }))}
+              onToggleMarker={(decisionId) => selectedScenario && setMarkersByScenario((currentMarkers) => ({ ...currentMarkers, [selectedScenario.id]: { ...(currentMarkers[selectedScenario.id] ?? {}), [decisionId]: !currentMarkers[selectedScenario.id]?.[decisionId] } }))}
+              scenario={selectedScenario}
+            />
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/mission-briefing/MissionTimeline.tsx
+++ b/src/components/mission-briefing/MissionTimeline.tsx
@@ -1,0 +1,59 @@
+import styles from "@/app/mission-briefing/mission-briefing.module.css";
+import type { MissionScenario } from "@/app/mission-briefing/mission-data";
+import { statusLabels } from "@/app/mission-briefing/mission-data";
+
+export function MissionTimeline({
+  scenario,
+}: Readonly<{
+  scenario: MissionScenario | null;
+}>) {
+  return (
+    <section className={`${styles.panel} ${styles.section}`}>
+      <div className={styles.head}>
+        <div>
+          <p className={styles.eyebrow}>Phase Timeline</p>
+          <h2 className={styles.sectionTitle}>Execution path</h2>
+        </div>
+        {scenario ? <span className={styles.tag}>{scenario.horizon}</span> : null}
+      </div>
+      {!scenario ? (
+        <div className={styles.empty}>
+          <strong>No active mission focus.</strong>
+          <p>Choose a scenario card to inspect phase timing, owners, and blockers.</p>
+        </div>
+      ) : (
+        <div className={styles.list}>
+          {scenario.timeline.map((phase, index) => (
+            <article className={styles.card} key={phase.id}>
+              <div className={styles.head}>
+                <div>
+                  <p className={styles.small}>
+                    {index + 1}. {phase.window} · {phase.owner}
+                  </p>
+                  <div>
+                    <h3 className={styles.cardTitle}>{phase.label}</h3>
+                  </div>
+                </div>
+                <span className={styles.status} data-state={phase.status}>
+                  {statusLabels[phase.status]}
+                </span>
+              </div>
+              <p className={styles.copy}>{phase.objective}</p>
+              <div className={styles.chips}>
+                {phase.blockers.length === 0 ? (
+                  <span className={styles.tag}>No blockers</span>
+                ) : (
+                  phase.blockers.map((blocker) => (
+                    <span className={styles.chip} data-severity={blocker.severity} key={`${phase.id}-${blocker.label}`}>
+                      {blocker.label}
+                    </span>
+                  ))
+                )}
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/mission-briefing/ReadinessMatrix.tsx
+++ b/src/components/mission-briefing/ReadinessMatrix.tsx
@@ -1,0 +1,50 @@
+import styles from "@/app/mission-briefing/mission-briefing.module.css";
+import type { MissionScenario } from "@/app/mission-briefing/mission-data";
+import { statusLabels } from "@/app/mission-briefing/mission-data";
+
+export function ReadinessMatrix({
+  scenario,
+}: Readonly<{
+  scenario: MissionScenario | null;
+}>) {
+  return (
+    <section className={`${styles.panel} ${styles.section}`}>
+      <div className={styles.head}>
+        <div>
+          <p className={styles.eyebrow}>Readiness Matrix</p>
+          <h2 className={styles.sectionTitle}>Team posture</h2>
+        </div>
+        {scenario ? <span className={styles.tag}>{scenario.readiness.filter((team) => team.readiness === "ready").length} ready</span> : null}
+      </div>
+      {!scenario ? (
+        <div className={styles.empty}>
+          <strong>Matrix unavailable.</strong>
+          <p>Team confidence and focus appear after a scenario is selected.</p>
+        </div>
+      ) : (
+        <div className={styles.list}>
+          {scenario.readiness.map((team) => (
+            <article className={styles.card} key={team.id}>
+              <div className={styles.head}>
+                <div>
+                  <p className={styles.small}>{team.lead}</p>
+                  <h3 className={styles.cardTitle}>{team.name}</h3>
+                </div>
+                <span className={styles.status} data-state={team.readiness}>
+                  {statusLabels[team.readiness]}
+                </span>
+              </div>
+              <div className={styles.item}>
+                <span className={styles.tag}>Confidence {team.confidence}</span>
+                <div className={styles.confidence}>
+                  <span className={styles.fill} style={{ width: team.confidence }} />
+                </div>
+              </div>
+              <p className={styles.copy}>{team.focus}</p>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/mission-briefing/ScenarioRail.tsx
+++ b/src/components/mission-briefing/ScenarioRail.tsx
@@ -1,0 +1,107 @@
+import styles from "@/app/mission-briefing/mission-briefing.module.css";
+import type { MissionScenario, MissionStatus } from "@/app/mission-briefing/mission-data";
+import { statusLabels } from "@/app/mission-briefing/mission-data";
+
+type ScenarioFilter = "all" | MissionStatus;
+
+const filterLabels: Record<ScenarioFilter, string> = { all: "All", ready: "Ready", watch: "Watch", blocked: "Blocked" };
+
+export function ScenarioRail({
+  activeScenarioId,
+  isPending,
+  onFilterChange,
+  onQueryChange,
+  onSelect,
+  query,
+  scenarios,
+  statusFilter,
+}: Readonly<{
+  activeScenarioId: string | null;
+  isPending: boolean;
+  onFilterChange: (nextFilter: ScenarioFilter) => void;
+  onQueryChange: (nextQuery: string) => void;
+  onSelect: (scenarioId: string) => void;
+  query: string;
+  scenarios: MissionScenario[];
+  statusFilter: ScenarioFilter;
+}>) {
+  return (
+    <aside className={`${styles.panel} ${styles.rail}`}>
+      <div>
+        <p className={styles.eyebrow}>Scenario Rail</p>
+        <h2 className={styles.sectionTitle}>Mission set</h2>
+        <p className={styles.muted}>Toggle a card to reload the workspace without leaving the route.</p>
+      </div>
+      <div>
+        <label className={styles.small} htmlFor="mission-scenario-search">Search scenarios</label>
+        <input
+          className={styles.field}
+          id="mission-scenario-search"
+          onChange={(event) => onQueryChange(event.target.value)}
+          placeholder="Callsign, lead, or theater"
+          type="search"
+          value={query}
+        />
+      </div>
+
+      <div className={styles.filters}>
+        {Object.entries(filterLabels).map(([key, label]) => (
+          <button
+            className={styles.button}
+            data-active={statusFilter === key}
+            key={key}
+            onClick={() => onFilterChange(key as ScenarioFilter)}
+            type="button"
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {scenarios.length === 0 ? (
+        <div className={styles.empty}>
+          <strong>No scenarios match this filter.</strong>
+          <p>Clear the search or widen the readiness filter to restore the rail.</p>
+        </div>
+      ) : (
+        <div className={styles.list}>
+          {scenarios.map((scenario) => (
+            <button
+              className={styles.cardButton}
+              data-active={activeScenarioId === scenario.id}
+              key={scenario.id}
+              onClick={() => onSelect(scenario.id)}
+              type="button"
+            >
+              <div className={styles.head}>
+                <div>
+                  <p className={styles.small}>{scenario.theater}</p>
+                  <h3 className={styles.cardTitle}>{scenario.callsign}</h3>
+                </div>
+                <span className={styles.status} data-state={scenario.status}>
+                  {statusLabels[scenario.status]}
+                </span>
+              </div>
+              <p className={styles.copy}>{scenario.summary}</p>
+              <div className={styles.badges}>
+                <span className={styles.tag}>{scenario.horizon}</span>
+                <span className={styles.tag}>{scenario.lead}</span>
+              </div>
+              <div className={styles.chips}>
+                {scenario.blockers.map((blocker) => (
+                  <span className={styles.chip} data-severity={blocker.severity} key={blocker.label}>
+                    {blocker.label}
+                  </span>
+                ))}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+      <div className={styles.badges}>
+        <span className={styles.tag}>{scenarios.length} visible</span>
+        {isPending ? <span className={styles.tag}>Syncing focus</span> : null}
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/mission-briefing` App Router root with feature-local mock data and styling
- build a client-side scenario workspace with rail selection, timeline, readiness matrix, and decision notes
- cover client filtering and note persistence with a focused feature test

Closes #17