### PR TITLE
feat: add isolated alert journal route

### DIFF
--- a/src/app/alert-journal/alert-journal-data.ts
+++ b/src/app/alert-journal/alert-journal-data.ts
@@ -1,0 +1,89 @@
+export const alertSeverityValues = ["critical", "high", "medium", "low"] as const;
+export type AlertSeverity = (typeof alertSeverityValues)[number];
+
+export const resolutionStateValues = ["open", "monitoring", "resolved"] as const;
+export type ResolutionState = (typeof resolutionStateValues)[number];
+
+export type AlertJournalAlert = {
+  id: string;
+  startedAt: string;
+  title: string;
+  summary: string;
+  service: string;
+  zone: string;
+  severity: AlertSeverity;
+  owner: string;
+  nextStep: string;
+  initialResolution: ResolutionState;
+  tags: string[];
+};
+
+export type AlertJournalDay = {
+  id: string;
+  label: string;
+  dateLabel: string;
+  handoffWindow: string;
+  note: string;
+  alerts: AlertJournalAlert[];
+};
+
+export const severityOptions = [
+  { value: "critical", label: "Critical" },
+  { value: "high", label: "High" },
+  { value: "medium", label: "Medium" },
+  { value: "low", label: "Low" },
+] as const;
+
+export const resolutionOptions = [
+  { value: "open", label: "Open" },
+  { value: "monitoring", label: "Monitoring" },
+  { value: "resolved", label: "Resolved" },
+] as const;
+
+function createAlert(
+  id: string,
+  startedAt: string,
+  title: string,
+  summary: string,
+  service: string,
+  zone: string,
+  severity: AlertSeverity,
+  owner: string,
+  nextStep: string,
+  initialResolution: ResolutionState,
+  tags: string[],
+): AlertJournalAlert {
+  return { id, startedAt, title, summary, service, zone, severity, owner, nextStep, initialResolution, tags };
+}
+
+function createDay(
+  id: string,
+  label: string,
+  dateLabel: string,
+  handoffWindow: string,
+  note: string,
+  alerts: AlertJournalAlert[],
+): AlertJournalDay {
+  return { id, label, dateLabel, handoffWindow, note, alerts };
+}
+
+export const alertJournalDays: AlertJournalDay[] = [
+  createDay("sat-19", "Today", "Sat 19 Apr", "03:00 to 11:00 UTC", "Ingress pressure peaked during handoff and two alerts still need a closeout marker.", [
+    createAlert("aj-101", "04:12 UTC", "Satellite uplink drift breached packet threshold", "Relay Mesh 4 crossed sustained packet loss above the handoff threshold for eight minutes.", "Relay Mesh 4", "Polar corridor", "critical", "Comms watch", "Re-lock beam alignment before the 05:00 verification pass.", "open", ["packet loss", "handoff"]),
+    createAlert("aj-102", "05:36 UTC", "Thermal spike on vault inverter pair", "The inverter pair trended 7C over baseline after the backup rail picked up morning load.", "Vault power ring", "East rack lane", "high", "Facilities", "Keep bypass fans staged until the next telemetry sweep settles.", "monitoring", ["thermal", "power"]),
+    createAlert("aj-103", "07:02 UTC", "Credential replay blocked on support proxy", "Replay attempts were stopped locally, but the offending support key still needs rotation.", "Support proxy", "Edge auth tier", "medium", "Identity team", "Rotate the service credential and confirm no secondary retries appear.", "open", ["auth", "proxy"]),
+    createAlert("aj-104", "08:41 UTC", "Queue depth warning on intake parser", "Backlog expanded during the morning burst and drained after a worker rebalance.", "Intake parser", "North ingest", "low", "Data ops", "Leave the extra worker online through the next upload pulse.", "resolved", ["queue", "ingest"]),
+  ]),
+  createDay("fri-18", "Yesterday", "Fri 18 Apr", "11:00 to 19:00 UTC", "Volume stayed higher than normal, but the shift closed without a critical escalation.", [
+    createAlert("aj-201", "11:28 UTC", "Replication lag climbed past audit tolerance", "Audit replicas in the western pool lagged 94 seconds behind the primary trail.", "Audit replicas", "West pool", "high", "Platform DB", "Keep catch-up mode active until lag falls below 20 seconds.", "monitoring", ["replication", "audit"]),
+    createAlert("aj-202", "13:11 UTC", "Unauthorized device registration attempt", "A staged kiosk fingerprint failed attestation and was denied before enrollment completed.", "Registration broker", "Dock access", "high", "Endpoint security", "Review the failed fingerprint and hold the staging lane until cleared.", "open", ["device", "attestation"]),
+    createAlert("aj-203", "16:05 UTC", "Operator note mismatch on change ledger", "The ledger write succeeded, but the attached shift note referenced the wrong fallback plan.", "Change ledger", "Ops archive", "medium", "Shift lead", "Correct the note chain before exporting the daily packet.", "resolved", ["ledger", "notes"]),
+    createAlert("aj-204", "18:17 UTC", "Bandwidth watch triggered on training mirror", "Mirror traffic briefly exceeded the usual test window after delayed media sync.", "Training mirror", "South edge", "low", "Infra support", "Throttle nonessential sync jobs during the next overlap.", "resolved", ["bandwidth", "sync"]),
+  ]),
+  createDay("thu-17", "Thu 17", "Thu 17 Apr", "19:00 to 03:00 UTC", "Earlier alerts are quieter now, but one corridor still carries elevated risk into the weekend.", [
+    createAlert("aj-301", "19:46 UTC", "Sensor corridor dropouts repeated across three relays", "Dropouts repeated after the corridor switched to the backup relay chain during weather shear.", "Field relay chain", "North ridge", "critical", "Telemetry team", "Keep the backup chain pinned until the ridge path validates cleanly.", "monitoring", ["sensors", "weather"]),
+    createAlert("aj-302", "21:09 UTC", "Drift warning on clock sync broker", "Broker drift touched the alert line but stayed within the rollback-free correction window.", "Clock sync broker", "Core timing", "medium", "Runtime core", "Review oscillator noise after the nightly maintenance sweep.", "resolved", ["timing", "broker"]),
+    createAlert("aj-303", "23:52 UTC", "Archive export retry exceeded normal cadence", "The export eventually completed, but retry cadence stayed noisy for the remainder of the shift.", "Archive export", "Compliance lane", "low", "Archive ops", "Trim the retry budget before the next compliance batch opens.", "monitoring", ["archive", "retries"]),
+    createAlert("aj-304", "02:21 UTC", "Review queue backlog reopened after route flap", "A route flap reopened part of the review queue, but no records were lost in replay.", "Review queue", "Approval mesh", "low", "Workflow ops", "Verify the route pins before the queue resumes normal priority.", "open", ["queue", "route"]),
+  ]),
+];

--- a/src/app/alert-journal/page.tsx
+++ b/src/app/alert-journal/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { alertJournalDays } from "./alert-journal-data";
+import { AlertJournalShell } from "@/components/alert-journal/alert-journal-shell";
+
+export const metadata: Metadata = {
+  title: "Alert Journal",
+  description: "Mock alert journal with local grouping, filters, and resolution markers.",
+};
+
+export default function AlertJournalPage() {
+  return <AlertJournalShell initialDays={alertJournalDays} />;
+}

--- a/src/components/alert-journal/alert-day-groups.tsx
+++ b/src/components/alert-journal/alert-day-groups.tsx
@@ -1,0 +1,111 @@
+import type { AlertJournalAlert, AlertJournalDay, ResolutionState } from "@/app/alert-journal/alert-journal-data";
+
+type AlertDayGroupsProps = { days: Array<AlertJournalDay & { visibleAlerts: AlertJournalAlert[] }>; expandedDayIds: string[]; resolutionById: Record<string, ResolutionState>; selectedAlertId: string | null; selectedDayId: string | null; onRestoreFilters: () => void; onSelectAlert: (dayId: string, alertId: string) => void; onSelectDay: (dayId: string) => void; onToggleDay: (dayId: string) => void; };
+
+export function AlertDayGroups({
+  days,
+  expandedDayIds,
+  resolutionById,
+  selectedAlertId,
+  selectedDayId,
+  onRestoreFilters,
+  onSelectAlert,
+  onSelectDay,
+  onToggleDay,
+}: AlertDayGroupsProps) {
+  const totalVisibleAlerts = days.reduce((count, day) => count + day.visibleAlerts.length, 0);
+
+  if (totalVisibleAlerts === 0) {
+    return (
+      <section className="space-y-4" aria-label="Daily alert groups">
+        <div className="rounded-[1.75rem] border border-dashed border-white/15 bg-slate-950/35 p-8 text-center">
+          <h2 className="text-xl font-semibold text-white">No alerts match the current severity filter.</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-300">Re-enable one or more severities to reopen the journal list and detail rail.</p>
+          <button className="mt-4 rounded-full border border-white/15 px-4 py-2 text-sm text-slate-200 transition hover:border-white/30 hover:bg-white/10" type="button" onClick={onRestoreFilters}>Restore all severities</button>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-4" aria-label="Daily alert groups">
+      {days.map((day) => {
+        const isExpanded = expandedDayIds.includes(day.id);
+        const isSelectedDay = selectedDayId === day.id;
+        const openCount = day.alerts.filter((alert) => resolutionById[alert.id] === "open").length;
+
+        return (
+          <article
+            key={day.id}
+            className={`rounded-[1.75rem] border p-4 backdrop-blur transition ${
+              isSelectedDay ? "border-cyan-300/30 bg-cyan-400/10" : "border-white/10 bg-slate-950/45"
+            }`}
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <button className="min-w-0 text-left" type="button" onClick={() => onSelectDay(day.id)}>
+                <p className="text-xs uppercase tracking-[0.22em] text-slate-400">{day.dateLabel}</p>
+                <h2 className="mt-1 text-xl font-semibold text-white">{day.label}</h2>
+                <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-300">{day.note}</p>
+                <p className="mt-2 text-sm text-slate-400">{day.visibleAlerts.length} visible of {day.alerts.length} alerts, {openCount} still open</p>
+              </button>
+              <button aria-expanded={isExpanded} className="rounded-full border border-white/10 px-3 py-2 text-sm text-slate-200 transition hover:border-white/20 hover:bg-white/10" type="button" onClick={() => onToggleDay(day.id)}>{isExpanded ? "Collapse" : "Expand"}</button>
+            </div>
+            {isExpanded ? (
+              day.visibleAlerts.length > 0 ? (
+                <div className="mt-4 space-y-3">
+                  {day.visibleAlerts.map((alert) => {
+                    const isSelectedAlert = selectedAlertId === alert.id;
+
+                    return (
+                      <button
+                        key={alert.id}
+                        className={`w-full rounded-[1.35rem] border p-4 text-left transition ${
+                          isSelectedAlert
+                            ? "border-cyan-300/45 bg-cyan-300/10"
+                            : "border-white/10 bg-white/5 hover:border-white/20 hover:bg-white/10"
+                        }`}
+                        type="button"
+                        onClick={() => onSelectAlert(day.id, alert.id)}
+                      >
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div className="space-y-2">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <span className={`rounded-full px-2.5 py-1 text-xs font-medium ${severityTone(alert.severity)}`}>{alert.severity}</span>
+                              <span className={`rounded-full px-2.5 py-1 text-xs font-medium ${resolutionTone(resolutionById[alert.id])}`}>{resolutionById[alert.id]}</span>
+                              <span className="text-xs uppercase tracking-[0.18em] text-slate-400">{alert.startedAt}</span>
+                            </div>
+                            <p className="text-lg font-medium text-white">{alert.title}</p>
+                            <p className="max-w-3xl text-sm leading-6 text-slate-300">{alert.summary}</p>
+                          </div>
+                          <dl className="grid gap-1 text-sm text-slate-300 sm:text-right">
+                            <div><dt className="text-xs uppercase tracking-[0.18em] text-slate-500">Service</dt><dd>{alert.service}</dd></div>
+                            <div><dt className="text-xs uppercase tracking-[0.18em] text-slate-500">Zone</dt><dd>{alert.zone}</dd></div>
+                          </dl>
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="mt-4 rounded-[1.35rem] border border-dashed border-white/15 bg-white/5 p-6 text-sm leading-6 text-slate-300">No alerts remain visible for this day. Change the severity mix to repopulate the group.</div>
+              )
+            ) : null}
+          </article>
+        );
+      })}
+    </section>
+  );
+}
+
+function severityTone(severity: AlertJournalAlert["severity"]) {
+  if (severity === "critical") return "bg-rose-500/20 text-rose-100";
+  if (severity === "high") return "bg-orange-500/20 text-orange-100";
+  if (severity === "medium") return "bg-amber-500/20 text-amber-100";
+  return "bg-emerald-500/20 text-emerald-100";
+}
+
+function resolutionTone(resolution: ResolutionState) {
+  if (resolution === "resolved") return "bg-emerald-500/20 text-emerald-100";
+  if (resolution === "monitoring") return "bg-cyan-500/20 text-cyan-100";
+  return "bg-slate-200/10 text-slate-100";
+}

--- a/src/components/alert-journal/alert-detail-rail.tsx
+++ b/src/components/alert-journal/alert-detail-rail.tsx
@@ -1,0 +1,86 @@
+import { resolutionOptions, type AlertJournalAlert, type ResolutionState } from "@/app/alert-journal/alert-journal-data";
+
+type AlertDetailRailProps = {
+  alert: AlertJournalAlert | null;
+  dayLabel: string | null;
+  isVisibleInCurrentFilters: boolean;
+  resolution: ResolutionState | null;
+  onUpdateResolution: (alertId: string, resolution: ResolutionState) => void;
+};
+
+export function AlertDetailRail({
+  alert,
+  dayLabel,
+  isVisibleInCurrentFilters,
+  resolution,
+  onUpdateResolution,
+}: AlertDetailRailProps) {
+  const detailItems = alert
+    ? [
+        { label: "Service", value: alert.service },
+        { label: "Zone", value: alert.zone },
+        { label: "Owner", value: alert.owner },
+        { label: "Next step", value: alert.nextStep },
+      ]
+    : [];
+
+  return (
+    <aside className="rounded-[1.9rem] border border-white/10 bg-slate-950/55 p-5 shadow-[0_24px_80px_rgba(15,23,42,0.45)] backdrop-blur xl:sticky xl:top-6 xl:self-start">
+      <p className="text-xs uppercase tracking-[0.24em] text-slate-400">Alert detail</p>
+      {alert ? (
+        <div className="mt-4 space-y-5">
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.18em] text-slate-400">
+              <span>{dayLabel}</span>
+              <span>{alert.startedAt}</span>
+            </div>
+            <h2 className="text-2xl font-semibold text-white">{alert.title}</h2>
+            <p className="text-sm leading-6 text-slate-300">{alert.summary}</p>
+          </div>
+          {!isVisibleInCurrentFilters ? (
+            <div className="rounded-[1.2rem] border border-amber-300/20 bg-amber-300/10 p-4 text-sm leading-6 text-amber-50">This alert is still selected, but it is hidden by the active severity filter.</div>
+          ) : null}
+          <dl className="grid gap-4 rounded-[1.2rem] border border-white/10 bg-white/5 p-4 text-sm text-slate-200 sm:grid-cols-2">
+            {detailItems.map((item) => (
+              <div key={item.label} className="space-y-1">
+                <dt className="text-xs uppercase tracking-[0.18em] text-slate-500">{item.label}</dt>
+                <dd className="leading-6">{item.value}</dd>
+              </div>
+            ))}
+          </dl>
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Resolution marker</p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {resolutionOptions.map((option) => {
+                const isActive = resolution === option.value;
+                return (
+                  <button
+                    key={option.value}
+                    aria-pressed={isActive}
+                    className={`rounded-full border px-3 py-2 text-sm transition ${
+                      isActive
+                        ? "border-cyan-300/40 bg-cyan-300/15 text-cyan-50"
+                        : "border-white/10 bg-white/5 text-slate-200 hover:border-white/20 hover:bg-white/10"
+                    }`}
+                    type="button"
+                    onClick={() => onUpdateResolution(alert.id, option.value)}
+                  >
+                    {option.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Tags</p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {alert.tags.map((tag) => <span key={tag} className="rounded-full border border-white/10 bg-slate-900/80 px-3 py-1.5 text-sm text-slate-200">{tag}</span>)}
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-4 rounded-[1.2rem] border border-dashed border-white/15 bg-white/5 p-6 text-sm leading-6 text-slate-300">Select an alert card to inspect its handoff context and change its local resolution marker.</div>
+      )}
+    </aside>
+  );
+}

--- a/src/components/alert-journal/alert-journal-header.tsx
+++ b/src/components/alert-journal/alert-journal-header.tsx
@@ -1,0 +1,75 @@
+import type { AlertJournalDay } from "@/app/alert-journal/alert-journal-data";
+
+type AlertJournalHeaderProps = { days: AlertJournalDay[]; monitoringCount: number; openCount: number; resolvedCount: number; selectedDay: AlertJournalDay | null; selectedDayId: string | null; selectedDayVisibleCount: number; totalAlerts: number; onSelectDay: (dayId: string) => void; };
+
+export function AlertJournalHeader({ days, monitoringCount, openCount, resolvedCount, selectedDay, selectedDayId, selectedDayVisibleCount, totalAlerts, onSelectDay }: AlertJournalHeaderProps) {
+  const stats = [{ label: "Total alerts", value: totalAlerts }, { label: "Open", value: openCount }, { label: "Monitoring", value: monitoringCount }, { label: "Resolved", value: resolvedCount }];
+
+  return (
+    <section className="rounded-[2rem] border border-white/10 bg-white/5 p-6 shadow-[0_24px_80px_rgba(15,23,42,0.45)] backdrop-blur">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.9fr)]">
+        <div className="space-y-4">
+          <div>
+            <p className="text-sm uppercase tracking-[0.28em] text-cyan-200/70">Alert Journal</p>
+            <h1 className="mt-3 max-w-3xl text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+              Daily alert groups, severity trims, and local resolution markers for a mock watch desk.
+            </h1>
+            <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-300">
+              This route is fully isolated. Filters, expanded groups, selected alerts, and resolution markers stay in local client state.
+            </p>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-4">
+            {stats.map((stat) => <StatCard key={stat.label} label={stat.label} value={stat.value} />)}
+          </div>
+        </div>
+        <div className="rounded-[1.5rem] border border-white/10 bg-slate-950/45 p-4">
+          <p className="text-xs uppercase tracking-[0.24em] text-slate-400">Selected day</p>
+          {selectedDay ? (
+            <div className="mt-3 space-y-3">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-xl font-semibold text-white">{selectedDay.dateLabel}</h2>
+                  <p className="text-sm text-slate-400">{selectedDay.handoffWindow}</p>
+                </div>
+                <span className="rounded-full border border-cyan-400/30 bg-cyan-400/10 px-3 py-1 text-xs font-medium text-cyan-100">
+                  {selectedDayVisibleCount} visible
+                </span>
+              </div>
+              <p className="text-sm leading-6 text-slate-300">{selectedDay.note}</p>
+            </div>
+          ) : (
+            <p className="mt-3 text-sm leading-6 text-slate-300">Select a day chip to pin its handoff summary while keeping the full journal open below.</p>
+          )}
+          <div className="mt-4 flex flex-wrap gap-2">
+            {days.map((day) => {
+              const isActive = selectedDayId === day.id;
+              return (
+                <button
+                  key={day.id}
+                  className={`rounded-full border px-3 py-2 text-sm transition ${
+                    isActive
+                      ? "border-cyan-300/50 bg-cyan-300/15 text-cyan-50"
+                      : "border-white/10 bg-white/5 text-slate-200 hover:border-white/20 hover:bg-white/10"
+                  }`}
+                  type="button"
+                  onClick={() => onSelectDay(day.id)}
+                >
+                  {day.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-[1.25rem] border border-white/10 bg-slate-950/45 px-4 py-3">
+      <p className="text-xs uppercase tracking-[0.2em] text-slate-400">{label}</p>
+      <p className="mt-2 text-2xl font-semibold text-white">{value}</p>
+    </div>
+  );
+}

--- a/src/components/alert-journal/alert-journal-shell.tsx
+++ b/src/components/alert-journal/alert-journal-shell.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { startTransition, useState } from "react";
+import { severityOptions, type AlertJournalDay, type AlertSeverity, type ResolutionState } from "@/app/alert-journal/alert-journal-data";
+import { AlertDayGroups } from "./alert-day-groups";
+import { AlertDetailRail } from "./alert-detail-rail";
+import { AlertJournalHeader } from "./alert-journal-header";
+import { SeverityFilterBar } from "./severity-filter-bar";
+
+type AlertJournalShellProps = { initialDays: AlertJournalDay[] };
+
+const allSeverityValues = severityOptions.map((option) => option.value);
+
+export function AlertJournalShell({ initialDays }: AlertJournalShellProps) {
+  const [activeSeverities, setActiveSeverities] = useState<AlertSeverity[]>(allSeverityValues);
+  const [expandedDayIds, setExpandedDayIds] = useState<string[]>(initialDays.map((day) => day.id));
+  const [selectedDayId, setSelectedDayId] = useState<string | null>(initialDays[0]?.id ?? null);
+  const [selectedAlertId, setSelectedAlertId] = useState<string | null>(initialDays[0]?.alerts[0]?.id ?? null);
+  const [resolutionById, setResolutionById] = useState<Record<string, ResolutionState>>(() => Object.fromEntries(initialDays.flatMap((day) => day.alerts.map((alert) => [alert.id, alert.initialResolution]))));
+  const allAlerts = initialDays.flatMap((day) => day.alerts);
+  const visibleDays = initialDays.map((day) => ({ ...day, visibleAlerts: day.alerts.filter((alert) => activeSeverities.includes(alert.severity)) }));
+  const selectedDay = selectedDayId ? initialDays.find((day) => day.id === selectedDayId) ?? null : null;
+  const selectedDayView = selectedDayId ? visibleDays.find((day) => day.id === selectedDayId) ?? null : null;
+  const selectedAlert = selectedAlertId ? allAlerts.find((alert) => alert.id === selectedAlertId) ?? null : null;
+  const selectedAlertDayLabel = initialDays.find((day) => day.alerts.some((entry) => entry.id === selectedAlertId))?.dateLabel ?? null;
+  const selectedAlertVisible = selectedAlertId ? visibleDays.some((day) => day.visibleAlerts.some((alert) => alert.id === selectedAlertId)) : false;
+  const totalVisibleAlerts = visibleDays.reduce((count, day) => count + day.visibleAlerts.length, 0);
+  const openCount = allAlerts.filter((alert) => resolutionById[alert.id] === "open").length;
+  const monitoringCount = allAlerts.filter((alert) => resolutionById[alert.id] === "monitoring").length;
+  const resolvedCount = allAlerts.filter((alert) => resolutionById[alert.id] === "resolved").length;
+
+  function toggleSeverity(severity: AlertSeverity) {
+    startTransition(() => setActiveSeverities((current) => current.includes(severity) ? current.filter((value) => value !== severity) : [...current, severity]));
+  }
+
+  function restoreSeverityFilters() { startTransition(() => setActiveSeverities(allSeverityValues)); }
+
+  function toggleDay(dayId: string) {
+    startTransition(() => setExpandedDayIds((current) => current.includes(dayId) ? current.filter((value) => value !== dayId) : [...current, dayId]));
+  }
+
+  function selectDay(dayId: string) {
+    const nextDayId = selectedDayId === dayId ? null : dayId;
+    const nextDay = initialDays.find((day) => day.id === nextDayId);
+    startTransition(() => {
+      setSelectedDayId(nextDayId);
+      setSelectedAlertId(nextDay?.alerts.find((alert) => activeSeverities.includes(alert.severity))?.id ?? null);
+      setExpandedDayIds((current) => (nextDayId && !current.includes(nextDayId) ? [...current, nextDayId] : current));
+    });
+  }
+
+  function selectAlert(dayId: string, alertId: string) {
+    startTransition(() => {
+      setSelectedDayId(dayId);
+      setSelectedAlertId(alertId);
+      setExpandedDayIds((current) => (current.includes(dayId) ? current : [...current, dayId]));
+    });
+  }
+
+  function updateResolution(alertId: string, resolution: ResolutionState) { startTransition(() => setResolutionById((current) => ({ ...current, [alertId]: resolution }))); }
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(244,114,182,0.18),transparent_28%),radial-gradient(circle_at_right,rgba(59,130,246,0.16),transparent_24%),linear-gradient(180deg,#0f172a_0%,#111827_55%,#050816_100%)] px-4 py-6 text-slate-100 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <AlertJournalHeader
+          days={initialDays}
+          monitoringCount={monitoringCount}
+          openCount={openCount}
+          resolvedCount={resolvedCount}
+          selectedDay={selectedDay}
+          selectedDayId={selectedDayId}
+          selectedDayVisibleCount={selectedDayView?.visibleAlerts.length ?? 0}
+          totalAlerts={allAlerts.length}
+          onSelectDay={selectDay}
+        />
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.65fr)_minmax(320px,0.95fr)]">
+          <div className="space-y-6">
+            <SeverityFilterBar activeSeverities={activeSeverities} totalAlerts={allAlerts.length} totalVisibleAlerts={totalVisibleAlerts} onRestoreAll={restoreSeverityFilters} onToggleSeverity={toggleSeverity} />
+            <AlertDayGroups days={visibleDays} expandedDayIds={expandedDayIds} resolutionById={resolutionById} selectedAlertId={selectedAlertId} selectedDayId={selectedDayId} onRestoreFilters={restoreSeverityFilters} onSelectAlert={selectAlert} onSelectDay={selectDay} onToggleDay={toggleDay} />
+          </div>
+          <AlertDetailRail alert={selectedAlert} dayLabel={selectedAlertDayLabel} isVisibleInCurrentFilters={selectedAlertVisible} resolution={selectedAlert ? resolutionById[selectedAlert.id] : null} onUpdateResolution={updateResolution} />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/alert-journal/severity-filter-bar.tsx
+++ b/src/components/alert-journal/severity-filter-bar.tsx
@@ -1,0 +1,51 @@
+import { severityOptions, type AlertSeverity } from "@/app/alert-journal/alert-journal-data";
+
+type SeverityFilterBarProps = {
+  activeSeverities: AlertSeverity[];
+  totalAlerts: number;
+  totalVisibleAlerts: number;
+  onRestoreAll: () => void;
+  onToggleSeverity: (severity: AlertSeverity) => void;
+};
+
+export function SeverityFilterBar({
+  activeSeverities,
+  totalAlerts,
+  totalVisibleAlerts,
+  onRestoreAll,
+  onToggleSeverity,
+}: SeverityFilterBarProps) {
+  const showRestore = activeSeverities.length !== severityOptions.length;
+
+  return (
+    <section className="rounded-[1.75rem] border border-white/10 bg-slate-950/45 p-4 backdrop-blur">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-[0.24em] text-slate-400">Severity filters</p>
+          <p className="mt-2 text-sm text-slate-300">Showing {totalVisibleAlerts} of {totalAlerts} alerts.</p>
+        </div>
+        {showRestore ? <button className="rounded-full border border-white/15 px-3 py-2 text-sm text-slate-200 transition hover:border-white/30 hover:bg-white/10" type="button" onClick={onRestoreAll}>Restore all severities</button> : null}
+      </div>
+      <div className="mt-4 flex flex-wrap gap-2">
+        {severityOptions.map((option) => {
+          const isActive = activeSeverities.includes(option.value);
+          return (
+            <button
+              key={option.value}
+              aria-pressed={isActive}
+              className={`rounded-full border px-3 py-2 text-sm transition ${
+                isActive
+                  ? "border-amber-300/40 bg-amber-300/15 text-amber-50"
+                  : "border-white/10 bg-white/5 text-slate-300 hover:border-white/20 hover:bg-white/10"
+              }`}
+              type="button"
+              onClick={() => onToggleSeverity(option.value)}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/alert-journal` route with feature-local mock data and client-side journal state
- include daily grouped alerts, severity filters, expansion controls, and a detail rail with local resolution markers
- keep the implementation scoped to `src/app/alert-journal` and `src/components/alert-journal`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`

Closes #40