### PR TITLE
feat: add isolated audit trail route

### DIFF
--- a/src/app/audit-trail/mock-data.ts
+++ b/src/app/audit-trail/mock-data.ts
@@ -1,0 +1,89 @@
+export type ReviewState =
+  | "pending"
+  | "approved"
+  | "watch"
+  | "changes-requested";
+
+export type CategoryTag = {
+  id: string;
+  label: string;
+};
+
+export type ReviewFlag = {
+  id: string;
+  label: string;
+  description: string;
+  tone: "amber" | "rose" | "sky" | "emerald";
+};
+
+export type Reviewer = {
+  id: string;
+  name: string;
+  initials: string;
+};
+
+export type ChangeRecord = {
+  id: string;
+  title: string;
+  service: string;
+  categoryId: string;
+  reviewState: ReviewState;
+  actor: string;
+  changedAt: string;
+  diffLabel: string;
+  summary: string;
+  reviewerIds: string[];
+  suggestedFlagIds: string[];
+};
+
+export const categoryTags: CategoryTag[] = [
+  { id: "access", label: "Access" }, { id: "schema", label: "Schema" }, { id: "policy", label: "Policy" },
+  { id: "integrity", label: "Integrity" }, { id: "workflow", label: "Workflow" },
+];
+
+export const reviewFlags: ReviewFlag[] = [
+  { id: "signoff", label: "Missing sign-off", description: "Split ownership or incomplete reviewer confirmation.", tone: "rose" },
+  { id: "timing", label: "Timing window", description: "Expiry dates and rollout windows deserve a second pass.", tone: "amber" },
+  { id: "blast-radius", label: "Blast radius", description: "Downstream consumers will feel the change immediately.", tone: "sky" },
+  { id: "manual", label: "Manual follow-up", description: "Backfills or operator notes still need local tracking.", tone: "emerald" },
+];
+
+export const reviewers: Reviewer[] = [
+  { id: "lara", name: "Lara Moon", initials: "LM" }, { id: "jon", name: "Jon Park", initials: "JP" },
+  { id: "mira", name: "Mira Sol", initials: "MS" }, { id: "ezra", name: "Ezra Lane", initials: "EL" },
+  { id: "talia", name: "Talia Reed", initials: "TR" },
+];
+
+export const changeRecords: ChangeRecord[] = [
+  {
+    id: "access-window", title: "Rotate partner upload tokens with reviewer note capture", service: "Gateway",
+    categoryId: "access", reviewState: "pending", actor: "A. Patel", changedAt: "Apr 18, 22:10 UTC",
+    diffLabel: "5 files • 61 lines", summary: "Partner upload grants now expire sooner and record a reviewer note whenever a shared token is refreshed.",
+    reviewerIds: ["lara", "jon", "mira"], suggestedFlagIds: ["signoff", "timing"],
+  }, {
+    id: "webhook-retry-ledger", title: "Record webhook retry reason in settlement audit feed", service: "Events",
+    categoryId: "integrity", reviewState: "approved", actor: "D. Alvarez", changedAt: "Apr 18, 19:40 UTC",
+    diffLabel: "4 files • 38 lines", summary: "Settlement retries now carry a reason code so ledger operators can trace a replay without reopening raw payload history.",
+    reviewerIds: ["ezra", "talia"], suggestedFlagIds: ["blast-radius"],
+  }, {
+    id: "payout-export-schema", title: "Tighten dispute export schema for payout reversals", service: "Payouts",
+    categoryId: "schema", reviewState: "changes-requested", actor: "N. Brooks", changedAt: "Apr 18, 17:05 UTC",
+    diffLabel: "6 files • 74 lines", summary: "The export draft removes nullable reversal fields, but review notes still call out one downstream CSV mapper that expects the older shape.",
+    reviewerIds: ["talia", "mira", "ezra"], suggestedFlagIds: ["blast-radius", "manual"],
+  }, {
+    id: "manual-credit-backfill", title: "Backfill actor trace for manual credit adjustments", service: "Ledger",
+    categoryId: "integrity", reviewState: "approved", actor: "K. Imani", changedAt: "Apr 18, 14:20 UTC",
+    diffLabel: "3 files • 29 lines", summary: "Manual credit adjustments now stamp the acting reviewer into the change ledger before a backfill is released to support tooling.",
+    reviewerIds: ["ezra", "jon"], suggestedFlagIds: ["manual"],
+  }, {
+    id: "sandbox-waiver", title: "Gate sandbox replay endpoint behind waiver review", service: "Sandbox",
+    categoryId: "policy", reviewState: "pending", actor: "R. Chen", changedAt: "Apr 18, 12:55 UTC",
+    diffLabel: "5 files • 47 lines", summary: "Replay access now requires a waiver reference before operators can reopen a sandbox stream from the audit console.",
+    reviewerIds: ["mira", "lara"], suggestedFlagIds: ["signoff", "manual"],
+  }, {
+    id: "reviewer-dedupe", title: "Collapse duplicate reviewer assignments in the queue handoff", service: "Review Queue",
+    categoryId: "workflow", reviewState: "watch", actor: "S. Wells", changedAt: "Apr 18, 10:30 UTC",
+    diffLabel: "4 files • 33 lines", summary: "Queue handoff rules now collapse repeated reviewer assignments so the same owner is not re-added during intake and escalation.",
+    reviewerIds: ["jon", "talia"], suggestedFlagIds: ["timing"],
+  },
+];

--- a/src/app/audit-trail/page.tsx
+++ b/src/app/audit-trail/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+import { AuditTrailShell } from "@/components/audit-trail/audit-trail-shell";
+
+export const metadata: Metadata = {
+  title: "Audit Trail | API Test",
+  description:
+    "Mock audit ledger with local review filters, reviewer badges, and session-only flags.",
+};
+
+export default function AuditTrailPage() {
+  return <AuditTrailShell />;
+}

--- a/src/components/audit-trail/audit-trail-filters.tsx
+++ b/src/components/audit-trail/audit-trail-filters.tsx
@@ -1,0 +1,78 @@
+type AuditTrailFiltersProps = {
+  visibleCount: number;
+  totalCount: number;
+  selectedCategory: string;
+  selectedReviewState: string;
+  categoryCounts: Record<string, number>;
+  reviewCounts: Record<string, number>;
+  onCategoryChange: (value: string) => void;
+  onReviewStateChange: (value: string) => void;
+  categories: ReadonlyArray<{ id: string; label: string }>;
+  reviewTabs: ReadonlyArray<{ id: string; label: string }>;
+};
+
+export function AuditTrailFilters({
+  visibleCount,
+  totalCount,
+  selectedCategory,
+  selectedReviewState,
+  categoryCounts,
+  reviewCounts,
+  onCategoryChange,
+  onReviewStateChange,
+  categories,
+  reviewTabs,
+}: AuditTrailFiltersProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-slate-200/70 bg-white/85 p-5 shadow-lg shadow-slate-200/50 backdrop-blur">
+      <div className="flex flex-col gap-5">
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">Review filters</p>
+            <h2 className="mt-2 text-2xl font-semibold text-slate-950">Narrow the ledger by category or review state.</h2>
+          </div>
+          <p className="text-sm text-slate-500">Showing <span className="font-semibold text-slate-950">{visibleCount}</span> of {totalCount} records</p>
+        </div>
+
+        <div className="space-y-4">
+          <div className="flex flex-wrap gap-2">
+            <button
+              className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                selectedCategory === "all"
+                  ? "bg-slate-950 text-slate-50"
+                  : "border border-slate-200 bg-slate-50 text-slate-700"
+              }`}
+              onClick={() => onCategoryChange("all")}
+              type="button"
+            >
+              All categories ({totalCount})
+            </button>
+            {categories.map((category) => (
+              <button
+                className={`rounded-full px-4 py-2 text-sm font-medium transition ${selectedCategory === category.id ? "bg-teal-700 text-white" : "border border-slate-200 bg-white text-slate-700"}`}
+                key={category.id}
+                onClick={() => onCategoryChange(category.id)}
+                type="button"
+              >
+                {category.label} ({categoryCounts[category.id] ?? 0})
+              </button>
+            ))}
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            {reviewTabs.map((tab) => (
+              <button
+                className={`rounded-full px-4 py-2 text-sm font-medium transition ${selectedReviewState === tab.id ? "bg-amber-500 text-slate-950" : "border border-slate-200 bg-white text-slate-700"}`}
+                key={tab.id}
+                onClick={() => onReviewStateChange(tab.id)}
+                type="button"
+              >
+                {tab.label} ({reviewCounts[tab.id] ?? 0})
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/audit-trail/audit-trail-header.tsx
+++ b/src/components/audit-trail/audit-trail-header.tsx
@@ -1,0 +1,44 @@
+type AuditTrailHeaderProps = {
+  totalChanges: number;
+  reviewedCount: number;
+  pendingCount: number;
+  localFlagCount: number;
+  activeReviewerCount: number;
+};
+
+export function AuditTrailHeader({
+  totalChanges,
+  reviewedCount,
+  pendingCount,
+  localFlagCount,
+  activeReviewerCount,
+}: AuditTrailHeaderProps) {
+  const stats = [
+    { label: "Change records", value: totalChanges, tone: "bg-slate-950 text-slate-50" }, { label: "Reviewed lanes", value: reviewedCount, tone: "bg-teal-100 text-teal-950" },
+    { label: "Pending", value: pendingCount, tone: "bg-amber-100 text-amber-950" }, { label: "Local flags", value: localFlagCount, tone: "bg-rose-100 text-rose-950" },
+  ];
+
+  return (
+    <section className="overflow-hidden rounded-[2rem] border border-slate-200/70 bg-[linear-gradient(135deg,_rgba(255,255,255,0.96),_rgba(252,244,232,0.96)_52%,_rgba(237,247,245,0.94)_100%)] shadow-xl shadow-amber-100/60">
+      <div className="grid gap-6 px-6 py-8 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)] lg:px-8">
+        <div className="space-y-4">
+          <div className="inline-flex items-center gap-3 rounded-full border border-slate-200 bg-white/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.28em] text-slate-600">
+            Audit Trail
+            <span className="rounded-full bg-slate-950 px-2 py-1 tracking-[0.18em] text-slate-50">{activeReviewerCount} reviewers</span>
+          </div>
+          <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">Change ledger with review filters, reviewer handoffs, and session-local flags.</h1>
+          <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">Everything on this route is mock and isolated. Filters and review flags live only inside this page and reset with the session.</p>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          {stats.map((stat) => (
+            <div className={`rounded-[1.5rem] px-5 py-4 shadow-sm ${stat.tone}`} key={stat.label}>
+              <p className="text-sm opacity-75">{stat.label}</p>
+              <p className="mt-2 text-3xl font-semibold">{stat.value}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/audit-trail/audit-trail-shell.tsx
+++ b/src/components/audit-trail/audit-trail-shell.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { startTransition, useState } from "react";
+
+import {
+  categoryTags,
+  changeRecords,
+  reviewFlags,
+  reviewers,
+  type ReviewState,
+} from "@/app/audit-trail/mock-data";
+import { AuditTrailFilters } from "./audit-trail-filters";
+import { AuditTrailHeader } from "./audit-trail-header";
+import { ChangeLedger } from "./change-ledger";
+import { ReviewFlagPanel } from "./review-flag-panel";
+
+const reviewersById = Object.fromEntries(
+  reviewers.map((reviewer) => [reviewer.id, reviewer]),
+);
+const categoriesById = Object.fromEntries(
+  categoryTags.map((category) => [category.id, category]),
+);
+const reviewTabs = [
+  { id: "all", label: "All reviews" },
+  { id: "pending", label: "Pending" },
+  { id: "approved", label: "Approved" },
+  { id: "watch", label: "Watch" },
+  { id: "changes-requested", label: "Changes requested" },
+] as const;
+
+type ReviewFilter = "all" | ReviewState;
+
+function toggleId(items: string[], id: string) {
+  return items.includes(id)
+    ? items.filter((item) => item !== id)
+    : [...items, id];
+}
+
+export function AuditTrailShell() {
+  const [selectedCategory, setSelectedCategory] = useState("all");
+  const [selectedReviewState, setSelectedReviewState] = useState<ReviewFilter>("all");
+  const [flaggedIds, setFlaggedIds] = useState<string[]>([]);
+
+  const visibleRecords = changeRecords.filter(
+    (record) =>
+      (selectedCategory === "all" || record.categoryId === selectedCategory) &&
+      (selectedReviewState === "all" || record.reviewState === selectedReviewState),
+  );
+  const flaggedRecords = visibleRecords.filter((record) => flaggedIds.includes(record.id));
+  const hiddenFlagCount = flaggedIds.length - flaggedRecords.length;
+  const pendingCount = changeRecords.filter((record) => record.reviewState === "pending").length;
+  const reviewedCount = changeRecords.length - pendingCount;
+  const activeReviewerCount = new Set(changeRecords.flatMap((record) => record.reviewerIds)).size;
+  const hasFilters = selectedCategory !== "all" || selectedReviewState !== "all";
+
+  const reviewCounts = Object.fromEntries(
+    reviewTabs.map((tab) => [
+      tab.id,
+      tab.id === "all" ? changeRecords.length : changeRecords.filter((record) => record.reviewState === tab.id).length,
+    ]),
+  ) as Record<string, number>;
+  const categoryCounts = Object.fromEntries(
+    categoryTags.map((category) => [category.id, changeRecords.filter((record) => record.categoryId === category.id).length]),
+  ) as Record<string, number>;
+
+  const handleCategoryChange = (value: string) => startTransition(() => setSelectedCategory(value));
+  const handleReviewStateChange = (value: string) => startTransition(() => setSelectedReviewState(value as ReviewFilter));
+  const handleToggleFlag = (recordId: string) => startTransition(() => setFlaggedIds((current) => toggleId(current, recordId)));
+  const handleResetFilters = () => startTransition(() => { setSelectedCategory("all"); setSelectedReviewState("all"); });
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(251,191,36,0.12),_transparent_32%),radial-gradient(circle_at_right,_rgba(20,184,166,0.12),_transparent_26%),linear-gradient(180deg,_#fffaf3_0%,_#f8fafc_45%,_#f5f7fb_100%)] px-4 py-8 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <AuditTrailHeader
+          activeReviewerCount={activeReviewerCount}
+          localFlagCount={flaggedIds.length}
+          pendingCount={pendingCount}
+          reviewedCount={reviewedCount}
+          totalChanges={changeRecords.length}
+        />
+
+        <AuditTrailFilters
+          categories={categoryTags}
+          categoryCounts={categoryCounts}
+          onCategoryChange={handleCategoryChange}
+          onReviewStateChange={handleReviewStateChange}
+          reviewCounts={reviewCounts}
+          reviewTabs={reviewTabs}
+          selectedCategory={selectedCategory}
+          selectedReviewState={selectedReviewState}
+          totalCount={changeRecords.length}
+          visibleCount={visibleRecords.length}
+        />
+
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.85fr)]">
+          <ChangeLedger
+            categoriesById={categoriesById}
+            flaggedIds={flaggedIds}
+            hasFilters={hasFilters}
+            onResetFilters={handleResetFilters}
+            onToggleFlag={handleToggleFlag}
+            records={visibleRecords}
+            reviewersById={reviewersById}
+          />
+
+          <ReviewFlagPanel
+            categoriesById={categoriesById}
+            flagDefinitions={reviewFlags}
+            flaggedRecords={flaggedRecords}
+            hiddenFlagCount={hiddenFlagCount}
+            onToggleFlag={handleToggleFlag}
+            reviewersById={reviewersById}
+            totalFlaggedCount={flaggedIds.length}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/audit-trail/change-ledger.tsx
+++ b/src/components/audit-trail/change-ledger.tsx
@@ -1,0 +1,111 @@
+import type { CategoryTag, ChangeRecord, Reviewer } from "@/app/audit-trail/mock-data";
+
+import { ReviewerBadges } from "./reviewer-badges";
+
+const stateStyles = {
+  pending: "bg-amber-100 text-amber-950",
+  approved: "bg-emerald-100 text-emerald-950",
+  watch: "bg-sky-100 text-sky-950",
+  "changes-requested": "bg-rose-100 text-rose-950",
+} as const;
+
+const stateLabels = {
+  pending: "Pending",
+  approved: "Approved",
+  watch: "Watch",
+  "changes-requested": "Changes requested",
+} as const;
+
+type ChangeLedgerProps = {
+  records: ChangeRecord[];
+  flaggedIds: string[];
+  hasFilters: boolean;
+  onResetFilters: () => void;
+  onToggleFlag: (recordId: string) => void;
+  reviewersById: Record<string, Reviewer>;
+  categoriesById: Record<string, CategoryTag>;
+};
+
+export function ChangeLedger({
+  records,
+  flaggedIds,
+  hasFilters,
+  onResetFilters,
+  onToggleFlag,
+  reviewersById,
+  categoriesById,
+}: ChangeLedgerProps) {
+  return (
+    <section className="rounded-[2rem] border border-slate-200/70 bg-white/90 p-5 shadow-xl shadow-slate-200/50">
+      <div className="flex flex-col gap-2 border-b border-slate-200/80 pb-5">
+        <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">Change ledger</p>
+        <h2 className="text-2xl font-semibold text-slate-950">Review the mock change stream and flag items locally.</h2>
+      </div>
+
+      {records.length > 0 ? (
+        <div className="mt-5 space-y-4">
+          {records.map((record) => {
+            const category = categoriesById[record.categoryId];
+            const isFlagged = flaggedIds.includes(record.id);
+
+            return (
+              <article
+                className={`rounded-[1.6rem] border p-5 transition ${
+                  isFlagged
+                    ? "border-rose-200 bg-rose-50/70 text-slate-900 shadow-lg shadow-rose-100/60"
+                    : "border-slate-200 bg-[linear-gradient(180deg,_rgba(255,255,255,0.96),_rgba(248,250,252,0.88))] text-slate-900"
+                }`}
+                key={record.id}
+              >
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                  <div>
+                    <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em]">
+                      <span className={`rounded-full px-3 py-1 ${stateStyles[record.reviewState]}`}>
+                        {stateLabels[record.reviewState]}
+                      </span>
+                      <span className="text-slate-500">{record.service}</span>
+                      <span className="text-slate-400">{record.changedAt}</span>
+                    </div>
+                    <h3 className="mt-3 text-2xl font-semibold tracking-tight">{record.title}</h3>
+                    <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-600">{record.summary}</p>
+                  </div>
+
+                  <button
+                    className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                      isFlagged
+                        ? "bg-rose-500 text-white"
+                        : "border border-slate-200 bg-slate-50 text-slate-700"
+                    }`}
+                    onClick={() => onToggleFlag(record.id)}
+                    type="button"
+                  >
+                    {isFlagged ? "Remove flag" : "Flag for review"}
+                  </button>
+                </div>
+
+                <div className="mt-4 flex flex-wrap gap-2 text-xs font-medium">
+                  <span className="rounded-full bg-teal-100 px-3 py-1 text-teal-950">{category?.label ?? "Unsorted"}</span>
+                  <span className="rounded-full bg-slate-100 px-3 py-1 text-slate-700">{record.diffLabel}</span>
+                  <span className="rounded-full bg-slate-100 px-3 py-1 text-slate-700">Actor: {record.actor}</span>
+                </div>
+
+                <div className="mt-4"><ReviewerBadges reviewerIds={record.reviewerIds} reviewersById={reviewersById} /></div>
+              </article>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="mt-5 rounded-[1.6rem] border border-dashed border-slate-300 bg-slate-50 px-6 py-10 text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">No ledger matches</p>
+          <h3 className="mt-3 text-2xl font-semibold text-slate-950">No change records fit the active filters.</h3>
+          <p className="mt-3 text-sm leading-6 text-slate-600">Switch back to all categories or another review state to repopulate the isolated mock ledger.</p>
+          {hasFilters ? (
+            <button className="mt-5 rounded-full bg-slate-950 px-5 py-2 text-sm font-medium text-slate-50" onClick={onResetFilters} type="button">
+              Clear filters
+            </button>
+          ) : null}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/audit-trail/review-flag-panel.tsx
+++ b/src/components/audit-trail/review-flag-panel.tsx
@@ -1,0 +1,122 @@
+import type {
+  CategoryTag,
+  ChangeRecord,
+  ReviewFlag,
+  Reviewer,
+} from "@/app/audit-trail/mock-data";
+
+import { ReviewerBadges } from "./reviewer-badges";
+
+const toneStyles = {
+  amber: "border-amber-200 bg-amber-50/90 text-amber-950",
+  rose: "border-rose-200 bg-rose-50/90 text-rose-950",
+  sky: "border-sky-200 bg-sky-50/90 text-sky-950",
+  emerald: "border-emerald-200 bg-emerald-50/90 text-emerald-950",
+} as const;
+
+type ReviewFlagPanelProps = {
+  flagDefinitions: ReviewFlag[];
+  flaggedRecords: ChangeRecord[];
+  totalFlaggedCount: number;
+  hiddenFlagCount: number;
+  reviewersById: Record<string, Reviewer>;
+  categoriesById: Record<string, CategoryTag>;
+  onToggleFlag: (recordId: string) => void;
+};
+
+export function ReviewFlagPanel({
+  flagDefinitions,
+  flaggedRecords,
+  totalFlaggedCount,
+  hiddenFlagCount,
+  reviewersById,
+  categoriesById,
+  onToggleFlag,
+}: ReviewFlagPanelProps) {
+  const flagById = Object.fromEntries(flagDefinitions.map((flag) => [flag.id, flag])) as Record<string, ReviewFlag>;
+
+  return (
+    <section className="rounded-[2rem] border border-slate-200/70 bg-[linear-gradient(180deg,_rgba(255,255,255,0.96),_rgba(248,245,240,0.94))] p-5 shadow-xl shadow-slate-200/50 lg:sticky lg:top-6">
+      <div>
+        <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">Review flags</p>
+        <h2 className="mt-2 text-2xl font-semibold text-slate-950">Stage local review follow-ups without leaving the route.</h2>
+        <p className="mt-3 text-sm leading-6 text-slate-600">These cues are mock-only and session-local. Use them to build a small review stack while you sort the ledger.</p>
+      </div>
+
+      <div className="mt-5 grid gap-3">
+        {flagDefinitions.map((flag) => (
+          <div className={`rounded-[1.4rem] border px-4 py-3 ${toneStyles[flag.tone]}`} key={flag.id}>
+            <p className="text-sm font-semibold">{flag.label}</p>
+            <p className="mt-1 text-sm opacity-80">{flag.description}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-6 border-t border-slate-200/80 pt-6">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">Flagged items</p>
+            <h3 className="mt-2 text-xl font-semibold text-slate-950">Session queue ({totalFlaggedCount})</h3>
+          </div>
+        </div>
+
+        {flaggedRecords.length > 0 ? (
+          <div className="mt-4 space-y-4">
+            {flaggedRecords.map((record) => (
+              <article
+                className="rounded-[1.5rem] border border-slate-200 bg-white/90 p-4"
+                key={record.id}
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                      {record.service}
+                    </p>
+                    <h4 className="mt-2 text-lg font-semibold text-slate-950">{record.title}</h4>
+                  </div>
+                  <button className="rounded-full border border-slate-200 bg-slate-50 px-3 py-2 text-xs font-medium text-slate-700" onClick={() => onToggleFlag(record.id)} type="button">
+                    Remove
+                  </button>
+                </div>
+
+                <div className="mt-3 flex flex-wrap gap-2 text-xs font-medium">
+                  <span className="rounded-full bg-slate-100 px-3 py-1 text-slate-700">
+                    {categoriesById[record.categoryId]?.label ?? "Unsorted"}
+                  </span>
+                  {record.suggestedFlagIds.map((flagId) => {
+                    const flag = flagById[flagId];
+                    if (!flag) return null;
+
+                    return (
+                      <span className={`rounded-full px-3 py-1 ${toneStyles[flag.tone]}`} key={flag.id}>
+                        {flag.label}
+                      </span>
+                    );
+                  })}
+                </div>
+
+                <p className="mt-3 text-sm leading-6 text-slate-600">{record.summary}</p>
+
+                <div className="mt-4"><ReviewerBadges reviewerIds={record.reviewerIds} reviewersById={reviewersById} /></div>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <div className="mt-4 rounded-[1.5rem] border border-dashed border-slate-300 bg-white/70 px-6 py-8 text-center">
+            <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">Nothing visible</p>
+            <h4 className="mt-3 text-xl font-semibold text-slate-950">
+              {hiddenFlagCount > 0
+                ? "Local flags exist, but the active filters hide them."
+                : "No items are flagged for local review yet."}
+            </h4>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              {hiddenFlagCount > 0
+                ? `Clear or change the ledger filters to reopen ${hiddenFlagCount} hidden flagged item${hiddenFlagCount === 1 ? "" : "s"}.`
+                : "Use a ledger toggle to stage a review follow-up and this queue will populate here."}
+            </p>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/audit-trail/reviewer-badges.tsx
+++ b/src/components/audit-trail/reviewer-badges.tsx
@@ -1,0 +1,27 @@
+import type { Reviewer } from "@/app/audit-trail/mock-data";
+
+type ReviewerBadgesProps = {
+  reviewerIds: string[];
+  reviewersById: Record<string, Reviewer>;
+};
+
+export function ReviewerBadges({
+  reviewerIds,
+  reviewersById,
+}: ReviewerBadgesProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {reviewerIds.map((reviewerId) => {
+        const reviewer = reviewersById[reviewerId];
+        if (!reviewer) return null;
+
+        return (
+          <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white/90 px-3 py-1 text-xs text-slate-700" key={reviewer.id}>
+            <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-slate-950 text-[11px] font-semibold text-slate-50">{reviewer.initials}</span>
+            <span>{reviewer.name}</span>
+          </span>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/audit-trail` route with local mock audit data and metadata
- add feature-local header, filters, ledger, reviewer badges, and review flag panel components
- keep all state and interactions inside the audit-trail feature folders with mobile-friendly layout and empty states

## Verification
- npm run lint
- npm test
- npm run build

Closes #35