### PR TITLE
feat: add isolated incident deck route

### DIFF
--- a/src/app/incident-deck/mock-data.ts
+++ b/src/app/incident-deck/mock-data.ts
@@ -1,0 +1,319 @@
+export type IncidentSeverity = "critical" | "high" | "medium" | "low";
+export type IncidentSeverityFilter = IncidentSeverity | "all";
+export type ResponderStatus = "On bridge" | "Deploying" | "Relief" | "Monitoring";
+
+export type SeverityLevel = {
+  id: IncidentSeverity;
+  label: string;
+  summary: string;
+  badgeClass: string;
+  surfaceClass: string;
+};
+
+export type IncidentRecord = {
+  id: string;
+  code: string;
+  title: string;
+  service: string;
+  severity: IncidentSeverity;
+  status: string;
+  openedAt: string;
+  lead: string;
+  region: string;
+  affectedUsers: string;
+  summary: string;
+  activeTask: string;
+  responderIds: string[];
+};
+
+export type ResponderRecord = {
+  id: string;
+  name: string;
+  role: string;
+  team: string;
+  status: ResponderStatus;
+  zone: string;
+  specialties: string[];
+  note: string;
+};
+
+export type TimelineEntry = {
+  id: string;
+  incidentId: string;
+  kind: string;
+  title: string;
+  detail: string;
+  at: string;
+  channel: string;
+  responderIds: string[];
+};
+
+export const incidentSeverities = [
+  {
+    id: "critical",
+    label: "Critical",
+    summary: "Customer-impacting and actively mitigating.",
+    badgeClass: "border border-rose-400/30 bg-rose-500/15 text-rose-100",
+    surfaceClass: "bg-rose-500/10 text-rose-100 ring-rose-400/30",
+  },
+  {
+    id: "high",
+    label: "High",
+    summary: "Escalated and tracking a recovery owner.",
+    badgeClass: "border border-orange-300/30 bg-orange-400/15 text-orange-50",
+    surfaceClass: "bg-orange-400/10 text-orange-100 ring-orange-300/30",
+  },
+  {
+    id: "medium",
+    label: "Medium",
+    summary: "Contained but still consuming operator time.",
+    badgeClass: "border border-amber-300/30 bg-amber-400/15 text-amber-50",
+    surfaceClass: "bg-amber-400/10 text-amber-100 ring-amber-300/30",
+  },
+  {
+    id: "low",
+    label: "Low",
+    summary: "Observed and held in an active watch lane.",
+    badgeClass: "border border-cyan-300/30 bg-cyan-400/15 text-cyan-50",
+    surfaceClass: "bg-cyan-400/10 text-cyan-100 ring-cyan-300/30",
+  },
+] satisfies SeverityLevel[];
+
+export const incidentResponders = [
+  {
+    id: "maya-tran",
+    name: "Maya Tran",
+    role: "Incident commander",
+    team: "Core platform",
+    status: "On bridge",
+    zone: "UTC-7",
+    specialties: ["Traffic shaping", "Rollback control"],
+    note: "Holding write pressure below the burn threshold while the cache patch rolls out.",
+  },
+  {
+    id: "jonah-price",
+    name: "Jonah Price",
+    role: "Database on-call",
+    team: "Data systems",
+    status: "Deploying",
+    zone: "UTC-5",
+    specialties: ["Replica recovery", "Failover checks"],
+    note: "Validating follower lag after the replica pool drained stale lease holders.",
+  },
+  {
+    id: "leila-ortega",
+    name: "Leila Ortega",
+    role: "Edge specialist",
+    team: "Network runtime",
+    status: "On bridge",
+    zone: "UTC+1",
+    specialties: ["Cache routing", "Token propagation"],
+    note: "Shadowing auth edge nodes and confirming config parity before widening traffic.",
+  },
+  {
+    id: "cameron-reeves",
+    name: "Cameron Reeves",
+    role: "Comms lead",
+    team: "Customer ops",
+    status: "Monitoring",
+    zone: "UTC-4",
+    specialties: ["Status updates", "Escalation pacing"],
+    note: "Preparing the next external update if the canary lane stays stable for one more interval.",
+  },
+  {
+    id: "talia-brooks",
+    name: "Talia Brooks",
+    role: "Queue response",
+    team: "Workflow control",
+    status: "Relief",
+    zone: "UTC-6",
+    specialties: ["Backlog draining", "Replay safety"],
+    note: "Keeping replay pressure under the alert threshold while secondary workers warm up.",
+  },
+  {
+    id: "owen-singh",
+    name: "Owen Singh",
+    role: "Delivery analyst",
+    team: "Partner systems",
+    status: "Monitoring",
+    zone: "UTC+5:30",
+    specialties: ["Webhook fan-out", "Partner retry policy"],
+    note: "Watching late-arriving carrier events and pruning duplicates before they reach merchants.",
+  },
+] satisfies ResponderRecord[];
+
+export const incidents = [
+  {
+    id: "deck-441",
+    code: "INC-441",
+    title: "Checkout token refresh failures spike in the primary lane",
+    service: "payments-api",
+    severity: "critical",
+    status: "Mitigating",
+    openedAt: "09:12 UTC",
+    lead: "Maya Tran",
+    region: "us-east / eu-west",
+    affectedUsers: "11% checkout attempts",
+    summary: "Edge-issued refresh tokens are expiring ahead of session rollover after a hot shard rebalance.",
+    activeTask: "Patch auth cache eviction policy and widen traffic only after burn rate normalizes.",
+    responderIds: ["maya-tran", "jonah-price", "cameron-reeves"],
+  },
+  {
+    id: "deck-438",
+    code: "INC-438",
+    title: "Edge auth config drift holds back new session issuance",
+    service: "gateway-edge",
+    severity: "high",
+    status: "Containing",
+    openedAt: "09:37 UTC",
+    lead: "Leila Ortega",
+    region: "ap-south / eu-central",
+    affectedUsers: "4 regional POPs",
+    summary: "A delayed config propagation wave left standby nodes serving an outdated issuer bundle.",
+    activeTask: "Reseed the standby nodes and watch session parity before rejoining the pool.",
+    responderIds: ["leila-ortega", "maya-tran", "cameron-reeves"],
+  },
+  {
+    id: "deck-435",
+    code: "INC-435",
+    title: "Webhook replay queue grows after partner retry burst",
+    service: "shipment-webhooks",
+    severity: "medium",
+    status: "Watching",
+    openedAt: "10:05 UTC",
+    lead: "Talia Brooks",
+    region: "global queue mesh",
+    affectedUsers: "Delayed delivery events",
+    summary: "Carrier retries arrived out of order and saturated the replay workers assigned to the recovery lane.",
+    activeTask: "Drain the backlog without duplicating carrier notifications for merchants already reconciled.",
+    responderIds: ["talia-brooks", "owen-singh", "cameron-reeves"],
+  },
+  {
+    id: "deck-431",
+    code: "INC-431",
+    title: "Audit fan-out stays under watch after canary rule change",
+    service: "event-audit",
+    severity: "low",
+    status: "Monitoring",
+    openedAt: "10:31 UTC",
+    lead: "Owen Singh",
+    region: "secondary workers",
+    affectedUsers: "Internal review queues",
+    summary: "A narrow audit rule change increased side-channel fan-out, but retry pressure is now flattening.",
+    activeTask: "Keep the watch lane open until the next worker sample shows duplicate events below baseline.",
+    responderIds: ["owen-singh", "talia-brooks"],
+  },
+] satisfies IncidentRecord[];
+
+export const incidentTimeline = [
+  {
+    id: "deck-441-detect",
+    incidentId: "deck-441",
+    kind: "Detection",
+    title: "Synthetic checkout monitors jump above the burn budget",
+    detail: "Token refreshes start failing on hot shards and the rollback guardrail blocks the latest config promotion.",
+    at: "09:14 UTC",
+    channel: "signal-bus",
+    responderIds: ["maya-tran", "jonah-price"],
+  },
+  {
+    id: "deck-441-mitigate",
+    incidentId: "deck-441",
+    kind: "Mitigation",
+    title: "Replica pool rotated and cache eviction patch enters canary",
+    detail: "Database recovery clears stale lease holders while the platform lane tests a narrower token eviction window.",
+    at: "09:23 UTC",
+    channel: "ops-bridge",
+    responderIds: ["jonah-price", "maya-tran"],
+  },
+  {
+    id: "deck-441-comms",
+    incidentId: "deck-441",
+    kind: "Comms",
+    title: "Customer status banner held at investigating while burn rate falls",
+    detail: "External comms stay conservative until the next sample shows stable session recovery across both primary regions.",
+    at: "09:31 UTC",
+    channel: "status-page",
+    responderIds: ["cameron-reeves"],
+  },
+  {
+    id: "deck-438-detect",
+    incidentId: "deck-438",
+    kind: "Detection",
+    title: "Standby edge nodes fail issuer parity checks",
+    detail: "Session issuance begins splitting between old and new issuer bundles after a staggered deploy window.",
+    at: "09:41 UTC",
+    channel: "edge-watch",
+    responderIds: ["leila-ortega"],
+  },
+  {
+    id: "deck-438-remediate",
+    incidentId: "deck-438",
+    kind: "Mitigation",
+    title: "Config reseed pushes updated bundles into the held POPs",
+    detail: "The affected standby nodes rejoin in a shadow lane while traffic remains pinned away from the stale replicas.",
+    at: "09:52 UTC",
+    channel: "ops-bridge",
+    responderIds: ["leila-ortega", "maya-tran"],
+  },
+  {
+    id: "deck-438-comms",
+    incidentId: "deck-438",
+    kind: "Handoff",
+    title: "Support queue gets regional holding copy for new sessions",
+    detail: "The customer team shares a narrow advisory for impacted geographies instead of broad incident messaging.",
+    at: "10:01 UTC",
+    channel: "support-room",
+    responderIds: ["cameron-reeves"],
+  },
+  {
+    id: "deck-435-detect",
+    incidentId: "deck-435",
+    kind: "Detection",
+    title: "Partner retry storm piles into the replay lane",
+    detail: "Workers protecting duplicate merchant notifications refuse the newest burst and queue depth doubles in one interval.",
+    at: "10:08 UTC",
+    channel: "queue-ops",
+    responderIds: ["talia-brooks", "owen-singh"],
+  },
+  {
+    id: "deck-435-mitigate",
+    incidentId: "deck-435",
+    kind: "Mitigation",
+    title: "Warm spare workers absorb the oldest replay partition",
+    detail: "Replay pressure begins flattening once carrier-specific retry windows are spread across the spare pool.",
+    at: "10:19 UTC",
+    channel: "workflow-control",
+    responderIds: ["talia-brooks"],
+  },
+  {
+    id: "deck-435-comms",
+    incidentId: "deck-435",
+    kind: "Comms",
+    title: "Merchant-facing delivery updates held until dedupe clears",
+    detail: "Partner systems keep the delivery banner quiet to avoid sending duplicate status changes during recovery.",
+    at: "10:24 UTC",
+    channel: "partner-room",
+    responderIds: ["owen-singh", "cameron-reeves"],
+  },
+  {
+    id: "deck-431-watch",
+    incidentId: "deck-431",
+    kind: "Detection",
+    title: "Audit retries drift above the watch threshold",
+    detail: "A new canary rule causes duplicate event fan-out inside the secondary worker lane, but downstream queues remain healthy.",
+    at: "10:34 UTC",
+    channel: "audit-watch",
+    responderIds: ["owen-singh"],
+  },
+  {
+    id: "deck-431-monitor",
+    incidentId: "deck-431",
+    kind: "Monitoring",
+    title: "Secondary workers hold duplicate events below the paging line",
+    detail: "Queue control leaves the watch lane open, but the latest sample suggests the issue is decaying without intervention.",
+    at: "10:42 UTC",
+    channel: "workflow-control",
+    responderIds: ["talia-brooks", "owen-singh"],
+  },
+] satisfies TimelineEntry[];

--- a/src/app/incident-deck/page.tsx
+++ b/src/app/incident-deck/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { IncidentDeckShell } from "@/components/incident-deck/incident-deck-shell";
+
+export const metadata: Metadata = {
+  title: "Incident Deck",
+  description:
+    "Mock incident workspace with local severity filters, response timeline, and responder detail state.",
+};
+
+export default function IncidentDeckPage() {
+  return <IncidentDeckShell />;
+}

--- a/src/components/incident-deck/incident-deck-header.tsx
+++ b/src/components/incident-deck/incident-deck-header.tsx
@@ -1,0 +1,80 @@
+import type {
+  IncidentSeverityFilter,
+  SeverityLevel,
+} from "@/app/incident-deck/mock-data";
+
+type SeverityCount = SeverityLevel & { count: number };
+
+type IncidentDeckHeaderProps = {
+  totalCount: number;
+  visibleCount: number;
+  selectedSeverity: IncidentSeverityFilter;
+  severitySummary: SeverityCount[];
+};
+
+export function IncidentDeckHeader({
+  totalCount,
+  visibleCount,
+  selectedSeverity,
+  severitySummary,
+}: IncidentDeckHeaderProps) {
+  const selectedLabel =
+    selectedSeverity === "all"
+      ? "All severities"
+      : severitySummary.find((severity) => severity.id === selectedSeverity)
+          ?.label ?? "Filtered";
+
+  return (
+    <section className="overflow-hidden rounded-[2rem] border border-white/10 bg-slate-950/55 shadow-2xl shadow-slate-950/30 backdrop-blur">
+      <div className="grid gap-6 px-6 py-7 lg:grid-cols-[minmax(0,1.25fr)_minmax(18rem,0.75fr)] lg:px-8">
+        <div className="space-y-4">
+          <p className="text-sm font-semibold uppercase tracking-[0.35em] text-sky-300">
+            Incident Deck
+          </p>
+          <div className="space-y-3">
+            <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+              Mock incident workspace for active stacks, response pacing, and
+              operator handoffs.
+            </h1>
+            <p className="max-w-2xl text-base leading-7 text-slate-300 sm:text-lg">
+              Everything on this route is feature-local: incidents, severity
+              filters, responder focus, and the response timeline all stay
+              inside the client session.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {severitySummary.map((severity) => (
+              <span
+                className={`inline-flex rounded-full px-3 py-1 text-sm font-medium ring-1 ${severity.surfaceClass}`}
+                key={severity.id}
+              >
+                {severity.count} {severity.label}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1">
+          <div className="rounded-3xl border border-white/10 bg-white/5 px-5 py-4">
+            <p className="text-sm text-slate-400">Active incidents</p>
+            <p className="mt-2 text-3xl font-semibold text-white">
+              {totalCount}
+            </p>
+          </div>
+          <div className="rounded-3xl border border-sky-400/20 bg-sky-400/10 px-5 py-4">
+            <p className="text-sm text-sky-200">Visible in deck</p>
+            <p className="mt-2 text-3xl font-semibold text-white">
+              {visibleCount}
+            </p>
+          </div>
+          <div className="rounded-3xl border border-orange-300/20 bg-orange-400/10 px-5 py-4">
+            <p className="text-sm text-orange-100">Current filter</p>
+            <p className="mt-2 text-lg font-semibold text-white">
+              {selectedLabel}
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/incident-deck/incident-deck-shell.tsx
+++ b/src/components/incident-deck/incident-deck-shell.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { startTransition, useState } from "react";
+import {
+  incidentResponders,
+  incidents,
+  incidentSeverities,
+  incidentTimeline,
+  type IncidentSeverity,
+  type IncidentSeverityFilter,
+  type ResponderRecord,
+  type SeverityLevel,
+} from "@/app/incident-deck/mock-data";
+import { IncidentDeckHeader } from "./incident-deck-header";
+import { IncidentStack } from "./incident-stack";
+import { ResponderPanel } from "./responder-panel";
+import { ResponseTimeline } from "./response-timeline";
+import { SeverityFilterBar } from "./severity-filter-bar";
+
+export function IncidentDeckShell() {
+  const [selectedSeverity, setSelectedSeverity] =
+    useState<IncidentSeverityFilter>("all");
+  const [selectedIncidentId, setSelectedIncidentId] = useState<string | null>(
+    incidents[0]?.id ?? null,
+  );
+  const [selectedResponderId, setSelectedResponderId] = useState<string | null>(
+    null,
+  );
+
+  const visibleIncidents = incidents.filter(
+    (incident) =>
+      selectedSeverity === "all" || incident.severity === selectedSeverity,
+  );
+  const activeIncidentId =
+    selectedIncidentId &&
+    visibleIncidents.some((incident) => incident.id === selectedIncidentId)
+      ? selectedIncidentId
+      : (visibleIncidents[0]?.id ?? null);
+  const activeIncident =
+    incidents.find((incident) => incident.id === activeIncidentId) ?? null;
+  const activeResponders = activeIncident
+    ? activeIncident.responderIds.flatMap((responderId) => {
+        const responder = incidentResponders.find(
+          (candidate) => candidate.id === responderId,
+        );
+
+        return responder ? [responder] : [];
+      })
+    : [];
+  const selectedResponder =
+    activeResponders.find((responder) => responder.id === selectedResponderId) ??
+    null;
+  const timelineEntries = incidentTimeline.filter((entry) => {
+    if (entry.incidentId !== activeIncident?.id) return false;
+    if (!selectedResponderId) return true;
+    return entry.responderIds.includes(selectedResponderId);
+  });
+  const severitySummary = incidentSeverities
+    .map((severity) => ({
+      ...severity,
+      count: incidents.filter((incident) => incident.severity === severity.id)
+        .length,
+    }))
+    .filter((severity) => severity.count > 0);
+  const severityLookup = Object.fromEntries(
+    incidentSeverities.map((severity) => [severity.id, severity]),
+  ) as Record<IncidentSeverity, SeverityLevel>;
+  const respondersById = Object.fromEntries(
+    incidentResponders.map((responder) => [responder.id, responder]),
+  ) as Record<string, ResponderRecord>;
+
+  function handleSeverityChange(nextSeverity: IncidentSeverityFilter) {
+    startTransition(() => {
+      setSelectedSeverity(nextSeverity);
+      setSelectedResponderId(null);
+    });
+  }
+
+  function handleSelectIncident(incidentId: string) {
+    startTransition(() => {
+      setSelectedIncidentId(incidentId);
+      setSelectedResponderId(null);
+    });
+  }
+
+  function handleFocusResponder(incidentId: string, responderId: string) {
+    startTransition(() => {
+      setSelectedIncidentId(incidentId);
+      setSelectedResponderId((current) =>
+        activeIncidentId === incidentId && current === responderId
+          ? null
+          : responderId,
+      );
+    });
+  }
+
+  function handleSelectResponder(responderId: string) {
+    startTransition(() => {
+      setSelectedResponderId((current) =>
+        current === responderId ? null : responderId,
+      );
+    });
+  }
+
+  function resetFilters() {
+    startTransition(() => {
+      setSelectedSeverity("all");
+      setSelectedIncidentId(incidents[0]?.id ?? null);
+      setSelectedResponderId(null);
+    });
+  }
+
+  function clearResponderFocus() {
+    startTransition(() => {
+      setSelectedResponderId(null);
+    });
+  }
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.18),transparent_33%),radial-gradient(circle_at_top_right,rgba(249,115,22,0.14),transparent_28%),linear-gradient(180deg,#081121_0%,#10192f_45%,#182133_100%)] px-4 py-6 text-slate-100 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <IncidentDeckHeader
+          selectedSeverity={selectedSeverity}
+          severitySummary={severitySummary}
+          totalCount={incidents.length}
+          visibleCount={visibleIncidents.length}
+        />
+
+        <SeverityFilterBar
+          activeSeverity={selectedSeverity}
+          options={severitySummary}
+          totalCount={incidents.length}
+          visibleCount={visibleIncidents.length}
+          onSelect={handleSeverityChange}
+        />
+
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(0,1.25fr)]">
+          <IncidentStack
+            activeIncidentId={activeIncidentId}
+            incidents={visibleIncidents}
+            respondersById={respondersById}
+            selectedResponderId={selectedResponderId}
+            severityLookup={severityLookup}
+            onFocusResponder={handleFocusResponder}
+            onResetFilters={resetFilters}
+            onSelectIncident={handleSelectIncident}
+          />
+
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1.15fr)_minmax(18rem,0.85fr)]">
+            <ResponseTimeline
+              entries={timelineEntries}
+              hasResponderFocus={selectedResponderId !== null}
+              incident={activeIncident}
+              respondersById={respondersById}
+              selectedResponder={selectedResponder}
+              onClearResponder={clearResponderFocus}
+              onSelectResponder={handleSelectResponder}
+            />
+            <ResponderPanel
+              incident={activeIncident}
+              responders={activeResponders}
+              selectedResponder={selectedResponder}
+              onClearResponder={clearResponderFocus}
+              onSelectResponder={handleSelectResponder}
+            />
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/incident-deck/incident-stack.tsx
+++ b/src/components/incident-deck/incident-stack.tsx
@@ -1,0 +1,163 @@
+import type {
+  IncidentRecord,
+  IncidentSeverity,
+  ResponderRecord,
+  SeverityLevel,
+} from "@/app/incident-deck/mock-data";
+
+type IncidentStackProps = {
+  incidents: IncidentRecord[];
+  activeIncidentId: string | null;
+  selectedResponderId: string | null;
+  respondersById: Record<string, ResponderRecord>;
+  severityLookup: Record<IncidentSeverity, SeverityLevel>;
+  onSelectIncident: (incidentId: string) => void;
+  onFocusResponder: (incidentId: string, responderId: string) => void;
+  onResetFilters: () => void;
+};
+
+export function IncidentStack({
+  incidents,
+  activeIncidentId,
+  selectedResponderId,
+  respondersById,
+  severityLookup,
+  onSelectIncident,
+  onFocusResponder,
+  onResetFilters,
+}: IncidentStackProps) {
+  return (
+    <section className="space-y-4 rounded-[1.75rem] border border-white/10 bg-slate-950/45 p-4 shadow-xl shadow-slate-950/20 backdrop-blur">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-400">
+            Active incident stack
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">
+            Select a lane to review the response plan.
+          </h2>
+        </div>
+      </div>
+
+      {incidents.length > 0 ? (
+        <div className="space-y-4">
+          {incidents.map((incident) => {
+            const severity = severityLookup[incident.severity];
+            const isActive = incident.id === activeIncidentId;
+
+            return (
+              <article
+                className={`rounded-[1.5rem] border p-5 transition ${
+                  isActive
+                    ? "border-sky-400/50 bg-sky-400/10 shadow-lg shadow-sky-950/20"
+                    : "border-white/10 bg-white/5"
+                }`}
+                key={incident.id}
+              >
+                <div className="flex flex-col gap-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="space-y-2">
+                      <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">
+                        {incident.code} · {incident.service}
+                      </p>
+                      <button
+                        className="text-left text-xl font-semibold text-white transition hover:text-sky-200"
+                        onClick={() => onSelectIncident(incident.id)}
+                        type="button"
+                      >
+                        {incident.title}
+                      </button>
+                      <p className="max-w-2xl text-sm leading-6 text-slate-300">
+                        {incident.summary}
+                      </p>
+                    </div>
+                    <span
+                      className={`inline-flex rounded-full px-3 py-1 text-sm font-medium ${severity.badgeClass}`}
+                    >
+                      {severity.label}
+                    </span>
+                  </div>
+
+                  <div className="grid gap-3 text-sm text-slate-300 sm:grid-cols-2">
+                    <div className="rounded-2xl border border-white/10 bg-slate-950/45 p-3">
+                      <p className="text-xs uppercase tracking-[0.24em] text-slate-500">
+                        Lead
+                      </p>
+                      <p className="mt-2 font-medium text-white">
+                        {incident.lead}
+                      </p>
+                      <p className="mt-1 text-slate-400">{incident.openedAt}</p>
+                    </div>
+                    <div className="rounded-2xl border border-white/10 bg-slate-950/45 p-3">
+                      <p className="text-xs uppercase tracking-[0.24em] text-slate-500">
+                        Impact
+                      </p>
+                      <p className="mt-2 font-medium text-white">
+                        {incident.affectedUsers}
+                      </p>
+                      <p className="mt-1 text-slate-400">{incident.region}</p>
+                    </div>
+                  </div>
+
+                  <div className="rounded-2xl border border-white/10 bg-slate-950/55 p-4">
+                    <p className="text-xs uppercase tracking-[0.24em] text-slate-500">
+                      Active task
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-slate-200">
+                      {incident.activeTask}
+                    </p>
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    {incident.responderIds.map((responderId) => {
+                      const responder = respondersById[responderId];
+                      if (!responder) return null;
+
+                      const isFocused =
+                        isActive && selectedResponderId === responder.id;
+
+                      return (
+                        <button
+                          className={`rounded-full border px-3 py-2 text-sm transition ${
+                            isFocused
+                              ? "border-sky-300/50 bg-sky-400/15 text-sky-100"
+                              : "border-white/10 bg-white/5 text-slate-200 hover:bg-white/10"
+                          }`}
+                          key={responder.id}
+                          onClick={() => onFocusResponder(incident.id, responder.id)}
+                          type="button"
+                        >
+                          {responder.name} · {responder.role}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="rounded-[1.5rem] border border-dashed border-slate-600 bg-slate-950/50 p-8 text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-400">
+            No active lane
+          </p>
+          <h3 className="mt-3 text-2xl font-semibold text-white">
+            No incidents match the current severity filter.
+          </h3>
+          <p className="mt-3 text-sm leading-6 text-slate-300">
+            Reset the deck to reopen every active incident and restore the
+            response timeline.
+          </p>
+          <button
+            className="mt-5 rounded-full bg-white px-4 py-2 text-sm font-medium text-slate-950 transition hover:bg-slate-200"
+            onClick={onResetFilters}
+            type="button"
+          >
+            Show all active incidents
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/incident-deck/responder-panel.tsx
+++ b/src/components/incident-deck/responder-panel.tsx
@@ -1,0 +1,143 @@
+import type {
+  IncidentRecord,
+  ResponderRecord,
+} from "@/app/incident-deck/mock-data";
+
+type ResponderPanelProps = {
+  incident: IncidentRecord | null;
+  responders: ResponderRecord[];
+  selectedResponder: ResponderRecord | null;
+  onSelectResponder: (responderId: string) => void;
+  onClearResponder: () => void;
+};
+
+export function ResponderPanel({
+  incident,
+  responders,
+  selectedResponder,
+  onSelectResponder,
+  onClearResponder,
+}: ResponderPanelProps) {
+  return (
+    <aside className="rounded-[1.75rem] border border-white/10 bg-slate-950/45 p-4 shadow-xl shadow-slate-950/20 backdrop-blur">
+      <div className="border-b border-white/10 pb-4">
+        <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-400">
+          Responder detail
+        </p>
+        <h2 className="mt-2 text-2xl font-semibold text-white">
+          {incident ? "Bridge roster" : "Waiting for incident"}
+        </h2>
+        <p className="mt-2 text-sm leading-6 text-slate-300">
+          {incident
+            ? "Choose a responder to inspect ownership, shift status, and recovery notes."
+            : "No responder roster is available until an incident lane is visible."}
+        </p>
+      </div>
+
+      {incident ? (
+        <div className="mt-4 space-y-4">
+          <div className="grid gap-2">
+            {responders.map((responder) => (
+              <button
+                className={`rounded-[1.25rem] border p-3 text-left transition ${
+                  selectedResponder?.id === responder.id
+                    ? "border-sky-300/40 bg-sky-400/10"
+                    : "border-white/10 bg-white/5 hover:bg-white/10"
+                }`}
+                key={responder.id}
+                onClick={() => onSelectResponder(responder.id)}
+                type="button"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="font-medium text-white">{responder.name}</p>
+                    <p className="mt-1 text-sm text-slate-300">
+                      {responder.role} · {responder.team}
+                    </p>
+                  </div>
+                  <span className="rounded-full border border-white/10 bg-slate-950/60 px-2.5 py-1 text-xs text-slate-300">
+                    {responder.status}
+                  </span>
+                </div>
+              </button>
+            ))}
+          </div>
+
+          {selectedResponder ? (
+            <div className="rounded-[1.35rem] border border-white/10 bg-slate-950/55 p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.24em] text-slate-500">
+                    Focused responder
+                  </p>
+                  <h3 className="mt-2 text-xl font-semibold text-white">
+                    {selectedResponder.name}
+                  </h3>
+                </div>
+                <button
+                  className="rounded-full border border-white/15 bg-white/5 px-3 py-2 text-sm text-white transition hover:bg-white/10"
+                  onClick={onClearResponder}
+                  type="button"
+                >
+                  Clear focus
+                </button>
+              </div>
+
+              <div className="mt-4 grid gap-3 text-sm text-slate-300 sm:grid-cols-2">
+                <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+                  <p className="text-xs uppercase tracking-[0.24em] text-slate-500">
+                    Zone
+                  </p>
+                  <p className="mt-2 font-medium text-white">
+                    {selectedResponder.zone}
+                  </p>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+                  <p className="text-xs uppercase tracking-[0.24em] text-slate-500">
+                    Assigned lane
+                  </p>
+                  <p className="mt-2 font-medium text-white">{incident.code}</p>
+                </div>
+              </div>
+
+              <p className="mt-4 text-sm leading-6 text-slate-200">
+                {selectedResponder.note}
+              </p>
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                {selectedResponder.specialties.map((specialty) => (
+                  <span
+                    className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.18em] text-slate-300"
+                    key={specialty}
+                  >
+                    {specialty}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-[1.35rem] border border-dashed border-slate-600 bg-slate-950/50 p-6">
+              <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-400">
+                No responder selected
+              </p>
+              <h3 className="mt-3 text-xl font-semibold text-white">
+                Pick a responder to inspect their current recovery lane.
+              </h3>
+              <p className="mt-3 text-sm leading-6 text-slate-300">
+                The selection stays local to this route and also narrows the
+                response timeline to that person&apos;s handoff trail.
+              </p>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="mt-4 rounded-[1.35rem] border border-dashed border-slate-600 bg-slate-950/50 p-6">
+          <p className="text-sm leading-6 text-slate-300">
+            Incident responders will appear here once the deck has an active
+            incident in view.
+          </p>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/components/incident-deck/response-timeline.tsx
+++ b/src/components/incident-deck/response-timeline.tsx
@@ -1,0 +1,136 @@
+import type {
+  IncidentRecord,
+  ResponderRecord,
+  TimelineEntry,
+} from "@/app/incident-deck/mock-data";
+
+type ResponseTimelineProps = {
+  incident: IncidentRecord | null;
+  entries: TimelineEntry[];
+  hasResponderFocus: boolean;
+  respondersById: Record<string, ResponderRecord>;
+  selectedResponder: ResponderRecord | null;
+  onSelectResponder: (responderId: string) => void;
+  onClearResponder: () => void;
+};
+
+export function ResponseTimeline({
+  incident,
+  entries,
+  hasResponderFocus,
+  respondersById,
+  selectedResponder,
+  onSelectResponder,
+  onClearResponder,
+}: ResponseTimelineProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-white/10 bg-slate-950/45 p-4 shadow-xl shadow-slate-950/20 backdrop-blur">
+      <div className="flex flex-col gap-3 border-b border-white/10 pb-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-400">
+              Response timeline
+            </p>
+            <h2 className="mt-2 text-2xl font-semibold text-white">
+              {incident ? `${incident.code} recovery log` : "Timeline waiting"}
+            </h2>
+          </div>
+          {selectedResponder ? (
+            <button
+              className="rounded-full border border-sky-300/40 bg-sky-400/10 px-3 py-2 text-sm text-sky-100 transition hover:bg-sky-400/15"
+              onClick={onClearResponder}
+              type="button"
+            >
+              Focused on {selectedResponder.name} · clear
+            </button>
+          ) : null}
+        </div>
+        <p className="text-sm leading-6 text-slate-300">
+          {incident
+            ? incident.activeTask
+            : "Select an incident lane to inspect the response sequence and latest handoff notes."}
+        </p>
+      </div>
+
+      {incident ? (
+        entries.length > 0 ? (
+          <div className="mt-4 space-y-4">
+            {entries.map((entry) => (
+              <article
+                className="rounded-[1.35rem] border border-white/10 bg-white/5 p-4"
+                key={entry.id}
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="rounded-full border border-white/10 bg-slate-950/50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-slate-300">
+                    {entry.kind}
+                  </span>
+                  <div className="text-right text-sm text-slate-400">
+                    <p>{entry.at}</p>
+                    <p>{entry.channel}</p>
+                  </div>
+                </div>
+                <h3 className="mt-4 text-lg font-semibold text-white">
+                  {entry.title}
+                </h3>
+                <p className="mt-2 text-sm leading-6 text-slate-300">
+                  {entry.detail}
+                </p>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {entry.responderIds.map((responderId) => {
+                    const responder = respondersById[responderId];
+                    if (!responder) return null;
+
+                    return (
+                      <button
+                        className={`rounded-full border px-3 py-2 text-sm transition ${
+                          selectedResponder?.id === responder.id
+                            ? "border-sky-300/50 bg-sky-400/15 text-sky-100"
+                            : "border-white/10 bg-slate-950/50 text-slate-200 hover:bg-white/10"
+                        }`}
+                        key={responder.id}
+                        onClick={() => onSelectResponder(responder.id)}
+                        type="button"
+                      >
+                        {responder.name}
+                      </button>
+                    );
+                  })}
+                </div>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <div className="mt-4 rounded-[1.35rem] border border-dashed border-slate-600 bg-slate-950/50 p-6">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-400">
+              Empty timeline
+            </p>
+            <h3 className="mt-3 text-xl font-semibold text-white">
+              No timeline entries match the current responder focus.
+            </h3>
+            <p className="mt-3 text-sm leading-6 text-slate-300">
+              {hasResponderFocus
+                ? "Clear the responder filter to bring back every recovery event for the selected incident."
+                : "This incident does not have local timeline activity yet."}
+            </p>
+            {hasResponderFocus ? (
+              <button
+                className="mt-5 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/10"
+                onClick={onClearResponder}
+                type="button"
+              >
+                Show full timeline
+              </button>
+            ) : null}
+          </div>
+        )
+      ) : (
+        <div className="mt-4 rounded-[1.35rem] border border-dashed border-slate-600 bg-slate-950/50 p-6">
+          <p className="text-sm leading-6 text-slate-300">
+            The response timeline will appear here once an incident is visible in
+            the current deck.
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/incident-deck/severity-filter-bar.tsx
+++ b/src/components/incident-deck/severity-filter-bar.tsx
@@ -1,0 +1,64 @@
+import type {
+  IncidentSeverityFilter,
+  SeverityLevel,
+} from "@/app/incident-deck/mock-data";
+
+type SeverityCount = SeverityLevel & { count: number };
+
+type SeverityFilterBarProps = {
+  activeSeverity: IncidentSeverityFilter;
+  totalCount: number;
+  visibleCount: number;
+  options: SeverityCount[];
+  onSelect: (severity: IncidentSeverityFilter) => void;
+};
+
+export function SeverityFilterBar({
+  activeSeverity,
+  totalCount,
+  visibleCount,
+  options,
+  onSelect,
+}: SeverityFilterBarProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-white/10 bg-slate-900/55 p-4 shadow-xl shadow-slate-950/20 backdrop-blur">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-400">
+            Severity lanes
+          </p>
+          <p className="mt-2 text-sm text-slate-300">
+            Showing {visibleCount} of {totalCount} active incidents in the deck.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+              activeSeverity === "all"
+                ? "bg-white text-slate-950"
+                : "border border-white/10 bg-white/5 text-slate-200 hover:bg-white/10"
+            }`}
+            onClick={() => onSelect("all")}
+            type="button"
+          >
+            All active
+          </button>
+          {options.map((option) => (
+            <button
+              className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                activeSeverity === option.id
+                  ? option.surfaceClass
+                  : "border border-white/10 bg-white/5 text-slate-200 hover:bg-white/10"
+              }`}
+              key={option.id}
+              onClick={() => onSelect(option.id)}
+              type="button"
+            >
+              {option.label} · {option.count}
+            </button>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/incident-deck` app route with feature-local mock data and metadata
- build a client workspace with severity filters, an active incident stack, a response timeline, and responder focus state
- keep the implementation fully scoped to `src/app/incident-deck/**` and `src/components/incident-deck/**`

## Testing
- npm test
- npm run lint
- npm run typecheck
- npm run build

Closes #23