### PR TITLE
feat: add runbook studio route

### DIFF
--- a/src/app/runbook-studio/page.tsx
+++ b/src/app/runbook-studio/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+import RunbookStudioShell from "@/components/runbook-studio/runbook-studio-shell";
+
+export const metadata: Metadata = {
+  title: "Runbook Studio | API Test",
+  description:
+    "Isolated mock runbook authoring surface with procedure cards, execution stages, and a preview panel.",
+};
+
+export default function RunbookStudioPage() {
+  return <RunbookStudioShell />;
+}

--- a/src/components/runbook-studio/execution-preview-panel.tsx
+++ b/src/components/runbook-studio/execution-preview-panel.tsx
@@ -1,0 +1,155 @@
+import {
+  executionStages,
+  type Procedure,
+  type StageId,
+} from "./runbook-studio-data";
+
+const stageClasses = {
+  ready: "border-emerald-200 bg-emerald-50 text-emerald-900",
+  watch: "border-amber-200 bg-amber-50 text-amber-900",
+  blocked: "border-rose-200 bg-rose-50 text-rose-900",
+} as const;
+
+type ChecklistState = Record<string, boolean>;
+
+type ExecutionPreviewPanelProps = {
+  procedure: Procedure | null;
+  hiddenStageIds: StageId[];
+  completedSteps: ChecklistState | undefined;
+  onToggleStage: (stageId: StageId) => void;
+  onToggleStep: (procedureId: string, stepId: string) => void;
+};
+
+export default function ExecutionPreviewPanel({
+  procedure,
+  hiddenStageIds,
+  completedSteps,
+  onToggleStage,
+  onToggleStep,
+}: ExecutionPreviewPanelProps) {
+  if (!procedure) {
+    return (
+      <aside className="rounded-[2rem] border border-dashed border-slate-300 bg-white/70 p-6 shadow-[0_18px_70px_rgba(15,23,42,0.06)]">
+        <p className="text-xs font-semibold uppercase tracking-[0.35em] text-slate-500">Preview</p>
+        <h2 className="mt-3 text-2xl font-semibold text-slate-950">No procedure is visible for the current section filter.</h2>
+        <p className="mt-3 text-sm leading-6 text-slate-600">Reopen a section or return to all cards to restore the execution preview.</p>
+      </aside>
+    );
+  }
+
+  const hiddenStageSet = new Set(hiddenStageIds);
+  const visibleStages = executionStages.filter((stage) => !hiddenStageSet.has(stage.id));
+  const visibleStepCount = procedure.steps.filter((step) => !hiddenStageSet.has(step.stageId)).length;
+  const completedCount = procedure.steps.filter((step) => completedSteps?.[step.id] && !hiddenStageSet.has(step.stageId)).length;
+
+  return (
+    <aside className="rounded-[2rem] border border-slate-200/80 bg-white/92 p-6 shadow-[0_24px_90px_rgba(15,23,42,0.08)] backdrop-blur">
+      <div className="flex flex-col gap-4 border-b border-slate-200 pb-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-slate-500">Execution Preview</p>
+            <h2 className="mt-2 text-2xl font-semibold text-slate-950">{procedure.title}</h2>
+          </div>
+          <span className="rounded-full border border-slate-200 bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-slate-700">
+            {procedure.section}
+          </span>
+        </div>
+        <p className="text-sm leading-6 text-slate-600">{procedure.preview.summary}</p>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="rounded-2xl bg-slate-950 px-4 py-3 text-slate-50">
+            <p className="text-xs uppercase tracking-[0.25em] text-slate-400">Visible stages</p>
+            <p className="mt-2 text-2xl font-semibold">{visibleStages.length}</p>
+          </div>
+          <div className="rounded-2xl bg-slate-100 px-4 py-3 text-slate-950">
+            <p className="text-xs uppercase tracking-[0.25em] text-slate-500">Checklist</p>
+            <p className="mt-2 text-2xl font-semibold">{completedCount}/{visibleStepCount}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-5">
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Stage visibility</p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {executionStages.map((stage) => {
+            const isHidden = hiddenStageSet.has(stage.id);
+            return (
+              <button
+                className={`rounded-full border px-3 py-2 text-sm font-medium transition ${isHidden ? "border-slate-200 bg-white text-slate-500" : "border-slate-950 bg-slate-950 text-white"}`}
+                key={stage.id}
+                onClick={() => onToggleStage(stage.id)}
+                type="button"
+              >
+                {stage.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {visibleStages.length === 0 ? (
+        <div className="mt-6 rounded-[1.75rem] border border-dashed border-slate-300 bg-slate-50 p-6 text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-500">Zero stages visible</p>
+          <p className="mt-3 text-sm leading-6 text-slate-600">Turn at least one stage back on to rebuild the preview and checklist.</p>
+        </div>
+      ) : (
+        <div className="mt-6 space-y-4">
+          {visibleStages.map((stage) => {
+            const detail = procedure.stages.find((item) => item.id === stage.id);
+            const stageSteps = procedure.steps.filter((item) => item.stageId === stage.id);
+            if (!detail) {
+              return null;
+            }
+            return (
+              <section className="rounded-[1.6rem] border border-slate-200 bg-slate-50/80 p-4" key={stage.id}>
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">{stage.label}</p>
+                    <h3 className="mt-2 text-lg font-semibold text-slate-950">{detail.title}</h3>
+                  </div>
+                  <span className={`rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] ${stageClasses[detail.status]}`}>
+                    {detail.status}
+                  </span>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-slate-600">{detail.detail}</p>
+                <div className="mt-4 space-y-2">
+                  {stageSteps.map((step) => {
+                    const isComplete = Boolean(completedSteps?.[step.id]);
+                    return (
+                      <button
+                        className={`flex w-full gap-3 rounded-2xl border px-3 py-3 text-left transition ${isComplete ? "border-emerald-200 bg-emerald-50" : "border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50"}`}
+                        key={step.id}
+                        onClick={() => onToggleStep(procedure.id, step.id)}
+                        type="button"
+                      >
+                        <span
+                          className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-xs font-semibold ${isComplete ? "border-emerald-500 bg-emerald-500 text-white" : "border-slate-300 text-slate-400"}`}
+                        >
+                          {isComplete ? "✓" : ""}
+                        </span>
+                        <span>
+                          <span className="block text-sm font-medium text-slate-900">{step.label}</span>
+                          <span className="mt-1 block text-sm leading-5 text-slate-600">{step.note}</span>
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="mt-6 rounded-[1.6rem] bg-slate-950 p-5 text-slate-50">
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Preview outputs</p>
+        <div className="mt-4 space-y-2">
+          {procedure.preview.outputs.map((output) => (
+            <div className="rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-slate-200" key={output}>
+              {output}
+            </div>
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/runbook-studio/procedure-card.tsx
+++ b/src/components/runbook-studio/procedure-card.tsx
@@ -1,0 +1,62 @@
+import type { Procedure } from "./runbook-studio-data";
+
+const validationClasses = {
+  ready: "border-emerald-200 bg-emerald-50 text-emerald-900",
+  watch: "border-amber-200 bg-amber-50 text-amber-900",
+  blocked: "border-rose-200 bg-rose-50 text-rose-900",
+} as const;
+
+type ProcedureCardProps = {
+  procedure: Procedure;
+  completedCount: number;
+  isSelected: boolean;
+  onSelect: (procedureId: string) => void;
+};
+
+export default function ProcedureCard({
+  procedure,
+  completedCount,
+  isSelected,
+  onSelect,
+}: ProcedureCardProps) {
+  return (
+    <button
+      className={`rounded-[1.75rem] border p-5 text-left transition ${isSelected ? "border-slate-950 bg-slate-950 text-white shadow-[0_20px_70px_rgba(15,23,42,0.2)]" : "border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50"}`}
+      onClick={() => onSelect(procedure.id)}
+      type="button"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className={`text-xs font-semibold uppercase tracking-[0.3em] ${isSelected ? "text-slate-300" : "text-slate-500"}`}>{procedure.section}</p>
+          <h2 className="mt-2 text-xl font-semibold">{procedure.title}</h2>
+        </div>
+        <span className={`rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ${isSelected ? "border-white/15 bg-white/10 text-white" : validationClasses[procedure.validation.tone]}`}>
+          {procedure.validation.label}
+        </span>
+      </div>
+      <p className={`mt-3 text-sm leading-6 ${isSelected ? "text-slate-200" : "text-slate-600"}`}>{procedure.summary}</p>
+      <div className="mt-5 grid gap-3 sm:grid-cols-3">
+        <div>
+          <p className={`text-xs uppercase tracking-[0.24em] ${isSelected ? "text-slate-400" : "text-slate-500"}`}>Owner</p>
+          <p className="mt-1 text-sm font-medium">{procedure.owner}</p>
+        </div>
+        <div>
+          <p className={`text-xs uppercase tracking-[0.24em] ${isSelected ? "text-slate-400" : "text-slate-500"}`}>Duration</p>
+          <p className="mt-1 text-sm font-medium">{procedure.duration}</p>
+        </div>
+        <div>
+          <p className={`text-xs uppercase tracking-[0.24em] ${isSelected ? "text-slate-400" : "text-slate-500"}`}>Checklist</p>
+          <p className="mt-1 text-sm font-medium">{completedCount}/{procedure.steps.length} done</p>
+        </div>
+      </div>
+      <p className={`mt-4 text-sm ${isSelected ? "text-slate-300" : "text-slate-600"}`}>{procedure.validation.note}</p>
+      <div className="mt-4 flex flex-wrap gap-2">
+        {procedure.markers.map((marker) => (
+          <span className={`rounded-full px-3 py-1 text-xs ${isSelected ? "bg-white/10 text-slate-100" : "bg-slate-100 text-slate-600"}`} key={marker}>
+            {marker}
+          </span>
+        ))}
+      </div>
+    </button>
+  );
+}

--- a/src/components/runbook-studio/runbook-studio-data.ts
+++ b/src/components/runbook-studio/runbook-studio-data.ts
@@ -1,0 +1,117 @@
+export const runbookSections = ["Intake", "Contain", "Recover", "Report"] as const;
+
+export const executionStages = [{ id: "capture", label: "Capture" }, { id: "checks", label: "Checks" }, { id: "execute", label: "Execute" }, { id: "handoff", label: "Handoff" }] as const;
+
+export type RunbookSection = (typeof runbookSections)[number];
+export type SectionFilter = RunbookSection | "all";
+export type StageId = (typeof executionStages)[number]["id"];
+export type ValidationTone = "ready" | "watch" | "blocked";
+
+export type Procedure = {
+  id: string;
+  title: string;
+  section: RunbookSection;
+  owner: string;
+  duration: string;
+  summary: string;
+  validation: { label: string; tone: ValidationTone; note: string };
+  markers: readonly string[];
+  preview: { summary: string; outputs: readonly string[] };
+  stages: readonly { id: StageId; title: string; status: ValidationTone; detail: string }[];
+  steps: readonly { id: string; stageId: StageId; label: string; note: string }[];
+};
+
+export const procedures: readonly Procedure[] = [
+  {
+    id: "intake-triage-lane",
+    title: "Intake Triage Lane",
+    section: "Intake",
+    owner: "Operations Desk",
+    duration: "14 min",
+    summary: "Route new incidents into the right path before live operator work begins.",
+    validation: { label: "Verified", tone: "ready", note: "Decision gates were rehearsed this week." },
+    markers: ["Dependency map", "Draft notes", "Observer ready"],
+    preview: { summary: "Intake front-loads ownership and prerequisites before execution.", outputs: ["Owner assigned", "Severity tagged", "Rollback noted"] },
+    stages: [
+      { id: "capture", title: "Collect context", status: "ready", detail: "Pull alerts, notes, and prior handoffs into one draft." },
+      { id: "checks", title: "Gate entry", status: "ready", detail: "Confirm the trigger matches this runbook." },
+      { id: "execute", title: "Open lane", status: "watch", detail: "Notify the primary owner before work starts." },
+      { id: "handoff", title: "Assign follow-through", status: "ready", detail: "Attach the intake summary for downstream teams." },
+    ],
+    steps: [
+      { id: "intake-capture", stageId: "capture", label: "Capture alert source and scope", note: "Keep the first symptom visible." },
+      { id: "intake-checks", stageId: "checks", label: "Verify the incident belongs here", note: "Reject duplicates before they fork extra work." },
+      { id: "intake-execute", stageId: "execute", label: "Open the draft lane and assign a responder", note: "Record the handoff target inside the card." },
+      { id: "intake-handoff", stageId: "handoff", label: "Publish intake notes to the next stage", note: "Downstream cards should not rebuild the story." },
+    ],
+  },
+  {
+    id: "contain-edge-fence",
+    title: "Contain Edge Fence",
+    section: "Contain",
+    owner: "Platform Control",
+    duration: "19 min",
+    summary: "Fence the affected surface, keep safe traffic moving, and protect rollback.",
+    validation: { label: "Needs review", tone: "watch", note: "One observer sign-off is still missing." },
+    markers: ["Traffic split", "Fallback path", "Pending sign-off"],
+    preview: { summary: "Containment keeps the blast radius narrow while preserving rollback switches.", outputs: ["Fence applied", "Fallback retained", "Stakeholders updated"] },
+    stages: [
+      { id: "capture", title: "Map exposure", status: "ready", detail: "List the surfaces that need isolation and the ones that stay online." },
+      { id: "checks", title: "Validate guardrails", status: "watch", detail: "Confirm rollback controls before traffic changes." },
+      { id: "execute", title: "Fence traffic", status: "watch", detail: "Apply the narrowest change first and watch the safe lane." },
+      { id: "handoff", title: "Share active constraints", status: "ready", detail: "Document what remains fenced for the next owner." },
+    ],
+    steps: [
+      { id: "contain-capture", stageId: "capture", label: "Identify the exposed edge and safe bypass", note: "Treat unaffected segments as capacity you keep." },
+      { id: "contain-checks", stageId: "checks", label: "Confirm rollback controls are live", note: "Do not fence traffic without an unwind path." },
+      { id: "contain-execute", stageId: "execute", label: "Apply the narrow containment rule", note: "Pause after the first cut and inspect drift." },
+      { id: "contain-handoff", stageId: "handoff", label: "Publish the active constraints list", note: "The recovery owner needs the same fence map." },
+    ],
+  },
+  {
+    id: "recover-traffic-swap",
+    title: "Recover Traffic Swap",
+    section: "Recover",
+    owner: "Service Reliability",
+    duration: "23 min",
+    summary: "Move the path back onto the preferred service shape and retire fallback cleanly.",
+    validation: { label: "Verified", tone: "ready", note: "Checklist and preview notes match the latest drill." },
+    markers: ["Recovery gate", "Rollback timer", "Success snapshot"],
+    preview: { summary: "Recovery keeps the rollback timer visible so the team can stop cleanly.", outputs: ["Preferred path restored", "Fallback retired", "Success note captured"] },
+    stages: [
+      { id: "capture", title: "Read the current lane", status: "ready", detail: "Snapshot current traffic and rollback timer before the swap." },
+      { id: "checks", title: "Confirm readiness", status: "ready", detail: "Verify the target path can absorb production load again." },
+      { id: "execute", title: "Promote preferred path", status: "ready", detail: "Shift traffic and watch the fallback for stragglers." },
+      { id: "handoff", title: "Close the loop", status: "watch", detail: "Record the success signal and note unresolved follow-up." },
+    ],
+    steps: [
+      { id: "recover-capture", stageId: "capture", label: "Snapshot current routing and timer state", note: "Use the same timer reference in closeout." },
+      { id: "recover-checks", stageId: "checks", label: "Verify the preferred path is stable", note: "The target lane should already be clean." },
+      { id: "recover-execute", stageId: "execute", label: "Shift traffic and watch the fallback lane", note: "Look for stragglers before removing the route." },
+      { id: "recover-handoff", stageId: "handoff", label: "Capture the success note and unresolved items", note: "A short follow-up list keeps the card usable." },
+    ],
+  },
+  {
+    id: "report-closeout-brief",
+    title: "Report Closeout Brief",
+    section: "Report",
+    owner: "Program Ops",
+    duration: "11 min",
+    summary: "Turn working notes into a clean closeout with the next owner and follow-up.",
+    validation: { label: "Missing evidence", tone: "blocked", note: "The closeout template still needs updated screenshots." },
+    markers: ["Evidence gap", "Owner roster", "Retro prompt"],
+    preview: { summary: "This card stays incomplete so the route shows a blocked validation state with local-only data.", outputs: ["Audience list ready", "Follow-up owner named", "Retro prompt drafted"] },
+    stages: [
+      { id: "capture", title: "Collect the final notes", status: "watch", detail: "Pull the observations that justify the final status." },
+      { id: "checks", title: "Check evidence quality", status: "blocked", detail: "Screenshots and linkbacks are not complete enough to publish." },
+      { id: "execute", title: "Draft the brief", status: "watch", detail: "Write the brief in publish order so the next reviewer can scan it." },
+      { id: "handoff", title: "Assign the next review", status: "ready", detail: "Name the follow-up owner before the draft leaves the studio." },
+    ],
+    steps: [
+      { id: "report-capture", stageId: "capture", label: "Collect final observations and owner notes", note: "Avoid summary language until evidence is attached." },
+      { id: "report-checks", stageId: "checks", label: "Verify screenshots and supporting links", note: "This card stays blocked until the evidence gap closes." },
+      { id: "report-execute", stageId: "execute", label: "Draft the closeout brief in publish order", note: "Readers should not need side tabs to follow the outcome." },
+      { id: "report-handoff", stageId: "handoff", label: "Assign a reviewer and next update time", note: "The draft should leave with a clear owner." },
+    ],
+  },
+];

--- a/src/components/runbook-studio/runbook-studio-header.tsx
+++ b/src/components/runbook-studio/runbook-studio-header.tsx
@@ -1,0 +1,48 @@
+type RunbookStudioHeaderProps = {
+  procedureCount: number;
+  stageCount: number;
+  attentionCount: number;
+};
+
+export default function RunbookStudioHeader({
+  procedureCount,
+  stageCount,
+  attentionCount,
+}: RunbookStudioHeaderProps) {
+  const panels = [
+    { label: "Procedure cards", value: procedureCount, detail: "Feature-local mock drafts" },
+    { label: "Execution stages", value: stageCount, detail: "Mapped into the preview rail" },
+    { label: "Needs validation", value: attentionCount, detail: "Cards with watch or blocked markers" },
+  ];
+
+  return (
+    <header className="overflow-hidden rounded-[2rem] border border-slate-200/80 bg-white/88 p-6 shadow-[0_24px_90px_rgba(15,23,42,0.08)] backdrop-blur">
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+        <div className="max-w-3xl">
+          <div className="flex flex-wrap items-center gap-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-500">Runbook Studio</p>
+            <span className="rounded-full border border-amber-300 bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-amber-900">
+              Draft Sync
+            </span>
+          </div>
+          <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+            Procedure cards, stage gates, and a live execution preview in one isolated route.
+          </h1>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600 sm:text-base">
+            All data and interactions stay local: section filtering, validation review, stage visibility,
+            and step completion never leave this route.
+          </p>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-3">
+          {panels.map((panel) => (
+            <div className="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3" key={panel.label}>
+              <p className="text-xs uppercase tracking-[0.28em] text-slate-500">{panel.label}</p>
+              <p className="mt-2 text-2xl font-semibold text-slate-950">{panel.value}</p>
+              <p className="mt-1 text-sm text-slate-600">{panel.detail}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/runbook-studio/runbook-studio-shell.tsx
+++ b/src/components/runbook-studio/runbook-studio-shell.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { startTransition, useDeferredValue, useState } from "react";
+
+import ExecutionPreviewPanel from "./execution-preview-panel";
+import ProcedureCard from "./procedure-card";
+import RunbookStudioHeader from "./runbook-studio-header";
+import {
+  executionStages,
+  procedures,
+  runbookSections,
+  type RunbookSection,
+  type SectionFilter,
+  type StageId,
+} from "./runbook-studio-data";
+
+type ChecklistState = Record<string, Record<string, boolean>>;
+
+function toggleId(items: StageId[], id: StageId) {
+  return items.includes(id) ? items.filter((item) => item !== id) : [...items, id];
+}
+
+const sectionCounts = Object.fromEntries(
+  runbookSections.map((section) => [
+    section,
+    procedures.filter((procedure) => procedure.section === section).length,
+  ]),
+) as Record<RunbookSection, number>;
+
+const sectionFilters: { id: SectionFilter; label: string; count: number }[] = [
+  { id: "all", label: "All sections", count: procedures.length },
+  ...runbookSections.map((section) => ({
+    id: section,
+    label: section,
+    count: sectionCounts[section],
+  })),
+];
+
+const attentionCount = procedures.filter(
+  (procedure) => procedure.validation.tone !== "ready",
+).length;
+
+export default function RunbookStudioShell() {
+  const [selectedSection, setSelectedSection] = useState<SectionFilter>("all");
+  const [selectedProcedureId, setSelectedProcedureId] = useState<string | null>(procedures[0]?.id ?? null);
+  const [hiddenStageIds, setHiddenStageIds] = useState<StageId[]>([]);
+  const [checklistState, setChecklistState] = useState<ChecklistState>({});
+
+  const deferredSection = useDeferredValue(selectedSection);
+  const filteredProcedures = procedures.filter((procedure) => deferredSection === "all" || procedure.section === deferredSection);
+  const activeProcedureId = filteredProcedures.some((procedure) => procedure.id === selectedProcedureId) ? selectedProcedureId : (filteredProcedures[0]?.id ?? null);
+  const activeProcedure = filteredProcedures.find((procedure) => procedure.id === activeProcedureId) ?? null;
+
+  const handleSelectSection = (section: SectionFilter) => startTransition(() => setSelectedSection(section));
+  const handleSelectProcedure = (procedureId: string) => startTransition(() => setSelectedProcedureId(procedureId));
+  const handleToggleStage = (stageId: StageId) => startTransition(() => setHiddenStageIds((items) => toggleId(items, stageId)));
+
+  const handleToggleStep = (procedureId: string, stepId: string) => {
+    startTransition(() => {
+      setChecklistState((state) => ({
+        ...state,
+        [procedureId]: {
+          ...state[procedureId],
+          [stepId]: !state[procedureId]?.[stepId],
+        },
+      }));
+    });
+  };
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(249,115,22,0.16),transparent_28%),radial-gradient(circle_at_right,rgba(15,23,42,0.08),transparent_24%),linear-gradient(180deg,#fffaf5_0%,#f8fafc_48%,#eef2ff_100%)] px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <RunbookStudioHeader
+          attentionCount={attentionCount}
+          procedureCount={procedures.length}
+          stageCount={executionStages.length}
+        />
+        <section className="grid gap-6 xl:grid-cols-[minmax(0,1.08fr)_minmax(340px,0.92fr)]">
+          <div className="rounded-[2rem] border border-slate-200/80 bg-white/90 p-6 shadow-[0_24px_90px_rgba(15,23,42,0.08)] backdrop-blur">
+            <div className="flex flex-col gap-4 border-b border-slate-200 pb-5">
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.35em] text-slate-500">Procedure Cards</p>
+                  <h2 className="mt-2 text-2xl font-semibold text-slate-950">Filter drafts by section and open one into the live preview.</h2>
+                </div>
+                <p className="text-sm text-slate-600">{filteredProcedures.length} of {procedures.length} cards visible</p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {sectionFilters.map((filter) => {
+                  const isSelected = selectedSection === filter.id;
+                  return (
+                    <button
+                      className={`rounded-full border px-4 py-2 text-sm font-medium transition ${isSelected ? "border-slate-950 bg-slate-950 text-white" : "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50"}`}
+                      key={filter.id}
+                      onClick={() => handleSelectSection(filter.id)}
+                      type="button"
+                    >
+                      {filter.label}
+                      <span className={`ml-2 rounded-full px-2 py-0.5 text-xs ${isSelected ? "bg-white/15 text-white" : "bg-slate-100 text-slate-500"}`}>
+                        {filter.count}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            {filteredProcedures.length === 0 ? (
+              <div className="mt-6 rounded-[1.75rem] border border-dashed border-slate-300 bg-slate-50 p-8 text-center">
+                <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-500">No cards in this section</p>
+                <h3 className="mt-3 text-2xl font-semibold text-slate-950">The selected section has no local runbook drafts yet.</h3>
+                <p className="mt-3 text-sm leading-6 text-slate-600">Switch sections or return to all cards to restore the authoring surface.</p>
+              </div>
+            ) : (
+              <div className="mt-6 grid gap-4 md:grid-cols-2">
+                {filteredProcedures.map((procedure) => {
+                  const completedCount = procedure.steps.filter((step) => checklistState[procedure.id]?.[step.id]).length;
+                  return (
+                    <ProcedureCard
+                      completedCount={completedCount}
+                      isSelected={procedure.id === activeProcedureId}
+                      key={procedure.id}
+                      onSelect={handleSelectProcedure}
+                      procedure={procedure}
+                    />
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          <ExecutionPreviewPanel
+            completedSteps={activeProcedure ? checklistState[activeProcedure.id] : undefined}
+            hiddenStageIds={hiddenStageIds}
+            onToggleStage={handleToggleStage}
+            onToggleStep={handleToggleStep}
+            procedure={activeProcedure}
+          />
+        </section>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/runbook-studio` app route with local mock data and metadata
- build a client-side studio shell with section filtering, procedure selection, validation states, and preview stage toggles
- include zero-states for empty filters and fully hidden stages while keeping all logic feature-local

## Validation
- npm run lint
- npm run typecheck
- npm run test
- npm run build

Closes #36