### PR TITLE
feat: add lab notebook route

### DIFF
--- a/src/app/lab-notebook/notebook-data.ts
+++ b/src/app/lab-notebook/notebook-data.ts
@@ -1,0 +1,101 @@
+export type ExperimentStatus = "active" | "watch" | "stabilizing" | "archived";
+export type StatusFilter = ExperimentStatus | "all";
+export type ObservationSection = "notes" | "flags" | "timeline";
+
+export type NotebookStatus = { label: string; phase: string; syncLabel: string; lastEntrySummary: string };
+export type StatusOption = { id: StatusFilter; label: string };
+export type MilestoneTag = { id: string; label: string; tone: "sky" | "amber" | "emerald" | "rose" };
+export type Experiment = {
+  id: string; title: string; lead: string; status: ExperimentStatus; summary: string; focus: string;
+  window: string; progressValue: number; progressLabel: string; sampleCount: number; lastEntry: string; milestoneIds: string[];
+};
+export type ObservationEntry = {
+  id: string; experimentId: string; section: ObservationSection; headline: string; snippet: string;
+  detail: string; capturedAt: string; recorder: string; milestoneId?: string;
+};
+
+export const notebookStatus: NotebookStatus = {
+  label: "Notebook online",
+  phase: "Bench 4 sync window",
+  syncLabel: "Synced 18 minutes ago",
+  lastEntrySummary: "Heat drift dropped after the solvent ratio moved from 28% to 24%.",
+};
+
+export const statusOptions: StatusOption[] = [
+  { id: "all", label: "All cards" }, { id: "active", label: "Active" }, { id: "watch", label: "Watch" },
+  { id: "stabilizing", label: "Stabilizing" }, { id: "archived", label: "Archived" },
+];
+
+export const milestoneTags: MilestoneTag[] = [
+  { id: "capture", label: "Signal capture", tone: "sky" }, { id: "mix", label: "Ratio swap", tone: "amber" },
+  { id: "stability", label: "Stability gate", tone: "emerald" }, { id: "variance", label: "Variance watch", tone: "rose" },
+];
+
+export const experiments: Experiment[] = [
+  {
+    id: "vector-12", title: "Vector 12 catalyst assay", lead: "Dr. Lin Mora", status: "active",
+    summary: "Comparing solvent ratios across four trays to tighten signal consistency before the next review window.",
+    focus: "Tray C retained the strongest read without the late-cycle spike.", window: "Next readout in 42 min",
+    progressValue: 72, progressLabel: "Run 6 of 8", sampleCount: 24,
+    lastEntry: "Signal tightened after the second ratio swap and held across the last two pulls.", milestoneIds: ["capture", "mix", "stability"],
+  },
+  {
+    id: "amber-04", title: "Amber 04 thermal loop", lead: "Ira Sol", status: "watch",
+    summary: "Following an intermittent rise in coil temperature during the cooldown band after each third pulse.",
+    focus: "Thermal recovery is stable until pulse three, then slips outside the preferred curve.", window: "Manual watch until 19:40",
+    progressValue: 46, progressLabel: "Pulse set 3", sampleCount: 18,
+    lastEntry: "Cooldown lag reappeared on the final pulse set with a shorter plateau than yesterday.", milestoneIds: ["variance", "capture"],
+  },
+  {
+    id: "north-arc", title: "North Arc reagent ladder", lead: "M. Ortega", status: "stabilizing",
+    summary: "Verifying whether the updated reagent ladder reduces noise in the lower-band observations.",
+    focus: "The middle rung is now steady, but the lower rung still needs one more clean repeat.", window: "Review checkpoint at 20:15",
+    progressValue: 88, progressLabel: "Validation pass", sampleCount: 31,
+    lastEntry: "The lower rung cleared one repeat without drift and now needs a second confirmation.", milestoneIds: ["mix", "stability"],
+  },
+];
+
+export const observationEntries: ObservationEntry[] = [
+  {
+    id: "v12-note-1", experimentId: "vector-12", section: "notes", headline: "Ratio swap narrowed the spread",
+    snippet: "Cycle six closed to a 3.2% variance after the solvent ratio moved down four points.",
+    detail: "Tray C and Tray D converged within the same tolerance band after the swap, which did not happen in the previous two runs.",
+    capturedAt: "18:12", recorder: "L. Mora", milestoneId: "mix",
+  },
+  {
+    id: "v12-flag-1", experimentId: "vector-12", section: "flags", headline: "Watch the final tray handoff",
+    snippet: "The last tray still warms faster than the others during the transfer interval.",
+    detail: "If the handoff warm-up exceeds three minutes again, pause the next pull and repeat the transfer with the shorter dwell setting.",
+    capturedAt: "18:25", recorder: "A. Pike", milestoneId: "variance",
+  },
+  {
+    id: "v12-time-1", experimentId: "vector-12", section: "timeline", headline: "Stability gate cleared",
+    snippet: "Two consecutive pulls stayed within the notebook target band after the ratio change.",
+    detail: "That clears the local stability gate and keeps the assay on track for the final review window tonight.",
+    capturedAt: "18:31", recorder: "L. Mora", milestoneId: "stability",
+  },
+  {
+    id: "a04-note-1", experimentId: "amber-04", section: "notes", headline: "Thermal rise stayed late",
+    snippet: "Pulse three still drifted high, but the rise started twenty seconds later than the earlier run.",
+    detail: "That delay suggests the shield is helping, though not enough to remove the deviation completely.",
+    capturedAt: "17:58", recorder: "I. Sol", milestoneId: "capture",
+  },
+  {
+    id: "a04-flag-1", experimentId: "amber-04", section: "flags", headline: "Hold for manual watch",
+    snippet: "Leave this loop under operator watch until another cooldown cycle clears without a spike.",
+    detail: "The notebook should stay on the watch filter until the recovery curve stays under the upper bound for two consecutive pulse sets.",
+    capturedAt: "18:05", recorder: "R. Vale", milestoneId: "variance",
+  },
+  {
+    id: "na-note-1", experimentId: "north-arc", section: "notes", headline: "Lower rung nearly steady",
+    snippet: "The lower rung held cleanly through one repeat with no edge noise in the final band.",
+    detail: "A matching repeat would let the team close this ladder as stable and move the notebook card out of active handling.",
+    capturedAt: "17:42", recorder: "M. Ortega", milestoneId: "stability",
+  },
+  {
+    id: "na-time-1", experimentId: "north-arc", section: "timeline", headline: "Validation pass queued",
+    snippet: "The second confirmation run is staged for the 20:15 checkpoint with the revised reagent ladder.",
+    detail: "If the lower rung holds again, the notebook can promote the card from stabilizing to complete in the next review cycle.",
+    capturedAt: "17:49", recorder: "N. Hsu", milestoneId: "mix",
+  },
+];

--- a/src/app/lab-notebook/page.tsx
+++ b/src/app/lab-notebook/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+import { LabNotebookShell } from "@/components/lab-notebook/lab-notebook-shell";
+
+import { experiments, milestoneTags, notebookStatus, observationEntries, statusOptions } from "./notebook-data";
+
+export const metadata: Metadata = {
+  title: "Lab Notebook | API Test",
+  description: "Mock notebook workspace with experiment cards, status filters, and an observation drawer.",
+};
+
+export default function LabNotebookPage() {
+  return <LabNotebookShell experiments={experiments} milestoneTags={milestoneTags} notebookStatus={notebookStatus} observationEntries={observationEntries} statusOptions={statusOptions} />;
+}

--- a/src/components/lab-notebook/experiment-board.tsx
+++ b/src/components/lab-notebook/experiment-board.tsx
@@ -1,0 +1,114 @@
+import type {
+  Experiment,
+  ExperimentStatus,
+  MilestoneTag,
+} from "@/app/lab-notebook/notebook-data";
+
+type ExperimentBoardProps = {
+  experiments: Experiment[];
+  milestoneTagsById: Record<string, MilestoneTag>;
+  onSelect: (experimentId: string) => void;
+  selectedExperimentId: string | null;
+};
+
+const statusClasses: Record<ExperimentStatus, string> = {
+  active: "border-emerald-700/15 bg-emerald-600/10 text-emerald-900",
+  watch: "border-rose-700/15 bg-rose-500/10 text-rose-900",
+  stabilizing: "border-sky-700/15 bg-sky-500/10 text-sky-900",
+  archived: "border-stone-900/10 bg-stone-300/30 text-stone-700",
+};
+
+const toneClasses = {
+  amber: "border-amber-700/15 bg-amber-500/10 text-amber-900",
+  emerald: "border-emerald-700/15 bg-emerald-500/10 text-emerald-900",
+  rose: "border-rose-700/15 bg-rose-500/10 text-rose-900",
+  sky: "border-sky-700/15 bg-sky-500/10 text-sky-900",
+};
+
+export function ExperimentBoard({
+  experiments,
+  milestoneTagsById,
+  onSelect,
+  selectedExperimentId,
+}: ExperimentBoardProps) {
+  if (experiments.length === 0) {
+    return (
+      <section className="rounded-[2rem] border border-dashed border-stone-900/15 bg-white/70 p-8 text-center shadow-[0_20px_70px_rgba(120,53,15,0.1)]">
+        <p className="text-xs font-semibold uppercase tracking-[0.34em] text-stone-500">Zero state</p>
+        <h2 className="mt-3 text-2xl font-semibold tracking-[-0.03em] text-stone-950">No experiment cards match the current filter.</h2>
+        <p className="mt-3 text-sm leading-6 text-stone-600">This notebook keeps the empty state local. Switch back to active, watch, or stabilizing cards to reopen the workspace.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-1">
+      {experiments.map((experiment) => {
+        const isSelected = experiment.id === selectedExperimentId;
+
+        return (
+          <article
+            className={`rounded-[2rem] border p-5 shadow-[0_22px_80px_rgba(120,53,15,0.12)] transition ${
+              isSelected
+                ? "border-stone-950 bg-[linear-gradient(135deg,rgba(255,251,235,0.98),rgba(254,240,138,0.74))]"
+                : "border-stone-900/10 bg-white/82 hover:border-stone-900/20"
+            }`}
+            key={experiment.id}
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-stone-500">{experiment.lead}</p>
+                <h2 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-stone-950">{experiment.title}</h2>
+              </div>
+              <span className={`rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] ${statusClasses[experiment.status]}`}>{experiment.status}</span>
+            </div>
+
+            <p className="mt-3 text-sm leading-6 text-stone-700">{experiment.summary}</p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              {experiment.milestoneIds.map((milestoneId) => {
+                const milestone = milestoneTagsById[milestoneId];
+
+                return milestone ? (
+                  <span className={`rounded-full border px-3 py-1 text-xs font-medium ${toneClasses[milestone.tone]}`} key={milestone.id}>
+                    {milestone.label}
+                  </span>
+                ) : null;
+              })}
+            </div>
+
+            <div className="mt-5 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+              <div>
+                <div className="flex items-center justify-between text-sm text-stone-700">
+                  <span className="font-medium">{experiment.progressLabel}</span>
+                  <span>{experiment.progressValue}%</span>
+                </div>
+                <div className="mt-2 h-2 rounded-full bg-stone-200">
+                  <div className="h-full rounded-full bg-stone-950" style={{ width: `${experiment.progressValue}%` }} />
+                </div>
+              </div>
+              <span className="rounded-full border border-stone-900/10 bg-stone-100/75 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-600">{experiment.sampleCount} samples</span>
+            </div>
+
+            <div className="mt-5 grid gap-3 text-sm text-stone-700 sm:grid-cols-2">
+              <div className="rounded-[1.35rem] bg-stone-100/70 p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">Focus</p>
+                <p className="mt-2 leading-6">{experiment.focus}</p>
+              </div>
+              <div className="rounded-[1.35rem] bg-stone-100/70 p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">Next window</p>
+                <p className="mt-2 leading-6">{experiment.window}</p>
+              </div>
+            </div>
+
+            <div className="mt-5 flex flex-wrap items-center justify-between gap-3">
+              <p className="max-w-xl text-sm leading-6 text-stone-700">{experiment.lastEntry}</p>
+              <button className="rounded-full bg-stone-950 px-4 py-2 text-sm text-stone-50 transition hover:bg-stone-800" onClick={() => onSelect(experiment.id)} type="button">
+                {isSelected ? "Focused in drawer" : "Open in drawer"}
+              </button>
+            </div>
+          </article>
+        );
+      })}
+    </section>
+  );
+}

--- a/src/components/lab-notebook/lab-notebook-header.tsx
+++ b/src/components/lab-notebook/lab-notebook-header.tsx
@@ -1,0 +1,46 @@
+import type { NotebookStatus } from "@/app/lab-notebook/notebook-data";
+
+type LabNotebookHeaderProps = {
+  activeCount: number; flaggedCount: number; lastEntrySummary: string; notebookStatus: NotebookStatus; visibleCount: number;
+};
+
+export function LabNotebookHeader({
+  activeCount,
+  flaggedCount,
+  lastEntrySummary,
+  notebookStatus,
+  visibleCount,
+}: LabNotebookHeaderProps) {
+  return (
+    <section className="grid gap-4 lg:grid-cols-[minmax(0,1.25fr)_minmax(21rem,0.8fr)]">
+      <article className="rounded-[2rem] border border-stone-900/10 bg-[linear-gradient(135deg,rgba(255,251,235,0.98),rgba(254,243,199,0.86))] p-6 shadow-[0_28px_90px_rgba(120,53,15,0.18)]">
+        <p className="text-xs font-semibold uppercase tracking-[0.34em] text-stone-500">Lab Notebook Route</p>
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <span className="rounded-full border border-emerald-700/15 bg-emerald-600/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-emerald-900">{notebookStatus.label}</span>
+          <span className="rounded-full border border-stone-900/10 bg-white/65 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-600">{notebookStatus.phase}</span>
+        </div>
+        <h1 className="mt-4 max-w-2xl text-4xl font-semibold tracking-[-0.04em] text-stone-950 sm:text-5xl">Experiment cards anchored to a local observation notebook.</h1>
+        <p className="mt-4 max-w-2xl text-sm leading-6 text-stone-700">Every card, filter, milestone tag, and drawer interaction lives only inside this route, mirroring a notebook workspace without touching shared app state.</p>
+      </article>
+      <article className="rounded-[2rem] border border-stone-900/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.96),rgba(41,37,36,0.94))] p-6 text-stone-100 shadow-[0_28px_90px_rgba(15,23,42,0.28)]">
+        <p className="text-xs font-semibold uppercase tracking-[0.32em] text-amber-200/75">{notebookStatus.syncLabel}</p>
+        <h2 className="mt-3 text-2xl font-semibold tracking-[-0.03em]">Last-entry summary</h2>
+        <p className="mt-3 text-sm leading-6 text-stone-300">{lastEntrySummary}</p>
+        <div className="mt-5 grid grid-cols-3 gap-3 text-center">
+          <div className="rounded-[1.4rem] border border-white/10 bg-white/5 px-3 py-4">
+            <p className="text-2xl font-semibold">{visibleCount}</p>
+            <p className="mt-1 text-xs uppercase tracking-[0.24em] text-stone-400">Visible cards</p>
+          </div>
+          <div className="rounded-[1.4rem] border border-white/10 bg-white/5 px-3 py-4">
+            <p className="text-2xl font-semibold">{activeCount}</p>
+            <p className="mt-1 text-xs uppercase tracking-[0.24em] text-stone-400">Active bench</p>
+          </div>
+          <div className="rounded-[1.4rem] border border-white/10 bg-white/5 px-3 py-4">
+            <p className="text-2xl font-semibold">{flaggedCount}</p>
+            <p className="mt-1 text-xs uppercase tracking-[0.24em] text-stone-400">Watch notes</p>
+          </div>
+        </div>
+      </article>
+    </section>
+  );
+}

--- a/src/components/lab-notebook/lab-notebook-shell.tsx
+++ b/src/components/lab-notebook/lab-notebook-shell.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { startTransition, useState } from "react";
+
+import type {
+  Experiment,
+  MilestoneTag,
+  NotebookStatus,
+  ObservationEntry,
+  ObservationSection,
+  StatusFilter,
+  StatusOption,
+} from "@/app/lab-notebook/notebook-data";
+import { ExperimentBoard } from "./experiment-board";
+import { LabNotebookHeader } from "./lab-notebook-header";
+import { ObservationDrawer } from "./observation-drawer";
+import { StatusFilterBar } from "./status-filter-bar";
+
+type LabNotebookShellProps = {
+  experiments: Experiment[]; milestoneTags: MilestoneTag[]; notebookStatus: NotebookStatus;
+  observationEntries: ObservationEntry[]; statusOptions: StatusOption[];
+};
+
+function matchesStatus(experiment: Experiment, filter: StatusFilter) {
+  return filter === "all" || experiment.status === filter;
+}
+
+export function LabNotebookShell({
+  experiments,
+  milestoneTags,
+  notebookStatus,
+  observationEntries,
+  statusOptions,
+}: LabNotebookShellProps) {
+  const [selectedFilter, setSelectedFilter] = useState<StatusFilter>("all");
+  const [selectedExperimentId, setSelectedExperimentId] = useState<string | null>(experiments[0]?.id ?? null);
+  const [drawerSection, setDrawerSection] = useState<ObservationSection>("notes");
+  const [expandedEntryId, setExpandedEntryId] = useState<string | null>(null);
+  const visibleExperiments = experiments.filter((experiment) => matchesStatus(experiment, selectedFilter));
+  const selectedExperiment = visibleExperiments.find((experiment) => experiment.id === selectedExperimentId) ?? null;
+  const selectedEntries = observationEntries.filter((entry) => entry.experimentId === selectedExperimentId);
+  const lastEntrySummary = selectedExperiment?.lastEntry ?? notebookStatus.lastEntrySummary;
+  const activeCount = experiments.filter((experiment) => experiment.status === "active").length;
+  const flaggedCount = observationEntries.filter((entry) => entry.section === "flags").length;
+  const counts = {
+    all: experiments.length,
+    active: experiments.filter((experiment) => experiment.status === "active").length,
+    watch: experiments.filter((experiment) => experiment.status === "watch").length,
+    stabilizing: experiments.filter((experiment) => experiment.status === "stabilizing").length,
+    archived: experiments.filter((experiment) => experiment.status === "archived").length,
+  } as Record<StatusFilter, number>;
+  const milestoneTagsById = Object.fromEntries(milestoneTags.map((tag) => [tag.id, tag])) as Record<string, MilestoneTag>;
+
+  const handleFilterChange = (filter: StatusFilter) => {
+    startTransition(() => {
+      setSelectedFilter(filter);
+      setExpandedEntryId(null);
+
+      const nextVisible = experiments.filter((experiment) => matchesStatus(experiment, filter));
+      if (!nextVisible.some((experiment) => experiment.id === selectedExperimentId)) {
+        setSelectedExperimentId(nextVisible[0]?.id ?? null);
+      }
+    });
+  };
+  const handleSelectExperiment = (experimentId: string) => {
+    startTransition(() => {
+      setSelectedExperimentId(experimentId);
+      setExpandedEntryId(null);
+    });
+  };
+  const handleSectionChange = (section: ObservationSection) => {
+    startTransition(() => {
+      setDrawerSection(section);
+      setExpandedEntryId(null);
+    });
+  };
+
+  const handleExpandEntry = (entryId: string) => {
+    startTransition(() => {
+      setExpandedEntryId((current) => (current === entryId ? null : entryId));
+    });
+  };
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(251,191,36,0.12),transparent_30%),radial-gradient(circle_at_right,rgba(20,184,166,0.1),transparent_24%),linear-gradient(180deg,#fefce8_0%,#fffbeb_34%,#f8fafc_100%)] px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <LabNotebookHeader
+          activeCount={activeCount}
+          flaggedCount={flaggedCount}
+          lastEntrySummary={lastEntrySummary}
+          notebookStatus={notebookStatus}
+          visibleCount={visibleExperiments.length}
+        />
+        <StatusFilterBar counts={counts} onChange={handleFilterChange} selectedFilter={selectedFilter} statusOptions={statusOptions} />
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.25fr)_minmax(22rem,0.88fr)]">
+          <ExperimentBoard
+            experiments={visibleExperiments}
+            milestoneTagsById={milestoneTagsById}
+            onSelect={handleSelectExperiment}
+            selectedExperimentId={selectedExperimentId}
+          />
+          <ObservationDrawer
+            entries={selectedEntries}
+            expandedEntryId={expandedEntryId}
+            experiment={selectedExperiment}
+            milestoneTagsById={milestoneTagsById}
+            onExpandEntry={handleExpandEntry}
+            onSectionChange={handleSectionChange}
+            section={drawerSection}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/lab-notebook/observation-drawer.tsx
+++ b/src/components/lab-notebook/observation-drawer.tsx
@@ -1,0 +1,117 @@
+import type {
+  Experiment,
+  MilestoneTag,
+  ObservationEntry,
+  ObservationSection,
+} from "@/app/lab-notebook/notebook-data";
+
+type ObservationDrawerProps = {
+  entries: ObservationEntry[];
+  experiment: Experiment | null;
+  expandedEntryId: string | null;
+  milestoneTagsById: Record<string, MilestoneTag>;
+  onExpandEntry: (entryId: string) => void;
+  onSectionChange: (section: ObservationSection) => void;
+  section: ObservationSection;
+};
+
+const sectionLabels: Record<ObservationSection, string> = {
+  notes: "Notes",
+  flags: "Flags",
+  timeline: "Timeline",
+};
+
+const toneClasses = {
+  amber: "border-amber-300/20 bg-amber-400/10 text-amber-100",
+  emerald: "border-emerald-300/20 bg-emerald-400/10 text-emerald-100",
+  rose: "border-rose-300/20 bg-rose-400/10 text-rose-100",
+  sky: "border-sky-300/20 bg-sky-400/10 text-sky-100",
+};
+
+export function ObservationDrawer({
+  entries,
+  experiment,
+  expandedEntryId,
+  milestoneTagsById,
+  onExpandEntry,
+  onSectionChange,
+  section,
+}: ObservationDrawerProps) {
+  const sectionEntries = entries.filter((entry) => entry.section === section);
+  const counts = {
+    notes: entries.filter((entry) => entry.section === "notes").length,
+    flags: entries.filter((entry) => entry.section === "flags").length,
+    timeline: entries.filter((entry) => entry.section === "timeline").length,
+  };
+
+  return (
+    <aside className="rounded-[2rem] border border-stone-900/10 bg-[linear-gradient(180deg,rgba(12,10,9,0.96),rgba(41,37,36,0.97))] p-5 text-stone-100 shadow-[0_28px_90px_rgba(15,23,42,0.3)] sm:p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-amber-200/75">Observation drawer</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-[-0.03em]">{experiment ? experiment.title : "Choose an experiment"}</h2>
+          <p className="mt-2 text-sm leading-6 text-stone-300">
+            {experiment
+              ? `${experiment.window}. Local sections switch between notebook notes, watch items, and milestone timing.`
+              : "Select an experiment card to open the drawer. Until then, the notebook keeps this region in a local waiting state."}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        {(["notes", "flags", "timeline"] as ObservationSection[]).map((nextSection) => (
+          <button
+            className={`rounded-full px-4 py-2 text-sm transition ${
+              nextSection === section
+                ? "bg-stone-50 text-stone-950"
+                : "border border-white/12 bg-white/5 text-stone-200 hover:bg-white/10"
+            }`}
+            key={nextSection}
+            onClick={() => onSectionChange(nextSection)}
+            type="button"
+          >
+            {sectionLabels[nextSection]} <span className="text-xs opacity-70">{counts[nextSection]}</span>
+          </button>
+        ))}
+      </div>
+
+      {!experiment ? (
+        <div className="mt-5 rounded-[1.75rem] border border-dashed border-white/12 bg-white/[0.04] p-6 text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-stone-400">Waiting on selection</p>
+          <p className="mt-3 text-sm leading-6 text-stone-300">Pick any card from the notebook board to review note snippets, watch markers, and milestone timing without leaving this route.</p>
+        </div>
+      ) : sectionEntries.length === 0 ? (
+        <div className="mt-5 rounded-[1.75rem] border border-dashed border-white/12 bg-white/[0.04] p-6 text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-stone-400">Section clear</p>
+          <h3 className="mt-3 text-xl font-semibold">No {sectionLabels[section].toLowerCase()} are parked for this experiment.</h3>
+          <p className="mt-3 text-sm leading-6 text-stone-300">The drawer stays open, but this section is empty. Switch sections or return to another card if you want a fuller observation trail.</p>
+        </div>
+      ) : (
+        <div className="mt-5 space-y-3">
+          {sectionEntries.map((entry) => {
+            const milestone = entry.milestoneId ? milestoneTagsById[entry.milestoneId] : undefined;
+            const isExpanded = expandedEntryId === entry.id;
+
+            return (
+              <article className="rounded-[1.55rem] border border-white/10 bg-white/5 p-4" key={entry.id}>
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-300">{entry.capturedAt}</span>
+                  <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-300">{entry.recorder}</span>
+                  {milestone ? (
+                    <span className={`rounded-full border px-3 py-1 text-xs font-medium ${toneClasses[milestone.tone]}`}>{milestone.label}</span>
+                  ) : null}
+                </div>
+                <h3 className="mt-3 text-lg font-semibold">{entry.headline}</h3>
+                <p className="mt-2 text-sm leading-6 text-stone-300">{entry.snippet}</p>
+                {isExpanded ? <p className="mt-3 text-sm leading-6 text-stone-200">{entry.detail}</p> : null}
+                <button className="mt-4 rounded-full border border-white/12 bg-white/5 px-4 py-2 text-sm text-stone-100 transition hover:bg-white/10" onClick={() => onExpandEntry(entry.id)} type="button">
+                  {isExpanded ? "Hide detail" : "Expand detail"}
+                </button>
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/components/lab-notebook/status-filter-bar.tsx
+++ b/src/components/lab-notebook/status-filter-bar.tsx
@@ -1,0 +1,30 @@
+import type { StatusFilter, StatusOption } from "@/app/lab-notebook/notebook-data";
+
+type StatusFilterBarProps = {
+  counts: Record<StatusFilter, number>; onChange: (filter: StatusFilter) => void; selectedFilter: StatusFilter; statusOptions: StatusOption[];
+};
+
+export function StatusFilterBar({
+  counts,
+  onChange,
+  selectedFilter,
+  statusOptions,
+}: StatusFilterBarProps) {
+  return (
+    <section className="rounded-[1.8rem] border border-stone-900/10 bg-white/80 p-4 shadow-[0_20px_70px_rgba(120,53,15,0.12)]">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-stone-500">Status filters</p>
+          <p className="mt-2 text-sm text-stone-600">Filter the notebook without leaving the route or mutating any shared workspace.</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {statusOptions.map((option) => (
+            <button className={`rounded-full px-4 py-2 text-sm transition ${option.id === selectedFilter ? "bg-stone-950 text-stone-50" : "border border-stone-900/10 bg-stone-100/80 text-stone-700 hover:bg-stone-200/80"}`} key={option.id} onClick={() => onChange(option.id)} type="button">
+              {option.label} <span className="text-xs opacity-75">{counts[option.id]}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/lab-notebook` app route with feature-local mock notebook data
- render experiment cards with status filters, progress badges, and route-local selection state
- add an observation drawer with section toggles, note snippets, and zero states

## Verification
- npm run lint -- src/app/lab-notebook src/components/lab-notebook
- npm run typecheck
- npm run build

Closes #31