### PR TITLE
feat: add isolated shift planner route

### DIFF
--- a/src/app/shift-planner/page.tsx
+++ b/src/app/shift-planner/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import { ShiftPlannerWorkspace } from "@/components/shift-planner/shift-planner-workspace";
+
+export const metadata: Metadata = {
+  title: "Shift Planner | API Test",
+  description: "Mock staffing workspace with role coverage, shift filters, and local hand-off notes.",
+};
+
+export default function ShiftPlannerPage() {
+  return <ShiftPlannerWorkspace />;
+}

--- a/src/app/shift-planner/shift-planner-data.ts
+++ b/src/app/shift-planner/shift-planner-data.ts
@@ -1,0 +1,168 @@
+export const plannerShifts = [
+  { id: "dawn", label: "Dawn", window: "05:30-13:30" },
+  { id: "swing", label: "Swing", window: "13:30-21:30" },
+  { id: "night", label: "Night", window: "21:30-05:30" },
+] as const;
+
+export type PlannerShift = (typeof plannerShifts)[number];
+export type PlannerShiftId = (typeof plannerShifts)[number]["id"];
+
+export const plannerRoles = [
+  { id: "triage", label: "Triage Lead", squad: "Intake Desk" },
+  { id: "dispatch", label: "Dispatch", squad: "Routing Board" },
+  { id: "floor", label: "Floor Support", squad: "Floor Coverage" },
+  { id: "qa", label: "QA Escalation", squad: "Escalation Loop" },
+] as const;
+
+export type PlannerRole = (typeof plannerRoles)[number];
+export type PlannerRoleId = (typeof plannerRoles)[number]["id"];
+export type CoverageTone = "ready" | "watch" | "gap";
+export type HandoffStatus = "ready" | "pending";
+
+export type PlannerTeamMember = {
+  id: string;
+  name: string;
+  roleId: PlannerRoleId;
+  focus: string;
+};
+
+export type PlannerCoverageBlock = {
+  shiftId: PlannerShiftId;
+  target: number;
+  assigneeIds: string[];
+  tone: CoverageTone;
+  note: string;
+};
+
+export type PlannerCoverageRow = {
+  roleId: PlannerRoleId;
+  note: string;
+  assignments: PlannerCoverageBlock[];
+};
+
+export type HandoffNote = {
+  id: string;
+  title: string;
+  shiftId: PlannerShiftId;
+  ownerId: string;
+  status: HandoffStatus;
+  body: string;
+};
+
+export type PlannerDay = {
+  id: string;
+  label: string;
+  dateLabel: string;
+  focus: string;
+  staffing: { scheduled: number; target: number; onCall: number };
+  coverage: PlannerCoverageRow[];
+  handoffNotes: HandoffNote[];
+};
+
+export const plannerTeamMembers: PlannerTeamMember[] = [
+  { id: "maya", name: "Maya Chen", roleId: "triage", focus: "priority queues" },
+  { id: "noor", name: "Noor Patel", roleId: "triage", focus: "refund review" },
+  { id: "ellis", name: "Ellis Grant", roleId: "dispatch", focus: "lane balancing" },
+  { id: "jo", name: "Jo Alvarez", roleId: "dispatch", focus: "overflow reroutes" },
+  { id: "rhea", name: "Rhea Singh", roleId: "floor", focus: "counter coverage" },
+  { id: "omar", name: "Omar Reed", roleId: "floor", focus: "dock support" },
+  { id: "ivy", name: "Ivy Park", roleId: "qa", focus: "handoff validation" },
+  { id: "tess", name: "Tess Moore", roleId: "qa", focus: "escalation audit" },
+  { id: "luca", name: "Luca Diaz", roleId: "triage", focus: "backlog sweep" },
+  { id: "sana", name: "Sana Brooks", roleId: "floor", focus: "late swing flex" },
+];
+
+export const shiftPlannerDays: PlannerDay[] = [
+  {
+    id: "sat-19", label: "Sat 19", dateLabel: "Saturday, Apr 19", focus: "Weekend queue cleanup",
+    staffing: { scheduled: 14, target: 16, onCall: 3 },
+    coverage: [
+      { roleId: "triage", note: "Frontline queue ownership and refund triage.", assignments: [
+        { shiftId: "dawn", target: 2, assigneeIds: ["maya", "luca"], tone: "ready", note: "Refund backlog clears before noon dispatch handoff." },
+        { shiftId: "swing", target: 2, assigneeIds: ["noor"], tone: "gap", note: "One open seat remains for retail surge coverage." },
+        { shiftId: "night", target: 1, assigneeIds: ["maya"], tone: "ready", note: "Single lead covers the overnight drip queue." },
+      ] },
+      { roleId: "dispatch", note: "Lane balancing and courier reroute control.", assignments: [
+        { shiftId: "dawn", target: 1, assigneeIds: ["ellis"], tone: "ready", note: "Outbound cutover is fully staffed." },
+        { shiftId: "swing", target: 2, assigneeIds: ["ellis", "jo"], tone: "ready", note: "Peak pickup window has both routing leads online." },
+        { shiftId: "night", target: 1, assigneeIds: [], tone: "gap", note: "Night dispatch is still waiting on callback confirmation." },
+      ] },
+      { roleId: "floor", note: "Counter support, dock float, and break relief.", assignments: [
+        { shiftId: "dawn", target: 2, assigneeIds: ["rhea"], tone: "watch", note: "Coverage holds if dock load stays under forecast." },
+        { shiftId: "swing", target: 2, assigneeIds: ["rhea", "sana"], tone: "ready", note: "Flex pair can absorb callouts after 16:00." },
+        { shiftId: "night", target: 1, assigneeIds: ["omar"], tone: "ready", note: "Dock handoff lands with one steady closer." },
+      ] },
+      { roleId: "qa", note: "Escalation review and closing readiness checks.", assignments: [
+        { shiftId: "dawn", target: 1, assigneeIds: ["ivy"], tone: "ready", note: "Morning audits are covered without overflow risk." },
+        { shiftId: "swing", target: 1, assigneeIds: ["tess"], tone: "ready", note: "Escalation sign-off remains on cadence." },
+        { shiftId: "night", target: 1, assigneeIds: [], tone: "watch", note: "Dispatch gap may pull QA into floating review mode." },
+      ] },
+    ],
+    handoffNotes: [
+      { id: "sat-19-dawn", title: "Dawn backlog watch", shiftId: "dawn", ownerId: "maya", status: "ready", body: "Refund queue should stay below 12 tickets if dock scans land before 08:30." },
+      { id: "sat-19-swing", title: "Swing relief", shiftId: "swing", ownerId: "rhea", status: "pending", body: "Keep Sana floating near the retail counter until the second dispatch lead is settled." },
+      { id: "sat-19-night", title: "Night callback", shiftId: "night", ownerId: "ivy", status: "pending", body: "Confirm who owns dispatch fallback before 20:00 or reduce after-hours intake." },
+    ],
+  },
+  {
+    id: "sun-20", label: "Sun 20", dateLabel: "Sunday, Apr 20", focus: "Short weekend crew",
+    staffing: { scheduled: 12, target: 15, onCall: 4 },
+    coverage: [
+      { roleId: "triage", note: "Light demand, but returns spike after noon.", assignments: [
+        { shiftId: "dawn", target: 2, assigneeIds: ["maya"], tone: "watch", note: "Single opener is fine until return drop-offs begin." },
+        { shiftId: "swing", target: 2, assigneeIds: ["noor", "luca"], tone: "ready", note: "Backlog sweep is paired for the afternoon." },
+        { shiftId: "night", target: 1, assigneeIds: [], tone: "gap", note: "Overnight triage is intentionally unfilled pending demand check." },
+      ] },
+      { roleId: "dispatch", note: "Reroutes and weekend exception holds.", assignments: [
+        { shiftId: "dawn", target: 1, assigneeIds: ["jo"], tone: "ready", note: "Courier exception queue is stable." },
+        { shiftId: "swing", target: 1, assigneeIds: ["ellis"], tone: "ready", note: "Single controller is enough for planned volume." },
+        { shiftId: "night", target: 1, assigneeIds: ["jo"], tone: "ready", note: "Late reroutes fold into the same desk." },
+      ] },
+      { roleId: "floor", note: "Weekend counter and dock split.", assignments: [
+        { shiftId: "dawn", target: 2, assigneeIds: ["rhea"], tone: "watch", note: "Break coverage depends on on-call support arriving." },
+        { shiftId: "swing", target: 2, assigneeIds: ["sana"], tone: "gap", note: "Counter queue is short one relief partner." },
+        { shiftId: "night", target: 1, assigneeIds: ["omar"], tone: "ready", note: "Dock close remains fully owned." },
+      ] },
+      { roleId: "qa", note: "Limited review queue with tight handoff windows.", assignments: [
+        { shiftId: "dawn", target: 1, assigneeIds: ["ivy"], tone: "ready", note: "Morning review desk stays stable." },
+        { shiftId: "swing", target: 1, assigneeIds: [], tone: "gap", note: "Escalation sign-off needs a borrowed reviewer." },
+        { shiftId: "night", target: 1, assigneeIds: ["tess"], tone: "ready", note: "Night close-out can absorb a small spillover." },
+      ] },
+    ],
+    handoffNotes: [
+      { id: "sun-20-dawn", title: "Returns spike prep", shiftId: "dawn", ownerId: "noor", status: "ready", body: "If return volume jumps after lunch, move Luca back to the front of queue triage." },
+      { id: "sun-20-swing", title: "Review coverage", shiftId: "swing", ownerId: "tess", status: "pending", body: "QA still needs a swing partner; dispatch should avoid handing off unresolved audit flags." },
+    ],
+  },
+  {
+    id: "mon-21", label: "Mon 21", dateLabel: "Monday, Apr 21", focus: "Launch day staffing ramp",
+    staffing: { scheduled: 17, target: 17, onCall: 2 },
+    coverage: [
+      { roleId: "triage", note: "Morning launch queue and same-day corrections.", assignments: [
+        { shiftId: "dawn", target: 2, assigneeIds: ["maya", "noor"], tone: "ready", note: "Launch-day intake opens with full coverage." },
+        { shiftId: "swing", target: 2, assigneeIds: ["luca", "maya"], tone: "ready", note: "Backlog rollover remains paired through peak hours." },
+        { shiftId: "night", target: 1, assigneeIds: ["noor"], tone: "ready", note: "Night queue keeps a single experienced lead." },
+      ] },
+      { roleId: "dispatch", note: "Courier resets and reroute recovery.", assignments: [
+        { shiftId: "dawn", target: 2, assigneeIds: ["ellis", "jo"], tone: "ready", note: "Launch cutover has both routing controllers online." },
+        { shiftId: "swing", target: 2, assigneeIds: ["ellis", "jo"], tone: "ready", note: "Peak traffic stays paired all afternoon." },
+        { shiftId: "night", target: 1, assigneeIds: ["ellis"], tone: "ready", note: "Late exceptions remain inside normal thresholds." },
+      ] },
+      { roleId: "floor", note: "Counter support with launch-day relief pair.", assignments: [
+        { shiftId: "dawn", target: 2, assigneeIds: ["rhea", "omar"], tone: "ready", note: "Opening lanes are fully staffed." },
+        { shiftId: "swing", target: 2, assigneeIds: ["rhea", "sana"], tone: "ready", note: "Break relief is fully covered." },
+        { shiftId: "night", target: 1, assigneeIds: ["omar"], tone: "ready", note: "Close-out team stays within target." },
+      ] },
+      { roleId: "qa", note: "Extra launch-day review headroom.", assignments: [
+        { shiftId: "dawn", target: 1, assigneeIds: ["ivy"], tone: "ready", note: "Morning review queue is staffed." },
+        { shiftId: "swing", target: 1, assigneeIds: ["tess"], tone: "ready", note: "Escalation loop has clear sign-off ownership." },
+        { shiftId: "night", target: 1, assigneeIds: ["ivy"], tone: "ready", note: "Final audit pass stays in-house." },
+      ] },
+    ],
+    handoffNotes: [
+      { id: "mon-21-dawn", title: "Launch board sweep", shiftId: "dawn", ownerId: "ellis", status: "ready", body: "Dispatch board is balanced; keep one triage lead paired with courier exceptions until 10:00." },
+      { id: "mon-21-swing", title: "Afternoon buffer", shiftId: "swing", ownerId: "sana", status: "ready", body: "Floor support is healthy enough to release on-call backup unless the counter queue doubles." },
+      { id: "mon-21-night", title: "Close-out script", shiftId: "night", ownerId: "ivy", status: "ready", body: "Night QA owns final audit, then hands the clean board to the launch recap in the morning." },
+    ],
+  },
+];

--- a/src/components/shift-planner/coverage-matrix.tsx
+++ b/src/components/shift-planner/coverage-matrix.tsx
@@ -1,0 +1,131 @@
+import type {
+  PlannerCoverageRow,
+  PlannerShiftId,
+  PlannerShift,
+  PlannerTeamMember,
+} from "@/app/shift-planner/shift-planner-data";
+import { plannerRoles } from "@/app/shift-planner/shift-planner-data";
+
+type ShiftFilter = PlannerShiftId | "all";
+
+type CoverageMatrixProps = {
+  memberDirectory: Record<string, PlannerTeamMember>;
+  rows: PlannerCoverageRow[];
+  selectedDayLabel: string;
+  selectedShiftId: ShiftFilter;
+  shifts: readonly PlannerShift[];
+};
+
+const toneStyles = {
+  ready: "border-emerald-400/30 bg-emerald-400/10 text-emerald-100",
+  watch: "border-amber-300/30 bg-amber-300/10 text-amber-50",
+  gap: "border-rose-400/30 bg-rose-400/10 text-rose-100",
+} as const;
+
+const roleDirectory = Object.fromEntries(
+  plannerRoles.map((role) => [role.id, role]),
+);
+
+export function CoverageMatrix({
+  memberDirectory,
+  rows,
+  selectedDayLabel,
+  selectedShiftId,
+  shifts,
+}: CoverageMatrixProps) {
+  if (rows.length === 0) {
+    return (
+      <section className="rounded-[1.9rem] border border-dashed border-white/15 bg-slate-950/50 p-8 text-center">
+        <p className="text-xs uppercase tracking-[0.32em] text-slate-400">No coverage</p>
+        <h2 className="mt-3 text-2xl font-semibold text-white">No roles match the current scope.</h2>
+        <p className="mt-3 text-sm leading-6 text-slate-300">
+          Reset the role filter or switch to another day to reopen the matrix.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-[1.9rem] border border-white/10 bg-slate-950/65 p-5 shadow-[0_20px_60px_rgba(2,8,23,0.28)] backdrop-blur">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.3em] text-sky-300">Coverage Matrix</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">{selectedDayLabel}</h2>
+        </div>
+        <p className="max-w-lg text-sm leading-6 text-slate-300">
+          Each block tracks the target headcount, assigned teammates, and readiness for the selected role and shift scope.
+        </p>
+      </div>
+      <div className="mt-5 space-y-4">
+        {rows.map((row) => (
+          <article className="rounded-[1.6rem] border border-white/10 bg-white/5 p-4" key={row.roleId}>
+            <div className="flex flex-col gap-2 border-b border-white/10 pb-4 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <h3 className="text-xl font-semibold text-white">{roleDirectory[row.roleId]?.label ?? row.roleId}</h3>
+                <p className="mt-1 text-sm text-slate-300">{row.note}</p>
+              </div>
+              <p className="text-xs uppercase tracking-[0.22em] text-slate-400">
+                {selectedShiftId === "all" ? "All shifts" : "Focused shift"}
+              </p>
+            </div>
+            <div className={`mt-4 grid gap-3 ${shifts.length > 1 ? "lg:grid-cols-3" : ""}`}>
+              {shifts.map((shift) => {
+                const assignment = row.assignments.find(
+                  (block) => block.shiftId === shift.id,
+                );
+
+                if (!assignment) return null;
+
+                const delta = assignment.target - assignment.assigneeIds.length;
+                const resolvedNames = assignment.assigneeIds.map(
+                  (memberId) => memberDirectory[memberId]?.name ?? memberId,
+                );
+                const deltaLabel =
+                  delta > 0
+                    ? `${delta} open seat${delta > 1 ? "s" : ""}`
+                    : delta < 0
+                      ? `${Math.abs(delta)} flex cover`
+                      : "Target met";
+
+                return (
+                  <div
+                    className={`rounded-[1.35rem] border p-4 ${toneStyles[assignment.tone]}`}
+                    key={shift.id}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-semibold">{shift.label}</p>
+                        <p className="mt-1 text-xs uppercase tracking-[0.22em] opacity-80">{shift.window}</p>
+                      </div>
+                      <span className="rounded-full border border-current/30 px-2.5 py-1 text-xs uppercase tracking-[0.18em]">
+                        {assignment.tone}
+                      </span>
+                    </div>
+                    <p className="mt-4 text-3xl font-semibold">
+                      {assignment.assigneeIds.length}/{assignment.target}
+                    </p>
+                    <p className="mt-1 text-sm opacity-90">{deltaLabel}</p>
+                    <p className="mt-3 text-sm leading-6 opacity-90">{assignment.note}</p>
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      {resolvedNames.length > 0 ? (
+                        resolvedNames.map((name) => (
+                          <span className="rounded-full bg-slate-950/25 px-2.5 py-1 text-xs font-medium text-white" key={name}>
+                            {name}
+                          </span>
+                        ))
+                      ) : (
+                        <span className="rounded-full bg-slate-950/25 px-2.5 py-1 text-xs font-medium text-white">
+                          Unassigned
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/shift-planner/handoff-notes-panel.tsx
+++ b/src/components/shift-planner/handoff-notes-panel.tsx
@@ -1,0 +1,99 @@
+import type { HandoffStatus, PlannerShiftId } from "@/app/shift-planner/shift-planner-data";
+
+type ShiftFilter = PlannerShiftId | "all";
+
+type EditableNote = {
+  id: string;
+  title: string;
+  shiftId: PlannerShiftId;
+  ownerName: string;
+  status: HandoffStatus;
+  body: string;
+};
+
+type HandoffNotesPanelProps = {
+  notes: EditableNote[];
+  onBodyChange: (noteId: string, body: string) => void;
+  onToggleStatus: (noteId: string) => void;
+  selectedDayLabel: string;
+  selectedShiftId: ShiftFilter;
+};
+
+const shiftLabels: Record<PlannerShiftId, string> = {
+  dawn: "Dawn",
+  swing: "Swing",
+  night: "Night",
+};
+
+export function HandoffNotesPanel({
+  notes,
+  onBodyChange,
+  onToggleStatus,
+  selectedDayLabel,
+  selectedShiftId,
+}: HandoffNotesPanelProps) {
+  const readyCount = notes.filter((note) => note.status === "ready").length;
+
+  return (
+    <aside className="rounded-[1.9rem] border border-white/10 bg-slate-950/65 p-5 shadow-[0_20px_60px_rgba(2,8,23,0.28)] backdrop-blur">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.3em] text-sky-300">Hand-off Notes</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">Local notes for {selectedDayLabel}</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-300">
+            Drafts stay in local state only. Toggle readiness when a note is fit for the next shift.
+          </p>
+        </div>
+        <div className="rounded-[1.35rem] border border-white/10 bg-white/5 px-4 py-3 text-right">
+          <p className="text-xs uppercase tracking-[0.24em] text-slate-400">Readiness</p>
+          <p className="mt-2 text-2xl font-semibold text-white">{readyCount}/{notes.length}</p>
+        </div>
+      </div>
+      {notes.length > 0 ? (
+        <div className="mt-5 space-y-4">
+          {notes.map((note) => (
+            <article className="rounded-[1.55rem] border border-white/10 bg-white/5 p-4" key={note.id}>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.22em] text-sky-200/70">{shiftLabels[note.shiftId]}</p>
+                  <h3 className="mt-2 text-lg font-semibold text-white">{note.title}</h3>
+                  <p className="mt-1 text-sm text-slate-300">Owned by {note.ownerName}</p>
+                </div>
+                <button
+                  className={`rounded-full border px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] transition ${
+                    note.status === "ready"
+                      ? "border-emerald-400/30 bg-emerald-400/10 text-emerald-100"
+                      : "border-amber-300/30 bg-amber-300/10 text-amber-50"
+                  }`}
+                  onClick={() => onToggleStatus(note.id)}
+                  type="button"
+                >
+                  {note.status === "ready" ? "Ready to hand off" : "Needs review"}
+                </button>
+              </div>
+              <textarea
+                className="mt-4 min-h-28 w-full rounded-[1.2rem] border border-white/10 bg-slate-950/55 px-4 py-3 text-sm leading-6 text-slate-100 outline-none transition placeholder:text-slate-500 focus:border-sky-300/50"
+                onChange={(event) => onBodyChange(note.id, event.target.value)}
+                placeholder="Leave a local hand-off note"
+                value={note.body}
+              />
+              <p className="mt-3 text-xs uppercase tracking-[0.2em] text-slate-500">
+                Draft saved in memory for this route only.
+              </p>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-5 rounded-[1.55rem] border border-dashed border-white/15 bg-white/5 p-8 text-center">
+          <p className="text-xs uppercase tracking-[0.3em] text-slate-400">No notes</p>
+          <h3 className="mt-3 text-xl font-semibold text-white">No hand-off notes match this shift filter.</h3>
+          <p className="mt-3 text-sm leading-6 text-slate-300">
+            {selectedShiftId === "all"
+              ? "Switch to another day to review seeded notes."
+              : "Change the shift filter back to all shifts to reopen the local note queue."}
+          </p>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/components/shift-planner/shift-planner-filters.tsx
+++ b/src/components/shift-planner/shift-planner-filters.tsx
@@ -1,0 +1,92 @@
+import type {
+  PlannerRole,
+  PlannerRoleId,
+  PlannerShift,
+  PlannerShiftId,
+} from "@/app/shift-planner/shift-planner-data";
+
+type RoleFilter = PlannerRoleId | "all";
+type ShiftFilter = PlannerShiftId | "all";
+
+type ShiftPlannerFiltersProps = {
+  blockCount: number;
+  hasActiveFilters: boolean;
+  onClear: () => void;
+  onRoleChange: (roleId: RoleFilter) => void;
+  onShiftChange: (shiftId: ShiftFilter) => void;
+  roleCount: number;
+  roles: readonly PlannerRole[];
+  selectedRoleId: RoleFilter;
+  selectedShiftId: ShiftFilter;
+  shifts: readonly PlannerShift[];
+};
+
+function filterButton(active: boolean) {
+  return `rounded-full border px-3 py-2 text-sm font-medium transition ${
+    active
+      ? "border-sky-300 bg-sky-400/15 text-white"
+      : "border-white/10 bg-slate-950/40 text-slate-300 hover:border-sky-300/30 hover:text-white"
+  }`;
+}
+
+export function ShiftPlannerFilters({
+  blockCount,
+  hasActiveFilters,
+  onClear,
+  onRoleChange,
+  onShiftChange,
+  roleCount,
+  roles,
+  selectedRoleId,
+  selectedShiftId,
+  shifts,
+}: ShiftPlannerFiltersProps) {
+  return (
+    <section className="rounded-[1.8rem] border border-white/10 bg-slate-950/60 p-5 shadow-[0_18px_50px_rgba(2,8,23,0.3)] backdrop-blur">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.3em] text-sky-300">Filters</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">Role and shift scope</h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-300">
+            Narrow the matrix to a single desk or shift without leaving the day view.
+          </p>
+        </div>
+        <button
+          className="rounded-full border border-white/10 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-sky-300/40 hover:text-white disabled:cursor-not-allowed disabled:opacity-45"
+          disabled={!hasActiveFilters}
+          onClick={onClear}
+          type="button"
+        >
+          Reset filters
+        </button>
+      </div>
+      <div className="mt-5 grid gap-4 lg:grid-cols-2">
+        <div>
+          <p className="text-xs uppercase tracking-[0.24em] text-slate-400">Role</p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button className={filterButton(selectedRoleId === "all")} onClick={() => onRoleChange("all")} type="button">All roles</button>
+            {roles.map((role) => (
+              <button className={filterButton(selectedRoleId === role.id)} key={role.id} onClick={() => onRoleChange(role.id)} type="button">
+                {role.label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div>
+          <p className="text-xs uppercase tracking-[0.24em] text-slate-400">Shift</p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button className={filterButton(selectedShiftId === "all")} onClick={() => onShiftChange("all")} type="button">All shifts</button>
+            {shifts.map((shift) => (
+              <button className={filterButton(selectedShiftId === shift.id)} key={shift.id} onClick={() => onShiftChange(shift.id)} type="button">
+                {shift.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+      <p className="mt-5 text-sm text-slate-300">
+        {roleCount} roles and {blockCount} coverage blocks visible in the current view.
+      </p>
+    </section>
+  );
+}

--- a/src/components/shift-planner/shift-planner-header.tsx
+++ b/src/components/shift-planner/shift-planner-header.tsx
@@ -1,0 +1,90 @@
+import type { PlannerDay } from "@/app/shift-planner/shift-planner-data";
+
+type ShiftPlannerHeaderProps = {
+  days: PlannerDay[];
+  gapCount: number;
+  onSelectDay: (dayId: string) => void;
+  readyCount: number;
+  readyNotes: number;
+  selectedDayId: string;
+  staffing: PlannerDay["staffing"];
+  totalNotes: number;
+  watchCount: number;
+};
+
+function SummaryCard({
+  detail,
+  label,
+  value,
+}: {
+  detail: string;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-[1.4rem] border border-white/10 bg-white/5 px-4 py-3">
+      <p className="text-xs uppercase tracking-[0.26em] text-sky-200/70">{label}</p>
+      <p className="mt-2 text-2xl font-semibold text-white">{value}</p>
+      <p className="mt-1 text-sm text-slate-300">{detail}</p>
+    </div>
+  );
+}
+
+export function ShiftPlannerHeader({
+  days,
+  gapCount,
+  onSelectDay,
+  readyCount,
+  readyNotes,
+  selectedDayId,
+  staffing,
+  totalNotes,
+  watchCount,
+}: ShiftPlannerHeaderProps) {
+  const openSeats = Math.max(staffing.target - staffing.scheduled, 0);
+
+  return (
+    <section className="rounded-[2rem] border border-white/10 bg-slate-950/65 p-5 shadow-[0_24px_70px_rgba(2,8,23,0.4)] backdrop-blur sm:p-6">
+      <div className="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
+        <div className="max-w-3xl">
+          <p className="text-xs uppercase tracking-[0.45em] text-sky-300">Shift Planner</p>
+          <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+            Coverage matrix with local hand-off control.
+          </h1>
+          <p className="mt-3 text-sm leading-6 text-slate-300 sm:text-base">
+            Review role coverage by shift, keep staffing gaps visible, and leave
+            route-local notes for the next team without touching shared app state.
+          </p>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 xl:w-[29rem] xl:grid-cols-4">
+          <SummaryCard detail={openSeats ? `${openSeats} open seats` : "Target met"} label="Staffing" value={`${staffing.scheduled}/${staffing.target}`} />
+          <SummaryCard detail={`${watchCount} watch blocks`} label="Coverage" value={`${readyCount} ready`} />
+          <SummaryCard detail={`${gapCount} unresolved blocks`} label="Risk" value={gapCount ? "Gaps open" : "Stable"} />
+          <SummaryCard detail="Saved only in this route" label="Notes" value={`${readyNotes}/${totalNotes}`} />
+        </div>
+      </div>
+      <div className="mt-6 flex flex-wrap gap-3">
+        {days.map((day) => {
+          const isActive = day.id === selectedDayId;
+
+          return (
+            <button
+              className={`rounded-[1.4rem] border px-4 py-3 text-left transition ${
+                isActive
+                  ? "border-sky-300/80 bg-sky-400/15 text-white shadow-[0_16px_36px_rgba(14,165,233,0.18)]"
+                  : "border-white/10 bg-white/5 text-slate-200 hover:border-sky-300/40 hover:bg-white/10"
+              }`}
+              key={day.id}
+              onClick={() => onSelectDay(day.id)}
+              type="button"
+            >
+              <p className="text-sm font-semibold">{day.label}</p>
+              <p className="mt-1 text-sm text-slate-300">{day.dateLabel}</p>
+              <p className="mt-2 text-xs uppercase tracking-[0.22em] text-sky-200/70">{day.focus}</p>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/shift-planner/shift-planner-workspace.tsx
+++ b/src/components/shift-planner/shift-planner-workspace.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { startTransition, useState } from "react";
+import {
+  plannerRoles,
+  plannerShifts,
+  plannerTeamMembers,
+  shiftPlannerDays,
+  type HandoffStatus,
+  type PlannerDay,
+  type PlannerRoleId,
+  type PlannerShiftId,
+} from "@/app/shift-planner/shift-planner-data";
+import { CoverageMatrix } from "./coverage-matrix";
+import { HandoffNotesPanel } from "./handoff-notes-panel";
+import { ShiftPlannerFilters } from "./shift-planner-filters";
+import { ShiftPlannerHeader } from "./shift-planner-header";
+
+type RoleFilter = PlannerRoleId | "all";
+type ShiftFilter = PlannerShiftId | "all";
+type NoteDrafts = Record<string, { body: string; status: HandoffStatus }>;
+
+const memberDirectory = Object.fromEntries(
+  plannerTeamMembers.map((member) => [member.id, member]),
+);
+
+function createNoteDrafts(days: PlannerDay[]) {
+  return Object.fromEntries(
+    days.flatMap((day) =>
+      day.handoffNotes.map((note) => [
+        note.id,
+        { body: note.body, status: note.status },
+      ]),
+    ),
+  ) as NoteDrafts;
+}
+
+export function ShiftPlannerWorkspace() {
+  const [selectedDayId, setSelectedDayId] = useState(shiftPlannerDays[0]?.id ?? "");
+  const [selectedRoleId, setSelectedRoleId] = useState<RoleFilter>("all");
+  const [selectedShiftId, setSelectedShiftId] = useState<ShiftFilter>("all");
+  const [noteDrafts, setNoteDrafts] = useState(() => createNoteDrafts(shiftPlannerDays));
+
+  const selectedDay =
+    shiftPlannerDays.find((day) => day.id === selectedDayId) ?? shiftPlannerDays[0];
+  const visibleShifts =
+    selectedShiftId === "all"
+      ? plannerShifts
+      : plannerShifts.filter((shift) => shift.id === selectedShiftId);
+  const visibleRows = selectedDay.coverage.filter(
+    (row) => selectedRoleId === "all" || row.roleId === selectedRoleId,
+  );
+  const visibleBlockCount = visibleRows.reduce(
+    (count, row) =>
+      count +
+      row.assignments.filter(
+        (assignment) =>
+          selectedShiftId === "all" || assignment.shiftId === selectedShiftId,
+      ).length,
+    0,
+  );
+  const coverageTotals = selectedDay.coverage.flatMap((row) => row.assignments).reduce(
+    (counts, assignment) => ({ ...counts, [assignment.tone]: counts[assignment.tone] + 1 }),
+    { ready: 0, watch: 0, gap: 0 },
+  );
+  const dayReadyNotes = selectedDay.handoffNotes.filter(
+    (note) => noteDrafts[note.id]?.status === "ready",
+  ).length;
+  const visibleNotes = selectedDay.handoffNotes
+    .filter((note) => selectedShiftId === "all" || note.shiftId === selectedShiftId)
+    .map((note) => ({
+      ...note,
+      body: noteDrafts[note.id]?.body ?? note.body,
+      status: noteDrafts[note.id]?.status ?? note.status,
+      ownerName: memberDirectory[note.ownerId]?.name ?? note.ownerId,
+    }));
+  const hasActiveFilters = selectedRoleId !== "all" || selectedShiftId !== "all";
+
+  const handleNoteChange = (noteId: string, body: string) => {
+    startTransition(() => {
+      setNoteDrafts((current) => ({
+        ...current,
+        [noteId]: { ...current[noteId], body },
+      }));
+    });
+  };
+
+  const handleToggleStatus = (noteId: string) => {
+    startTransition(() => {
+      setNoteDrafts((current) => ({
+        ...current,
+        [noteId]: {
+          ...current[noteId],
+          status: current[noteId]?.status === "ready" ? "pending" : "ready",
+        },
+      }));
+    });
+  };
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(14,165,233,0.16),transparent_30%),linear-gradient(180deg,#03121c_0%,#08111d_55%,#020617_100%)] px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <ShiftPlannerHeader
+          days={shiftPlannerDays}
+          gapCount={coverageTotals.gap}
+          onSelectDay={(dayId) => startTransition(() => setSelectedDayId(dayId))}
+          readyCount={coverageTotals.ready}
+          readyNotes={dayReadyNotes}
+          selectedDayId={selectedDay.id}
+          staffing={selectedDay.staffing}
+          totalNotes={selectedDay.handoffNotes.length}
+          watchCount={coverageTotals.watch}
+        />
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(21rem,0.9fr)]">
+          <section className="space-y-6">
+            <ShiftPlannerFilters
+              blockCount={visibleBlockCount}
+              hasActiveFilters={hasActiveFilters}
+              onClear={() =>
+                startTransition(() => {
+                  setSelectedRoleId("all");
+                  setSelectedShiftId("all");
+                })
+              }
+              onRoleChange={(roleId) => startTransition(() => setSelectedRoleId(roleId))}
+              onShiftChange={(shiftId) => startTransition(() => setSelectedShiftId(shiftId))}
+              roleCount={visibleRows.length}
+              roles={plannerRoles}
+              selectedRoleId={selectedRoleId}
+              selectedShiftId={selectedShiftId}
+              shifts={plannerShifts}
+            />
+            <CoverageMatrix
+              memberDirectory={memberDirectory}
+              rows={visibleRows}
+              selectedDayLabel={selectedDay.dateLabel}
+              selectedShiftId={selectedShiftId}
+              shifts={visibleShifts}
+            />
+          </section>
+          <HandoffNotesPanel
+            notes={visibleNotes}
+            onBodyChange={handleNoteChange}
+            onToggleStatus={handleToggleStatus}
+            selectedDayLabel={selectedDay.dateLabel}
+            selectedShiftId={selectedShiftId}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/shift-planner` App Router route with local mock data and metadata
- build a client-side planner workspace with day selection, staffing summary, role and shift filters, and a coverage matrix
- add local editable hand-off notes with readiness markers and an empty state for filtered notes

Closes #27

## Validation
- `npx eslint src/app/shift-planner src/components/shift-planner --quiet`
- `npm run typecheck`
- `npm run build`
- `npm test` *(fails in existing `src/components/mission-briefing/MissionBriefingShell.test.tsx` due a timeout unrelated to this route)*