### PR TITLE
feat: add parcel hub dashboard route

### DIFF
--- a/src/app/parcel-hub/page.tsx
+++ b/src/app/parcel-hub/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import { ParcelHubShell } from "@/components/parcel-hub/parcel-hub-shell";
+
+export const metadata: Metadata = {
+  title: "Parcel Hub | API Test",
+  description: "Mock parcel operations route with lane summaries and local exception handling.",
+};
+
+export default function ParcelHubPage() {
+  return <ParcelHubShell />;
+}

--- a/src/components/parcel-hub/exception-drawer.tsx
+++ b/src/components/parcel-hub/exception-drawer.tsx
@@ -1,0 +1,117 @@
+import type { LaneException, ShipmentLane } from "./parcel-hub-data";
+
+export type DrawerScope = "open" | "resolved" | "all";
+
+type ExceptionDrawerProps = {
+  exceptions: LaneException[]; onClearSelection: () => void; onScopeChange: (scope: DrawerScope) => void;
+  onToggleResolved: (exceptionId: string) => void; resolvedIds: Record<string, boolean>; scope: DrawerScope; selectedLane: ShipmentLane | null;
+};
+
+const severityClasses = {
+  high: "border-rose-300/20 bg-rose-400/10 text-rose-100",
+  medium: "border-amber-300/20 bg-amber-300/10 text-amber-100",
+  low: "border-sky-300/20 bg-sky-300/10 text-sky-100",
+};
+
+export function ExceptionDrawer({
+  exceptions,
+  onClearSelection,
+  onScopeChange,
+  onToggleResolved,
+  resolvedIds,
+  scope,
+  selectedLane,
+}: ExceptionDrawerProps) {
+  const scopedExceptions = exceptions.filter((exception) => {
+    const isResolved = Boolean(resolvedIds[exception.id]);
+    if (scope === "open") return !isResolved;
+    if (scope === "resolved") return isResolved;
+    return true;
+  });
+
+  return (
+    <aside
+      aria-label="Exception drawer"
+      className="rounded-[2rem] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.92),rgba(2,6,23,0.96))] p-5 shadow-[0_22px_80px_rgba(0,0,0,0.42)] sm:p-6"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Exception drawer</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">{selectedLane ? selectedLane.laneCode : "Choose a lane"}</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-300">
+            {selectedLane
+              ? `${selectedLane.origin} to ${selectedLane.destination} with ${selectedLane.departureWindow} dispatch window.`
+              : "Select a lane card to inspect active exceptions or verify that a clear lane has nothing parked."}
+          </p>
+        </div>
+        {selectedLane ? (
+          <button className="rounded-full border border-white/12 bg-white/5 px-3 py-2 text-sm text-slate-200 transition hover:bg-white/10" onClick={onClearSelection} type="button">Close</button>
+        ) : null}
+      </div>
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        {(["open", "resolved", "all"] as DrawerScope[]).map((nextScope) => (
+          <button
+            className={`rounded-full px-3 py-2 text-sm transition ${
+              nextScope === scope
+                ? "bg-white text-slate-950"
+                : "border border-white/12 bg-white/5 text-slate-200 hover:bg-white/10"
+            }`}
+            key={nextScope}
+            onClick={() => onScopeChange(nextScope)}
+            type="button"
+          >
+            {nextScope === "open" ? "Open" : nextScope === "resolved" ? "Resolved" : "All"}
+          </button>
+        ))}
+      </div>
+
+      {!selectedLane ? (
+        <div className="mt-5 rounded-[1.75rem] border border-dashed border-white/12 bg-white/[0.03] p-6 text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-400">Waiting on selection</p>
+          <p className="mt-3 text-sm leading-6 text-slate-300">The drawer stays local to this route. Pick any lane to review exception details or confirm that a steady lane is clear.</p>
+        </div>
+      ) : scopedExceptions.length > 0 ? (
+        <div className="mt-5 space-y-3">
+          {scopedExceptions.map((exception) => {
+            const isResolved = Boolean(resolvedIds[exception.id]);
+
+            return (
+              <article className="rounded-[1.5rem] border border-white/10 bg-white/5 p-4" key={exception.id}>
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className={`rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-[0.2em] ${severityClasses[exception.severity]}`}>{exception.severity}</span>
+                  <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-300">{exception.type}</span>
+                  <span className="text-xs uppercase tracking-[0.2em] text-slate-500">{exception.updatedAt}</span>
+                </div>
+                <h3 className="mt-3 text-lg font-semibold text-white">{exception.title}</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-300">{exception.detail}</p>
+                <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+                  <p className="text-sm text-slate-300">{exception.owner}</p>
+                  <button
+                    className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                      isResolved ? "border border-emerald-300/25 bg-emerald-300/10 text-emerald-100 hover:bg-emerald-300/15" : "bg-amber-300 text-slate-950 hover:bg-amber-200"
+                    }`}
+                    onClick={() => onToggleResolved(exception.id)}
+                    type="button"
+                  >
+                    {isResolved ? "Reopen marker" : "Mark resolved"}
+                  </button>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="mt-5 rounded-[1.75rem] border border-dashed border-white/12 bg-white/[0.03] p-6 text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-400">Zero state</p>
+          <h3 className="mt-3 text-xl font-semibold text-white">{exceptions.length === 0 ? "This lane has no parked exceptions." : "No items match the current drawer view."}</h3>
+          <p className="mt-3 text-sm leading-6 text-slate-300">
+            {exceptions.length === 0
+              ? "The lane is clear right now. Switch to a different lane if you want to inspect active holds."
+              : "Try the open or all tabs to bring unresolved items back into view."}
+          </p>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/components/parcel-hub/lane-board.tsx
+++ b/src/components/parcel-hub/lane-board.tsx
@@ -1,0 +1,95 @@
+import type { ShipmentLane } from "./parcel-hub-data";
+
+type LaneBoardProps = { lanes: ShipmentLane[]; resolvedIds: Record<string, boolean>; selectedLaneId: string | null; onInspectLane: (laneId: string) => void };
+
+const laneToneClasses = {
+  steady: "border-emerald-300/25 bg-emerald-300/10 text-emerald-100",
+  watch: "border-amber-300/25 bg-amber-300/10 text-amber-100",
+  exception: "border-rose-300/25 bg-rose-300/10 text-rose-100",
+};
+
+const groupStatusClasses: Record<string, string> = {
+  "Address hold": "bg-amber-200/15 text-amber-100",
+  Buffered: "bg-sky-200/15 text-sky-100",
+  "Hold scan": "bg-rose-200/15 text-rose-100",
+  Loaded: "bg-emerald-200/15 text-emerald-100",
+  Ready: "bg-slate-200/15 text-slate-100",
+  Reweigh: "bg-orange-200/15 text-orange-100",
+  "Split sort": "bg-fuchsia-200/15 text-fuchsia-100",
+  "Weather hold": "bg-cyan-200/15 text-cyan-100",
+};
+
+export function LaneBoard({
+  lanes,
+  resolvedIds,
+  selectedLaneId,
+  onInspectLane,
+}: LaneBoardProps) {
+  if (lanes.length === 0) {
+    return (
+      <section className="rounded-[2rem] border border-dashed border-white/15 bg-slate-950/55 p-8 text-center text-slate-200">
+        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">No lanes</p>
+        <h2 className="mt-3 text-2xl font-semibold text-white">The current lane filter has nothing staged.</h2>
+        <p className="mt-3 text-sm leading-6 text-slate-300">Switch back to all lanes to reopen the board and inspect route-level exceptions.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-4">
+      {lanes.map((lane) => {
+        const unresolvedCount = lane.exceptionIds.filter((id) => !resolvedIds[id]).length;
+        const resolvedCount = lane.exceptionIds.filter((id) => resolvedIds[id]).length;
+        const isSelected = lane.id === selectedLaneId;
+
+        return (
+          <article
+            className={`rounded-[2rem] border p-5 shadow-[0_20px_80px_rgba(15,23,42,0.32)] transition sm:p-6 ${
+              isSelected
+                ? "border-amber-300/50 bg-slate-900/95"
+                : "border-white/10 bg-slate-950/72"
+            }`}
+            key={lane.id}
+          >
+            <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+              <div className="space-y-3">
+                <div className="flex flex-wrap gap-3">
+                  <span className={`rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-[0.22em] ${laneToneClasses[lane.tone]}`}>{lane.statusLabel}</span>
+                  <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.22em] text-slate-300">{lane.departureWindow}</span>
+                </div>
+                <div><h2 className="text-2xl font-semibold text-white">{lane.laneCode}</h2><p className="mt-1 text-sm text-slate-300">{lane.origin} to {lane.destination}</p></div>
+                <div className="flex flex-wrap gap-4 text-sm text-slate-300">
+                  <span>{lane.checkpoint}</span>
+                  <span>{lane.trailerFill}</span>
+                  <span>{lane.delayedParcels} parcels delayed</span>
+                </div>
+              </div>
+              <div className="flex flex-col gap-3 sm:min-w-52">
+                <div className="rounded-3xl border border-white/10 bg-white/5 p-4">
+                  <p className="text-xs uppercase tracking-[0.24em] text-slate-400">Exception queue</p>
+                  <p className="mt-2 text-2xl font-semibold text-white">{unresolvedCount}</p>
+                  <p className="mt-1 text-sm text-slate-300">{resolvedCount} resolved markers</p>
+                </div>
+                <button className="rounded-full bg-amber-300 px-4 py-2.5 text-sm font-semibold text-slate-950 transition hover:bg-amber-200" onClick={() => onInspectLane(lane.id)} type="button">
+                  {lane.exceptionIds.length > 0 ? "Open exception drawer" : "Review lane status"}
+                </button>
+              </div>
+            </div>
+            <div className="mt-5 grid gap-3 sm:grid-cols-3">
+              {lane.parcelGroups.map((group) => (
+                <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-4" key={group.id}>
+                  <p className="text-sm font-medium text-white">{group.label}</p>
+                  <div className="mt-3 flex items-end justify-between gap-3">
+                    <p className="text-2xl font-semibold text-slate-100">{group.count}</p>
+                    <span className={`rounded-full px-3 py-1 text-xs font-medium ${groupStatusClasses[group.statusLabel] ?? "bg-white/10 text-slate-100"}`}>{group.statusLabel}</span>
+                  </div>
+                  <p className="mt-2 text-xs uppercase tracking-[0.22em] text-slate-400">{group.zone}</p>
+                </div>
+              ))}
+            </div>
+          </article>
+        );
+      })}
+    </section>
+  );
+}

--- a/src/components/parcel-hub/lane-filter-bar.tsx
+++ b/src/components/parcel-hub/lane-filter-bar.tsx
@@ -1,0 +1,40 @@
+export type LaneFilter = "all" | "watch" | "steady";
+
+type LaneFilterBarProps = {
+  activeFilter: LaneFilter;
+  counts: Record<LaneFilter, number>;
+  onChange: (filter: LaneFilter) => void;
+};
+
+const filterLabels: Record<LaneFilter, string> = {
+  all: "All lanes",
+  watch: "Delay watch",
+  steady: "Clear lanes",
+};
+
+export function LaneFilterBar({
+  activeFilter,
+  counts,
+  onChange,
+}: LaneFilterBarProps) {
+  return (
+    <div className="rounded-[1.75rem] border border-white/10 bg-slate-950/70 p-4 shadow-[0_18px_60px_rgba(15,23,42,0.32)] backdrop-blur">
+      <div className="flex flex-wrap gap-3">
+        {(["all", "watch", "steady"] as LaneFilter[]).map((filter) => (
+          <button
+            className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+              filter === activeFilter
+                ? "bg-amber-300 text-slate-950"
+                : "border border-white/12 bg-white/5 text-slate-200 hover:border-amber-200/40 hover:bg-white/10"
+            }`}
+            key={filter}
+            onClick={() => onChange(filter)}
+            type="button"
+          >
+            {filterLabels[filter]} <span className="text-xs opacity-70">({counts[filter]})</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/parcel-hub/parcel-hub-data.ts
+++ b/src/components/parcel-hub/parcel-hub-data.ts
@@ -1,0 +1,104 @@
+export type ShipmentLaneTone = "steady" | "watch" | "exception";
+export type ParcelGroup = { id: string; label: string; count: number; statusLabel: string; zone: string };
+export type ShipmentLane = {
+  id: string; laneCode: string; origin: string; destination: string; departureWindow: string;
+  checkpoint: string; delayedParcels: number; trailerFill: string; tone: ShipmentLaneTone;
+  statusLabel: string; parcelGroups: ParcelGroup[]; exceptionIds: string[];
+};
+export type LaneException = {
+  id: string; laneId: string; type: string; title: string; detail: string;
+  severity: "high" | "medium" | "low"; owner: string; updatedAt: string;
+};
+export type PackageSummary = { id: string; label: string; count: number; share: string; note: string };
+
+export const parcelHubSyncLabel = "Dispatch sync 06:15 local";
+
+export const exceptionTypes = [
+  "Sort gap",
+  "Address hold",
+  "Trailer reweigh",
+  "Weather spillover",
+];
+
+export const packageSummaries: PackageSummary[] = [
+  { id: "priority", label: "Priority cartons", count: 684, share: "38%", note: "Most exposed to re-scan misses." },
+  { id: "satchels", label: "Metro satchels", count: 512, share: "28%", note: "Balanced across relays and hub transfers." },
+  { id: "returns", label: "Returns mesh", count: 291, share: "16%", note: "Backhaul volume is mostly clear." },
+  { id: "oversize", label: "Oversize pallets", count: 316, share: "18%", note: "Reweigh checks keep two lanes in watch." },
+];
+
+export const shipmentLanes: ShipmentLane[] = [
+  {
+    id: "den-chi", laneCode: "DEN -> CHI", origin: "Denver Hub", destination: "Chicago Sort",
+    departureWindow: "05:55-06:25", checkpoint: "Dock 4 closes in 18 min", delayedParcels: 148,
+    trailerFill: "84% trailer fill", tone: "watch", statusLabel: "Delay watch", exceptionIds: ["lane-ex-1", "lane-ex-2"],
+    parcelGroups: [
+      { id: "den-1", label: "Priority cartons", count: 128, statusLabel: "Hold scan", zone: "North belt" },
+      { id: "den-2", label: "Returns mesh", count: 42, statusLabel: "Ready", zone: "Backhaul" },
+      { id: "den-3", label: "Oversize pallets", count: 34, statusLabel: "Reweigh", zone: "Lift zone" },
+    ],
+  },
+  {
+    id: "phx-dfw", laneCode: "PHX -> DFW", origin: "Phoenix Hub", destination: "Dallas Relay",
+    departureWindow: "06:20-06:55", checkpoint: "Gate 2 staging complete", delayedParcels: 96,
+    trailerFill: "79% trailer fill", tone: "exception", statusLabel: "Exception focus", exceptionIds: ["lane-ex-3", "lane-ex-4"],
+    parcelGroups: [
+      { id: "phx-1", label: "Metro satchels", count: 164, statusLabel: "Split sort", zone: "South spur" },
+      { id: "phx-2", label: "Priority cartons", count: 73, statusLabel: "Address hold", zone: "Exception cage" },
+      { id: "phx-3", label: "Oversize pallets", count: 22, statusLabel: "Loaded", zone: "Lift zone" },
+    ],
+  },
+  {
+    id: "sea-sac", laneCode: "SEA -> SAC", origin: "Seattle Node", destination: "Sacramento Crossdock",
+    departureWindow: "06:45-07:10", checkpoint: "Weather pad in review", delayedParcels: 61,
+    trailerFill: "67% trailer fill", tone: "watch", statusLabel: "Pad extended", exceptionIds: ["lane-ex-5"],
+    parcelGroups: [
+      { id: "sea-1", label: "Metro satchels", count: 121, statusLabel: "Buffered", zone: "West mezzanine" },
+      { id: "sea-2", label: "Returns mesh", count: 38, statusLabel: "Ready", zone: "Backhaul" },
+      { id: "sea-3", label: "Priority cartons", count: 47, statusLabel: "Weather hold", zone: "Outbound belt" },
+    ],
+  },
+  {
+    id: "mia-atl", laneCode: "MIA -> ATL", origin: "Miami Spur", destination: "Atlanta Hub",
+    departureWindow: "07:05-07:35", checkpoint: "Seal check passed", delayedParcels: 0,
+    trailerFill: "91% trailer fill", tone: "steady", statusLabel: "Clear lane", exceptionIds: [],
+    parcelGroups: [
+      { id: "mia-1", label: "Priority cartons", count: 102, statusLabel: "Loaded", zone: "East dock" },
+      { id: "mia-2", label: "Metro satchels", count: 87, statusLabel: "Loaded", zone: "East dock" },
+      { id: "mia-3", label: "Returns mesh", count: 29, statusLabel: "Ready", zone: "Backhaul" },
+    ],
+  },
+];
+
+export const laneExceptions: LaneException[] = [
+  {
+    id: "lane-ex-1", laneId: "den-chi", type: "Sort gap",
+    title: "Inbound cage 4 missed the final consolidation sweep",
+    detail: "Forty-two priority cartons remained in the recycle buffer after the presort handoff.",
+    severity: "high", owner: "North dock lead", updatedAt: "11m ago",
+  },
+  {
+    id: "lane-ex-2", laneId: "den-chi", type: "Trailer reweigh",
+    title: "Oversize pallet pair needs a second axle balance check",
+    detail: "The lift zone flagged pallet spacing after the first trailer weight capture came in above plan.",
+    severity: "medium", owner: "Lift zone team", updatedAt: "6m ago",
+  },
+  {
+    id: "lane-ex-3", laneId: "phx-dfw", type: "Address hold",
+    title: "Seven satchels are parked for suite validation before release",
+    detail: "The route can still make cutoff, but local validation needs to clear before final manifest close.",
+    severity: "medium", owner: "Address desk", updatedAt: "4m ago",
+  },
+  {
+    id: "lane-ex-4", laneId: "phx-dfw", type: "Sort gap",
+    title: "South spur scanner drifted during metro bundle induction",
+    detail: "A temporary manual tally is active while the lane keeps the remaining satchel batch staged nearby.",
+    severity: "high", owner: "Automation specialist", updatedAt: "2m ago",
+  },
+  {
+    id: "lane-ex-5", laneId: "sea-sac", type: "Weather spillover",
+    title: "Pad release is waiting on the marine-layer visibility check",
+    detail: "The lane is still viable, but dispatch widened the departure window to absorb apron traffic and moisture checks.",
+    severity: "low", owner: "Dispatch desk", updatedAt: "8m ago",
+  },
+];

--- a/src/components/parcel-hub/parcel-hub-header.tsx
+++ b/src/components/parcel-hub/parcel-hub-header.tsx
@@ -1,0 +1,40 @@
+type ParcelHubHeaderProps = { delayedParcels: number; openExceptions: number; resolvedExceptions: number; syncLabel: string; totalLanes: number; watchLanes: number };
+
+export function ParcelHubHeader({
+  delayedParcels,
+  openExceptions,
+  resolvedExceptions,
+  syncLabel,
+  totalLanes,
+  watchLanes,
+}: ParcelHubHeaderProps) {
+  return (
+    <header className="rounded-[2rem] border border-white/10 bg-[linear-gradient(135deg,rgba(15,23,42,0.96),rgba(24,24,27,0.88))] p-6 shadow-[0_28px_100px_rgba(0,0,0,0.42)] sm:p-8">
+      <div className="flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
+        <div className="max-w-3xl">
+          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-amber-300">Parcel Hub</p>
+          <h1 className="mt-4 text-4xl font-semibold tracking-tight text-white sm:text-5xl">Lane health, grouped parcels, and exception handling in one isolated route.</h1>
+          <p className="mt-4 text-sm leading-6 text-slate-300 sm:text-base">
+            Review outbound lanes, spot delay concentration by parcel group, and mark exception work as resolved without touching shared app state.
+          </p>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 xl:w-[23rem]">
+          <div className="rounded-3xl border border-amber-300/20 bg-amber-300/10 p-4 text-amber-50">
+            <p className="text-sm text-amber-100/80">Active lanes</p>
+            <p className="mt-2 text-3xl font-semibold">{totalLanes}</p>
+            <p className="mt-1 text-sm text-amber-100/80">{watchLanes} in delay watch</p>
+          </div>
+          <div className="rounded-3xl border border-rose-300/20 bg-rose-300/10 p-4 text-rose-50">
+            <p className="text-sm text-rose-100/80">Delayed parcels</p>
+            <p className="mt-2 text-3xl font-semibold">{delayedParcels}</p>
+            <p className="mt-1 text-sm text-rose-100/80">{openExceptions} open exceptions</p>
+          </div>
+          <div className="rounded-3xl border border-emerald-300/20 bg-emerald-300/10 p-4 text-emerald-50 sm:col-span-2">
+            <p className="text-sm text-emerald-100/80">Resolution markers</p>
+            <div className="mt-2 flex flex-wrap items-end justify-between gap-3"><p className="text-2xl font-semibold">{resolvedExceptions} resolved locally</p><p className="text-sm text-emerald-100/80">{syncLabel}</p></div>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/parcel-hub/parcel-hub-shell.tsx
+++ b/src/components/parcel-hub/parcel-hub-shell.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { startTransition, useState } from "react";
+
+import { ExceptionDrawer, type DrawerScope } from "./exception-drawer";
+import { LaneBoard } from "./lane-board";
+import { LaneFilterBar, type LaneFilter } from "./lane-filter-bar";
+import {
+  exceptionTypes,
+  laneExceptions,
+  packageSummaries,
+  parcelHubSyncLabel,
+  shipmentLanes,
+  type ShipmentLane,
+} from "./parcel-hub-data";
+import { ParcelHubHeader } from "./parcel-hub-header";
+import { ParcelSummaryPanel } from "./parcel-summary-panel";
+
+function matchesLaneFilter(lane: ShipmentLane, filter: LaneFilter) {
+  if (filter === "watch") {
+    return lane.tone !== "steady";
+  }
+
+  if (filter === "steady") {
+    return lane.tone === "steady";
+  }
+
+  return true;
+}
+
+export function ParcelHubShell() {
+  const [laneFilter, setLaneFilter] = useState<LaneFilter>("all");
+  const [selectedLaneId, setSelectedLaneId] = useState<string | null>(null);
+  const [drawerScope, setDrawerScope] = useState<DrawerScope>("open");
+  const [resolvedIds, setResolvedIds] = useState<Record<string, boolean>>({});
+
+  const filteredLanes = shipmentLanes.filter((lane) => matchesLaneFilter(lane, laneFilter));
+  const selectedLane = shipmentLanes.find((lane) => lane.id === selectedLaneId) ?? null;
+  const selectedLaneExceptions = laneExceptions.filter((exception) => exception.laneId === selectedLaneId);
+  const totalParcels = packageSummaries.reduce((sum, summary) => sum + summary.count, 0);
+  const delayedParcels = shipmentLanes.reduce((sum, lane) => sum + lane.delayedParcels, 0);
+  const openExceptions = laneExceptions.filter((exception) => !resolvedIds[exception.id]).length;
+  const resolvedExceptions = laneExceptions.filter((exception) => resolvedIds[exception.id]).length;
+  const laneCounts = {
+    all: shipmentLanes.length,
+    watch: shipmentLanes.filter((lane) => matchesLaneFilter(lane, "watch")).length,
+    steady: shipmentLanes.filter((lane) => matchesLaneFilter(lane, "steady")).length,
+  };
+
+  const handleLaneFilterChange = (filter: LaneFilter) => {
+    startTransition(() => {
+      setLaneFilter(filter);
+
+      if (selectedLane && !matchesLaneFilter(selectedLane, filter)) {
+        setSelectedLaneId(null);
+      }
+    });
+  };
+
+  const handleInspectLane = (laneId: string) => {
+    startTransition(() => {
+      setSelectedLaneId(laneId);
+      setDrawerScope("open");
+    });
+  };
+
+  const handleToggleResolved = (exceptionId: string) => {
+    startTransition(() => {
+      setResolvedIds((current) => ({ ...current, [exceptionId]: !current[exceptionId] }));
+    });
+  };
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(251,191,36,0.15),transparent_34%),linear-gradient(180deg,#020617_0%,#0f172a_58%,#111827_100%)] px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <ParcelHubHeader
+          delayedParcels={delayedParcels}
+          openExceptions={openExceptions}
+          resolvedExceptions={resolvedExceptions}
+          syncLabel={parcelHubSyncLabel}
+          totalLanes={shipmentLanes.length}
+          watchLanes={laneCounts.watch}
+        />
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(22rem,0.95fr)]">
+          <section className="space-y-5">
+            <LaneFilterBar activeFilter={laneFilter} counts={laneCounts} onChange={handleLaneFilterChange} />
+            <LaneBoard lanes={filteredLanes} onInspectLane={handleInspectLane} resolvedIds={resolvedIds} selectedLaneId={selectedLaneId} />
+          </section>
+          <div className="space-y-6">
+            <ParcelSummaryPanel exceptionTypes={exceptionTypes} openExceptions={openExceptions} packageSummaries={packageSummaries} totalParcels={totalParcels} />
+            <ExceptionDrawer
+              exceptions={selectedLaneExceptions}
+              onClearSelection={() => setSelectedLaneId(null)}
+              onScopeChange={(scope) => setDrawerScope(scope)}
+              onToggleResolved={handleToggleResolved}
+              resolvedIds={resolvedIds}
+              scope={drawerScope}
+              selectedLane={selectedLane}
+            />
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/parcel-hub/parcel-summary-panel.tsx
+++ b/src/components/parcel-hub/parcel-summary-panel.tsx
@@ -1,0 +1,38 @@
+import type { PackageSummary } from "./parcel-hub-data";
+
+type ParcelSummaryPanelProps = { exceptionTypes: string[]; openExceptions: number; packageSummaries: PackageSummary[]; totalParcels: number };
+
+export function ParcelSummaryPanel({
+  exceptionTypes,
+  openExceptions,
+  packageSummaries,
+  totalParcels,
+}: ParcelSummaryPanelProps) {
+  return (
+    <section className="rounded-[2rem] border border-white/10 bg-slate-950/72 p-5 shadow-[0_18px_60px_rgba(15,23,42,0.32)] sm:p-6">
+      <div className="flex items-end justify-between gap-4">
+        <div><p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Parcel mix</p><h2 className="mt-2 text-2xl font-semibold text-white">Grouped volume summary</h2></div>
+        <div className="text-right"><p className="text-3xl font-semibold text-white">{totalParcels}</p><p className="text-sm text-slate-300">parcels staged</p></div>
+      </div>
+      <div className="mt-5 space-y-3">
+        {packageSummaries.map((summary) => (
+          <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-4" key={summary.id}>
+            <div className="flex items-start justify-between gap-3">
+              <div><p className="font-medium text-white">{summary.label}</p><p className="mt-1 text-sm text-slate-300">{summary.note}</p></div>
+              <div className="text-right"><p className="text-xl font-semibold text-white">{summary.count}</p><p className="text-xs uppercase tracking-[0.22em] text-slate-400">{summary.share}</p></div>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="mt-5 rounded-[1.5rem] border border-white/10 bg-white/5 p-4">
+        <p className="text-sm font-medium text-white">Exception types in rotation</p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {exceptionTypes.map((type) => (
+            <span className="rounded-full border border-white/10 bg-slate-900 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-300" key={type}>{type}</span>
+          ))}
+        </div>
+        <p className="mt-3 text-sm text-slate-300">{openExceptions} unresolved items remain in this local mock queue.</p>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary\n- add an isolated \/parcel-hub route with local mock shipment, parcel, and exception data\n- render lane health summaries, parcel group cards, lane filters, and a local exception drawer with resolution toggles\n- keep the feature fully scoped to src/app/parcel-hub and src/components/parcel-hub\n\nCloses #34\n\n## Verification\n- npm run lint -- src/app/parcel-hub src/components/parcel-hub\n- npm run typecheck\n- npm test\n- npm run build