### PR TITLE
feat: add isolated scenario board route

### DIFF
--- a/src/app/scenario-board/page.tsx
+++ b/src/app/scenario-board/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+import { ScenarioBoardShell } from "@/components/scenario-board/scenario-board-shell";
+
+export const metadata: Metadata = {
+  title: "Scenario Board",
+  description:
+    "Mock scenario-planning board with local playbooks, assumptions, and outcome matrix state.",
+};
+
+export default function ScenarioBoardPage() {
+  return <ScenarioBoardShell />;
+}

--- a/src/app/scenario-board/scenario-board-data.ts
+++ b/src/app/scenario-board/scenario-board-data.ts
@@ -1,0 +1,283 @@
+export type ScenarioMode = "Containment" | "Exploration";
+export type PlaybookLane = "stabilize" | "hedge" | "accelerate";
+export type PlaybookLaneFilter = PlaybookLane | "all";
+export type MatrixFilter = "all" | "downside";
+
+export type ScenarioMetric = { label: string; value: string };
+export type Playbook = {
+  id: string;
+  title: string;
+  summary: string;
+  lead: string;
+  lane: PlaybookLane;
+  readiness: string;
+  timeToImpact: string;
+  assumptionIds: string[];
+  modes: ScenarioMode[];
+};
+export type Assumption = {
+  id: string;
+  label: string;
+  note: string;
+  state: "confirmed" | "watch" | "strained";
+  owner: string;
+};
+export type Outcome = {
+  id: string;
+  title: string;
+  detail: string;
+  likelihood: "likely" | "unlikely";
+  direction: "upside" | "downside";
+  score: number;
+  owner: string;
+  assumptionIds: string[];
+  playbookIds: string[];
+  modes: ScenarioMode[];
+};
+export type ActionPrompt = {
+  id: string;
+  playbookId: string;
+  label: string;
+  detail: string;
+};
+
+export const scenarioModes: ScenarioMode[] = ["Containment", "Exploration"];
+export const laneFilters: { id: PlaybookLaneFilter; label: string }[] = [
+  { id: "all", label: "All lanes" },
+  { id: "stabilize", label: "Stabilize" },
+  { id: "hedge", label: "Hedge" },
+  { id: "accelerate", label: "Accelerate" },
+];
+
+export const activeScenario = {
+  title: "Harbor Shift 6",
+  brief:
+    "Port demand is rebounding before labor buffers reset, so the board is modeling how fast to protect premium freight without burning next-week capacity.",
+  window: "72-hour decision window",
+  decision: "Decision lock at 18:00 UTC",
+  modeBadges: {
+    Containment: "Risk lock",
+    Exploration: "Expansion sweep",
+  } satisfies Record<ScenarioMode, string>,
+  metrics: [
+    { label: "Demand pulse", value: "+18% inbound" },
+    { label: "Crew slack", value: "2 reserve teams" },
+    { label: "Overflow risk", value: "7.4 / 10" },
+  ] satisfies ScenarioMetric[],
+};
+
+export const playbooks: Playbook[] = [
+  {
+    id: "berth-buffer",
+    title: "Berth Buffer",
+    summary: "Reserve two swing berths for delayed priority loads and rebalance the yard only at shift handoff.",
+    lead: "Terminal Ops",
+    lane: "stabilize",
+    readiness: "Ready in 20 min",
+    timeToImpact: "Stabilizes tonight",
+    assumptionIds: ["dock-window", "rail-cutoff"],
+    modes: ["Containment", "Exploration"],
+  },
+  {
+    id: "vendor-surge",
+    title: "Vendor Surge",
+    summary: "Activate contracted handlers for two high-friction docks while core crews protect reefer throughput.",
+    lead: "Labor Desk",
+    lane: "hedge",
+    readiness: "Pending vendor hold",
+    timeToImpact: "Unlocks by dawn",
+    assumptionIds: ["labor-pool", "fuel-flat"],
+    modes: ["Containment"],
+  },
+  {
+    id: "night-rail-pivot",
+    title: "Night Rail Pivot",
+    summary: "Hold outbound rail cuts until the midnight sweep and convert missed windows into a single managed release.",
+    lead: "Rail Coordination",
+    lane: "stabilize",
+    readiness: "Ready in 1 hr",
+    timeToImpact: "Reduces misses tomorrow",
+    assumptionIds: ["rail-cutoff", "dock-window"],
+    modes: ["Containment"],
+  },
+  {
+    id: "priority-reroute",
+    title: "Priority Reroute",
+    summary: "Move premium loads to the east basin, accept longer drayage, and sell speed as the recovery promise.",
+    lead: "Commercial Desk",
+    lane: "accelerate",
+    readiness: "Ready in 35 min",
+    timeToImpact: "Improves margin this cycle",
+    assumptionIds: ["east-basin", "fuel-flat"],
+    modes: ["Exploration"],
+  },
+  {
+    id: "partner-lift",
+    title: "Partner Lift",
+    summary: "Share overflow with a partner terminal for one rotation to test whether premium demand remains sticky.",
+    lead: "Network Planning",
+    lane: "hedge",
+    readiness: "Draft agreement live",
+    timeToImpact: "Signals within 24 hr",
+    assumptionIds: ["east-basin", "labor-pool"],
+    modes: ["Exploration"],
+  },
+];
+
+export const assumptions: Assumption[] = [
+  {
+    id: "dock-window",
+    label: "Carriers accept a single widened dock window.",
+    note: "Breaks if queue times exceed 85 minutes.",
+    state: "confirmed",
+    owner: "Port Liaison",
+  },
+  {
+    id: "rail-cutoff",
+    label: "Rail cutoff can slide one cycle without tariff penalties.",
+    note: "Requires a joint sign-off before midnight.",
+    state: "watch",
+    owner: "Intermodal Lead",
+  },
+  {
+    id: "fuel-flat",
+    label: "Fuel surcharge remains flat through the next dispatch wave.",
+    note: "A surcharge spike erodes the reroute case first.",
+    state: "confirmed",
+    owner: "Finance Watch",
+  },
+  {
+    id: "labor-pool",
+    label: "Contract handlers can clear badging by first light.",
+    note: "Any delay shifts pressure back onto reefer crews.",
+    state: "strained",
+    owner: "Labor Desk",
+  },
+  {
+    id: "east-basin",
+    label: "East basin keeps one overflow gate open for premium freight.",
+    note: "Gate loss would collapse both exploration plays.",
+    state: "watch",
+    owner: "Gate Control",
+  },
+];
+
+export const outcomes: Outcome[] = [
+  {
+    id: "margin-recovery",
+    title: "Premium margin recovers before labor cost catches up.",
+    detail: "Commercial upside lands if premium loads convert faster than drayage cost expands.",
+    likelihood: "likely",
+    direction: "upside",
+    score: 7,
+    owner: "Commercial Desk",
+    assumptionIds: ["fuel-flat", "east-basin"],
+    playbookIds: ["priority-reroute", "partner-lift"],
+    modes: ["Exploration"],
+  },
+  {
+    id: "reefer-stability",
+    title: "Reefer queue remains flat through the overnight peak.",
+    detail: "The board protects cold-chain volume by concentrating resets at shift handoff only.",
+    likelihood: "likely",
+    direction: "upside",
+    score: 6,
+    owner: "Terminal Ops",
+    assumptionIds: ["dock-window", "rail-cutoff"],
+    playbookIds: ["berth-buffer", "night-rail-pivot"],
+    modes: ["Containment"],
+  },
+  {
+    id: "partner-stickiness",
+    title: "Overflow customers accept a partner terminal for one full cycle.",
+    detail: "A positive read keeps demand optionality open beyond the 72-hour board window.",
+    likelihood: "unlikely",
+    direction: "upside",
+    score: 5,
+    owner: "Network Planning",
+    assumptionIds: ["east-basin", "labor-pool"],
+    playbookIds: ["partner-lift"],
+    modes: ["Exploration"],
+  },
+  {
+    id: "tariff-hit",
+    title: "Late rail release triggers an avoidable tariff hit.",
+    detail: "Containment looks weaker if the midnight waiver slips or dispatch misses the manual hold.",
+    likelihood: "likely",
+    direction: "downside",
+    score: 8,
+    owner: "Intermodal Lead",
+    assumptionIds: ["rail-cutoff"],
+    playbookIds: ["night-rail-pivot"],
+    modes: ["Containment"],
+  },
+  {
+    id: "crew-burn",
+    title: "Overflow handling burns reserve crews before the weekend reset.",
+    detail: "Labor strain compounds if vendor onboarding drifts or the queue spills back to core teams.",
+    likelihood: "likely",
+    direction: "downside",
+    score: 9,
+    owner: "Labor Desk",
+    assumptionIds: ["labor-pool"],
+    playbookIds: ["vendor-surge", "partner-lift"],
+    modes: ["Containment", "Exploration"],
+  },
+  {
+    id: "gate-loss",
+    title: "East basin closes the overflow gate after the first reroute wave.",
+    detail: "Exploration upside disappears and premium freight re-enters the same contested queue.",
+    likelihood: "unlikely",
+    direction: "downside",
+    score: 8,
+    owner: "Gate Control",
+    assumptionIds: ["east-basin"],
+    playbookIds: ["priority-reroute", "partner-lift"],
+    modes: ["Exploration"],
+  },
+];
+
+export const actionPrompts: ActionPrompt[] = [
+  {
+    id: "berth-buffer-1",
+    playbookId: "berth-buffer",
+    label: "Freeze the two swing berths and publish the cutoff before shift handoff.",
+    detail: "This keeps the containment move simple enough for one dispatcher to run.",
+  },
+  {
+    id: "berth-buffer-2",
+    playbookId: "berth-buffer",
+    label: "Pair each protected berth with one manual exception path.",
+    detail: "That prevents premium loads from bypassing the reefer queue without accountability.",
+  },
+  {
+    id: "vendor-surge-1",
+    playbookId: "vendor-surge",
+    label: "Request the vendor surge only for docks 4 and 7.",
+    detail: "A narrow activation limits fatigue if the contract labor assumption breaks.",
+  },
+  {
+    id: "night-rail-pivot-1",
+    playbookId: "night-rail-pivot",
+    label: "Draft the waiver note and release plan in one message.",
+    detail: "The board wants the midnight hold to be reversible, not a hidden default.",
+  },
+  {
+    id: "priority-reroute-1",
+    playbookId: "priority-reroute",
+    label: "Draft carrier comms with a two-window premium promise.",
+    detail: "The commercial story needs to justify the added drayage before the first reroute leaves.",
+  },
+  {
+    id: "priority-reroute-2",
+    playbookId: "priority-reroute",
+    label: "Reserve one east basin gate marshal for the opening hour.",
+    detail: "The margin case collapses if premium trucks wait like standard overflow.",
+  },
+  {
+    id: "partner-lift-1",
+    playbookId: "partner-lift",
+    label: "Offer the partner terminal a one-rotation volume cap.",
+    detail: "It tests customer stickiness without turning the partner route into a standing dependency.",
+  },
+];

--- a/src/components/scenario-board/assumptions-panel.tsx
+++ b/src/components/scenario-board/assumptions-panel.tsx
@@ -1,0 +1,75 @@
+import type { Assumption, Playbook } from "@/app/scenario-board/scenario-board-data";
+
+type AssumptionsPanelProps = {
+  activeIds: string[];
+  assumptions: Assumption[];
+  onClear: () => void;
+  onReset: () => void;
+  onToggle: (assumptionId: string) => void;
+  selectedPlaybook: Playbook | null;
+};
+
+const stateTone: Record<Assumption["state"], string> = {
+  confirmed: "bg-emerald-400/15 text-emerald-100",
+  watch: "bg-amber-300/15 text-amber-100",
+  strained: "bg-rose-400/15 text-rose-100",
+};
+
+export function AssumptionsPanel({
+  activeIds,
+  assumptions,
+  onClear,
+  onReset,
+  onToggle,
+  selectedPlaybook,
+}: AssumptionsPanelProps) {
+  return (
+    <section className="space-y-5 rounded-[2rem] border border-white/10 bg-stone-950/60 p-5 shadow-[0_24px_80px_rgba(0,0,0,0.28)] backdrop-blur sm:p-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-stone-400">Assumptions</p>
+          <h2 className="mt-2 text-2xl font-semibold text-stone-50">Toggle the active premise set.</h2>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button className="rounded-full bg-white/5 px-4 py-2 text-sm text-stone-300 transition hover:bg-white/10" onClick={onClear} type="button">
+            Clear assumptions
+          </button>
+          <button className="rounded-full bg-stone-100 px-4 py-2 text-sm text-stone-950 transition hover:bg-white" onClick={onReset} type="button">
+            Reset all
+          </button>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        {assumptions.map((assumption) => {
+          const isActive = activeIds.includes(assumption.id);
+          const isUsedBySelection = selectedPlaybook?.assumptionIds.includes(assumption.id) ?? false;
+
+          return (
+            <button
+              aria-pressed={isActive}
+              className={`w-full rounded-[1.35rem] border p-4 text-left transition ${
+                isActive ? "border-sky-300/30 bg-sky-400/10" : "border-white/10 bg-white/[0.03] hover:bg-white/[0.06]"
+              }`}
+              key={assumption.id}
+              onClick={() => onToggle(assumption.id)}
+              type="button"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <span className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] ${stateTone[assumption.state]}`}>
+                  {assumption.state}
+                </span>
+                {isUsedBySelection ? (
+                  <span className="text-xs uppercase tracking-[0.2em] text-amber-200">Used by selected playbook</span>
+                ) : null}
+              </div>
+              <h3 className="mt-3 text-sm font-semibold text-stone-50">{assumption.label}</h3>
+              <p className="mt-2 text-sm leading-6 text-stone-300">{assumption.note}</p>
+              <p className="mt-3 text-xs uppercase tracking-[0.18em] text-stone-400">{assumption.owner}</p>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/scenario-board/outcome-matrix.tsx
+++ b/src/components/scenario-board/outcome-matrix.tsx
@@ -1,0 +1,93 @@
+import type { MatrixFilter, Outcome } from "@/app/scenario-board/scenario-board-data";
+
+type OutcomeMatrixProps = {
+  assumptionsActive: number;
+  filter: MatrixFilter;
+  onFilterChange: (filter: MatrixFilter) => void;
+  outcomes: Outcome[];
+};
+
+const quadrants = [
+  { direction: "downside", likelihood: "likely", title: "Likely downside", tone: "border-rose-300/20 bg-rose-400/10" },
+  { direction: "upside", likelihood: "likely", title: "Likely upside", tone: "border-emerald-300/20 bg-emerald-400/10" },
+  { direction: "downside", likelihood: "unlikely", title: "Unlikely downside", tone: "border-amber-300/20 bg-amber-400/10" },
+  { direction: "upside", likelihood: "unlikely", title: "Unlikely upside", tone: "border-sky-300/20 bg-sky-400/10" },
+] as const;
+
+export function OutcomeMatrix({
+  assumptionsActive,
+  filter,
+  onFilterChange,
+  outcomes,
+}: OutcomeMatrixProps) {
+  return (
+    <section aria-label="Outcome matrix" className="space-y-5 rounded-[2rem] border border-white/10 bg-stone-950/60 p-5 shadow-[0_24px_80px_rgba(0,0,0,0.28)] backdrop-blur sm:p-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-stone-400">Outcome matrix</p>
+          <h2 className="mt-2 text-2xl font-semibold text-stone-50">Model likely and edge-case board outcomes.</h2>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {(["all", "downside"] as MatrixFilter[]).map((option) => (
+            <button
+              aria-pressed={filter === option}
+              className={`rounded-full px-4 py-2 text-sm transition ${
+                filter === option ? "bg-stone-100 text-stone-950" : "bg-white/5 text-stone-300 hover:bg-white/10"
+              }`}
+              key={option}
+              onClick={() => onFilterChange(option)}
+              type="button"
+            >
+              {option === "all" ? "All paths" : "Downside only"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {outcomes.length > 0 ? (
+        <div className="grid gap-4 md:grid-cols-2">
+          {quadrants.map((quadrant) => {
+            const quadrantOutcomes = outcomes.filter(
+              (outcome) => outcome.direction === quadrant.direction && outcome.likelihood === quadrant.likelihood,
+            );
+
+            return (
+              <div className={`rounded-[1.5rem] border p-5 ${quadrant.tone}`} key={quadrant.title}>
+                <div className="flex items-center justify-between gap-3">
+                  <h3 className="text-lg font-semibold text-stone-50">{quadrant.title}</h3>
+                  <span className="rounded-full bg-black/20 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-200">
+                    {quadrantOutcomes.length}
+                  </span>
+                </div>
+                {quadrantOutcomes.length > 0 ? (
+                  <div className="mt-4 space-y-3">
+                    {quadrantOutcomes.map((outcome) => (
+                      <article className="rounded-2xl border border-black/10 bg-black/20 p-4" key={outcome.id}>
+                        <div className="flex items-center justify-between gap-3">
+                          <h4 className="text-sm font-semibold text-stone-50">{outcome.title}</h4>
+                          <span className="text-xs uppercase tracking-[0.2em] text-stone-300">Score {outcome.score}</span>
+                        </div>
+                        <p className="mt-2 text-sm leading-6 text-stone-300">{outcome.detail}</p>
+                        <p className="mt-3 text-xs uppercase tracking-[0.18em] text-stone-400">{outcome.owner}</p>
+                      </article>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="mt-4 text-sm leading-6 text-stone-300">No outcomes land in this quadrant under the current board filter.</p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="rounded-[1.5rem] border border-dashed border-white/15 bg-white/5 p-8 text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-stone-400">Matrix empty</p>
+          <h3 className="mt-3 text-2xl font-semibold text-stone-50">
+            {assumptionsActive === 0 ? "Re-enable at least one assumption to rebuild the matrix." : "No outcomes match the current board filters."}
+          </h3>
+          <p className="mt-3 text-sm leading-6 text-stone-300">The route keeps this state local, so clearing assumptions or narrowing the matrix only affects this board.</p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/scenario-board/playbook-rail.tsx
+++ b/src/components/scenario-board/playbook-rail.tsx
@@ -1,0 +1,120 @@
+import type { ActionPrompt, Playbook, PlaybookLaneFilter } from "@/app/scenario-board/scenario-board-data";
+
+type PlaybookRailProps = {
+  filters: { count: number; id: PlaybookLaneFilter; label: string }[];
+  modeLabel: string;
+  onLaneChange: (lane: PlaybookLaneFilter) => void;
+  onSelectPlaybook: (playbookId: string) => void;
+  prompts: ActionPrompt[];
+  selectedLane: PlaybookLaneFilter;
+  selectedPlaybook: Playbook | null;
+  selectedPlaybookId: string | null;
+  playbooks: Playbook[];
+};
+
+const laneTone: Record<Playbook["lane"], string> = {
+  stabilize: "bg-emerald-400/15 text-emerald-100",
+  hedge: "bg-amber-300/15 text-amber-100",
+  accelerate: "bg-sky-400/15 text-sky-100",
+};
+
+export function PlaybookRail({
+  filters,
+  modeLabel,
+  onLaneChange,
+  onSelectPlaybook,
+  prompts,
+  selectedLane,
+  selectedPlaybook,
+  selectedPlaybookId,
+  playbooks,
+}: PlaybookRailProps) {
+  return (
+    <section className="space-y-5 rounded-[2rem] border border-white/10 bg-stone-950/60 p-5 shadow-[0_24px_80px_rgba(0,0,0,0.28)] backdrop-blur sm:p-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-stone-400">Playbooks</p>
+          <h2 className="mt-2 text-2xl font-semibold text-stone-50">Plan lanes with local selection state.</h2>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {filters.map((filter) => (
+            <button
+              aria-pressed={selectedLane === filter.id}
+              className={`rounded-full px-4 py-2 text-sm transition ${
+                selectedLane === filter.id ? "bg-stone-100 text-stone-950" : "bg-white/5 text-stone-300 hover:bg-white/10"
+              }`}
+              key={filter.id}
+              onClick={() => onLaneChange(filter.id)}
+              type="button"
+            >
+              {filter.label} <span className="text-xs opacity-70">{filter.count}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {playbooks.length > 0 ? (
+        <div className="grid gap-5 xl:grid-cols-[minmax(0,1.15fr)_minmax(280px,0.85fr)]">
+          <div className="grid gap-4 md:grid-cols-2">
+            {playbooks.map((playbook) => (
+              <button
+                aria-label={`Open playbook: ${playbook.title}`}
+                aria-pressed={playbook.id === selectedPlaybookId}
+                className={`rounded-[1.5rem] border p-5 text-left transition ${
+                  playbook.id === selectedPlaybookId
+                    ? "border-amber-300/50 bg-amber-300/10 shadow-[0_20px_60px_rgba(251,191,36,0.12)]"
+                    : "border-white/8 bg-white/[0.03] hover:border-white/15 hover:bg-white/[0.06]"
+                }`}
+                key={playbook.id}
+                onClick={() => onSelectPlaybook(playbook.id)}
+                type="button"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <span className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] ${laneTone[playbook.lane]}`}>
+                    {playbook.lane}
+                  </span>
+                  <span className="text-xs uppercase tracking-[0.2em] text-stone-400">{playbook.readiness}</span>
+                </div>
+                <h3 className="mt-4 text-xl font-semibold text-stone-50">{playbook.title}</h3>
+                <p className="mt-3 text-sm leading-6 text-stone-300">{playbook.summary}</p>
+                <div className="mt-4 flex flex-wrap gap-3 text-sm text-stone-300">
+                  <span>{playbook.lead}</span>
+                  <span>{playbook.timeToImpact}</span>
+                </div>
+              </button>
+            ))}
+          </div>
+
+          <aside className="rounded-[1.5rem] border border-white/10 bg-black/20 p-5" aria-label="Selected playbook prompts">
+            {selectedPlaybook ? (
+              <>
+                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-amber-200/80">Action prompts</p>
+                <h3 className="mt-3 text-2xl font-semibold text-stone-50">{selectedPlaybook.title}</h3>
+                <p className="mt-3 text-sm leading-6 text-stone-300">{selectedPlaybook.summary}</p>
+                <div className="mt-5 space-y-3">
+                  {prompts.map((prompt) => (
+                    <div className="rounded-2xl border border-white/10 bg-white/5 p-4" key={prompt.id}>
+                      <p className="text-sm font-medium text-stone-100">{prompt.label}</p>
+                      <p className="mt-2 text-sm leading-6 text-stone-400">{prompt.detail}</p>
+                    </div>
+                  ))}
+                </div>
+              </>
+            ) : (
+              <div className="rounded-[1.25rem] border border-dashed border-white/15 bg-white/5 p-5 text-center">
+                <p className="text-sm font-semibold uppercase tracking-[0.24em] text-stone-400">No playbook selected</p>
+                <p className="mt-3 text-sm leading-6 text-stone-300">Choose a visible playbook to inspect its action prompts.</p>
+              </div>
+            )}
+          </aside>
+        </div>
+      ) : (
+        <div className="rounded-[1.5rem] border border-dashed border-white/15 bg-white/5 p-8 text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-stone-400">No matching playbooks</p>
+          <h3 className="mt-3 text-2xl font-semibold text-stone-50">No {modeLabel.toLowerCase()} lane matches the current filter.</h3>
+          <p className="mt-3 text-sm leading-6 text-stone-300">Switch the lane or mode to repopulate this isolated board.</p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/scenario-board/scenario-board-header.tsx
+++ b/src/components/scenario-board/scenario-board-header.tsx
@@ -1,0 +1,78 @@
+import { activeScenario, scenarioModes, type ScenarioMode } from "@/app/scenario-board/scenario-board-data";
+
+type ScenarioBoardHeaderProps = {
+  activeAssumptionCount: number;
+  mode: ScenarioMode;
+  outcomeCount: number;
+  playbookCount: number;
+  onModeChange: (mode: ScenarioMode) => void;
+};
+
+export function ScenarioBoardHeader({
+  activeAssumptionCount,
+  mode,
+  outcomeCount,
+  playbookCount,
+  onModeChange,
+}: ScenarioBoardHeaderProps) {
+  return (
+    <section className="overflow-hidden rounded-[2rem] border border-amber-200/15 bg-stone-950/70 p-6 shadow-[0_28px_90px_rgba(0,0,0,0.35)] backdrop-blur sm:p-8">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1.15fr)_minmax(300px,0.85fr)]">
+        <div className="space-y-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-amber-300/80">Scenario board</p>
+          <div className="flex flex-wrap items-center gap-3">
+            <h1 className="text-4xl font-semibold tracking-tight text-stone-50 sm:text-5xl">{activeScenario.title}</h1>
+            <span className="rounded-full border border-amber-300/25 bg-amber-400/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.28em] text-amber-200">
+              {activeScenario.modeBadges[mode]}
+            </span>
+          </div>
+          <p className="max-w-3xl text-sm leading-7 text-stone-300 sm:text-base">{activeScenario.brief}</p>
+          <div className="flex flex-wrap gap-3 text-sm text-stone-300">
+            <span className="rounded-full bg-white/5 px-3 py-1.5">{activeScenario.window}</span>
+            <span className="rounded-full bg-white/5 px-3 py-1.5">{activeScenario.decision}</span>
+          </div>
+        </div>
+
+        <div className="space-y-4 rounded-[1.5rem] border border-white/10 bg-white/5 p-5">
+          <div className="flex flex-wrap gap-2">
+            {scenarioModes.map((option) => (
+              <button
+                aria-pressed={option === mode}
+                className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                  option === mode ? "bg-amber-300 text-stone-950" : "bg-white/5 text-stone-200 hover:bg-white/10"
+                }`}
+                key={option}
+                onClick={() => onModeChange(option)}
+                type="button"
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+          <div className="grid gap-3 sm:grid-cols-3">
+            {activeScenario.metrics.map((metric) => (
+              <div className="rounded-2xl bg-black/20 p-4" key={metric.label}>
+                <p className="text-xs uppercase tracking-[0.24em] text-stone-400">{metric.label}</p>
+                <p className="mt-2 text-lg font-semibold text-stone-50">{metric.value}</p>
+              </div>
+            ))}
+          </div>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div className="rounded-2xl border border-emerald-400/20 bg-emerald-400/10 p-4">
+              <p className="text-xs uppercase tracking-[0.24em] text-emerald-200/80">Visible playbooks</p>
+              <p className="mt-2 text-2xl font-semibold text-emerald-100">{playbookCount}</p>
+            </div>
+            <div className="rounded-2xl border border-sky-400/20 bg-sky-400/10 p-4">
+              <p className="text-xs uppercase tracking-[0.24em] text-sky-200/80">Active assumptions</p>
+              <p className="mt-2 text-2xl font-semibold text-sky-100">{activeAssumptionCount}</p>
+            </div>
+            <div className="rounded-2xl border border-rose-400/20 bg-rose-400/10 p-4">
+              <p className="text-xs uppercase tracking-[0.24em] text-rose-200/80">Matrix outcomes</p>
+              <p className="mt-2 text-2xl font-semibold text-rose-100">{outcomeCount}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/scenario-board/scenario-board-shell.test.tsx
+++ b/src/components/scenario-board/scenario-board-shell.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ScenarioBoardShell } from "./scenario-board-shell";
+
+describe("ScenarioBoardShell", () => {
+  it("swaps the selected playbook prompts when the mode changes", () => {
+    render(<ScenarioBoardShell />);
+
+    fireEvent.click(screen.getByText("Exploration"));
+    fireEvent.click(screen.getByText("Priority Reroute"));
+
+    const promptPanel = screen.getByLabelText("Selected playbook prompts");
+
+    expect(
+      within(promptPanel).getByText("Draft carrier comms with a two-window premium promise."),
+    ).toBeInTheDocument();
+    expect(
+      within(promptPanel).getByText("Reserve one east basin gate marshal for the opening hour."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the matrix empty state when every assumption is cleared", () => {
+    render(<ScenarioBoardShell />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear assumptions" }));
+
+    expect(
+      screen.getByText("Re-enable at least one assumption to rebuild the matrix."),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/scenario-board/scenario-board-shell.tsx
+++ b/src/components/scenario-board/scenario-board-shell.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { startTransition, useState } from "react";
+
+import {
+  actionPrompts,
+  activeScenario,
+  assumptions,
+  laneFilters,
+  outcomes,
+  playbooks,
+  type MatrixFilter,
+  type PlaybookLaneFilter,
+  type ScenarioMode,
+} from "@/app/scenario-board/scenario-board-data";
+import { AssumptionsPanel } from "./assumptions-panel";
+import { OutcomeMatrix } from "./outcome-matrix";
+import { PlaybookRail } from "./playbook-rail";
+import { ScenarioBoardHeader } from "./scenario-board-header";
+
+function toggleId(items: string[], id: string) {
+  return items.includes(id) ? items.filter((item) => item !== id) : [...items, id];
+}
+
+export function ScenarioBoardShell() {
+  const [mode, setMode] = useState<ScenarioMode>("Containment");
+  const [selectedLane, setSelectedLane] = useState<PlaybookLaneFilter>("all");
+  const [selectedPlaybookId, setSelectedPlaybookId] = useState<string | null>(playbooks[0]?.id ?? null);
+  const [activeAssumptionIds, setActiveAssumptionIds] = useState<string[]>(assumptions.map((assumption) => assumption.id));
+  const [matrixFilter, setMatrixFilter] = useState<MatrixFilter>("all");
+
+  const visiblePlaybooks = playbooks.filter(
+    (playbook) => playbook.modes.includes(mode) && (selectedLane === "all" || playbook.lane === selectedLane),
+  );
+  const selectedPlaybook =
+    visiblePlaybooks.find((playbook) => playbook.id === selectedPlaybookId) ?? visiblePlaybooks[0] ?? null;
+  const visibleOutcomes = outcomes.filter((outcome) => {
+    if (!outcome.modes.includes(mode) || (matrixFilter === "downside" && outcome.direction !== "downside")) return false;
+    return activeAssumptionIds.length > 0 && outcome.assumptionIds.some((id) => activeAssumptionIds.includes(id));
+  });
+  const visiblePrompts = selectedPlaybook
+    ? actionPrompts.filter((prompt) => prompt.playbookId === selectedPlaybook.id)
+    : [];
+  const filterCounts = laneFilters.map((filter) => ({
+    ...filter,
+    count: playbooks.filter(
+      (playbook) => playbook.modes.includes(mode) && (filter.id === "all" || playbook.lane === filter.id),
+    ).length,
+  }));
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(251,191,36,0.18),_transparent_36%),linear-gradient(180deg,_#2a160d_0%,_#140d09_46%,_#070707_100%)] px-4 py-6 text-stone-100 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <ScenarioBoardHeader
+          activeAssumptionCount={activeAssumptionIds.length}
+          mode={mode}
+          outcomeCount={visibleOutcomes.length}
+          onModeChange={(nextMode) => startTransition(() => setMode(nextMode))}
+          playbookCount={visiblePlaybooks.length}
+        />
+
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
+          <div className="space-y-6">
+            <PlaybookRail
+              filters={filterCounts}
+              modeLabel={activeScenario.modeBadges[mode]}
+              onLaneChange={(lane) => startTransition(() => setSelectedLane(lane))}
+              onSelectPlaybook={(playbookId) => startTransition(() => setSelectedPlaybookId(playbookId))}
+              playbooks={visiblePlaybooks}
+              prompts={visiblePrompts}
+              selectedLane={selectedLane}
+              selectedPlaybook={selectedPlaybook}
+              selectedPlaybookId={selectedPlaybook?.id ?? null}
+            />
+            <OutcomeMatrix
+              assumptionsActive={activeAssumptionIds.length}
+              filter={matrixFilter}
+              onFilterChange={(nextFilter) => startTransition(() => setMatrixFilter(nextFilter))}
+              outcomes={visibleOutcomes}
+            />
+          </div>
+
+          <AssumptionsPanel
+            activeIds={activeAssumptionIds}
+            assumptions={assumptions}
+            onClear={() => startTransition(() => setActiveAssumptionIds([]))}
+            onReset={() => startTransition(() => setActiveAssumptionIds(assumptions.map((assumption) => assumption.id)))}
+            onToggle={(assumptionId) =>
+              startTransition(() => setActiveAssumptionIds((items) => toggleId(items, assumptionId)))
+            }
+            selectedPlaybook={selectedPlaybook}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/scenario-board` route with a local scenario header, mode badge, lane-filtered playbooks, action prompts, and an outcome matrix
- keep all mock data and client state inside the scenario-board feature folders, including empty-state handling for cleared assumptions and unmatched playbook filters
- add focused tests for playbook selection and the matrix empty state

## Testing
- npm run typecheck
- npm run lint -- src/app/scenario-board src/components/scenario-board
- npm test -- src/components/scenario-board/scenario-board-shell.test.tsx
- npm run build

Closes #29