### PR TITLE
feat: add isolated inventory bay route

### DIFF
--- a/src/app/inventory-bay/mock-data.ts
+++ b/src/app/inventory-bay/mock-data.ts
@@ -1,0 +1,74 @@
+export type StockBandId = "steady" | "watch" | "critical";
+
+export type StorageZone = {
+  id: string;
+  label: string;
+  shelf: string;
+  climate: string;
+  note: string;
+};
+
+export type StockBand = {
+  id: StockBandId;
+  label: string;
+  summary: string;
+  guidance: string;
+};
+
+export type InventoryItem = {
+  id: string;
+  sku: string;
+  name: string;
+  zoneId: StorageZone["id"];
+  bandId: StockBandId;
+  unitsOnHand: number;
+  capacity: number;
+  reorderPoint: number;
+  dailyPickRate: number;
+  leadTimeDays: number;
+  palletFace: string;
+  lastCountedAt: string;
+};
+
+export type RestockSuggestion = {
+  id: string;
+  itemId: InventoryItem["id"];
+  zoneId: StorageZone["id"];
+  priority: "routine" | "critical";
+  suggestedUnits: number;
+  supplier: string;
+  etaWindow: string;
+  rationale: string;
+};
+
+export const storageZones: StorageZone[] = [
+  { id: "north-cold", label: "North Cold Bay", shelf: "A1-A4", climate: "4 C chilled", note: "Rapid-turn coolants and seals" },
+  { id: "east-heavy", label: "East Heavy Rack", shelf: "B7-B11", climate: "Ambient", note: "Dense metal fittings and valve stock" },
+  { id: "south-pick", label: "South Pick Line", shelf: "C2-C6", climate: "Ambient", note: "Daily order picks and scanner kits" },
+  { id: "west-buffer", label: "West Buffer Deck", shelf: "D1-D3", climate: "Dry hold", note: "Overflow packs and backfill lanes" },
+];
+
+export const stockBands: StockBand[] = [
+  { id: "steady", label: "Steady", summary: "Healthy stock coverage", guidance: "Carry on with normal cycle counts and supplier cadence." },
+  { id: "watch", label: "Watch", summary: "Thresholds are narrowing", guidance: "Rebalance nearby zones or prepare the next replenishment batch." },
+  { id: "critical", label: "Critical", summary: "Reorder action is due", guidance: "Protect picks, escalate the restock, and avoid new allocations." },
+];
+
+export const inventoryItems: InventoryItem[] = [
+  { id: "coolant-capsules", sku: "CB-441", name: "Coolant Capsules", zoneId: "north-cold", bandId: "critical", unitsOnHand: 12, capacity: 64, reorderPoint: 16, dailyPickRate: 6, leadTimeDays: 3, palletFace: "Cold lane A2", lastCountedAt: "07:32" },
+  { id: "gasket-kits", sku: "GK-210", name: "Composite Gasket Kits", zoneId: "north-cold", bandId: "watch", unitsOnHand: 24, capacity: 72, reorderPoint: 20, dailyPickRate: 4, leadTimeDays: 5, palletFace: "Cold lane A4", lastCountedAt: "06:48" },
+  { id: "pressure-valves", sku: "PV-902", name: "Pressure Valve Assemblies", zoneId: "east-heavy", bandId: "steady", unitsOnHand: 68, capacity: 96, reorderPoint: 24, dailyPickRate: 3, leadTimeDays: 6, palletFace: "Rack B9", lastCountedAt: "08:11" },
+  { id: "sensor-housings", sku: "SH-118", name: "Sensor Housings", zoneId: "south-pick", bandId: "watch", unitsOnHand: 18, capacity: 48, reorderPoint: 14, dailyPickRate: 5, leadTimeDays: 2, palletFace: "Pick face C3", lastCountedAt: "08:02" },
+  { id: "cable-harnesses", sku: "CH-774", name: "Cable Harness Bundles", zoneId: "south-pick", bandId: "steady", unitsOnHand: 122, capacity: 150, reorderPoint: 40, dailyPickRate: 9, leadTimeDays: 4, palletFace: "Pick face C5", lastCountedAt: "07:54" },
+  { id: "sealant-pucks", sku: "SP-063", name: "Sealant Pucks", zoneId: "west-buffer", bandId: "critical", unitsOnHand: 9, capacity: 40, reorderPoint: 12, dailyPickRate: 2, leadTimeDays: 7, palletFace: "Deck D1", lastCountedAt: "05:59" },
+  { id: "filter-mesh", sku: "FM-337", name: "Filter Mesh Rolls", zoneId: "west-buffer", bandId: "watch", unitsOnHand: 34, capacity: 70, reorderPoint: 22, dailyPickRate: 3, leadTimeDays: 5, palletFace: "Deck D3", lastCountedAt: "07:06" },
+  { id: "rotor-bolts", sku: "RB-556", name: "Rotor Bolt Trays", zoneId: "east-heavy", bandId: "steady", unitsOnHand: 240, capacity: 280, reorderPoint: 90, dailyPickRate: 11, leadTimeDays: 8, palletFace: "Rack B7", lastCountedAt: "06:27" },
+];
+
+export const restockSuggestions: RestockSuggestion[] = [
+  { id: "restock-coolant", itemId: "coolant-capsules", zoneId: "north-cold", priority: "critical", suggestedUnits: 36, supplier: "CryoWorks", etaWindow: "ETA 18h", rationale: "Open orders exceed two pick windows and the cold lane has no swap stock." },
+  { id: "restock-sealant", itemId: "sealant-pucks", zoneId: "west-buffer", priority: "critical", suggestedUnits: 24, supplier: "BufferChem", etaWindow: "ETA 30h", rationale: "The deck is below buffer minimum and the next truck is already partially filled." },
+  { id: "restock-sensors", itemId: "sensor-housings", zoneId: "south-pick", priority: "routine", suggestedUnits: 20, supplier: "North Axis", etaWindow: "ETA 12h", rationale: "Morning scans show a tighter pick slope than forecast for the next shift." },
+  { id: "restock-gaskets", itemId: "gasket-kits", zoneId: "north-cold", priority: "routine", suggestedUnits: 18, supplier: "Seal Forge", etaWindow: "ETA 2d", rationale: "A top-up keeps the cold bay above the watch band through the weekend run." },
+  { id: "restock-filter-mesh", itemId: "filter-mesh", zoneId: "west-buffer", priority: "routine", suggestedUnits: 16, supplier: "Meshline", etaWindow: "ETA 36h", rationale: "One backfill lane is reserved for overflow, so replenishment needs a shorter lot." },
+];

--- a/src/app/inventory-bay/page.tsx
+++ b/src/app/inventory-bay/page.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+
+import {
+  inventoryItems,
+  restockSuggestions,
+  stockBands,
+  storageZones,
+} from "./mock-data";
+import { InventoryBayShell } from "@/components/inventory-bay/inventory-bay-shell";
+
+export const metadata: Metadata = {
+  title: "Inventory Bay | API Test",
+  description:
+    "Monitor mock stock bands, critical thresholds, and local restock suggestions for an isolated inventory bay.",
+};
+
+export default function InventoryBayPage() {
+  return (
+    <InventoryBayShell
+      items={inventoryItems}
+      suggestions={restockSuggestions}
+      bands={stockBands}
+      zones={storageZones}
+    />
+  );
+}

--- a/src/components/inventory-bay/inventory-bay-controls.tsx
+++ b/src/components/inventory-bay/inventory-bay-controls.tsx
@@ -1,0 +1,93 @@
+import type { StockBand, StockBandId, StorageZone } from "@/app/inventory-bay/mock-data";
+
+type CountOption = {
+  id: string;
+  count: number;
+};
+
+type InventoryBayControlsProps = {
+  selectedZone: string;
+  selectedBand: StockBandId | "all";
+  criticalOnly: boolean;
+  hasFilters: boolean;
+  zones: StorageZone[];
+  bands: StockBand[];
+  zoneCounts: CountOption[];
+  bandCounts: CountOption[];
+  onZoneChange: (zoneId: string) => void;
+  onBandChange: (bandId: StockBandId | "all") => void;
+  onCriticalToggle: () => void;
+  onClear: () => void;
+};
+
+export function InventoryBayControls({
+  selectedZone,
+  selectedBand,
+  criticalOnly,
+  hasFilters,
+  zones,
+  bands,
+  zoneCounts,
+  bandCounts,
+  onZoneChange,
+  onBandChange,
+  onCriticalToggle,
+  onClear,
+}: InventoryBayControlsProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-stone-900/10 bg-white/75 p-5 shadow-[0_14px_48px_rgba(120,53,15,0.1)] backdrop-blur">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="text-sm text-stone-600">
+          Filter the bay by zone, stock band, or critical-only pressure.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <button className={`rounded-2xl px-4 py-3 text-sm font-semibold transition ${
+            criticalOnly ? "bg-rose-600 text-white shadow-lg shadow-rose-600/25" : "bg-stone-200 text-stone-700 hover:bg-stone-300"
+          }`} onClick={onCriticalToggle} type="button">
+            Critical floor only
+          </button>
+          <button
+            className="rounded-2xl border border-stone-300 px-4 py-3 text-sm font-semibold text-stone-700 transition hover:border-stone-400 hover:bg-stone-50 disabled:cursor-default disabled:opacity-50"
+            disabled={!hasFilters}
+            onClick={onClear}
+            type="button"
+          >
+            Reset view
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-5 space-y-4">
+        <div className="flex flex-wrap gap-2">
+          <button className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+            selectedZone === "all" ? "bg-stone-950 text-white" : "bg-stone-100 text-stone-700"
+          }`} onClick={() => onZoneChange("all")} type="button">
+            All zones
+          </button>
+          {zones.map((zone) => (
+            <button className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+              selectedZone === zone.id ? "bg-amber-600 text-white" : "bg-amber-50 text-amber-900"
+            }`} key={zone.id} onClick={() => onZoneChange(zone.id)} type="button">
+              {zone.label} ({zoneCounts.find((option) => option.id === zone.id)?.count ?? 0})
+            </button>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <button className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+            selectedBand === "all" ? "bg-stone-950 text-white" : "bg-stone-100 text-stone-700"
+          }`} onClick={() => onBandChange("all")} type="button">
+            All bands
+          </button>
+          {bands.map((band) => (
+            <button className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+              selectedBand === band.id ? "bg-emerald-700 text-white" : "bg-emerald-50 text-emerald-900"
+            }`} key={band.id} onClick={() => onBandChange(band.id)} type="button">
+              {band.label} ({bandCounts.find((option) => option.id === band.id)?.count ?? 0})
+            </button>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/inventory-bay/inventory-bay-shell.tsx
+++ b/src/components/inventory-bay/inventory-bay-shell.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { startTransition, useState } from "react";
+
+import type {
+  InventoryItem,
+  RestockSuggestion,
+  StockBand,
+  StockBandId,
+  StorageZone,
+} from "@/app/inventory-bay/mock-data";
+import { InventoryBayControls } from "./inventory-bay-controls";
+import { RestockSuggestionsPanel } from "./restock-suggestions-panel";
+import { StockBandBoard } from "./stock-band-board";
+
+type InventoryBayShellProps = {
+  items: InventoryItem[];
+  suggestions: RestockSuggestion[];
+  bands: StockBand[];
+  zones: StorageZone[];
+};
+
+export function InventoryBayShell({
+  items,
+  suggestions,
+  bands,
+  zones,
+}: InventoryBayShellProps) {
+  const [selectedZone, setSelectedZone] = useState<string>("all");
+  const [selectedBand, setSelectedBand] = useState<StockBandId | "all">("all");
+  const [criticalOnly, setCriticalOnly] = useState(false);
+  const [acknowledgedIds, setAcknowledgedIds] = useState<string[]>([]);
+  const [showAcknowledged, setShowAcknowledged] = useState(false);
+  const zoneMap = Object.fromEntries(zones.map((zone) => [zone.id, zone])) as Record<
+    string,
+    StorageZone
+  >;
+  const itemMap = Object.fromEntries(items.map((item) => [item.id, item])) as Record<
+    string,
+    InventoryItem
+  >;
+
+  const visibleItems = items.filter((item) => {
+    return (
+      (selectedZone === "all" || item.zoneId === selectedZone) &&
+      (selectedBand === "all" || item.bandId === selectedBand) &&
+      (!criticalOnly || item.bandId === "critical" || item.unitsOnHand <= item.reorderPoint)
+    );
+  });
+
+  const visibleSuggestions = suggestions.filter((suggestion) => {
+    const item = itemMap[suggestion.itemId];
+    return (
+      !!item &&
+      visibleItems.some((visibleItem) => visibleItem.id === item.id) &&
+      (showAcknowledged || !acknowledgedIds.includes(suggestion.id))
+    );
+  });
+
+  const totalUnits = items.reduce((sum, item) => sum + item.unitsOnHand, 0);
+  const criticalCount = items.filter(
+    (item) => item.bandId === "critical" || item.unitsOnHand <= item.reorderPoint,
+  ).length;
+  const openSuggestionCount = suggestions.filter(
+    (suggestion) => !acknowledgedIds.includes(suggestion.id),
+  ).length;
+  const hasFilters = selectedZone !== "all" || selectedBand !== "all" || criticalOnly;
+  const activeBands = selectedBand === "all" ? bands : bands.filter((band) => band.id === selectedBand);
+
+  function clearFilters() {
+    startTransition(() => {
+      setSelectedZone("all");
+      setSelectedBand("all");
+      setCriticalOnly(false);
+    });
+  }
+
+  function toggleSuggestion(suggestionId: string) {
+    startTransition(() => {
+      setAcknowledgedIds((current) =>
+        current.includes(suggestionId)
+          ? current.filter((id) => id !== suggestionId)
+          : [...current, suggestionId],
+      );
+    });
+  }
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(245,158,11,0.18),transparent_28%),radial-gradient(circle_at_bottom_right,rgba(6,95,70,0.14),transparent_32%),linear-gradient(180deg,#fffaf1_0%,#f4ecdf_55%,#eadfcf_100%)] px-4 py-6 text-stone-950 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <section className="overflow-hidden rounded-[2rem] border border-stone-900/10 bg-white/80 shadow-[0_18px_60px_rgba(120,53,15,0.14)] backdrop-blur">
+          <div className="grid gap-6 px-6 py-8 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,0.85fr)] lg:px-8">
+            <div className="space-y-4">
+              <p className="text-sm font-semibold uppercase tracking-[0.35em] text-amber-700">
+                Inventory Bay
+              </p>
+              <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-stone-950 sm:text-5xl">
+                Mock stock bands, threshold pressure, and restock calls for one isolated bay.
+              </h1>
+              <p className="max-w-2xl text-base leading-7 text-stone-600 sm:text-lg">
+                Everything on this route is local: zone filters, band grouping, and
+                acknowledgement state never leave the client.
+              </p>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="rounded-3xl bg-stone-950 px-5 py-4 text-stone-50">
+                <p className="text-sm text-stone-300">Units on hand</p>
+                <p className="mt-2 text-3xl font-semibold">{totalUnits}</p>
+              </div>
+              <div className="rounded-3xl bg-rose-100 px-5 py-4 text-rose-950">
+                <p className="text-sm text-rose-700">Critical items</p>
+                <p className="mt-2 text-3xl font-semibold">{criticalCount}</p>
+              </div>
+              <div className="rounded-3xl bg-amber-100 px-5 py-4 text-amber-950">
+                <p className="text-sm text-amber-700">Open restocks</p>
+                <p className="mt-2 text-3xl font-semibold">{openSuggestionCount}</p>
+              </div>
+              <div className="rounded-3xl bg-emerald-100 px-5 py-4 text-emerald-950">
+                <p className="text-sm text-emerald-700">Visible / zones</p>
+                <p className="mt-2 text-3xl font-semibold">
+                  {visibleItems.length} / {zones.length}
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+        <InventoryBayControls
+          bandCounts={bands.map((band) => ({
+            id: band.id,
+            count: items.filter(
+              (item) =>
+                item.bandId === band.id &&
+                (selectedZone === "all" || item.zoneId === selectedZone) &&
+                (!criticalOnly || item.bandId === "critical" || item.unitsOnHand <= item.reorderPoint),
+            ).length,
+          }))}
+          bands={bands}
+          criticalOnly={criticalOnly}
+          hasFilters={hasFilters}
+          onBandChange={(bandId) => startTransition(() => setSelectedBand(bandId))}
+          onClear={clearFilters}
+          onCriticalToggle={() => startTransition(() => setCriticalOnly((value) => !value))}
+          onZoneChange={(zoneId) => startTransition(() => setSelectedZone(zoneId))}
+          selectedBand={selectedBand}
+          selectedZone={selectedZone}
+          zoneCounts={zones.map((zone) => ({
+            id: zone.id,
+            count: items.filter(
+              (item) =>
+                item.zoneId === zone.id &&
+                (selectedBand === "all" || item.bandId === selectedBand) &&
+                (!criticalOnly || item.bandId === "critical" || item.unitsOnHand <= item.reorderPoint),
+            ).length,
+          }))}
+          zones={zones}
+        />
+
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.55fr)_minmax(320px,0.9fr)]">
+          <StockBandBoard
+            activeBands={activeBands}
+            hasFilters={hasFilters}
+            items={visibleItems}
+            onClearFilters={clearFilters}
+            zoneMap={zoneMap}
+          />
+          <RestockSuggestionsPanel
+            acknowledgedIds={acknowledgedIds}
+            itemMap={itemMap}
+            onToggleSuggestion={toggleSuggestion}
+            showAcknowledged={showAcknowledged}
+            suggestions={visibleSuggestions}
+            toggleAcknowledgedView={() =>
+              startTransition(() => setShowAcknowledged((value) => !value))
+            }
+            zoneMap={zoneMap}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/inventory-bay/restock-suggestions-panel.tsx
+++ b/src/components/inventory-bay/restock-suggestions-panel.tsx
@@ -1,0 +1,69 @@
+import type { InventoryItem, RestockSuggestion, StorageZone } from "@/app/inventory-bay/mock-data";
+
+type RestockSuggestionsPanelProps = {
+  suggestions: RestockSuggestion[];
+  acknowledgedIds: string[];
+  showAcknowledged: boolean;
+  itemMap: Record<string, InventoryItem>;
+  zoneMap: Record<string, StorageZone>;
+  onToggleSuggestion: (suggestionId: string) => void;
+  toggleAcknowledgedView: () => void;
+};
+
+export function RestockSuggestionsPanel({
+  suggestions,
+  acknowledgedIds,
+  showAcknowledged,
+  itemMap,
+  zoneMap,
+  onToggleSuggestion,
+  toggleAcknowledgedView,
+}: RestockSuggestionsPanelProps) {
+  return (
+    <aside className="rounded-[1.75rem] border border-stone-900/10 bg-stone-950 p-5 text-stone-50 shadow-[0_18px_54px_rgba(28,25,23,0.32)]">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-amber-300">Restock Suggestions</p>
+          <h2 className="mt-2 text-2xl font-semibold">Local queue</h2>
+          <p className="mt-2 text-sm leading-6 text-stone-300">Acknowledge a suggestion to clear it from the default queue. The state resets with the session.</p>
+        </div>
+        <button className="rounded-full border border-stone-700 px-4 py-2 text-sm font-semibold text-stone-100 transition hover:border-stone-500" onClick={toggleAcknowledgedView} type="button">
+          {showAcknowledged ? "Hide acknowledged" : "Show acknowledged"}
+        </button>
+      </div>
+
+      <div className="mt-5 space-y-4">
+        {suggestions.length ? suggestions.map((suggestion) => {
+          const item = itemMap[suggestion.itemId];
+          const zone = zoneMap[suggestion.zoneId];
+          const isAcknowledged = acknowledgedIds.includes(suggestion.id);
+
+          return (
+            <article className="rounded-[1.5rem] border border-stone-800 bg-stone-900/80 p-4" key={suggestion.id}>
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.22em] text-stone-400">{zone.label}</p>
+                  <h3 className="mt-2 text-lg font-semibold text-stone-50">{item.name}</h3>
+                </div>
+                <span className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ${suggestion.priority === "critical" ? "bg-rose-500/20 text-rose-200" : "bg-amber-500/20 text-amber-200"}`}>{suggestion.priority}</span>
+              </div>
+              <p className="mt-4 text-sm text-stone-300">+{suggestion.suggestedUnits} units · {suggestion.supplier} · {suggestion.etaWindow} · {item.sku}</p>
+              <p className="mt-3 text-sm leading-6 text-stone-300">{suggestion.rationale}</p>
+              <button className={`mt-4 w-full rounded-2xl px-4 py-3 text-sm font-semibold transition ${
+                isAcknowledged ? "bg-stone-700 text-stone-100 hover:bg-stone-600" : "bg-amber-400 text-stone-950 hover:bg-amber-300"
+              }`} onClick={() => onToggleSuggestion(suggestion.id)} type="button">
+                {isAcknowledged ? "Reopen suggestion" : "Acknowledge suggestion"}
+              </button>
+            </article>
+          );
+        }) : (
+          <div className="rounded-[1.5rem] border border-dashed border-stone-700 bg-stone-900/70 px-5 py-8 text-center">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-stone-400">Queue empty</p>
+            <h3 className="mt-3 text-xl font-semibold text-stone-50">No restock suggestions are visible for this view.</h3>
+            <p className="mt-3 text-sm leading-6 text-stone-300">Adjust the bay filters or reveal acknowledged suggestions to inspect the full local queue again.</p>
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/inventory-bay/stock-band-board.tsx
+++ b/src/components/inventory-bay/stock-band-board.tsx
@@ -1,0 +1,87 @@
+import type { InventoryItem, StockBand, StorageZone } from "@/app/inventory-bay/mock-data";
+
+type StockBandBoardProps = {
+  activeBands: StockBand[];
+  items: InventoryItem[];
+  hasFilters: boolean;
+  onClearFilters: () => void;
+  zoneMap: Record<string, StorageZone>;
+};
+
+export function StockBandBoard({ activeBands, items, hasFilters, onClearFilters, zoneMap }: StockBandBoardProps) {
+  if (items.length === 0) {
+    return (
+      <section className="rounded-[1.75rem] border border-dashed border-stone-300 bg-white/75 p-8 text-center shadow-[0_14px_40px_rgba(120,53,15,0.08)]">
+        <p className="text-sm font-semibold uppercase tracking-[0.28em] text-stone-500">Bay clear</p>
+        <h2 className="mt-3 text-2xl font-semibold text-stone-950">No inventory lines match the current filters.</h2>
+        <p className="mt-3 text-sm leading-6 text-stone-600">Widen the zone or band selection to bring the mock stock lanes back into view.</p>
+        {hasFilters ? <button className="mt-5 rounded-full bg-stone-950 px-5 py-3 text-sm font-semibold text-white" onClick={onClearFilters} type="button">Reset inventory filters</button> : null}
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-5">
+      {activeBands.map((band) => {
+        const bandItems = items.filter((item) => item.bandId === band.id);
+
+        return (
+          <div className="rounded-[1.75rem] border border-stone-900/10 bg-white/78 p-5 shadow-[0_14px_48px_rgba(120,53,15,0.1)] backdrop-blur" key={band.id}>
+            <div className="flex flex-wrap items-end justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-[0.28em] text-stone-500">{band.label}</p>
+                <h2 className="mt-2 text-2xl font-semibold text-stone-950">{band.summary}</h2>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-stone-600">{band.guidance}</p>
+              </div>
+              <div className="rounded-2xl bg-stone-100 px-4 py-3 text-sm text-stone-700">{bandItems.length} SKU{bandItems.length === 1 ? "" : "s"}</div>
+            </div>
+
+            {bandItems.length ? (
+              <div className="mt-5 grid gap-4 md:grid-cols-2">
+                {bandItems.map((item) => {
+                  const zone = zoneMap[item.zoneId];
+                  const fillPercent = Math.min(100, Math.round((item.unitsOnHand / item.capacity) * 100));
+                  const thresholdPercent = Math.min(100, Math.round((item.reorderPoint / item.capacity) * 100));
+                  const needsAttention = item.bandId === "critical" || item.unitsOnHand <= item.reorderPoint;
+
+                  return (
+                    <article className="rounded-[1.5rem] border border-stone-900/10 bg-stone-50/90 p-5" key={item.id}>
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">{item.sku}</p>
+                          <h3 className="mt-2 text-xl font-semibold text-stone-950">{item.name}</h3>
+                        </div>
+                        <span className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] ${needsAttention ? "bg-rose-100 text-rose-800" : "bg-emerald-100 text-emerald-800"}`}>{needsAttention ? "Threshold" : "Covered"}</span>
+                      </div>
+                      <p className="mt-3 text-sm text-stone-600">{zone.label} · {zone.shelf} · {zone.climate}</p>
+                      <div className="mt-4 flex items-end justify-between gap-3">
+                        <div>
+                          <p className="text-sm text-stone-500">Units on hand</p>
+                          <p className="text-3xl font-semibold text-stone-950">{item.unitsOnHand}</p>
+                        </div>
+                        <div className="text-right text-sm text-stone-600">
+                          <p>Threshold {item.reorderPoint}</p>
+                          <p>Capacity {item.capacity}</p>
+                        </div>
+                      </div>
+                      <div className="relative mt-3 h-3 rounded-full bg-stone-200">
+                        <div className={`h-3 rounded-full ${needsAttention ? "bg-rose-500" : "bg-emerald-600"}`} style={{ width: `${fillPercent}%` }} />
+                        <span className="absolute top-[-4px] h-5 w-0.5 bg-stone-950/70" style={{ left: `${thresholdPercent}%` }} />
+                      </div>
+                      <div className="mt-4 flex flex-wrap gap-2 text-sm text-stone-600">
+                        <span className="rounded-full bg-white px-3 py-1">Pick {item.dailyPickRate}/day</span>
+                        <span className="rounded-full bg-white px-3 py-1">Lead {item.leadTimeDays}d</span>
+                        <span className="rounded-full bg-white px-3 py-1">{item.palletFace}</span>
+                        <span className="rounded-full bg-white px-3 py-1">Count {item.lastCountedAt}</span>
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            ) : <div className="mt-5 rounded-3xl border border-dashed border-stone-300 bg-stone-50 px-5 py-6 text-sm leading-6 text-stone-600">No stock lanes sit in this band for the current zone selection.</div>}
+          </div>
+        );
+      })}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/inventory-bay` route with feature-local mock data and metadata
- add local zone/band filters, grouped stock sections, and threshold-aware inventory cards
- add a local restock queue with acknowledge toggles and empty-state handling

Closes #38

## Verification
- npm run lint -- src/app/inventory-bay src/components/inventory-bay
- npm run typecheck
- npm run test
- npm run build