### PR TITLE
feat: add isolated route planner board

### DIFF
--- a/src/app/route-planner/page.tsx
+++ b/src/app/route-planner/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+import { RoutePlannerShell } from "@/components/route-planner/route-planner-shell";
+
+export const metadata: Metadata = {
+  title: "Route Planner",
+  description:
+    "Mock route planning board with local segment cards, constraint filters, and decision summaries.",
+};
+
+export default function RoutePlannerPage() {
+  return <RoutePlannerShell />;
+}

--- a/src/app/route-planner/route-planner-data.ts
+++ b/src/app/route-planner/route-planner-data.ts
@@ -1,0 +1,85 @@
+export type ConstraintId = "weather-window" | "dock-capacity" | "crew-turn" | "cold-chain" | "bridge-clearance";
+export type RouteConstraint = { id: ConstraintId; label: string; severity: "high" | "medium" | "low"; description: string };
+export type RouteSegment = {
+  id: string;
+  label: string;
+  start: string;
+  end: string;
+  mode: "Ground" | "Air" | "Relay";
+  window: string;
+  status: "locked" | "watch" | "reroute";
+  confidence: number;
+  bufferMinutes: number;
+  owner: string;
+  note: string;
+  fallback: string;
+  constraintIds: ConstraintId[];
+};
+export type PlannedRoute = {
+  id: string;
+  name: string;
+  planningMode: string;
+  objective: string;
+  selectedWindow: string;
+  summary: string;
+  dispatchLead: string;
+  routeScore: number;
+  segments: RouteSegment[];
+};
+
+const segment = (
+  id: string,
+  label: string,
+  start: string,
+  end: string,
+  mode: RouteSegment["mode"],
+  window: string,
+  status: RouteSegment["status"],
+  confidence: number,
+  bufferMinutes: number,
+  owner: string,
+  note: string,
+  fallback: string,
+  constraintIds: ConstraintId[],
+): RouteSegment => ({ id, label, start, end, mode, window, status, confidence, bufferMinutes, owner, note, fallback, constraintIds });
+
+const route = (
+  id: string,
+  name: string,
+  planningMode: string,
+  objective: string,
+  selectedWindow: string,
+  summary: string,
+  dispatchLead: string,
+  routeScore: number,
+  segments: RouteSegment[],
+): PlannedRoute => ({ id, name, planningMode, objective, selectedWindow, summary, dispatchLead, routeScore, segments });
+
+export const routeConstraints: RouteConstraint[] = [
+  { id: "weather-window", label: "Weather Window", severity: "high", description: "Surface segments with wind or visibility pressure." },
+  { id: "dock-capacity", label: "Dock Capacity", severity: "medium", description: "Show handoffs that need reassigned berths or queues." },
+  { id: "crew-turn", label: "Crew Turn", severity: "medium", description: "Highlight segments near labor or timing limits." },
+  { id: "cold-chain", label: "Cold Chain", severity: "high", description: "Focus on protected transfers with thermal exposure." },
+  { id: "bridge-clearance", label: "Bridge Clearance", severity: "low", description: "Track corridor segments with height or timing gates." },
+];
+
+export const plannedRoutes: PlannedRoute[] = [
+  route("north-delta", "North Delta Relay", "Adaptive relay", "Preserve the northern spine and keep all late-bound handoffs inside a 90 minute margin.", "06:10-11:40 UTC", "Fastest corridor with two protected handoffs and moderate weather exposure.", "Dispatch Cell A3", 92, [
+    segment("nd-1", "Harbor Intake", "Pier Intake 2", "Delta Staging", "Ground", "06:10-07:05", "locked", 95, 18, "Yard Team 4", "Clean release from berth lane with no thermal handling.", "Shift to Intake 4 if crane queue slips past 12 minutes.", ["dock-capacity"]),
+    segment("nd-2", "Lift Corridor", "Delta Staging", "North Air Ramp", "Air", "07:20-08:35", "watch", 84, 12, "Rotor Desk 2", "Crosswind risk builds after the first departure slot.", "Hold to the lower pass and trade 20 minutes of margin.", ["weather-window", "crew-turn"]),
+    segment("nd-3", "Thermal Handoff", "North Air Ramp", "Cold Spine Lockup", "Relay", "08:55-09:25", "watch", 81, 9, "Chain Custody", "Protected relay only if seal check clears on first scan.", "Use dock-side refrigerant locker and relabel the manifest.", ["cold-chain"]),
+    segment("nd-4", "Final Drop", "Cold Spine Lockup", "North Delta Hub", "Ground", "09:45-11:40", "locked", 90, 22, "Linehaul West", "Preferred arrival path through the east apron remains open.", "Flip to the ridge spur if apron demand spikes.", ["bridge-clearance"]),
+  ]),
+  route("harbor-spine", "Harbor Spine", "Constraint chase", "Contain queue growth around the central docks without losing the earliest delivery slot.", "07:00-12:15 UTC", "Most direct harbor route, but berth turnover and crew pacing are both tight.", "Queue Control B1", 86, [
+    segment("hs-1", "Dock Exit", "Harbor Stack 7", "Canal Merge", "Ground", "07:00-07:40", "watch", 82, 10, "Dock Marshal", "Earliest lane is available, but berth turnover remains noisy.", "Queue behind Stack 5 and release on the next green cycle.", ["dock-capacity", "crew-turn"]),
+    segment("hs-2", "Canal Transit", "Canal Merge", "South Bridge Gate", "Relay", "07:55-09:05", "reroute", 76, 6, "Transit Board", "Bridge timing conflict narrows the open passage to one cycle.", "Divert to the inner quay and accept a 28 minute delay.", ["bridge-clearance"]),
+    segment("hs-3", "Crew Exchange", "South Bridge Gate", "Spine Relay", "Ground", "09:25-10:10", "watch", 79, 14, "Crew Board", "Shift overlap is still viable, but only with the early release.", "Call reserve crew and slide the relay by one service band.", ["crew-turn"]),
+    segment("hs-4", "Harbor Finish", "Spine Relay", "South Yard", "Ground", "10:30-12:15", "locked", 88, 18, "Harbor Haul", "Final yard window holds if upstream timing stays inside tolerance.", "Use overflow yard slot 3 and hold the outbound release.", []),
+  ]),
+  route("cinder-arc", "Cinder Arc", "Cold-chain reserve", "Protect refrigerated transfer integrity while keeping the reserve corridor ready for escalation.", "05:50-10:50 UTC", "Reserve path with the best thermal handling, but weather and dock timing can both pinch capacity.", "Reserve Cell C7", 89, [
+    segment("ca-1", "Reserve Intake", "North Berth 1", "Cinder Prep", "Ground", "05:50-06:35", "locked", 93, 16, "Reserve Yard", "Thermal seal begins here and remains intact through the relay.", "Backfill through Berth 3 if intake handling runs long.", ["cold-chain"]),
+    segment("ca-2", "Sky Hook", "Cinder Prep", "Mesa Drop", "Air", "06:50-08:05", "watch", 80, 11, "Flight Board", "Visibility floor remains acceptable but trends down after sunrise.", "Break the leg into two lower hops via Mesa West.", ["weather-window", "cold-chain"]),
+    segment("ca-3", "Mesa Relay", "Mesa Drop", "Arc Lock", "Relay", "08:20-09:00", "locked", 91, 20, "Thermal Desk", "Fastest protected transfer in the reserve portfolio.", "Extend refrigeration dwell and delay the final launch.", ["cold-chain"]),
+    segment("ca-4", "Arc Delivery", "Arc Lock", "Cinder Hub", "Ground", "09:15-10:50", "watch", 83, 13, "Hub Dispatch", "Arrival slot is stable if the dock queue downstream stays flat.", "Switch to the reserve apron and absorb a short unload hold.", ["dock-capacity"]),
+  ]),
+];

--- a/src/components/route-planner/constraint-sidebar.tsx
+++ b/src/components/route-planner/constraint-sidebar.tsx
@@ -1,0 +1,126 @@
+import type {
+  ConstraintId,
+  RouteConstraint,
+  RouteSegment,
+} from "@/app/route-planner/route-planner-data";
+
+type DecisionState = { detail: string; label: string; title: string };
+type ConstraintSidebarProps = {
+  activeSegment: RouteSegment | null;
+  constraints: RouteConstraint[];
+  decision: DecisionState;
+  hasActiveFilters: boolean;
+  onClearFilters: () => void;
+  onToggleConstraint: (constraintId: ConstraintId) => void;
+  selectedConstraintIds: ConstraintId[];
+  totalBufferMinutes: number;
+  visibleSegments: RouteSegment[];
+};
+
+const severityStyles = {
+  high: "border-rose-200 bg-rose-50 text-rose-700",
+  medium: "border-amber-200 bg-amber-50 text-amber-700",
+  low: "border-emerald-200 bg-emerald-50 text-emerald-700",
+} as const;
+
+export function ConstraintSidebar({
+  activeSegment,
+  constraints,
+  decision,
+  hasActiveFilters,
+  onClearFilters,
+  onToggleConstraint,
+  selectedConstraintIds,
+  totalBufferMinutes,
+  visibleSegments,
+}: ConstraintSidebarProps) {
+  const rerouteCount = visibleSegments.filter((segment) => segment.status === "reroute").length;
+  const watchCount = visibleSegments.filter((segment) => segment.status === "watch").length;
+  const owners = [...new Set(visibleSegments.map((segment) => segment.owner))].slice(0, 3);
+
+  return (
+    <aside className="space-y-5 rounded-[1.75rem] border border-slate-200/80 bg-[linear-gradient(180deg,rgba(255,255,255,0.94),rgba(248,250,252,0.92))] p-5 shadow-[0_22px_60px_-42px_rgba(15,23,42,0.45)] sm:p-6">
+      <section>
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">Constraint Sidebar</p>
+            <h2 className="mt-2 text-2xl font-semibold text-slate-950">Decision inputs</h2>
+          </div>
+          {hasActiveFilters ? (
+            <button className="rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:bg-white" onClick={onClearFilters} type="button">
+              Clear all
+            </button>
+          ) : null}
+        </div>
+        <div className="mt-5 grid gap-3">
+          {constraints.map((constraint) => {
+            const isSelected = selectedConstraintIds.includes(constraint.id);
+            return (
+              <button aria-pressed={isSelected} className={`rounded-[1.35rem] border px-4 py-4 text-left transition ${isSelected ? "border-slate-900 bg-slate-950 text-white shadow-[0_22px_55px_-38px_rgba(15,23,42,0.9)]" : "border-slate-200 bg-white/80 hover:border-slate-300 hover:bg-white"}`} key={constraint.id} onClick={() => onToggleConstraint(constraint.id)} type="button">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h3 className="text-base font-semibold">{constraint.label}</h3>
+                    <p className={`mt-2 text-sm leading-6 ${isSelected ? "text-slate-300" : "text-slate-600"}`}>{constraint.description}</p>
+                  </div>
+                  <span className={`rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] ${isSelected ? "border-white/15 bg-white/10 text-white" : severityStyles[constraint.severity]}`}>{constraint.severity}</span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
+        <div className="rounded-[1.4rem] bg-slate-950 px-4 py-4 text-white">
+          <p className="text-xs uppercase tracking-[0.25em] text-slate-300">Buffer In View</p>
+          <p className="mt-2 text-2xl font-semibold">{totalBufferMinutes} min</p>
+        </div>
+        <div className="rounded-[1.4rem] bg-white px-4 py-4 shadow-sm">
+          <p className="text-xs uppercase tracking-[0.25em] text-slate-500">Watch Segments</p>
+          <p className="mt-2 text-2xl font-semibold text-slate-950">{watchCount}</p>
+        </div>
+        <div className="rounded-[1.4rem] bg-white px-4 py-4 shadow-sm">
+          <p className="text-xs uppercase tracking-[0.25em] text-slate-500">Reroute Calls</p>
+          <p className="mt-2 text-2xl font-semibold text-slate-950">{rerouteCount}</p>
+        </div>
+      </section>
+      <section className="rounded-[1.5rem] border border-slate-200 bg-white/85 p-5">
+        <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">Focused Segment</p>
+        {activeSegment ? (
+          <>
+            <h3 className="mt-3 text-xl font-semibold text-slate-950">{activeSegment.label}</h3>
+            <p className="mt-2 text-sm leading-6 text-slate-600">{activeSegment.start} to {activeSegment.end}</p>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+              <div className="rounded-[1.25rem] bg-slate-100 px-4 py-3">
+                <p className="text-xs uppercase tracking-[0.25em] text-slate-500">Window</p>
+                <p className="mt-2 text-sm font-semibold text-slate-950">{activeSegment.window}</p>
+              </div>
+              <div className="rounded-[1.25rem] bg-slate-100 px-4 py-3">
+                <p className="text-xs uppercase tracking-[0.25em] text-slate-500">Confidence</p>
+                <p className="mt-2 text-sm font-semibold text-slate-950">{activeSegment.confidence}%</p>
+              </div>
+            </div>
+            <p className="mt-4 text-sm leading-6 text-slate-600">{activeSegment.fallback}</p>
+          </>
+        ) : (
+          <p className="mt-3 text-sm leading-6 text-slate-600">No segment is visible for the current filter set.</p>
+        )}
+      </section>
+      <section className="rounded-[1.5rem] border border-amber-200 bg-amber-50/80 p-5">
+        <p className="text-sm font-semibold uppercase tracking-[0.25em] text-amber-700">Decision Sidebar</p>
+        <h3 className="mt-3 text-xl font-semibold text-slate-950">{decision.title}</h3>
+        <p className="mt-2 inline-flex rounded-full bg-white px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-slate-700">{decision.label}</p>
+        <p className="mt-4 text-sm leading-6 text-slate-700">{decision.detail}</p>
+        <div className="mt-4 flex flex-wrap gap-2">
+          {owners.length > 0 ? (
+            owners.map((owner) => (
+              <span className="rounded-full bg-white px-3 py-1 text-xs text-slate-700" key={owner}>{owner}</span>
+            ))
+          ) : (
+            <span className="rounded-full bg-white px-3 py-1 text-xs text-slate-700">No active owners in scope</span>
+          )}
+        </div>
+      </section>
+    </aside>
+  );
+}

--- a/src/components/route-planner/route-planner-header.tsx
+++ b/src/components/route-planner/route-planner-header.tsx
@@ -1,0 +1,34 @@
+type RoutePlannerHeaderProps = { activeConstraintCount: number; dispatchLead: string; objective: string; planningMode: string; routeName: string; routeScore: number; selectedWindow: string; summary: string; totalSegments: number; visibleSegments: number };
+
+export function RoutePlannerHeader({ activeConstraintCount, dispatchLead, objective, planningMode, routeName, routeScore, selectedWindow, summary, totalSegments, visibleSegments }: RoutePlannerHeaderProps) {
+  return (
+    <section className="overflow-hidden rounded-[2rem] border border-amber-200/70 bg-[linear-gradient(135deg,rgba(255,251,235,0.96),rgba(255,237,213,0.92))] p-6 shadow-[0_30px_80px_-45px_rgba(146,64,14,0.6)] sm:p-8">
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.5fr)_minmax(18rem,0.85fr)]">
+        <div className="space-y-4">
+          <p className="text-sm font-semibold uppercase tracking-[0.35em] text-amber-700">{planningMode}</p>
+          <div className="space-y-3">
+            <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">{routeName}</h1>
+            <p className="max-w-3xl text-base leading-7 text-slate-700 sm:text-lg">{summary}</p>
+            <p className="max-w-3xl text-sm leading-6 text-slate-600">{objective}</p>
+          </div>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
+          <div className="rounded-[1.5rem] bg-slate-950 px-5 py-4 text-slate-50">
+            <p className="text-xs uppercase tracking-[0.25em] text-amber-200">Route Score</p>
+            <p className="mt-2 text-3xl font-semibold">{routeScore}</p>
+          </div>
+          <div className="rounded-[1.5rem] bg-white/80 px-5 py-4 text-slate-900">
+            <p className="text-xs uppercase tracking-[0.25em] text-slate-500">Selected Window</p>
+            <p className="mt-2 text-lg font-semibold">{selectedWindow}</p>
+            <p className="mt-1 text-sm text-slate-600">{dispatchLead}</p>
+          </div>
+          <div className="rounded-[1.5rem] bg-white/80 px-5 py-4 text-slate-900">
+            <p className="text-xs uppercase tracking-[0.25em] text-slate-500">In Scope</p>
+            <p className="mt-2 text-lg font-semibold">{visibleSegments} of {totalSegments} segments</p>
+            <p className="mt-1 text-sm text-slate-600">{activeConstraintCount > 0 ? `${activeConstraintCount} active constraint filters` : "Baseline route view"}</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/route-planner/route-planner-shell.tsx
+++ b/src/components/route-planner/route-planner-shell.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { startTransition, useState } from "react";
+
+import {
+  plannedRoutes,
+  routeConstraints,
+  type ConstraintId,
+} from "@/app/route-planner/route-planner-data";
+import { ConstraintSidebar } from "./constraint-sidebar";
+import { RoutePlannerHeader } from "./route-planner-header";
+import { RouteSelector } from "./route-selector";
+import { SegmentRail } from "./segment-rail";
+
+export function RoutePlannerShell() {
+  const [selectedRouteId, setSelectedRouteId] = useState(plannedRoutes[0]?.id ?? "");
+  const [selectedSegmentId, setSelectedSegmentId] = useState<string | null>(plannedRoutes[0]?.segments[0]?.id ?? null);
+  const [selectedConstraintIds, setSelectedConstraintIds] = useState<ConstraintId[]>([]);
+  const activeRoute = plannedRoutes.find((route) => route.id === selectedRouteId) ?? plannedRoutes[0];
+  const hasActiveFilters = selectedConstraintIds.length > 0;
+  const activeConstraints = routeConstraints.filter((constraint) => selectedConstraintIds.includes(constraint.id));
+  const visibleSegments = activeRoute.segments.filter((segment) =>
+    selectedConstraintIds.length === 0 ? true : segment.constraintIds.some((constraintId) => selectedConstraintIds.includes(constraintId)),
+  );
+  const activeSegmentId = visibleSegments.some((segment) => segment.id === selectedSegmentId) ? selectedSegmentId : (visibleSegments[0]?.id ?? null);
+  const activeSegment = activeRoute.segments.find((segment) => segment.id === activeSegmentId) ?? null;
+  const totalBufferMinutes = visibleSegments.reduce((total, segment) => total + segment.bufferMinutes, 0);
+  const rerouteCount = visibleSegments.filter((segment) => segment.status === "reroute").length;
+  const watchCount = visibleSegments.filter((segment) => segment.status === "watch").length;
+  const decision =
+    visibleSegments.length === 0
+      ? { label: "Reset filters", title: "No live segments match the current constraint slice.", detail: "This route is still available, but none of its segments carry the filters currently enabled in the sidebar." }
+      : rerouteCount > 0
+        ? { label: "Escalate reroute", title: "A constrained segment now needs path reassignment.", detail: "Keep the route active, but move the flagged segment to its fallback corridor before downstream timing collapses." }
+        : watchCount > 1
+          ? { label: "Hold and monitor", title: "Multiple segments are stable but require close sequencing.", detail: "The plan is still viable if dispatch keeps each handoff inside the current time window and avoids compounding watch states." }
+          : { label: hasActiveFilters ? "Filtered view" : "Baseline plan", title: "Preferred corridor remains intact.", detail: "No reroute trigger is active in the visible chain, so operators can keep the current route as the working plan." };
+
+  function handleSelectRoute(routeId: string) {
+    const nextRoute = plannedRoutes.find((route) => route.id === routeId);
+    if (!nextRoute) return;
+    startTransition(() => {
+      setSelectedRouteId(routeId);
+      setSelectedSegmentId(nextRoute.segments[0]?.id ?? null);
+    });
+  }
+
+  function handleSelectSegment(segmentId: string) {
+    startTransition(() => setSelectedSegmentId(segmentId));
+  }
+
+  function handleToggleConstraint(constraintId: ConstraintId) {
+    startTransition(() => {
+      setSelectedConstraintIds((current) => current.includes(constraintId) ? current.filter((value) => value !== constraintId) : [...current, constraintId]);
+    });
+  }
+
+  function handleClearConstraints() {
+    startTransition(() => setSelectedConstraintIds([]));
+  }
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(245,158,11,0.2),transparent_30%),linear-gradient(180deg,#fffaf0_0%,#f8fafc_45%,#eef2ff_100%)] px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <RoutePlannerHeader
+          activeConstraintCount={activeConstraints.length}
+          dispatchLead={activeRoute.dispatchLead}
+          objective={activeRoute.objective}
+          planningMode={activeRoute.planningMode}
+          routeName={activeRoute.name}
+          routeScore={activeRoute.routeScore}
+          selectedWindow={activeRoute.selectedWindow}
+          summary={activeRoute.summary}
+          totalSegments={activeRoute.segments.length}
+          visibleSegments={visibleSegments.length}
+        />
+        <RouteSelector
+          onSelectRoute={handleSelectRoute}
+          routes={plannedRoutes}
+          selectedRouteId={activeRoute.id}
+        />
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.9fr)]">
+          <SegmentRail
+            constraints={routeConstraints}
+            hasActiveFilters={hasActiveFilters}
+            onClearFilters={handleClearConstraints}
+            onSelectSegment={handleSelectSegment}
+            routeName={activeRoute.name}
+            segments={visibleSegments}
+            selectedSegmentId={activeSegmentId}
+            totalSegments={activeRoute.segments.length}
+          />
+          <ConstraintSidebar
+            activeSegment={activeSegment}
+            constraints={routeConstraints}
+            decision={decision}
+            hasActiveFilters={hasActiveFilters}
+            onClearFilters={handleClearConstraints}
+            onToggleConstraint={handleToggleConstraint}
+            selectedConstraintIds={selectedConstraintIds}
+            totalBufferMinutes={totalBufferMinutes}
+            visibleSegments={visibleSegments}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/route-planner/route-selector.tsx
+++ b/src/components/route-planner/route-selector.tsx
@@ -1,0 +1,28 @@
+import type { PlannedRoute } from "@/app/route-planner/route-planner-data";
+
+type RouteSelectorProps = { onSelectRoute: (routeId: string) => void; routes: PlannedRoute[]; selectedRouteId: string };
+
+export function RouteSelector({ onSelectRoute, routes, selectedRouteId }: RouteSelectorProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-slate-200/80 bg-white/80 p-4 shadow-[0_20px_60px_-42px_rgba(15,23,42,0.35)] backdrop-blur">
+      <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">Route Set</p>
+      <h2 className="mt-2 text-xl font-semibold text-slate-950">Select a corridor and inspect its segment chain.</h2>
+      <div className="mt-4 grid gap-3 lg:grid-cols-3">
+        {routes.map((route) => {
+          const isSelected = route.id === selectedRouteId;
+          return (
+            <button aria-pressed={isSelected} className={`rounded-[1.5rem] border px-4 py-4 text-left transition ${isSelected ? "border-amber-300 bg-amber-50 shadow-[0_18px_45px_-32px_rgba(217,119,6,0.8)]" : "border-slate-200 bg-slate-50/80 hover:border-slate-300 hover:bg-white"}`} key={route.id} onClick={() => onSelectRoute(route.id)} type="button">
+              <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">{route.planningMode}</p>
+              <h3 className="mt-2 text-lg font-semibold text-slate-950">{route.name}</h3>
+              <p className="mt-2 text-sm leading-6 text-slate-600">{route.summary}</p>
+              <div className="mt-4 flex items-center justify-between text-sm text-slate-600">
+                <span>{route.segments.length} segments</span>
+                <span>{route.dispatchLead}</span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/route-planner/segment-rail.tsx
+++ b/src/components/route-planner/segment-rail.tsx
@@ -1,0 +1,83 @@
+import type {
+  RouteConstraint,
+  RouteSegment,
+} from "@/app/route-planner/route-planner-data";
+
+type SegmentRailProps = { constraints: RouteConstraint[]; hasActiveFilters: boolean; onClearFilters: () => void; onSelectSegment: (segmentId: string) => void; routeName: string; segments: RouteSegment[]; selectedSegmentId: string | null; totalSegments: number };
+
+const statusStyles = {
+  locked: "bg-emerald-100 text-emerald-800",
+  watch: "bg-amber-100 text-amber-800",
+  reroute: "bg-rose-100 text-rose-800",
+} as const;
+
+export function SegmentRail({
+  constraints,
+  hasActiveFilters,
+  onClearFilters,
+  onSelectSegment,
+  routeName,
+  segments,
+  selectedSegmentId,
+  totalSegments,
+}: SegmentRailProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-slate-200/80 bg-white/85 p-5 shadow-[0_22px_60px_-45px_rgba(15,23,42,0.4)] backdrop-blur sm:p-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">Segment Rail</p>
+          <h2 className="mt-2 text-2xl font-semibold text-slate-950">Active chain for {routeName}</h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">Inspect each handoff in sequence and narrow the board to the segments touched by current constraints.</p>
+        </div>
+        <div className="rounded-full bg-slate-100 px-4 py-2 text-sm text-slate-600">Showing {segments.length} of {totalSegments}</div>
+      </div>
+      {segments.length > 0 ? (
+        <div className="mt-6 flex gap-4 overflow-x-auto pb-2">
+          {segments.map((segment) => {
+            const isSelected = segment.id === selectedSegmentId;
+            return (
+              <button aria-pressed={isSelected} className={`min-w-[18.5rem] flex-1 rounded-[1.5rem] border px-5 py-5 text-left transition sm:min-w-[20rem] ${isSelected ? "border-slate-900 bg-slate-950 text-slate-50 shadow-[0_28px_70px_-42px_rgba(15,23,42,0.85)]" : "border-slate-200 bg-slate-50/80 text-slate-900 hover:border-slate-300 hover:bg-white"}`} key={segment.id} onClick={() => onSelectSegment(segment.id)} type="button">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className={`text-xs font-semibold uppercase tracking-[0.25em] ${isSelected ? "text-slate-300" : "text-slate-500"}`}>{segment.mode}</p>
+                    <h3 className="mt-2 text-xl font-semibold">{segment.label}</h3>
+                  </div>
+                  <span className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] ${isSelected ? "bg-white/12 text-white" : statusStyles[segment.status]}`}>{segment.status}</span>
+                </div>
+                <div className={`mt-5 rounded-[1.25rem] border px-4 py-4 ${isSelected ? "border-white/10 bg-white/6" : "border-slate-200 bg-white/70"}`}>
+                  <p className={isSelected ? "text-slate-300" : "text-slate-500"}>{segment.start}</p>
+                  <p className="mt-2 text-lg font-semibold">{segment.end}</p>
+                  <p className={`mt-2 text-sm ${isSelected ? "text-slate-300" : "text-slate-600"}`}>{segment.window} • {segment.bufferMinutes} min buffer</p>
+                </div>
+                <p className={`mt-4 text-sm leading-6 ${isSelected ? "text-slate-200" : "text-slate-600"}`}>{segment.note}</p>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {segment.constraintIds.length > 0 ? (
+                    segment.constraintIds.map((constraintId) => {
+                      const label = constraints.find((constraint) => constraint.id === constraintId)?.label ?? constraintId.replace("-", " ");
+                      return (
+                        <span className={`rounded-full px-3 py-1 text-xs ${isSelected ? "bg-white/12 text-slate-100" : "bg-slate-200 text-slate-700"}`} key={constraintId}>{label}</span>
+                      );
+                    })
+                  ) : (
+                    <span className={`rounded-full px-3 py-1 text-xs ${isSelected ? "bg-white/12 text-slate-100" : "bg-emerald-100 text-emerald-800"}`}>No active constraint tags</span>
+                  )}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="mt-6 rounded-[1.5rem] border border-dashed border-slate-300 bg-slate-50/70 p-8 text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">Zero State</p>
+          <h3 className="mt-3 text-2xl font-semibold text-slate-950">No segments match the current constraint focus.</h3>
+          <p className="mt-3 text-sm leading-6 text-slate-600">{hasActiveFilters ? "Clear one or more filters to restore the full route chain." : "Select another route to continue reviewing segment coverage."}</p>
+          {hasActiveFilters ? (
+            <button className="mt-5 rounded-full bg-slate-950 px-5 py-3 text-sm font-semibold text-white transition hover:bg-slate-800" onClick={onClearFilters} type="button">
+              Reset constraint filters
+            </button>
+          ) : null}
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/route-planner` app route with local mock route and constraint data
- build a client-side planner shell with route selection, segment cards, and a decision sidebar
- keep all state and UI scoped to the route-planner feature folders only

## Verification
- npm run lint
- npm run typecheck
- npm run build

Closes #37