### PR TITLE
feat: add isolated queue monitor route

### DIFF
--- a/src/app/queue-monitor/page.tsx
+++ b/src/app/queue-monitor/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+import { QueueMonitorShell } from "@/components/queue-monitor/queue-monitor-shell";
+
+export const metadata: Metadata = {
+  title: "Queue Monitor | API Test",
+  description: "Isolated backlog monitor route with queue columns, throughput indicators, and local escalation controls.",
+};
+
+export default function QueueMonitorPage() {
+  return <QueueMonitorShell />;
+}

--- a/src/components/queue-monitor/queue-column-board.tsx
+++ b/src/components/queue-monitor/queue-column-board.tsx
@@ -1,0 +1,117 @@
+import type { BacklogItem, AgeFilter, QueueScope, QueueSummary, EscalationLevelId } from "./queue-monitor-data";
+
+type QueueColumnBoardProps = {
+  ageFilter: AgeFilter; columns: { items: BacklogItem[]; queue: QueueSummary }[]; queueEscalations: Record<string, number>;
+  queueScope: QueueScope; queueTotals: Record<string, number>; selectedItemId: string | null; selectedQueueId: string | null;
+  escalationState: Record<string, { level: EscalationLevelId }>; onSelectItem: (queueId: string, itemId: string) => void; onSelectQueue: (queueId: string) => void;
+};
+
+const queueToneClasses = {
+  stable: "border-emerald-300/20 bg-emerald-300/10 text-emerald-50",
+  watch: "border-amber-300/20 bg-amber-300/10 text-amber-50",
+  critical: "border-rose-300/20 bg-rose-300/10 text-rose-50",
+};
+const severityClasses = {
+  low: "bg-slate-200/15 text-slate-100",
+  medium: "bg-amber-200/15 text-amber-100",
+  high: "bg-rose-200/15 text-rose-100",
+};
+const filterCopy = {
+  all: "all backlog items",
+  aging: "aging or breach items",
+  breach: "breach items",
+};
+const scopeCopy = {
+  all: "all queues",
+  watch: "attention queues",
+  stable: "stable queues",
+};
+
+export function QueueColumnBoard({
+  ageFilter,
+  columns,
+  queueEscalations,
+  queueScope,
+  queueTotals,
+  selectedItemId,
+  selectedQueueId,
+  escalationState,
+  onSelectItem,
+  onSelectQueue,
+}: QueueColumnBoardProps) {
+  const visibleItemTotal = columns.reduce((sum, column) => sum + column.items.length, 0);
+
+  if (visibleItemTotal === 0) {
+    return (
+      <section className="rounded-[2rem] border border-dashed border-white/15 bg-slate-950/55 p-8 text-center text-slate-200">
+        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">No items in view</p>
+        <h2 className="mt-3 text-2xl font-semibold text-white">The current filter mix leaves {scopeCopy[queueScope]} with no {filterCopy[ageFilter]}.</h2>
+        <p className="mt-3 text-sm leading-6 text-slate-300">Switch the queue scope or age filter to reopen the board and inspect live backlog cards.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="grid gap-4 xl:grid-cols-4">
+      {columns.map(({ items, queue }) => {
+        const isSelectedQueue = queue.id === selectedQueueId;
+        const throughputDelta = queue.clearedPerHour - queue.intakePerHour;
+
+        return (
+          <article className={`rounded-[1.9rem] border p-4 shadow-[0_20px_70px_rgba(15,23,42,0.32)] ${isSelectedQueue ? "border-orange-200/45 bg-slate-900/95" : "border-white/10 bg-slate-950/72"}`} key={queue.id}>
+            <button className="w-full text-left" onClick={() => onSelectQueue(queue.id)} type="button">
+              <div className="flex flex-wrap gap-2">
+                <span className={`rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-[0.2em] ${queueToneClasses[queue.tone]}`}>{queue.statusLabel}</span>
+                <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-300">{queue.slaWindow}</span>
+              </div>
+              <h2 className="mt-3 text-2xl font-semibold text-white">{queue.label}</h2>
+              <p className="mt-1 text-sm text-slate-300">{queue.region} · {queue.owner}</p>
+              <div className="mt-4 grid grid-cols-2 gap-3 text-sm text-slate-200">
+                <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+                  <p className="text-xs uppercase tracking-[0.22em] text-slate-400">Visible</p>
+                  <p className="mt-2 text-2xl font-semibold text-white">{items.length}</p>
+                  <p className="text-xs text-slate-400">of {queueTotals[queue.id]} items</p>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+                  <p className="text-xs uppercase tracking-[0.22em] text-slate-400">Throughput</p>
+                  <p className="mt-2 text-2xl font-semibold text-white">{queue.clearedPerHour}/{queue.intakePerHour}</p>
+                  <p className={`text-xs ${throughputDelta >= 0 ? "text-emerald-200" : "text-rose-200"}`}>{throughputDelta >= 0 ? `+${throughputDelta}` : throughputDelta} vs intake</p>
+                </div>
+              </div>
+              <div className="mt-3 flex items-center justify-between text-xs uppercase tracking-[0.2em] text-slate-400">
+                <span>{queue.oldestMinutes} min oldest</span>
+                <span>{queueEscalations[queue.id]} local escalations</span>
+              </div>
+            </button>
+            <div className="mt-4 space-y-3">
+              {items.length > 0 ? items.map((item) => {
+                const isSelectedItem = item.id === selectedItemId;
+                const localLevel = escalationState[item.id].level;
+
+                return (
+                  <button className={`block w-full rounded-[1.4rem] border p-4 text-left transition ${isSelectedItem ? "border-orange-200/45 bg-orange-200/10" : "border-white/10 bg-white/5 hover:bg-white/8"}`} key={item.id} onClick={() => onSelectItem(queue.id, item.id)} type="button">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className={`rounded-full px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.18em] ${severityClasses[item.severity]}`}>{item.severity}</span>
+                      <span className="rounded-full border border-white/10 px-2.5 py-1 text-[11px] uppercase tracking-[0.18em] text-slate-300">{item.ageMinutes} min</span>
+                    </div>
+                    <h3 className="mt-3 text-base font-semibold text-white">{item.title}</h3>
+                    <p className="mt-2 text-sm text-slate-300">{item.customer}</p>
+                    <div className="mt-3 flex items-center justify-between gap-3 text-xs text-slate-400">
+                      <span>{item.caseRef}</span>
+                      <span>{localLevel === "none" ? "Local watch" : localLevel === "lead" ? "Lead escalated" : "Director paged"}</span>
+                    </div>
+                  </button>
+                );
+              }) : (
+                <div className="rounded-[1.5rem] border border-dashed border-white/12 bg-white/[0.03] p-5 text-center">
+                  <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-400">Filtered clear</p>
+                  <p className="mt-3 text-sm leading-6 text-slate-300">No {filterCopy[ageFilter]} are parked in this queue right now.</p>
+                </div>
+              )}
+            </div>
+          </article>
+        );
+      })}
+    </section>
+  );
+}

--- a/src/components/queue-monitor/queue-detail-panel.tsx
+++ b/src/components/queue-monitor/queue-detail-panel.tsx
@@ -1,0 +1,102 @@
+import type { BacklogItem, EscalationLevel, EscalationLevelId, QueueSummary } from "./queue-monitor-data";
+
+type LocalEscalationState = {
+  addToDigest: boolean; holdRelease: boolean; level: EscalationLevelId; notifyFloor: boolean; reviewed: boolean;
+};
+
+type QueueDetailPanelProps = {
+  escalationLevels: EscalationLevel[]; itemState: LocalEscalationState | null; queueEscalations: number; queueItemsVisible: number;
+  selectedItem: BacklogItem | null; selectedQueue: QueueSummary | null; onEscalationLevelChange: (level: EscalationLevelId) => void;
+  onToggle: (key: keyof Omit<LocalEscalationState, "level">) => void;
+};
+
+const levelToneClasses = {
+  calm: "border-slate-300/20 bg-slate-300/10 text-slate-50",
+  watch: "border-amber-300/20 bg-amber-300/10 text-amber-50",
+  hot: "border-rose-300/20 bg-rose-300/10 text-rose-50",
+};
+
+const toggleLabels: { hint: string; key: keyof Omit<LocalEscalationState, "level">; label: string }[] = [
+  { key: "holdRelease", label: "Hold release", hint: "Keep this item parked in the queue preview." },
+  { key: "notifyFloor", label: "Notify floor", hint: "Bring operations into the next sweep." },
+  { key: "addToDigest", label: "Digest flag", hint: "Include the item in the manager digest." },
+  { key: "reviewed", label: "Reviewed", hint: "Mark the local preview as checked." },
+];
+
+export function QueueDetailPanel({
+  escalationLevels,
+  itemState,
+  queueEscalations,
+  queueItemsVisible,
+  selectedItem,
+  selectedQueue,
+  onEscalationLevelChange,
+  onToggle,
+}: QueueDetailPanelProps) {
+  return (
+    <aside className="rounded-[2rem] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.94),rgba(28,25,23,0.94))] p-5 shadow-[0_22px_80px_rgba(0,0,0,0.42)] sm:p-6">
+      <div className="rounded-[1.6rem] border border-white/10 bg-white/5 p-4">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Queue preview</p>
+        <h2 className="mt-3 text-2xl font-semibold text-white">{selectedQueue ? selectedQueue.label : "Choose a queue"}</h2>
+        <p className="mt-2 text-sm leading-6 text-slate-300">{selectedQueue ? `${selectedQueue.region} is owned by ${selectedQueue.owner}. ${queueItemsVisible} filtered items are visible with ${queueEscalations} local escalations applied.` : "Pick a queue column to inspect backlog details and adjust local escalation controls."}</p>
+        {selectedQueue ? (
+          <div className="mt-4 grid gap-3 sm:grid-cols-3">
+            <div className="rounded-2xl border border-white/10 bg-slate-950/50 p-3"><p className="text-xs uppercase tracking-[0.2em] text-slate-400">Oldest</p><p className="mt-2 text-xl font-semibold text-white">{selectedQueue.oldestMinutes} min</p></div>
+            <div className="rounded-2xl border border-white/10 bg-slate-950/50 p-3"><p className="text-xs uppercase tracking-[0.2em] text-slate-400">Intake</p><p className="mt-2 text-xl font-semibold text-white">{selectedQueue.intakePerHour}/hr</p></div>
+            <div className="rounded-2xl border border-white/10 bg-slate-950/50 p-3"><p className="text-xs uppercase tracking-[0.2em] text-slate-400">Cleared</p><p className="mt-2 text-xl font-semibold text-white">{selectedQueue.clearedPerHour}/hr</p></div>
+          </div>
+        ) : null}
+      </div>
+
+      {selectedItem && itemState ? (
+        <div className="mt-5 space-y-5">
+          <section className="rounded-[1.6rem] border border-white/10 bg-white/5 p-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-300">{selectedItem.caseRef}</span>
+              <span className="rounded-full border border-orange-300/20 bg-orange-300/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-orange-100">{selectedItem.ageMinutes} min open</span>
+            </div>
+            <h3 className="mt-3 text-xl font-semibold text-white">{selectedItem.title}</h3>
+            <p className="mt-2 text-sm text-slate-300">{selectedItem.customer} · {selectedItem.segment}</p>
+            <p className="mt-3 text-sm leading-6 text-slate-300">{selectedItem.detail}</p>
+            <div className="mt-4 rounded-[1.4rem] border border-white/10 bg-slate-950/45 p-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">Next action</p>
+              <p className="mt-2 text-sm leading-6 text-slate-200">{selectedItem.nextAction}</p>
+              <p className="mt-3 text-sm text-slate-400">Owner: {selectedItem.owner}</p>
+            </div>
+          </section>
+
+          <section className="rounded-[1.6rem] border border-white/10 bg-white/5 p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Escalation level</p>
+            <div className="mt-4 space-y-3">
+              {escalationLevels.map((level) => (
+                <button className={`flex w-full items-start justify-between gap-4 rounded-[1.3rem] border p-4 text-left transition ${itemState.level === level.id ? "border-orange-200/40 bg-orange-200/10" : `${levelToneClasses[level.tone]} hover:bg-white/10`}`} key={level.id} onClick={() => onEscalationLevelChange(level.id)} type="button">
+                  <div><p className="font-medium text-white">{level.label}</p><p className="mt-1 text-sm text-slate-300">{level.note}</p></div>
+                  <span className="text-xs uppercase tracking-[0.22em] text-slate-400">{itemState.level === level.id ? "Selected" : "Available"}</span>
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-[1.6rem] border border-white/10 bg-white/5 p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Local controls</p>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              {toggleLabels.map((toggle) => (
+                <button className={`rounded-[1.2rem] border p-4 text-left transition ${itemState[toggle.key] ? "border-emerald-300/30 bg-emerald-300/10 text-emerald-50" : "border-white/10 bg-slate-950/45 text-slate-200 hover:bg-white/10"}`} key={toggle.key} onClick={() => onToggle(toggle.key)} type="button">
+                  <p className="font-medium">{toggle.label}</p>
+                  <p className="mt-1 text-sm opacity-80">{toggle.hint}</p>
+                </button>
+              ))}
+            </div>
+            <p className="mt-4 text-sm text-slate-400">These toggles only update this route-local preview state. They do not affect any shared queue or page outside `/queue-monitor`.</p>
+          </section>
+        </div>
+      ) : (
+        <div className="mt-5 rounded-[1.75rem] border border-dashed border-white/12 bg-white/[0.03] p-6 text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-400">Nothing selected</p>
+          <h3 className="mt-3 text-xl font-semibold text-white">{selectedQueue ? "This queue has no items in the current filter view." : "Select a queue column to inspect the backlog."}</h3>
+          <p className="mt-3 text-sm leading-6 text-slate-300">{selectedQueue ? "Change the aging filter or choose another queue to reopen the detail preview." : "The detail panel will show item context and escalation controls once a backlog card is selected."}</p>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/components/queue-monitor/queue-filter-bar.tsx
+++ b/src/components/queue-monitor/queue-filter-bar.tsx
@@ -1,0 +1,59 @@
+import type { AgeFilter, QueueScope } from "./queue-monitor-data";
+
+type QueueFilterBarProps = {
+  ageCounts: Record<AgeFilter, number>; ageFilter: AgeFilter; queueCounts: Record<QueueScope, number>;
+  queueScope: QueueScope; onAgeFilterChange: (filter: AgeFilter) => void; onQueueScopeChange: (scope: QueueScope) => void;
+};
+
+const queueLabels: Record<QueueScope, string> = { all: "All queues", watch: "Attention only", stable: "Stable only" };
+const ageLabels: Record<AgeFilter, string> = { all: "All ages", aging: "Aging + breach", breach: "Breach only" };
+
+function FilterGroup<T extends string>({
+  active,
+  counts,
+  label,
+  labels,
+  onChange,
+  values,
+}: {
+  active: T; counts: Record<T, number>; label: string; labels: Record<T, string>; onChange: (value: T) => void; values: T[];
+}) {
+  return (
+    <div>
+      <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">{label}</p>
+      <div className="mt-3 flex flex-wrap gap-3">
+        {values.map((value) => (
+          <button
+            aria-pressed={value === active}
+            className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+              value === active ? "bg-orange-200 text-slate-950" : "border border-white/12 bg-white/5 text-slate-200 hover:border-orange-200/35 hover:bg-white/10"
+            }`}
+            key={value}
+            onClick={() => onChange(value)}
+            type="button"
+          >
+            {labels[value]} <span className="text-xs opacity-70">({counts[value]})</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function QueueFilterBar({
+  ageCounts,
+  ageFilter,
+  queueCounts,
+  queueScope,
+  onAgeFilterChange,
+  onQueueScopeChange,
+}: QueueFilterBarProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-white/10 bg-slate-950/72 p-4 shadow-[0_18px_60px_rgba(15,23,42,0.32)] backdrop-blur">
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+        <FilterGroup active={queueScope} counts={queueCounts} label="Queue scope" labels={queueLabels} onChange={onQueueScopeChange} values={["all", "watch", "stable"]} />
+        <FilterGroup active={ageFilter} counts={ageCounts} label="Aging filter" labels={ageLabels} onChange={onAgeFilterChange} values={["all", "aging", "breach"]} />
+      </div>
+    </section>
+  );
+}

--- a/src/components/queue-monitor/queue-monitor-data.ts
+++ b/src/components/queue-monitor/queue-monitor-data.ts
@@ -1,0 +1,53 @@
+export type QueueTone = "stable" | "watch" | "critical";
+export type AgeFilter = "all" | "aging" | "breach";
+export type QueueScope = "all" | "watch" | "stable";
+export type AgeBand = "fresh" | "aging" | "breach";
+export type EscalationLevelId = "none" | "lead" | "director";
+
+export type QueueSummary = {
+  id: string; label: string; region: string; owner: string; tone: QueueTone; statusLabel: string;
+  intakePerHour: number; clearedPerHour: number; oldestMinutes: number; slaWindow: string;
+};
+
+export type BacklogItem = {
+  id: string; queueId: string; caseRef: string; customer: string; title: string; detail: string;
+  owner: string; ageMinutes: number; ageBand: AgeBand; severity: "low" | "medium" | "high";
+  nextAction: string; segment: string; escalationLevel: EscalationLevelId;
+};
+
+export type ThroughputSummary = { id: string; label: string; value: string; note: string; tone: "up" | "flat" | "down" };
+export type EscalationLevel = { id: EscalationLevelId; label: string; note: string; tone: "calm" | "watch" | "hot" };
+
+export const queueMonitorSnapshot = "Snapshot 09:40 local";
+
+export const throughputSummaries: ThroughputSummary[] = [
+  { id: "inflow", label: "Inflow / hr", value: "142", note: "Eight more than the last half hour.", tone: "up" },
+  { id: "clearance", label: "Clearance / hr", value: "118", note: "Two queues are clearing below intake.", tone: "down" },
+  { id: "stability", label: "Projected carryover", value: "24", note: "If unchanged, two breach items remain by handoff.", tone: "flat" },
+];
+
+export const escalationLevels: EscalationLevel[] = [
+  { id: "none", label: "Local watch", note: "Keep the item inside the queue team.", tone: "calm" },
+  { id: "lead", label: "Shift lead", note: "Pull the queue lead into the next pass.", tone: "watch" },
+  { id: "director", label: "Director page", note: "Escalate immediately for deadline risk.", tone: "hot" },
+];
+
+export const queueSummaries: QueueSummary[] = [
+  { id: "claims", label: "Priority Claims", region: "North pod", owner: "Mika Patel", tone: "critical", statusLabel: "Backlog breach", intakePerHour: 38, clearedPerHour: 27, oldestMinutes: 128, slaWindow: "90 min target" },
+  { id: "identity", label: "Identity Review", region: "Trust desk", owner: "Cam Nguyen", tone: "watch", statusLabel: "Aging concentration", intakePerHour: 29, clearedPerHour: 24, oldestMinutes: 82, slaWindow: "75 min target" },
+  { id: "returns", label: "Returns Exceptions", region: "Marketplace lane", owner: "Jules Carter", tone: "watch", statusLabel: "Throughput drift", intakePerHour: 41, clearedPerHour: 35, oldestMinutes: 64, slaWindow: "70 min target" },
+  { id: "loyalty", label: "Loyalty Adjustments", region: "Retention desk", owner: "Ava Brooks", tone: "stable", statusLabel: "Within target", intakePerHour: 22, clearedPerHour: 25, oldestMinutes: 31, slaWindow: "60 min target" },
+];
+
+export const backlogItems: BacklogItem[] = [
+  { id: "claim-140", queueId: "claims", caseRef: "CLM-140", customer: "Northwind Health", title: "Appeal reopened after duplicate denial batch", detail: "Two denial reasons landed on the same claim packet and blocked the automatic close step.", owner: "Remy", ageMinutes: 128, ageBand: "breach", severity: "high", nextAction: "Pull the denial packet before the 10:15 sweep.", segment: "Enterprise", escalationLevel: "director" },
+  { id: "claim-156", queueId: "claims", caseRef: "CLM-156", customer: "Blue Basin Dental", title: "Refund hold waiting on payer trace", detail: "The repayment file is ready, but finance still needs the corrected trace number.", owner: "Nadia", ageMinutes: 93, ageBand: "breach", severity: "medium", nextAction: "Confirm trace ID with finance and release the hold.", segment: "SMB", escalationLevel: "lead" },
+  { id: "claim-162", queueId: "claims", caseRef: "CLM-162", customer: "Crown Labs", title: "Manual coding review queued after rule mismatch", detail: "The edit engine split the modifiers into two review branches, leaving one item parked.", owner: "Owen", ageMinutes: 46, ageBand: "aging", severity: "medium", nextAction: "Resolve the modifier branch and re-run coding.", segment: "Mid-market", escalationLevel: "none" },
+  { id: "id-404", queueId: "identity", caseRef: "ID-404", customer: "Horizon Clinics", title: "Beneficial-owner document failed checksum on resubmission", detail: "The resubmitted PDF is legible, but the checksum on the uploaded package does not match.", owner: "Theo", ageMinutes: 82, ageBand: "aging", severity: "high", nextAction: "Request a clean upload and hold release until it lands.", segment: "Enterprise", escalationLevel: "lead" },
+  { id: "id-417", queueId: "identity", caseRef: "ID-417", customer: "Studio Meridian", title: "Passport image review waiting on secondary verifier", detail: "The first reviewer cleared the image; the second verification slot has not picked it up yet.", owner: "Iris", ageMinutes: 58, ageBand: "aging", severity: "medium", nextAction: "Pull the item into the next trust desk pairing.", segment: "SMB", escalationLevel: "none" },
+  { id: "ret-212", queueId: "returns", caseRef: "RET-212", customer: "Evergreen Outfitters", title: "Warehouse exception lacks arrival scan for carton 3", detail: "The return is partially received, but one carton still shows as in transit in the partner feed.", owner: "Liam", ageMinutes: 64, ageBand: "aging", severity: "medium", nextAction: "Confirm the missing scan with the carrier rep.", segment: "Retail", escalationLevel: "lead" },
+  { id: "ret-229", queueId: "returns", caseRef: "RET-229", customer: "Paper Kite", title: "Carrier credit request paused on surcharge dispute", detail: "The refund total is agreed, but the surcharge line item is still contested in the handoff notes.", owner: "June", ageMinutes: 39, ageBand: "fresh", severity: "low", nextAction: "Clear the surcharge note and relaunch the credit memo.", segment: "SMB", escalationLevel: "none" },
+  { id: "ret-244", queueId: "returns", caseRef: "RET-244", customer: "Northstar Outdoors", title: "Restock rejection sent back for image proof", detail: "The warehouse note references damage, but the proof image never attached to the return record.", owner: "Piper", ageMinutes: 22, ageBand: "fresh", severity: "low", nextAction: "Attach warehouse proof and continue the rejection.", segment: "Retail", escalationLevel: "none" },
+  { id: "loy-087", queueId: "loyalty", caseRef: "LOY-087", customer: "Maple & Co.", title: "Points reversal waiting on duplicate-order check", detail: "The order pair is already linked, but the system has not cleared the reversal hold yet.", owner: "Sage", ageMinutes: 31, ageBand: "fresh", severity: "low", nextAction: "Verify duplicate ownership and post the reversal.", segment: "Consumer", escalationLevel: "none" },
+  { id: "loy-091", queueId: "loyalty", caseRef: "LOY-091", customer: "Pine Harbor", title: "Tier adjustment pending nightly balance sync", detail: "The requested tier move is ready to post after the next ledger snapshot completes.", owner: "Arlo", ageMinutes: 18, ageBand: "fresh", severity: "low", nextAction: "Carry this item into the overnight sync window.", segment: "Consumer", escalationLevel: "none" },
+];

--- a/src/components/queue-monitor/queue-monitor-header.tsx
+++ b/src/components/queue-monitor/queue-monitor-header.tsx
@@ -1,0 +1,62 @@
+import type { ThroughputSummary } from "./queue-monitor-data";
+
+type QueueMonitorHeaderProps = {
+  agingCount: number; backlogTotal: number; breachCount: number; escalatedCount: number;
+  queuesAtRisk: number; snapshot: string; throughputSummaries: ThroughputSummary[];
+};
+
+const throughputToneClasses = {
+  up: "border-sky-300/20 bg-sky-300/10 text-sky-50",
+  flat: "border-slate-300/20 bg-slate-300/10 text-slate-50",
+  down: "border-rose-300/20 bg-rose-300/10 text-rose-50",
+};
+
+export function QueueMonitorHeader({
+  agingCount,
+  backlogTotal,
+  breachCount,
+  escalatedCount,
+  queuesAtRisk,
+  snapshot,
+  throughputSummaries,
+}: QueueMonitorHeaderProps) {
+  return (
+    <header className="rounded-[2rem] border border-white/10 bg-[linear-gradient(140deg,rgba(17,24,39,0.96),rgba(67,20,7,0.82))] p-6 shadow-[0_28px_100px_rgba(0,0,0,0.42)] sm:p-8">
+      <div className="flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
+        <div className="max-w-3xl">
+          <p className="text-xs font-semibold uppercase tracking-[0.34em] text-orange-200">Queue monitor</p>
+          <h1 className="mt-4 text-4xl font-semibold tracking-tight text-white sm:text-5xl">Backlog pressure, queue throughput, and escalation decisions in one isolated route.</h1>
+          <p className="mt-4 text-sm leading-6 text-slate-200 sm:text-base">The totals, columns, and escalation controls below are driven entirely by feature-local mock data and client-side state.</p>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-3 xl:w-[27rem]">
+          <div className="rounded-3xl border border-white/10 bg-white/8 p-4 text-white">
+            <p className="text-sm text-slate-300">Backlog total</p>
+            <p className="mt-2 text-3xl font-semibold">{backlogTotal}</p>
+            <p className="mt-1 text-sm text-slate-300">{queuesAtRisk} queues need attention</p>
+          </div>
+          <div className="rounded-3xl border border-amber-300/20 bg-amber-300/10 p-4 text-amber-50">
+            <p className="text-sm text-amber-100/80">Aging items</p>
+            <p className="mt-2 text-3xl font-semibold">{agingCount}</p>
+            <p className="mt-1 text-sm text-amber-100/80">{breachCount} over target window</p>
+          </div>
+          <div className="rounded-3xl border border-orange-300/20 bg-orange-300/12 p-4 text-orange-50">
+            <p className="text-sm text-orange-100/80">Escalations</p>
+            <p className="mt-2 text-3xl font-semibold">{escalatedCount}</p>
+            <p className="mt-1 text-sm text-orange-100/80">{snapshot}</p>
+          </div>
+        </div>
+      </div>
+      <div className="mt-6 grid gap-3 lg:grid-cols-3">
+        {throughputSummaries.map((summary) => (
+          <div className={`rounded-[1.6rem] border p-4 ${throughputToneClasses[summary.tone]}`} key={summary.id}>
+            <p className="text-xs font-semibold uppercase tracking-[0.26em] opacity-75">{summary.label}</p>
+            <div className="mt-3 flex items-end justify-between gap-4">
+              <p className="text-3xl font-semibold">{summary.value}</p>
+              <p className="max-w-40 text-right text-sm opacity-80">{summary.note}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </header>
+  );
+}

--- a/src/components/queue-monitor/queue-monitor-shell.tsx
+++ b/src/components/queue-monitor/queue-monitor-shell.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { startTransition, useState } from "react";
+
+import { QueueColumnBoard } from "./queue-column-board";
+import { QueueDetailPanel } from "./queue-detail-panel";
+import { QueueFilterBar } from "./queue-filter-bar";
+import { QueueMonitorHeader } from "./queue-monitor-header";
+import {
+  backlogItems,
+  escalationLevels,
+  queueMonitorSnapshot,
+  queueSummaries,
+  throughputSummaries,
+  type AgeFilter,
+  type EscalationLevelId,
+  type QueueScope,
+} from "./queue-monitor-data";
+
+type LocalEscalationState = {
+  addToDigest: boolean; holdRelease: boolean; level: EscalationLevelId; notifyFloor: boolean; reviewed: boolean;
+};
+
+function matchesQueueScope(tone: (typeof queueSummaries)[number]["tone"], scope: QueueScope) {
+  if (scope === "watch") return tone !== "stable";
+  if (scope === "stable") return tone === "stable";
+  return true;
+}
+
+function matchesAgeFilter(ageBand: (typeof backlogItems)[number]["ageBand"], filter: AgeFilter) {
+  if (filter === "aging") return ageBand !== "fresh";
+  if (filter === "breach") return ageBand === "breach";
+  return true;
+}
+
+const initialEscalationState = Object.fromEntries(
+  backlogItems.map((item) => [item.id, {
+    level: item.escalationLevel,
+    holdRelease: item.ageBand === "breach",
+    notifyFloor: item.severity === "high",
+    addToDigest: item.escalationLevel === "director",
+    reviewed: false,
+  }]),
+) as Record<string, LocalEscalationState>;
+
+export function QueueMonitorShell() {
+  const [queueScope, setQueueScope] = useState<QueueScope>("all");
+  const [ageFilter, setAgeFilter] = useState<AgeFilter>("all");
+  const [selectedQueueId, setSelectedQueueId] = useState<string | null>(queueSummaries[0]?.id ?? null);
+  const [selectedItemId, setSelectedItemId] = useState<string | null>(backlogItems[0]?.id ?? null);
+  const [escalationState, setEscalationState] = useState<Record<string, LocalEscalationState>>(initialEscalationState);
+
+  const visibleQueues = queueSummaries.filter((queue) => matchesQueueScope(queue.tone, queueScope));
+  const columns = visibleQueues.map((queue) => ({
+    queue,
+    items: backlogItems.filter((item) => item.queueId === queue.id && matchesAgeFilter(item.ageBand, ageFilter)),
+  }));
+  const nextQueueId = visibleQueues.some((queue) => queue.id === selectedQueueId) ? selectedQueueId : visibleQueues[0]?.id ?? null;
+  const nextQueueItems = columns.find((column) => column.queue.id === nextQueueId)?.items ?? [];
+  const nextItemId = nextQueueItems.some((item) => item.id === selectedItemId) ? selectedItemId : nextQueueItems[0]?.id ?? null;
+
+  const selectedQueue = queueSummaries.find((queue) => queue.id === nextQueueId) ?? null;
+  const selectedItem = nextQueueItems.find((item) => item.id === nextItemId) ?? null;
+  const selectedItemState = selectedItem ? escalationState[selectedItem.id] : null;
+  const scopedItems = backlogItems.filter((item) => visibleQueues.some((queue) => queue.id === item.queueId));
+  const backlogTotal = backlogItems.length;
+  const agingCount = backlogItems.filter((item) => item.ageBand !== "fresh").length;
+  const breachCount = backlogItems.filter((item) => item.ageBand === "breach").length;
+  const escalatedCount = backlogItems.filter((item) => escalationState[item.id].level !== "none").length;
+  const queuesAtRisk = queueSummaries.filter((queue) => queue.tone !== "stable").length;
+  const queueCounts = {
+    all: queueSummaries.length,
+    watch: queueSummaries.filter((queue) => matchesQueueScope(queue.tone, "watch")).length,
+    stable: queueSummaries.filter((queue) => matchesQueueScope(queue.tone, "stable")).length,
+  };
+  const ageCounts = {
+    all: scopedItems.length,
+    aging: scopedItems.filter((item) => matchesAgeFilter(item.ageBand, "aging")).length,
+    breach: scopedItems.filter((item) => matchesAgeFilter(item.ageBand, "breach")).length,
+  };
+  const queueTotals = Object.fromEntries(queueSummaries.map((queue) => [queue.id, backlogItems.filter((item) => item.queueId === queue.id).length])) as Record<string, number>;
+  const queueEscalations = Object.fromEntries(queueSummaries.map((queue) => [queue.id, backlogItems.filter((item) => item.queueId === queue.id && escalationState[item.id].level !== "none").length])) as Record<string, number>;
+
+  const handleSelectQueue = (queueId: string) => {
+    const queueItems = columns.find((column) => column.queue.id === queueId)?.items ?? [];
+    startTransition(() => {
+      setSelectedQueueId(queueId);
+      setSelectedItemId(queueItems[0]?.id ?? null);
+    });
+  };
+
+  const handleSelectItem = (queueId: string, itemId: string) => {
+    startTransition(() => {
+      setSelectedQueueId(queueId);
+      setSelectedItemId(itemId);
+    });
+  };
+
+  const handleEscalationLevelChange = (level: EscalationLevelId) => {
+    if (!selectedItem) return;
+    startTransition(() => {
+      setEscalationState((current) => ({ ...current, [selectedItem.id]: { ...current[selectedItem.id], level } }));
+    });
+  };
+
+  const handleToggle = (key: keyof Omit<LocalEscalationState, "level">) => {
+    if (!selectedItem) return;
+    startTransition(() => {
+      setEscalationState((current) => ({ ...current, [selectedItem.id]: { ...current[selectedItem.id], [key]: !current[selectedItem.id][key] } }));
+    });
+  };
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(251,146,60,0.18),transparent_30%),radial-gradient(circle_at_top_right,rgba(248,113,113,0.14),transparent_26%),linear-gradient(180deg,#111827_0%,#0f172a_52%,#020617_100%)] px-4 py-6 text-slate-100 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <QueueMonitorHeader agingCount={agingCount} backlogTotal={backlogTotal} breachCount={breachCount} escalatedCount={escalatedCount} queuesAtRisk={queuesAtRisk} snapshot={queueMonitorSnapshot} throughputSummaries={throughputSummaries} />
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.65fr)_minmax(21rem,0.95fr)]">
+          <section className="space-y-5">
+            <QueueFilterBar ageCounts={ageCounts} ageFilter={ageFilter} onAgeFilterChange={(filter) => startTransition(() => setAgeFilter(filter))} onQueueScopeChange={(scope) => startTransition(() => setQueueScope(scope))} queueCounts={queueCounts} queueScope={queueScope} />
+            <QueueColumnBoard ageFilter={ageFilter} columns={columns} escalationState={escalationState} onSelectItem={handleSelectItem} onSelectQueue={handleSelectQueue} queueEscalations={queueEscalations} queueScope={queueScope} queueTotals={queueTotals} selectedItemId={nextItemId} selectedQueueId={nextQueueId} />
+          </section>
+          <QueueDetailPanel escalationLevels={escalationLevels} itemState={selectedItemState} onEscalationLevelChange={handleEscalationLevelChange} onToggle={handleToggle} queueEscalations={selectedQueue ? queueEscalations[selectedQueue.id] : 0} queueItemsVisible={nextQueueItems.length} selectedItem={selectedItem} selectedQueue={selectedQueue} />
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/queue-monitor` page backed entirely by feature-local mock data
- render backlog totals, throughput indicators, queue columns, filtered zero states, and a local detail/escalation panel
- keep the implementation scoped to `src/app/queue-monitor/**` and `src/components/queue-monitor/**` without touching shared app files

## Testing
- npm run lint -- src/app/queue-monitor/page.tsx src/components/queue-monitor
- npm run typecheck
- npm run build

Closes #28