### PR TITLE
feat: add isolated asset catalog route

### DIFF
--- a/src/app/asset-catalog/mock-data.ts
+++ b/src/app/asset-catalog/mock-data.ts
@@ -1,0 +1,221 @@
+export type AssetAvailability = "available" | "reserved" | "hold" | "maintenance";
+export type AssetCategoryId = "camera" | "audio" | "lighting" | "support";
+
+export type AssetCategory = {
+  id: AssetCategoryId;
+  label: string;
+  summary: string;
+};
+
+export type AvailabilityOption = {
+  id: AssetAvailability;
+  label: string;
+  note: string;
+};
+
+export type AssetCatalogItem = {
+  id: string;
+  name: string;
+  categoryId: AssetCategoryId;
+  availability: AssetAvailability;
+  sku: string;
+  zone: string;
+  summary: string;
+  nextWindow: string;
+  tags: string[];
+  kit: string[];
+  condition: string;
+};
+
+export type ReservationPreview = {
+  id: string;
+  assetId: string;
+  requester: string;
+  project: string;
+  pickupWindow: string;
+  returnWindow: string;
+  handoffZone: string;
+  checklist: string[];
+  note: string;
+};
+
+export const assetCatalogSyncLabel = "Inventory refresh 09:12 IST";
+
+export const assetCategories: AssetCategory[] = [
+  { id: "camera", label: "Camera", summary: "Bodies, handheld kits, and lens-ready capture gear." },
+  { id: "audio", label: "Audio", summary: "Wireless capture, field recorders, and lav sets." },
+  { id: "lighting", label: "Lighting", summary: "Portable panels, key lights, and modifier kits." },
+  { id: "support", label: "Support", summary: "Tripods, stabilizers, and grip accessories." },
+];
+
+export const availabilityOptions: AvailabilityOption[] = [
+  { id: "available", label: "Ready now", note: "Bench checked and clear for pickup." },
+  { id: "reserved", label: "Reserved", note: "Already staged for an upcoming handoff." },
+  { id: "hold", label: "On hold", note: "Temporarily blocked pending confirmation." },
+  { id: "maintenance", label: "Maintenance", note: "In service or calibration review." },
+];
+
+export const assetTags = [
+  "4k",
+  "wireless-monitor",
+  "livestream",
+  "battery-heavy",
+  "travel",
+  "studio",
+  "interview",
+  "fast-turn",
+];
+
+export const assetCatalogItems: AssetCatalogItem[] = [
+  {
+    id: "cam-fx3",
+    name: "Sony FX3 Field Kit",
+    categoryId: "camera",
+    availability: "available",
+    sku: "CAM-014",
+    zone: "Studio cage A",
+    summary: "Full-frame body paired with a handheld rig for same-day field pickup.",
+    nextWindow: "Ready for same-day pickup",
+    tags: ["4k", "wireless-monitor", "travel"],
+    kit: ["FX3 body", "24-70mm lens", "2x CFexpress cards"],
+    condition: "Bench checked 25 minutes ago",
+  },
+  {
+    id: "cam-c70",
+    name: "Canon C70 Interview Pack",
+    categoryId: "camera",
+    availability: "reserved",
+    sku: "CAM-029",
+    zone: "Reservation shelf 2",
+    summary: "Interview-ready cinema body with ND filters and a compact audio breakout.",
+    nextWindow: "Pickup window opens at 11:30",
+    tags: ["interview", "studio", "fast-turn"],
+    kit: ["C70 body", "RF 24-105mm lens", "Top-handle XLR module"],
+    condition: "Staged with printed checkout sheet",
+  },
+  {
+    id: "aud-mixpre",
+    name: "MixPre-6 Podcast Rig",
+    categoryId: "audio",
+    availability: "hold",
+    sku: "AUD-011",
+    zone: "Pending bin 4",
+    summary: "Six-input field recorder bundled for short-form interviews and live capture.",
+    nextWindow: "Awaiting producer confirmation",
+    tags: ["interview", "livestream", "fast-turn"],
+    kit: ["MixPre-6 II", "2x shotgun mics", "Headphone split"],
+    condition: "Battery pack topped off overnight",
+  },
+  {
+    id: "aud-lav",
+    name: "Dual Lav Wireless Set",
+    categoryId: "audio",
+    availability: "available",
+    sku: "AUD-024",
+    zone: "Audio locker 1",
+    summary: "Portable two-talent wireless set with spare transmitters and slate notes.",
+    nextWindow: "Ready for walk-up checkout",
+    tags: ["travel", "interview", "battery-heavy"],
+    kit: ["2x transmitters", "2x lav mics", "Receiver dock"],
+    condition: "RF scan passed on channel bank B",
+  },
+  {
+    id: "lit-aputure",
+    name: "Aputure 300D Key Light",
+    categoryId: "lighting",
+    availability: "reserved",
+    sku: "LGT-008",
+    zone: "Lighting cart 3",
+    summary: "High-output key light prepped with a softbox and ballast tie-downs.",
+    nextWindow: "Truck load-out at 13:15",
+    tags: ["studio", "fast-turn", "battery-heavy"],
+    kit: ["300D head", "Light Dome II", "C-stand adapter"],
+    condition: "Packed with sandbag tags",
+  },
+  {
+    id: "lit-tubes",
+    name: "RGB Tube Pair",
+    categoryId: "lighting",
+    availability: "maintenance",
+    sku: "LGT-026",
+    zone: "Repair bench",
+    summary: "Portable accent lights currently blocked for battery latch service.",
+    nextWindow: "Expected back after calibration",
+    tags: ["livestream", "travel", "studio"],
+    kit: ["2x RGB tubes", "Floor mounts", "Charging brick"],
+    condition: "Latch replacement in progress",
+  },
+  {
+    id: "sup-sachtler",
+    name: "Sachtler Tripod System",
+    categoryId: "support",
+    availability: "available",
+    sku: "SUP-006",
+    zone: "Grip wall",
+    summary: "Fluid-head tripod tuned for documentary crews and quick interview swaps.",
+    nextWindow: "Available for immediate reserve",
+    tags: ["travel", "studio", "4k"],
+    kit: ["Flowtech legs", "Fluid head", "Mid spreader"],
+    condition: "Counterbalance verified this morning",
+  },
+  {
+    id: "sup-rs4",
+    name: "RS 4 Gimbal Bundle",
+    categoryId: "support",
+    availability: "hold",
+    sku: "SUP-017",
+    zone: "Ready rack B",
+    summary: "Stabilizer bundle held while lens compatibility is confirmed with the camera team.",
+    nextWindow: "Hold expires at 10:45",
+    tags: ["travel", "wireless-monitor", "4k"],
+    kit: ["RS 4 combo", "Focus motor", "Briefcase handle"],
+    condition: "Balance plate marked for FX3 payload",
+  },
+];
+
+export const reservationPreviews: ReservationPreview[] = [
+  {
+    id: "res-c70",
+    assetId: "cam-c70",
+    requester: "Mina Torres",
+    project: "Customer Story Sprint",
+    pickupWindow: "11:30-12:00",
+    returnWindow: "Tomorrow by 17:30",
+    handoffZone: "Front desk handoff",
+    checklist: ["Lens cap and ND pack", "Fresh media cards", "Signed interview kit receipt"],
+    note: "Keep the top handle attached for the lav receiver bracket.",
+  },
+  {
+    id: "res-mixpre",
+    assetId: "aud-mixpre",
+    requester: "Jon Park",
+    project: "Founder Fireside",
+    pickupWindow: "Needs approval before 12:15",
+    returnWindow: "Same day by 19:00",
+    handoffZone: "Audio locker release",
+    checklist: ["Confirm guest count", "Attach backup SD card", "Add spare NP-F battery"],
+    note: "Reservation is blocked until the guest lineup is final.",
+  },
+  {
+    id: "res-300d",
+    assetId: "lit-aputure",
+    requester: "Rhea Malik",
+    project: "Warehouse Hero Shoot",
+    pickupWindow: "13:15 dock load-out",
+    returnWindow: "Two days after wrap",
+    handoffZone: "Lighting cart dispatch",
+    checklist: ["Softbox rods taped", "Ballast tie-down added", "Truck manifest signed"],
+    note: "Pair with the C-stand already assigned to lane 4.",
+  },
+  {
+    id: "res-rs4",
+    assetId: "sup-rs4",
+    requester: "Dev Gupta",
+    project: "Campus Walkthrough",
+    pickupWindow: "Hold until 10:45",
+    returnWindow: "Tomorrow by 10:00",
+    handoffZone: "Grip wall release",
+    checklist: ["Confirm lens weight", "Rebalance after battery swap", "Include focus motor cable"],
+    note: "If the lens swap is denied, release the hold back to ready inventory.",
+  },
+];

--- a/src/app/asset-catalog/page.tsx
+++ b/src/app/asset-catalog/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+
+import { AssetCatalogShell } from "@/components/asset-catalog/asset-catalog-shell";
+
+export const metadata: Metadata = {
+  title: "Asset Catalog | API Test",
+  description: "Searchable mock asset catalog with availability filters and local reservation previews.",
+};
+
+export default function AssetCatalogPage() {
+  return <AssetCatalogShell />;
+}

--- a/src/components/asset-catalog/asset-card.tsx
+++ b/src/components/asset-catalog/asset-card.tsx
@@ -1,0 +1,98 @@
+import type { AssetCatalogItem, ReservationPreview } from "@/app/asset-catalog/mock-data";
+
+type AssetCardProps = {
+  asset: AssetCatalogItem;
+  categoryLabel: string;
+  preview: ReservationPreview | null;
+  selected: boolean;
+  onSelect: () => void;
+};
+
+const availabilityStyles = {
+  available: "border-emerald-200 bg-emerald-50 text-emerald-900",
+  reserved: "border-amber-200 bg-amber-50 text-amber-900",
+  hold: "border-rose-200 bg-rose-50 text-rose-900",
+  maintenance: "border-slate-300 bg-slate-100 text-slate-800",
+} as const;
+
+export function AssetCard({ asset, categoryLabel, preview, selected, onSelect }: AssetCardProps) {
+  return (
+    <article
+      className={`rounded-[1.75rem] border p-5 transition ${
+        selected
+          ? "border-cyan-700 bg-cyan-950 text-white shadow-[0_20px_70px_-42px_rgba(8,145,178,0.85)]"
+          : "border-slate-200/80 bg-white/95 text-slate-900 shadow-[0_20px_70px_-46px_rgba(15,23,42,0.38)] hover:-translate-y-0.5 hover:border-cyan-200"
+      }`}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className={`rounded-full border px-2.5 py-1 text-xs font-medium ${selected ? "border-white/20 bg-white/10 text-white" : availabilityStyles[asset.availability]}`}>
+              {asset.availability}
+            </span>
+            <span className={`text-xs font-medium uppercase tracking-[0.2em] ${selected ? "text-cyan-100" : "text-slate-500"}`}>{categoryLabel}</span>
+          </div>
+          <div>
+            <h2 className="text-xl font-semibold tracking-tight">{asset.name}</h2>
+            <p className={`mt-1 text-sm leading-6 ${selected ? "text-cyan-50" : "text-slate-600"}`}>{asset.summary}</p>
+          </div>
+        </div>
+        <div className={`rounded-2xl border px-3 py-2 text-right text-xs ${selected ? "border-white/15 bg-white/10 text-cyan-50" : "border-slate-200 bg-slate-50 text-slate-600"}`}>
+          <p>{asset.sku}</p>
+          <p className="mt-1">{asset.zone}</p>
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-4 sm:grid-cols-2">
+        <div>
+          <p className={`text-xs uppercase tracking-[0.2em] ${selected ? "text-cyan-100" : "text-slate-500"}`}>Kit Includes</p>
+          <ul className={`mt-2 space-y-2 text-sm ${selected ? "text-cyan-50" : "text-slate-700"}`}>
+            {asset.kit.map((item) => (
+              <li key={item}>- {item}</li>
+            ))}
+          </ul>
+        </div>
+        <div className="space-y-3">
+          <div>
+            <p className={`text-xs uppercase tracking-[0.2em] ${selected ? "text-cyan-100" : "text-slate-500"}`}>Next Window</p>
+            <p className={`mt-2 text-sm ${selected ? "text-cyan-50" : "text-slate-700"}`}>{asset.nextWindow}</p>
+          </div>
+          <div>
+            <p className={`text-xs uppercase tracking-[0.2em] ${selected ? "text-cyan-100" : "text-slate-500"}`}>Condition</p>
+            <p className={`mt-2 text-sm ${selected ? "text-cyan-50" : "text-slate-700"}`}>{asset.condition}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        {asset.tags.map((tag) => (
+          <span
+            key={tag}
+            className={`rounded-full px-2.5 py-1 text-xs font-medium ${selected ? "bg-white/10 text-cyan-50" : "bg-slate-100 text-slate-600"}`}
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+
+      <div className="mt-5 flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
+        <p className={`text-sm ${selected ? "text-cyan-50" : "text-slate-600"}`}>
+          {preview ? `Reservation preview: ${preview.project}` : "No reservation preview attached yet."}
+        </p>
+        <button
+          aria-label={`${selected ? "Clear" : "Preview"} reservation: ${asset.name}`}
+          aria-pressed={selected}
+          className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+            selected
+              ? "bg-white text-cyan-950 hover:bg-cyan-50"
+              : "bg-cyan-950 text-white hover:bg-cyan-900"
+          }`}
+          onClick={onSelect}
+          type="button"
+        >
+          {selected ? "Clear preview" : "Preview reservation"}
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/src/components/asset-catalog/asset-catalog-header.tsx
+++ b/src/components/asset-catalog/asset-catalog-header.tsx
@@ -1,0 +1,60 @@
+type AssetCatalogHeaderProps = {
+  syncLabel: string;
+  totalAssets: number;
+  readyAssets: number;
+  reservedAssets: number;
+  attentionAssets: number;
+};
+
+export function AssetCatalogHeader({
+  syncLabel,
+  totalAssets,
+  readyAssets,
+  reservedAssets,
+  attentionAssets,
+}: AssetCatalogHeaderProps) {
+  return (
+    <section className="overflow-hidden rounded-[2rem] border border-slate-200/70 bg-white/90 shadow-[0_24px_80px_-40px_rgba(15,23,42,0.45)] backdrop-blur">
+      <div className="bg-[linear-gradient(135deg,rgba(14,116,144,0.14),rgba(251,191,36,0.14),rgba(255,255,255,0.9))] px-5 py-6 sm:px-7 sm:py-7">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+          <div className="max-w-3xl space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-cyan-700">Asset Catalog</p>
+            <div className="space-y-2">
+              <h1 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
+                Searchable checkout board for cameras, audio, lighting, and support gear.
+              </h1>
+              <p className="max-w-2xl text-sm leading-6 text-slate-600 sm:text-base">
+                Everything on this route is feature-local: mock inventory, availability logic, selection state, and reservation previews stay inside the asset catalog.
+              </p>
+            </div>
+          </div>
+          <div className="rounded-full border border-cyan-200 bg-cyan-50/80 px-4 py-2 text-sm font-medium text-cyan-900">
+            {syncLabel}
+          </div>
+        </div>
+      </div>
+      <div className="grid gap-3 border-t border-slate-200/70 px-5 py-5 sm:grid-cols-2 sm:px-7 lg:grid-cols-4">
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+          <p className="text-xs uppercase tracking-[0.24em] text-slate-500">Catalog</p>
+          <p className="mt-2 text-2xl font-semibold text-slate-900">{totalAssets}</p>
+          <p className="mt-1 text-sm text-slate-600">Mock assets in this isolated route.</p>
+        </div>
+        <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-4">
+          <p className="text-xs uppercase tracking-[0.24em] text-emerald-700">Ready Now</p>
+          <p className="mt-2 text-2xl font-semibold text-emerald-950">{readyAssets}</p>
+          <p className="mt-1 text-sm text-emerald-800">Clear for immediate checkout.</p>
+        </div>
+        <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-4">
+          <p className="text-xs uppercase tracking-[0.24em] text-amber-700">Reserved</p>
+          <p className="mt-2 text-2xl font-semibold text-amber-950">{reservedAssets}</p>
+          <p className="mt-1 text-sm text-amber-800">Already tied to a handoff window.</p>
+        </div>
+        <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-4">
+          <p className="text-xs uppercase tracking-[0.24em] text-rose-700">Needs Attention</p>
+          <p className="mt-2 text-2xl font-semibold text-rose-950">{attentionAssets}</p>
+          <p className="mt-1 text-sm text-rose-800">Items on hold or in maintenance.</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/asset-catalog/asset-catalog-shell.tsx
+++ b/src/components/asset-catalog/asset-catalog-shell.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { startTransition, useDeferredValue, useState } from "react";
+
+import {
+  assetCatalogItems,
+  assetCatalogSyncLabel,
+  assetCategories,
+  availabilityOptions,
+  reservationPreviews,
+  type AssetAvailability,
+  type AssetCategoryId,
+} from "@/app/asset-catalog/mock-data";
+import { AssetCard } from "./asset-card";
+import { AssetCatalogHeader } from "./asset-catalog-header";
+import { CatalogControls } from "./catalog-controls";
+import { CategoryTabs } from "./category-tabs";
+import { ReservationPreview } from "./reservation-preview";
+
+function matchesQuery(assetId: string, query: string) {
+  return assetId.includes(query);
+}
+
+export function AssetCatalogShell() {
+  const [query, setQuery] = useState("");
+  const [activeCategory, setActiveCategory] = useState<AssetCategoryId | "all">("all");
+  const [activeAvailability, setActiveAvailability] = useState<AssetAvailability | "all">("all");
+  const [selectedAssetId, setSelectedAssetId] = useState<string | null>(null);
+  const deferredQuery = useDeferredValue(query).trim().toLowerCase();
+
+  const visibleAssets = assetCatalogItems.filter((asset) => {
+    const searchable = [asset.name, asset.sku, asset.zone, asset.summary, asset.condition, ...asset.tags, ...asset.kit]
+      .join(" ")
+      .toLowerCase();
+
+    return (
+      (!deferredQuery || searchable.includes(deferredQuery) || matchesQuery(asset.id, deferredQuery)) &&
+      (activeCategory === "all" || asset.categoryId === activeCategory) &&
+      (activeAvailability === "all" || asset.availability === activeAvailability)
+    );
+  });
+
+  const selectedAsset = assetCatalogItems.find((asset) => asset.id === selectedAssetId) ?? null;
+  const selectionHidden = selectedAsset ? !visibleAssets.some((asset) => asset.id === selectedAsset.id) : false;
+  const selectedPreview = selectedAsset ? reservationPreviews.find((preview) => preview.assetId === selectedAsset.id) ?? null : null;
+  const hasFilters = query.trim().length > 0 || activeCategory !== "all" || activeAvailability !== "all";
+  const readyAssets = assetCatalogItems.filter((asset) => asset.availability === "available").length;
+  const reservedAssets = assetCatalogItems.filter((asset) => asset.availability === "reserved").length;
+  const attentionAssets = assetCatalogItems.filter((asset) => asset.availability === "hold" || asset.availability === "maintenance").length;
+
+  const categoryTabs = [
+    {
+      id: "all",
+      label: "All assets",
+      summary: "Entire checkout floor with every mock item in view.",
+      count: assetCatalogItems.length,
+    },
+    ...assetCategories.map((category) => ({
+      ...category,
+      count: assetCatalogItems.filter((asset) => asset.categoryId === category.id).length,
+    })),
+  ];
+
+  const availabilityCounts = availabilityOptions.map((availability) => ({
+    ...availability,
+    count: assetCatalogItems.filter((asset) => asset.availability === availability.id).length,
+  }));
+
+  const selectedCategoryLabel = selectedAsset
+    ? assetCategories.find((category) => category.id === selectedAsset.categoryId)?.label ?? null
+    : null;
+
+  const handleResetFilters = () => {
+    startTransition(() => {
+      setQuery("");
+      setActiveCategory("all");
+      setActiveAvailability("all");
+    });
+  };
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(8,145,178,0.18),transparent_28%),radial-gradient(circle_at_top_right,rgba(251,191,36,0.18),transparent_24%),linear-gradient(180deg,#f8fafc_0%,#fff7ed_48%,#ecfeff_100%)] px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <AssetCatalogHeader
+          attentionAssets={attentionAssets}
+          readyAssets={readyAssets}
+          reservedAssets={reservedAssets}
+          syncLabel={assetCatalogSyncLabel}
+          totalAssets={assetCatalogItems.length}
+        />
+
+        <CategoryTabs
+          activeCategory={activeCategory}
+          categories={categoryTabs}
+          onChange={(categoryId) => startTransition(() => setActiveCategory(categoryId as AssetCategoryId | "all"))}
+        />
+
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(21rem,0.92fr)]">
+          <section className="space-y-5">
+            <CatalogControls
+              activeAvailability={activeAvailability}
+              availabilityCounts={availabilityCounts}
+              hasFilters={hasFilters}
+              onAvailabilityChange={(availability) => startTransition(() => setActiveAvailability(availability))}
+              onQueryChange={(value) => startTransition(() => setQuery(value))}
+              onReset={handleResetFilters}
+              query={query}
+              resultCount={visibleAssets.length}
+              totalCount={assetCatalogItems.length}
+            />
+
+            <section className="space-y-4">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h2 className="text-lg font-semibold text-slate-900">Asset listing</h2>
+                  <p className="text-sm text-slate-600">Search results update on the client and never affect any other route.</p>
+                </div>
+                <div className="rounded-full border border-slate-200 bg-white/80 px-3 py-2 text-sm text-slate-600">
+                  {visibleAssets.length === 1 ? "1 matching asset" : `${visibleAssets.length} matching assets`}
+                </div>
+              </div>
+
+              {visibleAssets.length > 0 ? (
+                <div className="grid gap-4">
+                  {visibleAssets.map((asset) => (
+                    <AssetCard
+                      key={asset.id}
+                      asset={asset}
+                      categoryLabel={assetCategories.find((category) => category.id === asset.categoryId)?.label ?? asset.categoryId}
+                      onSelect={() =>
+                        startTransition(() => setSelectedAssetId((current) => current === asset.id ? null : asset.id))
+                      }
+                      preview={reservationPreviews.find((preview) => preview.assetId === asset.id) ?? null}
+                      selected={selectedAssetId === asset.id}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <div className="rounded-[1.9rem] border border-dashed border-slate-300 bg-white/85 p-8 text-center shadow-[0_20px_70px_-46px_rgba(15,23,42,0.38)]">
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">No Matches</p>
+                  <h3 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900">No assets match the current search and availability filters.</h3>
+                  <p className="mt-3 text-sm leading-6 text-slate-600">
+                    Try a different tag, switch categories, or clear the filters to bring the full mock catalog back into view.
+                  </p>
+                  {hasFilters ? (
+                    <button
+                      className="mt-5 rounded-full bg-cyan-950 px-4 py-2 text-sm font-medium text-white transition hover:bg-cyan-900"
+                      onClick={handleResetFilters}
+                      type="button"
+                    >
+                      Reset filters
+                    </button>
+                  ) : null}
+                </div>
+              )}
+            </section>
+          </section>
+
+          <div className="xl:sticky xl:top-6 xl:self-start">
+            <ReservationPreview
+              asset={selectedAsset}
+              categoryLabel={selectedCategoryLabel}
+              onClearSelection={() => startTransition(() => setSelectedAssetId(null))}
+              onResetFilters={handleResetFilters}
+              preview={selectedPreview}
+              selectionHidden={selectionHidden}
+            />
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/asset-catalog/catalog-controls.tsx
+++ b/src/components/asset-catalog/catalog-controls.tsx
@@ -1,0 +1,92 @@
+import type { AssetAvailability, AvailabilityOption } from "@/app/asset-catalog/mock-data";
+
+type CatalogControlsProps = {
+  activeAvailability: AssetAvailability | "all";
+  availabilityCounts: Array<AvailabilityOption & { count: number }>;
+  hasFilters: boolean;
+  onAvailabilityChange: (availability: AssetAvailability | "all") => void;
+  onQueryChange: (query: string) => void;
+  onReset: () => void;
+  query: string;
+  resultCount: number;
+  totalCount: number;
+};
+
+export function CatalogControls({
+  activeAvailability,
+  availabilityCounts,
+  hasFilters,
+  onAvailabilityChange,
+  onQueryChange,
+  onReset,
+  query,
+  resultCount,
+  totalCount,
+}: CatalogControlsProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-slate-200/80 bg-white/90 p-5 shadow-[0_20px_70px_-46px_rgba(15,23,42,0.4)]">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <label className="flex-1 space-y-2">
+          <span className="text-sm font-medium text-slate-700">Search inventory</span>
+          <input
+            aria-label="Search assets"
+            className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-cyan-500 focus:bg-white"
+            onChange={(event) => onQueryChange(event.target.value)}
+            placeholder="Search by name, tag, zone, or kit item"
+            type="search"
+            value={query}
+          />
+        </label>
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+          Showing <span className="font-semibold text-slate-900">{resultCount}</span> of{" "}
+          <span className="font-semibold text-slate-900">{totalCount}</span> assets
+        </div>
+      </div>
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        <button
+          aria-pressed={activeAvailability === "all"}
+          className={`rounded-full border px-3.5 py-2 text-sm font-medium transition ${
+            activeAvailability === "all"
+              ? "border-cyan-700 bg-cyan-950 text-white"
+              : "border-slate-200 bg-white text-slate-700 hover:border-cyan-200 hover:bg-cyan-50"
+          }`}
+          onClick={() => onAvailabilityChange("all")}
+          type="button"
+        >
+          Any status
+        </button>
+        {availabilityCounts.map((availability) => (
+          <button
+            key={availability.id}
+            aria-pressed={activeAvailability === availability.id}
+            className={`rounded-full border px-3.5 py-2 text-sm font-medium transition ${
+              activeAvailability === availability.id
+                ? "border-cyan-700 bg-cyan-950 text-white"
+                : "border-slate-200 bg-white text-slate-700 hover:border-cyan-200 hover:bg-cyan-50"
+            }`}
+            onClick={() => onAvailabilityChange(availability.id)}
+            type="button"
+          >
+            {availability.label} - {availability.count}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-slate-600">
+          Availability filters stay local to this route and only affect the mock asset catalog below.
+        </p>
+        {hasFilters ? (
+          <button
+            className="rounded-full border border-slate-300 px-3.5 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-100"
+            onClick={onReset}
+            type="button"
+          >
+            Reset search and filters
+          </button>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/components/asset-catalog/category-tabs.tsx
+++ b/src/components/asset-catalog/category-tabs.tsx
@@ -1,0 +1,46 @@
+type CategoryTab = {
+  id: string;
+  label: string;
+  summary: string;
+  count: number;
+};
+
+type CategoryTabsProps = {
+  activeCategory: string;
+  categories: CategoryTab[];
+  onChange: (categoryId: string) => void;
+};
+
+export function CategoryTabs({ activeCategory, categories, onChange }: CategoryTabsProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-slate-200/80 bg-white/90 p-3 shadow-[0_20px_70px_-46px_rgba(15,23,42,0.4)]">
+      <div className="flex gap-3 overflow-x-auto pb-1">
+        {categories.map((category) => {
+          const isActive = category.id === activeCategory;
+
+          return (
+            <button
+              key={category.id}
+              aria-pressed={isActive}
+              className={`min-w-[13rem] rounded-[1.35rem] border px-4 py-3 text-left transition ${
+                isActive
+                  ? "border-cyan-700 bg-cyan-950 text-white shadow-[0_16px_45px_-28px_rgba(8,145,178,0.9)]"
+                  : "border-slate-200 bg-slate-50 text-slate-900 hover:border-cyan-200 hover:bg-cyan-50"
+              }`}
+              onClick={() => onChange(category.id)}
+              type="button"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-sm font-semibold">{category.label}</span>
+                <span className={`rounded-full px-2.5 py-1 text-xs font-medium ${isActive ? "bg-white/15 text-white" : "bg-white text-slate-600"}`}>
+                  {category.count}
+                </span>
+              </div>
+              <p className={`mt-2 text-xs leading-5 ${isActive ? "text-cyan-50" : "text-slate-600"}`}>{category.summary}</p>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/asset-catalog/reservation-preview.tsx
+++ b/src/components/asset-catalog/reservation-preview.tsx
@@ -1,0 +1,128 @@
+import type { AssetCatalogItem, ReservationPreview as ReservationPreviewData } from "@/app/asset-catalog/mock-data";
+
+type ReservationPreviewProps = {
+  asset: AssetCatalogItem | null;
+  categoryLabel: string | null;
+  preview: ReservationPreviewData | null;
+  selectionHidden: boolean;
+  onClearSelection: () => void;
+  onResetFilters: () => void;
+};
+
+const availabilityCopy = {
+  available: "Ready to be staged immediately.",
+  reserved: "Already assigned to an upcoming checkout.",
+  hold: "Blocked until the current hold condition is cleared.",
+  maintenance: "Unavailable while service work is in progress.",
+} as const;
+
+export function ReservationPreview({
+  asset,
+  categoryLabel,
+  preview,
+  selectionHidden,
+  onClearSelection,
+  onResetFilters,
+}: ReservationPreviewProps) {
+  if (!asset) {
+    return (
+      <aside className="rounded-[1.9rem] border border-dashed border-slate-300 bg-white/80 p-6 shadow-[0_20px_70px_-46px_rgba(15,23,42,0.38)]">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">Reservation Preview</p>
+        <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900">Select an asset to inspect its handoff plan.</h2>
+        <p className="mt-3 text-sm leading-6 text-slate-600">
+          The side panel stays empty until you choose a card from the catalog. Selection and preview copy stay local to this route.
+        </p>
+      </aside>
+    );
+  }
+
+  if (selectionHidden) {
+    return (
+      <aside className="rounded-[1.9rem] border border-amber-200 bg-amber-50/90 p-6 shadow-[0_20px_70px_-46px_rgba(15,23,42,0.38)]">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-amber-700">Reservation Preview</p>
+        <h2 className="mt-3 text-2xl font-semibold tracking-tight text-amber-950">{asset.name} is outside the current filters.</h2>
+        <p className="mt-3 text-sm leading-6 text-amber-900">
+          The asset is still selected, but the active search or availability filter removed it from the visible catalog.
+        </p>
+        <div className="mt-5 flex flex-wrap gap-3">
+          <button
+            className="rounded-full bg-amber-950 px-4 py-2 text-sm font-medium text-white transition hover:bg-amber-900"
+            onClick={onResetFilters}
+            type="button"
+          >
+            Reset filters
+          </button>
+          <button
+            className="rounded-full border border-amber-300 px-4 py-2 text-sm font-medium text-amber-950 transition hover:bg-amber-100"
+            onClick={onClearSelection}
+            type="button"
+          >
+            Clear selection
+          </button>
+        </div>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="rounded-[1.9rem] border border-slate-200/80 bg-white/92 p-6 shadow-[0_20px_70px_-46px_rgba(15,23,42,0.38)]">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">Reservation Preview</p>
+          <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900">{asset.name}</h2>
+          <p className="mt-2 text-sm text-slate-600">{categoryLabel ?? asset.categoryId} - {asset.zone}</p>
+        </div>
+        <button
+          className="rounded-full border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100"
+          onClick={onClearSelection}
+          type="button"
+        >
+          Deselect
+        </button>
+      </div>
+
+      <div className="mt-5 rounded-[1.5rem] bg-slate-950 px-4 py-4 text-slate-50">
+        <p className="text-xs uppercase tracking-[0.22em] text-cyan-200">Availability</p>
+        <p className="mt-2 text-xl font-semibold capitalize">{asset.availability}</p>
+        <p className="mt-2 text-sm leading-6 text-slate-300">{availabilityCopy[asset.availability]}</p>
+      </div>
+
+      {preview ? (
+        <div className="mt-5 space-y-5">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+              <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Requester</p>
+              <p className="mt-2 text-lg font-semibold text-slate-900">{preview.requester}</p>
+              <p className="mt-1 text-sm text-slate-600">{preview.project}</p>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+              <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Handoff</p>
+              <p className="mt-2 text-sm font-medium text-slate-900">{preview.pickupWindow}</p>
+              <p className="mt-1 text-sm text-slate-600">{preview.handoffZone}</p>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-slate-200 bg-white px-4 py-4">
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-sm font-semibold text-slate-900">Return window</p>
+              <span className="rounded-full bg-cyan-50 px-2.5 py-1 text-xs font-medium text-cyan-800">{preview.returnWindow}</span>
+            </div>
+            <ul className="mt-4 space-y-3 text-sm text-slate-700">
+              {preview.checklist.map((item) => (
+                <li key={item}>- {item}</li>
+              ))}
+            </ul>
+            <p className="mt-4 rounded-2xl bg-slate-50 px-3 py-3 text-sm leading-6 text-slate-600">{preview.note}</p>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-5 rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-5">
+          <p className="text-sm font-semibold text-slate-900">No reservation is attached to this asset yet.</p>
+          <p className="mt-2 text-sm leading-6 text-slate-600">
+            {asset.nextWindow} This panel stays local and can represent either an empty scheduling slate or a simple ready-to-book handoff.
+          </p>
+        </div>
+      )}
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/asset-catalog` route with feature-local mock inventory data and metadata
- build a client-side catalog shell with category tabs, search, availability filters, and responsive asset cards
- add a reservation preview panel with empty, selected, and filtered-out states without touching shared routes or components

## Verification
- npm run lint -- src/app/asset-catalog src/components/asset-catalog
- npm run typecheck
- npm test
- npm run build

Closes #26