### PR TITLE
feat: add isolated service map route

### DIFF
--- a/src/app/service-map/page.tsx
+++ b/src/app/service-map/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+import { ServiceMapShell } from "@/components/service-map/service-map-shell";
+
+export const metadata: Metadata = {
+  title: "Service Map",
+  description:
+    "Mock service topology view with isolated node clusters, dependency highlights, and a focus inspector.",
+};
+
+export default function ServiceMapPage() {
+  return <ServiceMapShell />;
+}

--- a/src/app/service-map/service-map-data.ts
+++ b/src/app/service-map/service-map-data.ts
@@ -1,0 +1,76 @@
+export type ClusterHealth = "steady" | "watch" | "critical";
+export type NodeStatus = "healthy" | "watch" | "critical";
+export type LinkMode = "core" | "watch" | "buffered";
+
+export type ServiceCluster = { id: string; name: string; owner: string; region: string; health: ClusterHealth; healthScore: number; summary: string; riskLabel: string; nodeIds: string[] };
+export type ServiceNode = { id: string; clusterId: string; name: string; role: string; status: NodeStatus; latencyMs: number; traffic: string; onCall: string; summary: string; recentChange: string; inspectorNotes: string[] };
+export type DependencyLink = { id: string; fromId: string; toId: string; mode: LinkMode; summary: string; volume: string; highlight: string };
+
+export const serviceMapOverview = { healthMode: "Dependency Watch", generatedAt: "04:18 UTC", summary: "Six mocked services span three operational clusters with local focus, mute, and dependency highlighting controls." };
+
+export const serviceClusters: ServiceCluster[] = [
+  {
+    id: "ingress-mesh", name: "Ingress Mesh", owner: "Gateway Squad", region: "us-east-1",
+    health: "steady", healthScore: 97, riskLabel: "Signature replay watch",
+    summary: "Protects public traffic, stamps session context, and limits fan-out blast radius.",
+    nodeIds: ["edge-gateway", "session-router"],
+  }, {
+    id: "order-core", name: "Order Core", owner: "Commerce Runtime", region: "us-east-2",
+    health: "watch", healthScore: 89, riskLabel: "Queue lag rising",
+    summary: "Captures order intent and buffers settlement when downstream traffic stretches.",
+    nodeIds: ["orders-api", "billing-queue"],
+  }, {
+    id: "fulfillment-fabric", name: "Fulfillment Fabric", owner: "Carrier Ops", region: "us-west-2",
+    health: "watch", healthScore: 91, riskLabel: "Carrier retry budget",
+    summary: "Turns confirmed orders into dispatch plans and customer-facing timeline updates.",
+    nodeIds: ["dispatch-planner", "customer-timeline"],
+  },
+];
+
+export const serviceNodes: ServiceNode[] = [
+  {
+    id: "edge-gateway", clusterId: "ingress-mesh", name: "Edge Gateway", role: "Public ingress",
+    status: "healthy", latencyMs: 18, traffic: "12.4k rpm", onCall: "Gateway primary",
+    summary: "Terminates partner traffic and injects tenant headers before internal fan-out.",
+    recentChange: "Certificate bundle rotated 18 minutes ago.",
+    inspectorNotes: ["Replay threshold is elevated but below paging.", "Fallback WAF policy is warm."],
+  }, {
+    id: "session-router", clusterId: "ingress-mesh", name: "Session Router", role: "Context broker",
+    status: "watch", latencyMs: 31, traffic: "8.9k rpm", onCall: "Gateway secondary",
+    summary: "Maps partner tokens to workspace context and fans reads into order services.",
+    recentChange: "Rate-limit tables reloaded after a partner surge test.",
+    inspectorNotes: ["Cold-start variance widened in the last fifteen minutes.", "Sticky-session fallback stays off."],
+  }, {
+    id: "orders-api", clusterId: "order-core", name: "Orders API", role: "Intent aggregator",
+    status: "watch", latencyMs: 56, traffic: "6.3k rpm", onCall: "Checkout lead",
+    summary: "Normalizes order intent and coordinates settlement plus dispatch workflows.",
+    recentChange: "Write path now samples duplicate partner receipts.",
+    inspectorNotes: ["P95 latency is driven by cross-cluster dispatch confirmation.", "Fallback write queue is armed."],
+  }, {
+    id: "billing-queue", clusterId: "order-core", name: "Billing Queue", role: "Settlement buffer",
+    status: "critical", latencyMs: 94, traffic: "2.2k msgs", onCall: "Payments rotation",
+    summary: "Buffers settlement work when payment confirmation is slower than order assembly.",
+    recentChange: "Consumer lag climbed after carrier retries doubled.",
+    inspectorNotes: ["Lag is isolated to deferred settlement messages.", "Draining it would reduce timeline freshness."],
+  }, {
+    id: "dispatch-planner", clusterId: "fulfillment-fabric", name: "Dispatch Planner", role: "Route composer",
+    status: "healthy", latencyMs: 34, traffic: "3.8k rpm", onCall: "Fulfillment desk",
+    summary: "Builds dispatch plans from confirmed orders and publishes route intent.",
+    recentChange: "Planner weights now favor regional consolidation.",
+    inspectorNotes: ["Carrier preference scores remain stable.", "Manual override lane is hot-shipment only."],
+  }, {
+    id: "customer-timeline", clusterId: "fulfillment-fabric", name: "Customer Timeline", role: "Status projection",
+    status: "healthy", latencyMs: 23, traffic: "9.4k rpm", onCall: "Experience ops",
+    summary: "Projects fulfillment state back into customer-facing order history.",
+    recentChange: "Status cards gained a delayed-shipment fallback label.",
+    inspectorNotes: ["Outbound notification fan-out is muted in this route.", "Freshness remains inside budget."],
+  },
+];
+
+export const dependencyLinks: DependencyLink[] = [
+  { id: "edge-session", fromId: "edge-gateway", toId: "session-router", mode: "core", summary: "Ingress requests are signed, normalized, and handed to the context broker.", volume: "4.8k rpm", highlight: "Primary auth handoff" },
+  { id: "session-orders", fromId: "session-router", toId: "orders-api", mode: "watch", summary: "Session context opens the order write path after token mapping settles.", volume: "3.6k rpm", highlight: "Elevated read-to-write latency" },
+  { id: "billing-timeline", fromId: "billing-queue", toId: "customer-timeline", mode: "buffered", summary: "Deferred settlement events hold timeline updates until payment is safe to reveal.", volume: "420 msgs", highlight: "Buffered customer state" },
+  { id: "orders-dispatch", fromId: "orders-api", toId: "dispatch-planner", mode: "core", summary: "Committed orders move into dispatch planning as soon as payment intent is durable.", volume: "1.8k rpm", highlight: "Cross-cluster commit" },
+  { id: "dispatch-timeline", fromId: "dispatch-planner", toId: "customer-timeline", mode: "core", summary: "Route plans refresh the customer timeline before carrier confirmations land.", volume: "1.1k rpm", highlight: "Visible fulfillment path" },
+];

--- a/src/components/service-map/cluster-list.tsx
+++ b/src/components/service-map/cluster-list.tsx
@@ -1,0 +1,123 @@
+import type { ServiceCluster, ServiceNode } from "@/app/service-map/service-map-data";
+
+const clusterTone = {
+  steady: "border-emerald-300/20 bg-emerald-300/8 text-emerald-100",
+  watch: "border-amber-300/20 bg-amber-300/8 text-amber-100",
+  critical: "border-rose-300/20 bg-rose-300/8 text-rose-100",
+};
+
+const nodeTone = {
+  healthy: "bg-emerald-400",
+  watch: "bg-amber-400",
+  critical: "bg-rose-400",
+};
+
+type ClusterListProps = {
+  clusters: ServiceCluster[]; focusedClusterId: string | null; mutedClusterIds: string[]; nodes: ServiceNode[];
+  onSelectCluster: (clusterId: string) => void; onSelectNode: (nodeId: string, clusterId: string) => void;
+  onToggleFocus: (clusterId: string) => void; onToggleMute: (clusterId: string) => void;
+  selectedClusterId: string; selectedNodeId: string | null;
+};
+
+export function ClusterList({
+  clusters,
+  focusedClusterId,
+  mutedClusterIds,
+  nodes,
+  onSelectCluster,
+  onSelectNode,
+  onToggleFocus,
+  onToggleMute,
+  selectedClusterId,
+  selectedNodeId,
+}: ClusterListProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-white/10 bg-black/25 p-5 shadow-xl shadow-black/20 backdrop-blur sm:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-stone-400">Node Clusters</p>
+          <h2 className="mt-2 text-2xl font-semibold text-stone-50">Cluster focus and mute controls stay local to this route.</h2>
+        </div>
+        <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs text-stone-300">{focusedClusterId ? "Focused scope active" : "Full topology"}</div>
+      </div>
+      <div className="mt-5 grid gap-4 lg:grid-cols-2">
+        {clusters.map((cluster) => {
+          const clusterNodes = nodes.filter((node) => node.clusterId === cluster.id);
+          const muted = mutedClusterIds.includes(cluster.id);
+          const active = selectedClusterId === cluster.id;
+          return (
+            <article
+              className={`rounded-[1.5rem] border p-4 transition ${
+                active
+                  ? "border-amber-300/35 bg-amber-300/10 shadow-lg shadow-amber-950/15"
+                  : "border-white/10 bg-white/[0.04]"
+              } ${muted ? "opacity-55" : ""}`}
+              key={cluster.id}
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <button className="space-y-2 text-left" onClick={() => onSelectCluster(cluster.id)} type="button">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="text-lg font-semibold text-stone-50">{cluster.name}</h3>
+                    <span className={`rounded-full border px-2.5 py-1 text-xs ${clusterTone[cluster.health]}`}>Score {cluster.healthScore}</span>
+                  </div>
+                  <p className="max-w-md text-sm leading-6 text-stone-300">{cluster.summary}</p>
+                </button>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    className={`rounded-full px-3 py-1.5 text-xs font-semibold ${
+                      focusedClusterId === cluster.id
+                        ? "bg-amber-300 text-stone-950"
+                        : "border border-white/10 bg-white/5 text-stone-200"
+                    }`}
+                    onClick={() => onToggleFocus(cluster.id)}
+                    type="button"
+                  >
+                    {focusedClusterId === cluster.id ? "Focused" : "Focus"}
+                  </button>
+                  <button
+                    className={`rounded-full px-3 py-1.5 text-xs font-semibold ${
+                      muted
+                        ? "bg-stone-100 text-stone-950"
+                        : "border border-white/10 bg-white/5 text-stone-200"
+                    }`}
+                    onClick={() => onToggleMute(cluster.id)}
+                    type="button"
+                  >
+                    {muted ? "Unmute" : "Mute"}
+                  </button>
+                </div>
+              </div>
+              <div className="mt-4 flex flex-wrap gap-2 text-xs text-stone-400"><span>{cluster.owner}</span><span>&bull;</span><span>{cluster.region}</span><span>&bull;</span><span>{cluster.riskLabel}</span></div>
+              <div className="mt-4 grid gap-2">
+                {clusterNodes.map((node) => {
+                  const selected = node.id === selectedNodeId;
+                  return (
+                    <button
+                      className={`flex items-center justify-between rounded-2xl border px-3 py-3 text-left transition ${
+                        selected
+                          ? "border-amber-300/40 bg-amber-300/10"
+                          : "border-white/10 bg-black/20 hover:border-white/20 hover:bg-white/[0.06]"
+                      }`}
+                      key={node.id}
+                      onClick={() => onSelectNode(node.id, cluster.id)}
+                      type="button"
+                    >
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className={`h-2.5 w-2.5 rounded-full ${nodeTone[node.status]}`} />
+                          <span className="truncate font-medium text-stone-50">{node.name}</span>
+                        </div>
+                        <p className="mt-1 truncate text-xs text-stone-400">{node.role}</p>
+                      </div>
+                      <div className="text-right text-xs text-stone-400"><p>{node.latencyMs} ms</p><p>{node.traffic}</p></div>
+                    </button>
+                  );
+                })}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/service-map/dependency-panel.tsx
+++ b/src/components/service-map/dependency-panel.tsx
@@ -1,0 +1,75 @@
+import type {
+  DependencyLink,
+  ServiceCluster,
+  ServiceNode,
+} from "@/app/service-map/service-map-data";
+
+const modeTone = {
+  core: "border-emerald-300/20 bg-emerald-300/10 text-emerald-100",
+  watch: "border-amber-300/20 bg-amber-300/10 text-amber-100",
+  buffered: "border-sky-300/20 bg-sky-300/10 text-sky-100",
+};
+
+type DependencyPanelProps = {
+  activeCluster: ServiceCluster | null; activeNode: ServiceNode | null; highlightedLinkId: string | null;
+  isClusterMuted: boolean; links: DependencyLink[]; nodes: ServiceNode[]; onHighlight: (linkId: string) => void;
+};
+
+export function DependencyPanel({
+  activeCluster,
+  activeNode,
+  highlightedLinkId,
+  isClusterMuted,
+  links,
+  nodes,
+  onHighlight,
+}: DependencyPanelProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-white/10 bg-black/25 p-5 shadow-xl shadow-black/20 backdrop-blur sm:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-stone-400">Dependency Highlights</p>
+          <h2 className="mt-2 text-2xl font-semibold text-stone-50">{activeNode ? activeNode.name : activeCluster?.name ?? "Select a cluster"}</h2>
+        </div>
+        <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-xs text-stone-300">{links.length} visible handoffs</span>
+      </div>
+      {links.length > 0 ? (
+        <div className="mt-5 space-y-3">
+          {links.map((link) => {
+            const fromNode = nodes.find((node) => node.id === link.fromId);
+            const toNode = nodes.find((node) => node.id === link.toId);
+            return (
+              <button
+                className={`w-full rounded-[1.5rem] border p-4 text-left transition ${
+                  highlightedLinkId === link.id
+                    ? "border-amber-300/40 bg-amber-300/10"
+                    : "border-white/10 bg-white/[0.04] hover:border-white/20 hover:bg-white/[0.06]"
+                }`}
+                key={link.id}
+                onClick={() => onHighlight(link.id)}
+                type="button"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <p className="text-sm font-semibold text-stone-50">{fromNode?.name} &rarr; {toNode?.name}</p>
+                  <span className={`rounded-full border px-2.5 py-1 text-xs ${modeTone[link.mode]}`}>{link.highlight}</span>
+                </div>
+                <p className="mt-2 text-sm leading-6 text-stone-300">{link.summary}</p>
+                <p className="mt-3 text-xs text-stone-400">{link.volume}</p>
+              </button>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="mt-5 rounded-[1.5rem] border border-dashed border-white/15 bg-white/[0.03] p-8 text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-stone-500">No visible links</p>
+          <h3 className="mt-3 text-xl font-semibold text-stone-100">{isClusterMuted ? "Dependency scan muted for this cluster." : "No handoff is pinned right now."}</h3>
+          <p className="mt-3 text-sm leading-6 text-stone-400">
+            {isClusterMuted
+              ? "Unmute the active cluster to restore local dependency highlights."
+              : "Select a node in the cluster list or clear the deselected state to restore highlights."}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/service-map/focus-inspector.tsx
+++ b/src/components/service-map/focus-inspector.tsx
@@ -1,0 +1,94 @@
+import type {
+  DependencyLink,
+  ServiceCluster,
+  ServiceNode,
+} from "@/app/service-map/service-map-data";
+
+const statusTone = {
+  healthy: "border-emerald-300/20 bg-emerald-300/10 text-emerald-100",
+  watch: "border-amber-300/20 bg-amber-300/10 text-amber-100",
+  critical: "border-rose-300/20 bg-rose-300/10 text-rose-100",
+};
+
+type FocusInspectorProps = {
+  activeCluster: ServiceCluster | null; activeNode: ServiceNode | null; focusedClusterName: string | null;
+  isClusterMuted: boolean; mutedNodeCount: number; spotlightLink: DependencyLink | null;
+  totalLinks: number; totalMutedClusters: number;
+};
+
+export function FocusInspector({
+  activeCluster,
+  activeNode,
+  focusedClusterName,
+  isClusterMuted,
+  mutedNodeCount,
+  spotlightLink,
+  totalLinks,
+  totalMutedClusters,
+}: FocusInspectorProps) {
+  return (
+    <aside className="rounded-[1.75rem] border border-white/10 bg-black/30 p-5 shadow-xl shadow-black/20 backdrop-blur sm:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-stone-400">Focus Inspector</p>
+          <h2 className="mt-2 text-2xl font-semibold text-stone-50">{activeNode ? activeNode.name : "Selection cleared"}</h2>
+        </div>
+        {activeNode ? (
+          <span className={`rounded-full border px-3 py-1.5 text-xs font-semibold ${statusTone[activeNode.status]}`}>{activeNode.status}</span>
+        ) : null}
+      </div>
+      {activeNode ? (
+        <div className="mt-5 space-y-5">
+          <div className="space-y-3">
+            <p className="text-sm leading-6 text-stone-300">{activeNode.summary}</p>
+            <div className="flex flex-wrap gap-2 text-xs text-stone-300">
+              <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1.5">{activeCluster?.name}</span>
+              <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1.5">{activeNode.role}</span>
+              <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1.5">{activeNode.onCall}</span>
+            </div>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <article className="rounded-3xl border border-white/10 bg-white/[0.04] px-4 py-4"><p className="text-xs uppercase tracking-[0.25em] text-stone-500">Latency</p><p className="mt-2 text-2xl font-semibold text-stone-50">{activeNode.latencyMs} ms</p></article>
+            <article className="rounded-3xl border border-white/10 bg-white/[0.04] px-4 py-4"><p className="text-xs uppercase tracking-[0.25em] text-stone-500">Traffic</p><p className="mt-2 text-2xl font-semibold text-stone-50">{activeNode.traffic}</p></article>
+            <article className="rounded-3xl border border-white/10 bg-white/[0.04] px-4 py-4"><p className="text-xs uppercase tracking-[0.25em] text-stone-500">Visible links</p><p className="mt-2 text-2xl font-semibold text-stone-50">{totalLinks}</p></article>
+          </div>
+          <section className="rounded-[1.5rem] border border-white/10 bg-white/[0.04] p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-stone-500">Inspector Notes</p>
+            <p className="mt-3 text-sm text-stone-300">{activeNode.recentChange}</p>
+            <ul className="mt-4 space-y-3 text-sm leading-6 text-stone-300">
+              {activeNode.inspectorNotes.map((note) => (
+                <li className="rounded-2xl border border-white/8 bg-black/20 px-3 py-3" key={note}>{note}</li>
+              ))}
+            </ul>
+          </section>
+          <section className="rounded-[1.5rem] border border-amber-300/15 bg-amber-300/[0.06] p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-amber-100/70">Dependency Spotlight</p>
+            {spotlightLink ? (
+              <>
+                <p className="mt-3 text-lg font-semibold text-stone-50">{spotlightLink.highlight}</p>
+                <p className="mt-2 text-sm leading-6 text-stone-300">{spotlightLink.summary}</p>
+                <p className="mt-3 text-xs text-stone-400">{spotlightLink.volume}</p>
+              </>
+            ) : (
+              <p className="mt-3 text-sm leading-6 text-stone-300">Select a dependency card to pin one handoff in the inspector.</p>
+            )}
+          </section>
+          <div className="rounded-[1.5rem] border border-white/10 bg-white/[0.04] p-4 text-sm leading-6 text-stone-300">
+            <p>Focused scope: {focusedClusterName ?? "All clusters"}</p>
+            <p>Muted clusters: {totalMutedClusters} / muted nodes: {mutedNodeCount}</p>
+            <p>{isClusterMuted ? "Active cluster output is muted from the dependency scan." : "Dependency scan remains visible for this cluster."}</p>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-5 rounded-[1.5rem] border border-dashed border-white/15 bg-white/[0.03] p-8 text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-stone-500">Empty focus</p>
+          <h3 className="mt-3 text-xl font-semibold text-stone-100">No node is selected for inspection.</h3>
+          <p className="mt-3 text-sm leading-6 text-stone-400">Re-select a service from the cluster list to restore node detail, or leave the selection cleared to review the cluster without a pinned node.</p>
+          {activeCluster ? (
+            <p className="mt-4 text-xs text-stone-500">Active cluster: {activeCluster.name} {focusedClusterName ? `· focused as ${focusedClusterName}` : ""}</p>
+          ) : null}
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/components/service-map/service-map-shell.tsx
+++ b/src/components/service-map/service-map-shell.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { startTransition, useState } from "react";
+
+import {
+  dependencyLinks,
+  serviceClusters,
+  serviceMapOverview,
+  serviceNodes,
+} from "@/app/service-map/service-map-data";
+import { ClusterList } from "./cluster-list";
+import { DependencyPanel } from "./dependency-panel";
+import { FocusInspector } from "./focus-inspector";
+
+function toggleId(items: string[], id: string) {
+  return items.includes(id) ? items.filter((item) => item !== id) : [...items, id];
+}
+
+export function ServiceMapShell() {
+  const [selectedClusterId, setSelectedClusterId] = useState(serviceClusters[0]?.id ?? "");
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(serviceNodes[0]?.id ?? null);
+  const [focusedClusterId, setFocusedClusterId] = useState<string | null>(null);
+  const [mutedClusterIds, setMutedClusterIds] = useState<string[]>([]);
+  const [highlightedLinkId, setHighlightedLinkId] = useState<string | null>("edge-session");
+  const visibleClusters = focusedClusterId ? serviceClusters.filter((cluster) => cluster.id === focusedClusterId) : serviceClusters;
+  const activeClusterId = visibleClusters.some((cluster) => cluster.id === selectedClusterId) ? selectedClusterId : (visibleClusters[0]?.id ?? "");
+  const activeCluster = serviceClusters.find((cluster) => cluster.id === activeClusterId) ?? null;
+  const activeNode = serviceNodes.find((node) => node.id === selectedNodeId) ?? null;
+  const activeNodeVisible = activeNode ? visibleClusters.some((cluster) => cluster.id === activeNode.clusterId) : false;
+  const inspectorNode = activeNodeVisible ? activeNode : null;
+  const criticalNodeCount = serviceNodes.filter((node) => node.status === "critical").length;
+  const mutedNodeCount = serviceNodes.filter((node) => mutedClusterIds.includes(node.clusterId)).length;
+  const filteredLinks = dependencyLinks.filter((link) => {
+    const fromNode = serviceNodes.find((node) => node.id === link.fromId);
+    const toNode = serviceNodes.find((node) => node.id === link.toId);
+    return !mutedClusterIds.includes(fromNode?.clusterId ?? "") && !mutedClusterIds.includes(toNode?.clusterId ?? "");
+  });
+  const relatedLinks = filteredLinks.filter((link) => {
+    if (inspectorNode) return link.fromId === inspectorNode.id || link.toId === inspectorNode.id;
+    return activeCluster ? activeCluster.nodeIds.includes(link.fromId) || activeCluster.nodeIds.includes(link.toId) : false;
+  });
+  const spotlightLink = relatedLinks.find((link) => link.id === highlightedLinkId) ?? null;
+  const focusedClusterName = serviceClusters.find((cluster) => cluster.id === focusedClusterId)?.name ?? null;
+  function handleSelectCluster(clusterId: string) {
+    const cluster = serviceClusters.find((item) => item.id === clusterId);
+    startTransition(() => {
+      setSelectedClusterId(clusterId);
+      if (!selectedNodeId || activeNode?.clusterId !== clusterId) setSelectedNodeId(cluster?.nodeIds[0] ?? null);
+    });
+  }
+
+  function handleSelectNode(nodeId: string, clusterId: string) {
+    const nextNodeId = selectedNodeId === nodeId ? null : nodeId;
+    const nextLinkId = nextNodeId ? dependencyLinks.find((link) => link.fromId === nextNodeId || link.toId === nextNodeId)?.id ?? null : null;
+    startTransition(() => {
+      setSelectedClusterId(clusterId);
+      setSelectedNodeId(nextNodeId);
+      setHighlightedLinkId(nextLinkId);
+    });
+  }
+  function handleToggleFocus(clusterId: string) {
+    const nextFocusId = focusedClusterId === clusterId ? null : clusterId;
+    const cluster = serviceClusters.find((item) => item.id === clusterId);
+    startTransition(() => {
+      setFocusedClusterId(nextFocusId);
+      if (nextFocusId) {
+        setSelectedClusterId(clusterId);
+        setSelectedNodeId(cluster?.nodeIds[0] ?? null);
+        setHighlightedLinkId(dependencyLinks.find((link) => cluster?.nodeIds.includes(link.fromId) || cluster?.nodeIds.includes(link.toId))?.id ?? null);
+      }
+    });
+  }
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(251,191,36,0.18),_transparent_32%),linear-gradient(180deg,_#16110a_0%,_#211712_44%,_#09090b_100%)] px-4 py-6 text-stone-100 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <section className="overflow-hidden rounded-[2rem] border border-amber-200/15 bg-black/30 shadow-2xl shadow-amber-950/20 backdrop-blur">
+          <div className="grid gap-6 px-6 py-7 lg:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.8fr)] lg:px-8">
+            <div className="space-y-4">
+              <div className="flex flex-wrap items-center gap-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.35em] text-amber-200/70">Service Map</p>
+                <span className="rounded-full border border-amber-300/25 bg-amber-300/12 px-3 py-1 text-xs font-semibold text-amber-100">{serviceMapOverview.healthMode}</span>
+              </div>
+              <div className="space-y-3">
+                <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-stone-50 sm:text-5xl">
+                  Mock topology route with cluster focus, muted edges, and inspector detail.
+                </h1>
+                <p className="max-w-2xl text-sm leading-7 text-stone-300 sm:text-base">{serviceMapOverview.summary}</p>
+              </div>
+              <div className="flex flex-wrap gap-3 text-xs text-stone-300">
+                <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1.5">Snapshot {serviceMapOverview.generatedAt}</span>
+                <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1.5">Scope {focusedClusterName ?? "All clusters"}</span>
+              </div>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <article className="rounded-3xl border border-white/10 bg-white/5 px-4 py-4">
+                <p className="text-sm text-stone-400">Clusters / Services</p>
+                <p className="mt-2 text-3xl font-semibold text-stone-50">{serviceClusters.length} / {serviceNodes.length}</p>
+              </article>
+              <article className="rounded-3xl border border-amber-300/20 bg-amber-300/10 px-4 py-4 text-amber-50">
+                <p className="text-sm text-amber-100/80">Visible links</p>
+                <p className="mt-2 text-3xl font-semibold">{filteredLinks.length}</p>
+              </article>
+              <article className="rounded-3xl border border-rose-300/20 bg-rose-300/10 px-4 py-4 text-rose-50">
+                <p className="text-sm text-rose-100/80">Critical nodes</p>
+                <p className="mt-2 text-3xl font-semibold">{criticalNodeCount}</p>
+              </article>
+              <article className="rounded-3xl border border-sky-300/20 bg-sky-300/10 px-4 py-4 text-sky-50">
+                <p className="text-sm text-sky-100/80">Muted clusters</p>
+                <p className="mt-2 text-3xl font-semibold">{mutedClusterIds.length}</p>
+              </article>
+            </div>
+          </div>
+        </section>
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.95fr)]">
+          <div className="space-y-6">
+            <ClusterList
+              clusters={visibleClusters}
+              focusedClusterId={focusedClusterId}
+              mutedClusterIds={mutedClusterIds}
+              nodes={serviceNodes}
+              onSelectCluster={handleSelectCluster}
+              onSelectNode={handleSelectNode}
+              onToggleFocus={handleToggleFocus}
+              onToggleMute={(clusterId) => setMutedClusterIds((items) => toggleId(items, clusterId))}
+              selectedClusterId={activeClusterId}
+              selectedNodeId={selectedNodeId}
+            />
+            <DependencyPanel
+              activeCluster={activeCluster}
+              activeNode={inspectorNode}
+              highlightedLinkId={spotlightLink?.id ?? null}
+              isClusterMuted={activeCluster ? mutedClusterIds.includes(activeCluster.id) : false}
+              links={relatedLinks}
+              nodes={serviceNodes}
+              onHighlight={(linkId) => setHighlightedLinkId((current) => current === linkId ? null : linkId)}
+            />
+          </div>
+          <FocusInspector
+            activeCluster={activeCluster}
+            activeNode={inspectorNode}
+            focusedClusterName={focusedClusterName}
+            isClusterMuted={activeCluster ? mutedClusterIds.includes(activeCluster.id) : false}
+            mutedNodeCount={mutedNodeCount}
+            spotlightLink={spotlightLink}
+            totalLinks={relatedLinks.length}
+            totalMutedClusters={mutedClusterIds.length}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/service-map` route with feature-local topology data
- add cluster focus and mute controls, dependency highlights, and a focus inspector
- keep all implementation inside `src/app/service-map` and `src/components/service-map`

Closes #39

## Testing
- npm run lint
- npm run typecheck
- npm test
- npm run build