### PR TITLE
feat: add checkpoint grid route

### DIFF
--- a/src/app/checkpoint-grid/mock-data.ts
+++ b/src/app/checkpoint-grid/mock-data.ts
@@ -1,0 +1,59 @@
+export type CheckpointStatus = "complete" | "active" | "watch" | "blocked";
+export type MilestoneSummary = { title: string; cycle: string; dueWindow: string; reviewDate: string; summary: string };
+export type ProgressBand = { id: string; label: string; completed: number; total: number; focus: string };
+export type Checkpoint = {
+  id: string; title: string; band: string; owner: string; status: CheckpointStatus; completion: number;
+  dueLabel: string; summary: string; dependency: string; nextStep: string;
+};
+export type ReviewNote = { id: string; checkpointId: Checkpoint["id"]; author: string; timestamp: string; body: string };
+
+const band = (id: string, label: string, completed: number, total: number, focus: string): ProgressBand => ({ id, label, completed, total, focus });
+const checkpoint = (
+  id: string,
+  title: string,
+  bandName: string,
+  owner: string,
+  status: CheckpointStatus,
+  completion: number,
+  dueLabel: string,
+  summary: string,
+  dependency: string,
+  nextStep: string,
+): Checkpoint => ({ id, title, band: bandName, owner, status, completion, dueLabel, summary, dependency, nextStep });
+const note = (id: string, checkpointId: string, author: string, timestamp: string, body: string): ReviewNote => ({ id, checkpointId, author, timestamp, body });
+
+export const milestoneSummary: MilestoneSummary = {
+  title: "Milestone Checkpoint Grid",
+  cycle: "Cycle 12B",
+  dueWindow: "April 24 to April 28",
+  reviewDate: "April 26 review desk",
+  summary: "Feature-local dashboard for checkpoint review, owner triage, and note capture with no shared state.",
+};
+
+export const checkpointOwners = ["Ops North", "Platform", "QA Dock", "Release Desk"];
+export const progressBands = [
+  band("intake", "Intake", 1, 2, "Scope aligned and owner coverage assigned."),
+  band("assembly", "Assembly", 0, 2, "Dependencies are still settling across the middle lane."),
+  band("review", "Review", 1, 2, "Validation is healthy but one rollback brief is still active."),
+  band("approval", "Approval", 1, 2, "Leadership sign-off is blocked on a final handoff stack."),
+];
+
+export const checkpoints = [
+  checkpoint("intake-trim", "Intake trim locked", "Intake", "Platform", "complete", 100, "Locked April 19", "Scope trim and payload tags are stable for the next review pass.", "Tracker labels normalized", "Hand off the accepted brief to Ops North."),
+  checkpoint("spec-freeze", "Spec freeze handoff", "Intake", "Ops North", "active", 84, "Due April 22", "Owner checklist is almost complete, but two briefs still need confirmation.", "Final owner sign-off", "Confirm the remaining reviewer pair before noon."),
+  checkpoint("dependency-matrix", "Dependency matrix sweep", "Assembly", "QA Dock", "watch", 62, "Due April 23", "Coverage is broad enough to continue, but one lane is slipping behind expected pace.", "QA dock replay bundle", "Flag the unstable lane for a targeted replay."),
+  checkpoint("sandbox-burn", "Sandbox burn rehearsal", "Assembly", "Release Desk", "active", 48, "Due April 24", "The rehearsal deck is wired, although two operator prompts still need cleanup.", "Prompt revision packet", "Rehearse the fallback path with the release lead."),
+  checkpoint("rehearsal-pass", "Rehearsal pass signed", "Review", "QA Dock", "complete", 100, "Signed April 20", "The mock review completed with no carry-over issues for the next lane.", "Replay evidence archived", "Move the final note set into the approval queue."),
+  checkpoint("rollback-map", "Rollback map review", "Review", "Platform", "active", 92, "Due April 24", "Fallback routing is drafted and only needs the last operator check.", "Operator acknowledgment", "Confirm the rollback owner on the daily review call."),
+  checkpoint("signoff-stack", "Sign-off stack ready", "Approval", "Release Desk", "blocked", 36, "Blocked until April 25", "Leadership sign-off is waiting on an unresolved handoff between review and release.", "Approval packet from review", "Unblock the packet and re-open the sign-off lane."),
+  checkpoint("closeout-pack", "Closeout pack published", "Approval", "Ops North", "complete", 100, "Published April 18", "Closeout notes, owner map, and archived references are in the final package.", "Archive bundle complete", "Hold for the next milestone rollover."),
+];
+
+export const reviewNotes = [
+  note("note-01", "spec-freeze", "Review lead", "Apr 19, 09:15", "Owner matrix is clean; only the final reviewer pair needs a response."),
+  note("note-02", "dependency-matrix", "QA Dock", "Apr 19, 10:05", "One dependency lane is re-running with reduced scope so the broader sweep can continue."),
+  note("note-03", "sandbox-burn", "Release Desk", "Apr 19, 11:22", "Prompt cleanup is small, but it blocks the rehearsal script from being final."),
+  note("note-04", "rollback-map", "Platform", "Apr 19, 12:10", "Rollback routing looks solid; operator confirmation is the only remaining gate."),
+  note("note-05", "signoff-stack", "Approval desk", "Apr 19, 13:40", "Blocked until the review packet arrives with the corrected attachments."),
+  note("note-06", "closeout-pack", "Ops North", "Apr 19, 14:05", "Archive links were checked and the closeout package is ready for rollover."),
+];

--- a/src/app/checkpoint-grid/page.tsx
+++ b/src/app/checkpoint-grid/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+import { CheckpointGridShell } from "@/components/checkpoint-grid/checkpoint-grid-shell";
+
+export const metadata: Metadata = {
+  title: "Checkpoint Grid",
+  description:
+    "Mock milestone dashboard with checkpoint tiles, progress bands, and local review notes.",
+};
+
+export default function CheckpointGridPage() {
+  return <CheckpointGridShell />;
+}

--- a/src/components/checkpoint-grid/checkpoint-filters.tsx
+++ b/src/components/checkpoint-grid/checkpoint-filters.tsx
@@ -1,0 +1,76 @@
+import type { CheckpointStatus } from "@/app/checkpoint-grid/mock-data";
+
+const statusOptions: Array<{ value: CheckpointStatus | "all"; label: string }> = [
+  { value: "all", label: "All statuses" },
+  { value: "complete", label: "Complete" },
+  { value: "active", label: "Active" },
+  { value: "watch", label: "Watch" },
+  { value: "blocked", label: "Blocked" },
+];
+
+type CheckpointFiltersProps = {
+  onOwnerChange: (owner: string) => void; onReset: () => void; onStatusChange: (status: CheckpointStatus | "all") => void;
+  owners: string[]; selectedOwner: string; selectedStatus: CheckpointStatus | "all"; totalCount: number; visibleCount: number;
+};
+
+export function CheckpointFilters({ onOwnerChange, onReset, onStatusChange, owners, selectedOwner, selectedStatus, totalCount, visibleCount }: CheckpointFiltersProps) {
+  const filterButtonClass = "rounded-full border px-4 py-2 text-sm transition hover:border-sky-200/50 hover:text-white";
+
+  return (
+    <section className="rounded-[2rem] border border-white/10 bg-slate-950/65 p-6 backdrop-blur sm:p-8">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.24em] text-sky-200/75">Filters</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">Owner and status views</h2>
+        </div>
+        <p className="text-sm text-slate-300">Showing {visibleCount} of {totalCount} checkpoints.</p>
+      </div>
+      <div className="mt-6 space-y-5">
+        <div>
+          <p className="mb-3 text-xs uppercase tracking-[0.2em] text-slate-400">Owner</p>
+          <div className="flex flex-wrap gap-3">
+            <button
+              className={`${filterButtonClass} ${selectedOwner === "all" ? "border-sky-300/45 bg-sky-300/12 text-sky-100" : "border-white/10 bg-white/[0.03] text-slate-300"}`}
+              onClick={() => onOwnerChange("all")}
+              type="button"
+            >
+              All owners
+            </button>
+            {owners.map((owner) => (
+              <button
+                className={`${filterButtonClass} ${selectedOwner === owner ? "border-sky-300/45 bg-sky-300/12 text-sky-100" : "border-white/10 bg-white/[0.03] text-slate-300"}`}
+                key={owner}
+                onClick={() => onOwnerChange(owner)}
+                type="button"
+              >
+                {owner}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div>
+          <p className="mb-3 text-xs uppercase tracking-[0.2em] text-slate-400">Status</p>
+          <div className="flex flex-wrap gap-3">
+            {statusOptions.map((status) => (
+              <button
+                className={`${filterButtonClass} ${selectedStatus === status.value ? "border-amber-300/45 bg-amber-300/12 text-amber-100" : "border-white/10 bg-white/[0.03] text-slate-300"}`}
+                key={status.value}
+                onClick={() => onStatusChange(status.value)}
+                type="button"
+              >
+                {status.label}
+              </button>
+            ))}
+            <button
+              className="rounded-full border border-white/10 px-4 py-2 text-sm text-slate-300 transition hover:border-white/20 hover:text-white"
+              onClick={onReset}
+              type="button"
+            >
+              Reset
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/checkpoint-grid/checkpoint-grid-header.tsx
+++ b/src/components/checkpoint-grid/checkpoint-grid-header.tsx
@@ -1,0 +1,41 @@
+import type { MilestoneSummary } from "@/app/checkpoint-grid/mock-data";
+
+type CheckpointGridHeaderProps = {
+  activeCount: number; blockedCount: number; completionRatio: number; completeCount: number;
+  summary: MilestoneSummary; totalCheckpoints: number; totalNotes: number;
+};
+
+export function CheckpointGridHeader({ activeCount, blockedCount, completionRatio, completeCount, summary, totalCheckpoints, totalNotes }: CheckpointGridHeaderProps) {
+  return (
+    <header className="rounded-[2rem] border border-white/10 bg-slate-950/75 p-6 shadow-[0_30px_100px_rgba(0,0,0,0.35)] backdrop-blur sm:p-8">
+      <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <div className="flex flex-wrap gap-3 text-xs uppercase tracking-[0.24em] text-slate-300">
+            <span className="rounded-full border border-sky-300/25 bg-sky-300/10 px-4 py-2 text-sky-100">{summary.cycle}</span>
+            <span className="rounded-full border border-amber-300/25 bg-amber-300/10 px-4 py-2 text-amber-100">{summary.reviewDate}</span>
+          </div>
+          <h1 className="mt-5 text-4xl font-semibold tracking-tight text-white sm:text-5xl">{summary.title}</h1>
+          <p className="mt-4 max-w-3xl text-sm leading-6 text-slate-300 sm:text-base">{summary.summary}</p>
+        </div>
+        <div className="rounded-[1.6rem] border border-white/10 bg-white/[0.04] px-5 py-4 lg:min-w-[260px]">
+          <p className="text-xs uppercase tracking-[0.24em] text-slate-300">Completion ratio</p>
+          <div className="mt-3 flex items-end justify-between gap-4">
+            <div>
+              <p className="text-4xl font-semibold text-white">{completionRatio}%</p>
+              <p className="mt-1 text-sm text-slate-300">{summary.dueWindow}</p>
+            </div>
+            <div className="text-right text-sm text-slate-300">
+              <p>{completeCount} complete</p>
+              <p>{activeCount} active</p>
+              <p>{blockedCount} blocked</p>
+            </div>
+          </div>
+          <div className="mt-4 h-2 rounded-full bg-white/10">
+            <div className="h-full rounded-full bg-[linear-gradient(90deg,#7dd3fc_0%,#fbbf24_100%)]" style={{ width: `${completionRatio}%` }} />
+          </div>
+          <p className="mt-3 text-sm text-slate-300">{totalCheckpoints} checkpoints and {totalNotes} local review notes in this isolated route.</p>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/checkpoint-grid/checkpoint-grid-shell.tsx
+++ b/src/components/checkpoint-grid/checkpoint-grid-shell.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+
+import { checkpointOwners, checkpoints, milestoneSummary, progressBands, reviewNotes, type CheckpointStatus, type ReviewNote } from "@/app/checkpoint-grid/mock-data";
+import { CheckpointFilters } from "./checkpoint-filters";
+import { CheckpointGridHeader } from "./checkpoint-grid-header";
+import { CheckpointTile } from "./checkpoint-tile";
+import { ProgressBandStrip } from "./progress-band-strip";
+import { ReviewNotesPanel } from "./review-notes-panel";
+
+const groupNotesByCheckpoint = (items: ReviewNote[]) =>
+  items.reduce<Record<string, ReviewNote[]>>((groups, note) => ({ ...groups, [note.checkpointId]: [...(groups[note.checkpointId] ?? []), note] }), {});
+const formatLocalTimestamp = (date: Date) =>
+  new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }).format(date);
+
+export function CheckpointGridShell() {
+  const [selectedOwner, setSelectedOwner] = useState("all");
+  const [selectedStatus, setSelectedStatus] = useState<CheckpointStatus | "all">("all");
+  const [selectedCheckpointId, setSelectedCheckpointId] = useState<string | null>(checkpoints[1]?.id ?? null);
+  const [notesByCheckpoint, setNotesByCheckpoint] = useState(() => groupNotesByCheckpoint(reviewNotes));
+  const [draftsByCheckpoint, setDraftsByCheckpoint] = useState<Record<string, string>>({});
+
+  const visibleCheckpoints = checkpoints.filter((checkpoint) =>
+    (selectedOwner === "all" || checkpoint.owner === selectedOwner) &&
+    (selectedStatus === "all" || checkpoint.status === selectedStatus),
+  );
+  const selectedCheckpoint = checkpoints.find((checkpoint) => checkpoint.id === selectedCheckpointId) ?? null;
+  const activeCheckpoint = selectedCheckpoint && visibleCheckpoints.some((checkpoint) => checkpoint.id === selectedCheckpoint.id) ? selectedCheckpoint : null;
+  const activeNotes = activeCheckpoint ? notesByCheckpoint[activeCheckpoint.id] ?? [] : [];
+  const draftValue = activeCheckpoint ? draftsByCheckpoint[activeCheckpoint.id] ?? "" : "";
+  const completionRatio = Math.round(checkpoints.reduce((sum, checkpoint) => sum + checkpoint.completion, 0) / checkpoints.length);
+  const statusCounts = checkpoints.reduce(
+    (counts, checkpoint) => ({ ...counts, [checkpoint.status]: counts[checkpoint.status] + 1 }),
+    { complete: 0, active: 0, watch: 0, blocked: 0 },
+  );
+  const totalNotes = Object.values(notesByCheckpoint).reduce((sum, items) => sum + items.length, 0);
+
+  function handleSaveNote() {
+    if (!activeCheckpoint) return;
+    const body = (draftsByCheckpoint[activeCheckpoint.id] ?? "").trim();
+    if (!body) return;
+    const nextNote: ReviewNote = {
+      id: `local-${activeCheckpoint.id}-${Date.now()}`,
+      checkpointId: activeCheckpoint.id,
+      author: "Local reviewer",
+      timestamp: formatLocalTimestamp(new Date()),
+      body,
+    };
+    setNotesByCheckpoint((current) => ({ ...current, [activeCheckpoint.id]: [nextNote, ...(current[activeCheckpoint.id] ?? [])] }));
+    setDraftsByCheckpoint((current) => ({ ...current, [activeCheckpoint.id]: "" }));
+  }
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(96,165,250,0.22),transparent_28%),linear-gradient(180deg,#07111f_0%,#0b1324_48%,#050913_100%)] px-4 py-6 text-slate-100 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <CheckpointGridHeader
+          activeCount={statusCounts.active}
+          blockedCount={statusCounts.blocked}
+          completionRatio={completionRatio}
+          completeCount={statusCounts.complete}
+          summary={milestoneSummary}
+          totalCheckpoints={checkpoints.length}
+          totalNotes={totalNotes}
+        />
+        <ProgressBandStrip bands={progressBands} />
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.55fr)_minmax(320px,0.95fr)]">
+          <div className="space-y-6">
+            <CheckpointFilters
+              onOwnerChange={setSelectedOwner}
+              onReset={() => {
+                setSelectedOwner("all");
+                setSelectedStatus("all");
+              }}
+              onStatusChange={setSelectedStatus}
+              owners={checkpointOwners}
+              selectedOwner={selectedOwner}
+              selectedStatus={selectedStatus}
+              totalCount={checkpoints.length}
+              visibleCount={visibleCheckpoints.length}
+            />
+            <section className="rounded-[2rem] border border-white/10 bg-slate-950/65 p-6 backdrop-blur sm:p-8">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.24em] text-sky-200/75">Checkpoint tiles</p>
+                  <h2 className="mt-2 text-2xl font-semibold text-white">Filtered milestone lane</h2>
+                </div>
+                <p className="max-w-xl text-sm text-slate-300">
+                  Select a tile to inspect notes. Selecting the same tile again clears the panel.
+                </p>
+              </div>
+              {visibleCheckpoints.length === 0 ? (
+                <div className="mt-6 rounded-[1.6rem] border border-dashed border-white/15 bg-white/[0.03] px-6 py-10 text-center">
+                  <p className="text-sm uppercase tracking-[0.24em] text-amber-200/70">No matching checkpoints</p>
+                  <h3 className="mt-3 text-2xl font-semibold text-white">These filters cleared the grid.</h3>
+                  <p className="mx-auto mt-3 max-w-xl text-sm leading-6 text-slate-300">
+                    Reset the owner or status selection to bring tiles back into view and reopen notes.
+                  </p>
+                  <button className="mt-6 rounded-full bg-sky-300 px-5 py-2.5 text-sm font-semibold text-slate-950 transition hover:bg-sky-200" onClick={() => {
+                    setSelectedOwner("all");
+                    setSelectedStatus("all");
+                  }} type="button">
+                    Reset filters
+                  </button>
+                </div>
+              ) : (
+                <div className="mt-6 grid gap-4 lg:grid-cols-2">
+                  {visibleCheckpoints.map((checkpoint) => (
+                    <CheckpointTile
+                      checkpoint={checkpoint}
+                      isSelected={checkpoint.id === activeCheckpoint?.id}
+                      key={checkpoint.id}
+                      onSelect={(checkpointId) => setSelectedCheckpointId((current) => current === checkpointId ? null : checkpointId)}
+                    />
+                  ))}
+                </div>
+              )}
+            </section>
+          </div>
+          <ReviewNotesPanel
+            draftValue={draftValue}
+            hasVisibleCheckpoints={visibleCheckpoints.length > 0}
+            notes={activeNotes}
+            onDraftChange={(value) => activeCheckpoint && setDraftsByCheckpoint((current) => ({ ...current, [activeCheckpoint.id]: value }))}
+            onSaveNote={handleSaveNote}
+            selectedCheckpoint={activeCheckpoint}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/checkpoint-grid/checkpoint-tile.tsx
+++ b/src/components/checkpoint-grid/checkpoint-tile.tsx
@@ -1,0 +1,52 @@
+import type { Checkpoint } from "@/app/checkpoint-grid/mock-data";
+
+const statusClasses = {
+  complete: "border-emerald-400/20 bg-emerald-500/10 text-emerald-100",
+  active: "border-sky-300/25 bg-sky-300/10 text-sky-100",
+  watch: "border-amber-300/25 bg-amber-300/10 text-amber-100",
+  blocked: "border-rose-400/25 bg-rose-500/10 text-rose-100",
+};
+
+type CheckpointTileProps = { checkpoint: Checkpoint; isSelected: boolean; onSelect: (checkpointId: string) => void };
+
+export function CheckpointTile({ checkpoint, isSelected, onSelect }: CheckpointTileProps) {
+  return (
+    <button className={`rounded-[1.6rem] border p-5 text-left transition ${isSelected ? "border-sky-300/45 bg-sky-300/10 shadow-[0_18px_40px_rgba(14,165,233,0.12)]" : "border-white/10 bg-white/[0.04] hover:border-white/20 hover:bg-white/[0.06]"}`} onClick={() => onSelect(checkpoint.id)} type="button">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-[0.24em] text-slate-400">{checkpoint.band}</p>
+          <h3 className="mt-3 text-xl font-semibold text-white">{checkpoint.title}</h3>
+        </div>
+        <span className={`rounded-full border px-3 py-1 text-xs uppercase tracking-[0.2em] ${statusClasses[checkpoint.status]}`}>{checkpoint.status}</span>
+      </div>
+      <p className="mt-4 text-sm leading-6 text-slate-300">{checkpoint.summary}</p>
+      <div className="mt-5 grid gap-3 text-sm text-slate-300 sm:grid-cols-2">
+        <p>
+          <span className="block text-xs uppercase tracking-[0.2em] text-slate-500">Owner</span>
+          {checkpoint.owner}
+        </p>
+        <p>
+          <span className="block text-xs uppercase tracking-[0.2em] text-slate-500">Due</span>
+          {checkpoint.dueLabel}
+        </p>
+        <p>
+          <span className="block text-xs uppercase tracking-[0.2em] text-slate-500">Dependency</span>
+          {checkpoint.dependency}
+        </p>
+        <p>
+          <span className="block text-xs uppercase tracking-[0.2em] text-slate-500">Next step</span>
+          {checkpoint.nextStep}
+        </p>
+      </div>
+      <div className="mt-5">
+        <div className="flex items-center justify-between gap-4 text-sm">
+          <span className="text-slate-400">Completion</span>
+          <span className="font-medium text-white">{checkpoint.completion}%</span>
+        </div>
+        <div className="mt-2 h-2 rounded-full bg-white/10">
+          <div className="h-full rounded-full bg-[linear-gradient(90deg,#7dd3fc_0%,#f59e0b_100%)]" style={{ width: `${checkpoint.completion}%` }} />
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/src/components/checkpoint-grid/progress-band-strip.tsx
+++ b/src/components/checkpoint-grid/progress-band-strip.tsx
@@ -1,0 +1,37 @@
+import type { ProgressBand } from "@/app/checkpoint-grid/mock-data";
+
+type ProgressBandStripProps = { bands: ProgressBand[] };
+
+export function ProgressBandStrip({ bands }: ProgressBandStripProps) {
+  return (
+    <section className="rounded-[2rem] border border-white/10 bg-slate-950/65 p-6 backdrop-blur sm:p-8">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.24em] text-sky-200/75">Progress bands</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">Milestone lane coverage</h2>
+        </div>
+        <p className="max-w-xl text-sm text-slate-300">Each band summarizes how many checkpoint tiles are finished before the next review handoff.</p>
+      </div>
+      <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {bands.map((band) => {
+          const ratio = Math.round((band.completed / band.total) * 100);
+          return (
+            <article className="rounded-[1.5rem] border border-white/10 bg-white/[0.04] p-5" key={band.id}>
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.22em] text-slate-400">{band.label}</p>
+                  <p className="mt-3 text-3xl font-semibold text-white">{band.completed}/{band.total}</p>
+                </div>
+                <span className="rounded-full border border-sky-300/25 bg-sky-300/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-sky-100">{ratio}%</span>
+              </div>
+              <div className="mt-4 h-2 rounded-full bg-white/10">
+                <div className="h-full rounded-full bg-[linear-gradient(90deg,#7dd3fc_0%,#f59e0b_100%)]" style={{ width: `${ratio}%` }} />
+              </div>
+              <p className="mt-4 text-sm leading-6 text-slate-300">{band.focus}</p>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/checkpoint-grid/review-notes-panel.tsx
+++ b/src/components/checkpoint-grid/review-notes-panel.tsx
@@ -1,0 +1,70 @@
+import type { Checkpoint, ReviewNote } from "@/app/checkpoint-grid/mock-data";
+
+type ReviewNotesPanelProps = {
+  draftValue: string; hasVisibleCheckpoints: boolean; notes: ReviewNote[];
+  onDraftChange: (value: string) => void; onSaveNote: () => void; selectedCheckpoint: Checkpoint | null;
+};
+
+export function ReviewNotesPanel({ draftValue, hasVisibleCheckpoints, notes, onDraftChange, onSaveNote, selectedCheckpoint }: ReviewNotesPanelProps) {
+  if (!selectedCheckpoint) {
+    return (
+      <aside className="rounded-[2rem] border border-white/10 bg-slate-950/70 p-6 backdrop-blur sm:p-8">
+        <p className="text-xs uppercase tracking-[0.24em] text-sky-200/75">Review notes</p>
+        <h2 className="mt-3 text-2xl font-semibold text-white">No checkpoint selected</h2>
+        <p className="mt-4 text-sm leading-6 text-slate-300">
+          {hasVisibleCheckpoints ? "Choose a checkpoint tile to inspect its notes and write a local review update." : "Reset the filters first, then pick a checkpoint tile to reopen the notes panel."}
+        </p>
+      </aside>
+    );
+  }
+  const noteCount = notes.length;
+  const saveDisabled = draftValue.trim().length === 0;
+  return (
+    <aside className="rounded-[2rem] border border-white/10 bg-slate-950/70 p-6 backdrop-blur sm:p-8">
+      <div className="flex flex-col gap-3 border-b border-white/10 pb-5">
+        <p className="text-xs uppercase tracking-[0.24em] text-sky-200/75">Review notes</p>
+        <div>
+          <h2 className="text-2xl font-semibold text-white">{selectedCheckpoint.title}</h2>
+          <p className="mt-2 text-sm text-slate-300">
+            {selectedCheckpoint.owner} owns this checkpoint in the {selectedCheckpoint.band} lane.
+          </p>
+        </div>
+      </div>
+      <div className="mt-5 rounded-[1.5rem] border border-white/10 bg-white/[0.04] p-4">
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-sm font-medium text-white">Notes in lane</p>
+          <span className="rounded-full border border-amber-300/25 bg-amber-300/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-amber-100">{noteCount} saved</span>
+        </div>
+        <p className="mt-2 text-sm leading-6 text-slate-300">Local notes stay in this route session and are not shared with other pages.</p>
+      </div>
+      <div className="mt-5 space-y-3">
+        {noteCount === 0 ? (
+          <div className="rounded-[1.5rem] border border-dashed border-white/15 bg-white/[0.03] px-4 py-6 text-sm leading-6 text-slate-300">No local review notes exist for this checkpoint yet. Add the first one below to capture the next handoff detail.</div>
+        ) : (
+          notes.map((note) => (
+            <article className="rounded-[1.4rem] border border-white/10 bg-white/[0.04] p-4" key={note.id}>
+              <div className="flex items-center justify-between gap-3 text-sm">
+                <p className="font-medium text-white">{note.author}</p>
+                <p className="text-slate-400">{note.timestamp}</p>
+              </div>
+              <p className="mt-3 text-sm leading-6 text-slate-300">{note.body}</p>
+            </article>
+          ))
+        )}
+      </div>
+      <div className="mt-6 border-t border-white/10 pt-5">
+        <label className="text-xs uppercase tracking-[0.24em] text-slate-400" htmlFor="checkpoint-note">Add local note</label>
+        <textarea
+          className="mt-3 min-h-32 w-full rounded-[1.4rem] border border-white/10 bg-white/[0.04] px-4 py-3 text-sm leading-6 text-white outline-none transition placeholder:text-slate-500 focus:border-sky-300/45"
+          id="checkpoint-note"
+          onChange={(event) => onDraftChange(event.target.value)}
+          placeholder="Capture a review note, risk, or owner reminder for this checkpoint."
+          value={draftValue}
+        />
+        <button className="mt-4 rounded-full bg-sky-300 px-5 py-2.5 text-sm font-semibold text-slate-950 transition hover:bg-sky-200 disabled:cursor-not-allowed disabled:bg-slate-600 disabled:text-slate-300" disabled={saveDisabled} onClick={onSaveNote} type="button">
+          Save local note
+        </button>
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/checkpoint-grid` app route with feature-local mock milestone data
- build checkpoint filters, progress bands, selectable milestone tiles, and a local review notes panel
- keep the implementation scoped to `src/app/checkpoint-grid` and `src/components/checkpoint-grid`

## Verification
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #41