### PR TITLE
feat: add radar console route

### DIFF
--- a/src/app/radar-console/mock-data.ts
+++ b/src/app/radar-console/mock-data.ts
@@ -1,0 +1,81 @@
+export type SectorTone = "clear" | "watch" | "critical";
+export type ContactTone = "steady" | "watch" | "critical";
+
+export type SectorSummary = {
+  id: string;
+  label: string;
+  corridor: string;
+  tone: SectorTone;
+  contactCount: number;
+  alertCount: number;
+  sweepCoverage: number;
+  driftDelta: number;
+  readiness: string;
+};
+
+export type ContactCard = {
+  id: string;
+  callsign: string;
+  sectorId: string;
+  sectorLabel: string;
+  classification: string;
+  tone: ContactTone;
+  isAlerted: boolean;
+  altitude: number;
+  speed: number;
+  heading: string;
+  lastSeen: string;
+  summary: string;
+};
+
+export type AlertMarker = {
+  id: string;
+  label: string;
+  tone: ContactTone;
+  count: number;
+  detail: string;
+};
+
+export type InspectorDetail = {
+  contactId: string;
+  mission: string;
+  origin: string;
+  confidence: string;
+  handoffWindow: string;
+  snapshot: string;
+  noteChips: string[];
+  alertToggles: { id: string; label: string; description: string }[];
+};
+
+export const radarHeartbeatSeed = "2026-04-19T18:42:15.000Z";
+
+export const sectors: SectorSummary[] = [
+  { id: "nova", label: "Sector Nova", corridor: "North rim", tone: "critical", contactCount: 2, alertCount: 2, sweepCoverage: 94, driftDelta: 6, readiness: "Hold vector" },
+  { id: "sigma", label: "Sector Sigma", corridor: "Harbor lane", tone: "watch", contactCount: 2, alertCount: 1, sweepCoverage: 89, driftDelta: 11, readiness: "Queue intercept" },
+  { id: "orbit", label: "Sector Orbit", corridor: "Inner ring", tone: "clear", contactCount: 1, alertCount: 0, sweepCoverage: 98, driftDelta: 3, readiness: "Sweep stable" },
+  { id: "vanta", label: "Sector Vanta", corridor: "Far west", tone: "clear", contactCount: 1, alertCount: 0, sweepCoverage: 91, driftDelta: 5, readiness: "Passive hold" },
+];
+
+export const contacts: ContactCard[] = [
+  { id: "cinder-41", callsign: "Cinder-41", sectorId: "nova", sectorLabel: "Sector Nova", classification: "Fast mover", tone: "critical", isAlerted: true, altitude: 18200, speed: 612, heading: "047 NE", lastSeen: "18:42:15Z", summary: "High-energy climb crossing the north rim with unstable IFF returns." },
+  { id: "helix-12", callsign: "Helix-12", sectorId: "nova", sectorLabel: "Sector Nova", classification: "Relay drone", tone: "watch", isAlerted: true, altitude: 12400, speed: 318, heading: "101 E", lastSeen: "18:41:52Z", summary: "Holding a shallow eastbound arc while relay telemetry drifts outside tolerance." },
+  { id: "meridian-5", callsign: "Meridian-5", sectorId: "sigma", sectorLabel: "Sector Sigma", classification: "Surface skim", tone: "watch", isAlerted: true, altitude: 6400, speed: 274, heading: "189 S", lastSeen: "18:42:04Z", summary: "Harbor-lane contact pacing traffic flow with intermittent thermal bloom." },
+  { id: "aster-3", callsign: "Aster-3", sectorId: "sigma", sectorLabel: "Sector Sigma", classification: "Cargo escort", tone: "steady", isAlerted: false, altitude: 9600, speed: 228, heading: "214 SW", lastSeen: "18:41:39Z", summary: "Clean transponder pair on a routine escort path toward the outer docks." },
+  { id: "skipper-09", callsign: "Skipper-09", sectorId: "orbit", sectorLabel: "Sector Orbit", classification: "Survey wing", tone: "steady", isAlerted: false, altitude: 15100, speed: 192, heading: "332 NW", lastSeen: "18:41:18Z", summary: "Inner-ring survey loop remains inside assigned lane with stable telemetry." },
+  { id: "rook-77", callsign: "Rook-77", sectorId: "vanta", sectorLabel: "Sector Vanta", classification: "Silent track", tone: "steady", isAlerted: false, altitude: 8700, speed: 246, heading: "278 W", lastSeen: "18:40:55Z", summary: "Low-signature track coasting west with no fresh alert tags in the stack." },
+];
+
+export const alertMarkers: AlertMarker[] = [
+  { id: "burn", label: "Burn rate", tone: "critical", count: 2, detail: "Dual tracks exceeding nominal climb rate." },
+  { id: "iff", label: "IFF drift", tone: "watch", count: 3, detail: "Reply cadence outside synthetic baseline." },
+  { id: "handoff", label: "Handoff queue", tone: "watch", count: 1, detail: "One sector change pending confirmation." },
+];
+
+export const inspectorDetails: InspectorDetail[] = [
+  { contactId: "cinder-41", mission: "North rim containment", origin: "Beacon lattice 3A", confidence: "94% track confidence", handoffWindow: "02:14 until ridge exit", snapshot: "Cinder-41 is the current priority burn marker with enough closure to trigger a manual intercept recommendation.", noteChips: ["IFF stale", "Pitch spike", "Crosswind bias"], alertToggles: [{ id: "intercept", label: "Flag intercept", description: "Promote to the local intercept queue." }, { id: "jam", label: "Jam check", description: "Mark for spectrum verification on the next sweep." }, { id: "handoff", label: "Hold handoff", description: "Keep this track inside the current sector until review." }] },
+  { contactId: "helix-12", mission: "Relay integrity watch", origin: "Platform spine 6", confidence: "88% track confidence", handoffWindow: "03:27 until corridor edge", snapshot: "Helix-12 is maintaining route shape, but its relay signatures still pulse above the Nova watch band.", noteChips: ["Relay echo", "Vector split", "Low fuel bias"], alertToggles: [{ id: "stabilize", label: "Force stabilize", description: "Pin the contact to the current relay profile." }, { id: "probe", label: "Probe channel", description: "Queue a local telemetry replay check." }, { id: "shadow", label: "Shadow track", description: "Attach a second observer on the next cycle." }] },
+  { contactId: "meridian-5", mission: "Harbor lane verification", origin: "Pier sweep node 2", confidence: "81% track confidence", handoffWindow: "01:46 until dock line", snapshot: "Meridian-5 moves with the shipping pattern, but periodic thermal bloom keeps it on the Sigma watch board.", noteChips: ["Thermal bloom", "Wake masking", "Pier clutter"], alertToggles: [{ id: "intercept", label: "Flag intercept", description: "Escalate this skim track for closer watch." }, { id: "quiet", label: "Quiet ping", description: "Suppress noncritical pings for the next pass." }, { id: "escort", label: "Assign escort", description: "Mark for a local escort recommendation." }] },
+  { contactId: "aster-3", mission: "Escort continuity", origin: "Harbor relay mesh", confidence: "92% track confidence", handoffWindow: "04:11 until route merge", snapshot: "Aster-3 is clean and steady, serving as a low-noise reference track for the Sigma corridor.", noteChips: ["Cargo lane", "Stable transponder", "Routine merge"], alertToggles: [{ id: "mirror", label: "Mirror track", description: "Use this contact as a clean reference sample." }, { id: "handoff", label: "Prep handoff", description: "Stage the next sector transition." }, { id: "escort", label: "Extend escort", description: "Keep escort coverage on the next hop." }] },
+  { contactId: "skipper-09", mission: "Inner ring survey", origin: "Survey mast 4", confidence: "96% track confidence", handoffWindow: "05:06 until loop reset", snapshot: "Skipper-09 remains the calmest track in the sweep and helps anchor Orbit-sector drift checks.", noteChips: ["Survey loop", "Clear lane", "Stable sync"], alertToggles: [{ id: "anchor", label: "Anchor drift", description: "Use this track as the drift baseline." }, { id: "mirror", label: "Mirror sweep", description: "Replay on the next orbit pass." }, { id: "quiet", label: "Quiet ping", description: "Reduce console noise from routine updates." }] },
+  { contactId: "rook-77", mission: "Far west passive watch", origin: "Edge repeater 1", confidence: "84% track confidence", handoffWindow: "06:22 until fade line", snapshot: "Rook-77 is quiet, low-signature, and currently carries no active alert tags inside Sector Vanta.", noteChips: ["Silent track", "Low return", "Wide drift"], alertToggles: [{ id: "promote", label: "Promote watch", description: "Lift this track into the watch column manually." }, { id: "quiet", label: "Quiet ping", description: "Keep the console clear unless the tone changes." }, { id: "handoff", label: "Draft handoff", description: "Stage a westbound handoff package." }] },
+];

--- a/src/app/radar-console/page.tsx
+++ b/src/app/radar-console/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+import { RadarConsoleShell } from "@/components/radar-console/radar-console-shell";
+
+export const metadata: Metadata = {
+  title: "Radar Console | API Test",
+  description:
+    "Synthetic tracking console with sector summaries, contact cards, and a focused inspector panel.",
+};
+
+export default function RadarConsolePage() {
+  return <RadarConsoleShell />;
+}

--- a/src/components/radar-console/contact-inspector.tsx
+++ b/src/components/radar-console/contact-inspector.tsx
@@ -1,0 +1,110 @@
+import type { ContactCard, InspectorDetail } from "@/app/radar-console/mock-data";
+
+type ContactInspectorProps = {
+  activeAlertIds: string[];
+  activeNoteIds: string[];
+  contact: ContactCard | null;
+  detail: InspectorDetail | null;
+  onClearSelection: () => void;
+  onToggleAlert: (alertId: string) => void;
+  onToggleNote: (noteId: string) => void;
+};
+
+export function ContactInspector({
+  activeAlertIds,
+  activeNoteIds,
+  contact,
+  detail,
+  onClearSelection,
+  onToggleAlert,
+  onToggleNote,
+}: ContactInspectorProps) {
+  return (
+    <aside
+      aria-label="Contact inspector"
+      className="rounded-[2rem] border border-cyan-300/15 bg-slate-950/78 p-5 text-slate-100 backdrop-blur"
+    >
+      {!contact || !detail ? (
+        <div className="flex min-h-80 flex-col items-center justify-center rounded-[1.6rem] border border-dashed border-white/15 bg-black/15 px-6 text-center">
+          <p className="text-xs uppercase tracking-[0.35em] text-cyan-300/70">Inspector idle</p>
+          <h2 className="mt-3 text-2xl font-semibold text-white">No track selected</h2>
+          <p className="mt-3 max-w-sm text-sm leading-6 text-slate-400">Choose a contact card to open the local inspector, then use the chips below to stage alert and note changes for this session.</p>
+        </div>
+      ) : (
+        <>
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-xs uppercase tracking-[0.35em] text-cyan-300/70">Inspector</p>
+              <h2 className="mt-2 text-3xl font-semibold text-white">{contact.callsign}</h2>
+              <p className="mt-1 text-sm text-slate-300">{detail.mission}</p>
+            </div>
+            <button
+              type="button"
+              onClick={onClearSelection}
+              className="rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-slate-200 transition hover:border-cyan-200/30 hover:text-white"
+            >
+              Clear
+            </button>
+          </div>
+
+          <div className="mt-5 rounded-[1.6rem] border border-white/10 bg-black/15 p-4">
+            <p className="text-sm leading-6 text-slate-300">{detail.snapshot}</p>
+            <div className="mt-4 grid gap-3 sm:grid-cols-3">
+              <div className="rounded-2xl bg-white/5 px-3 py-3"><span className="block text-xs uppercase tracking-[0.18em] text-slate-400">Origin</span>{detail.origin}</div>
+              <div className="rounded-2xl bg-white/5 px-3 py-3"><span className="block text-xs uppercase tracking-[0.18em] text-slate-400">Confidence</span>{detail.confidence}</div>
+              <div className="rounded-2xl bg-white/5 px-3 py-3"><span className="block text-xs uppercase tracking-[0.18em] text-slate-400">Handoff</span>{detail.handoffWindow}</div>
+            </div>
+          </div>
+
+          <section className="mt-5">
+            <p className="text-xs uppercase tracking-[0.3em] text-cyan-300/70">Local alert toggles</p>
+            <div className="mt-3 space-y-3">
+              {detail.alertToggles.map((toggle) => {
+                const isActive = activeAlertIds.includes(toggle.id);
+
+                return (
+                  <button
+                    key={toggle.id}
+                    type="button"
+                    aria-pressed={isActive}
+                    aria-label={`${isActive ? "Disable" : "Enable"} ${toggle.label}`}
+                    onClick={() => onToggleAlert(toggle.id)}
+                    className={`w-full rounded-[1.35rem] border px-4 py-3 text-left transition ${isActive ? "border-cyan-300/40 bg-cyan-300/10 text-cyan-100" : "border-white/10 bg-white/5 text-slate-100 hover:border-cyan-200/25"}`}
+                  >
+                    <span className="block text-sm font-semibold text-white">{toggle.label}</span>
+                    <span className="mt-1 block text-sm text-current/80">{toggle.description}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          <section className="mt-5">
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-xs uppercase tracking-[0.3em] text-cyan-300/70">Note chips</p>
+              <span className="text-xs uppercase tracking-[0.2em] text-slate-500">Local only</span>
+            </div>
+            <div className="mt-3 flex flex-wrap gap-3">
+              {detail.noteChips.map((note) => {
+                const isActive = activeNoteIds.includes(note);
+
+                return (
+                  <button
+                    key={note}
+                    type="button"
+                    aria-pressed={isActive}
+                    aria-label={`Toggle note ${note}`}
+                    onClick={() => onToggleNote(note)}
+                    className={`rounded-full border px-3 py-2 text-sm font-medium transition ${isActive ? "border-amber-300/35 bg-amber-300/12 text-amber-100" : "border-white/10 bg-white/5 text-slate-200 hover:border-amber-200/25 hover:text-white"}`}
+                  >
+                    {note}
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+        </>
+      )}
+    </aside>
+  );
+}

--- a/src/components/radar-console/contact-list.tsx
+++ b/src/components/radar-console/contact-list.tsx
@@ -1,0 +1,91 @@
+import type { ContactCard } from "@/app/radar-console/mock-data";
+
+type ContactListProps = {
+  alertsOnly: boolean;
+  contacts: ContactCard[];
+  focusedSector: string | null;
+  onSelectContact: (contactId: string) => void;
+  onToggleAlertsOnly: () => void;
+  selectedContactId: string | null;
+};
+
+const toneClasses = {
+  steady: "border-slate-700/80 bg-slate-900/80",
+  watch: "border-amber-300/20 bg-amber-300/8",
+  critical: "border-rose-400/20 bg-rose-400/8",
+};
+
+export function ContactList({
+  alertsOnly,
+  contacts,
+  focusedSector,
+  onSelectContact,
+  onToggleAlertsOnly,
+  selectedContactId,
+}: ContactListProps) {
+  const scopeLabel = focusedSector ?? "All sectors";
+
+  return (
+    <section className="rounded-[2rem] border border-cyan-300/15 bg-slate-950/70 p-5 text-slate-100 backdrop-blur">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.35em] text-cyan-300/70">Contacts</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">Tracks in scope</h2>
+          <p className="mt-1 text-sm text-slate-400">{scopeLabel}. Tap a card again to clear the inspector.</p>
+        </div>
+        <button
+          type="button"
+          onClick={onToggleAlertsOnly}
+          className={`rounded-full border px-4 py-2 text-sm font-medium transition ${alertsOnly ? "border-cyan-300/40 bg-cyan-300/10 text-cyan-100" : "border-white/10 bg-white/5 text-slate-200 hover:border-cyan-200/30 hover:text-white"}`}
+          aria-pressed={alertsOnly}
+          aria-label={alertsOnly ? "Show all contacts" : "Show alert contacts only"}
+        >
+          {alertsOnly ? "Alert-only filter active" : "Show alert contacts only"}
+        </button>
+      </div>
+
+      {contacts.length === 0 ? (
+        <div className="mt-5 rounded-[1.6rem] border border-dashed border-white/15 bg-black/15 px-5 py-8 text-center">
+          <p className="text-lg font-medium text-white">No alert-marked contacts remain in {scopeLabel}.</p>
+          <p className="mt-2 text-sm text-slate-400">Drop the alert-only filter or release the sector focus to widen the sweep.</p>
+        </div>
+      ) : (
+        <div className="mt-5 space-y-3">
+          {contacts.map((contact) => {
+            const isSelected = selectedContactId === contact.id;
+
+            return (
+              <button
+                key={contact.id}
+                type="button"
+                aria-pressed={isSelected}
+                onClick={() => onSelectContact(contact.id)}
+                className={`w-full rounded-[1.5rem] border p-4 text-left transition hover:border-cyan-200/35 ${toneClasses[contact.tone]} ${isSelected ? "ring-1 ring-cyan-300/60" : ""}`}
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.24em] text-slate-400">{contact.sectorLabel}</p>
+                    <h3 className="mt-2 text-xl font-semibold text-white">{contact.callsign}</h3>
+                    <p className="mt-1 text-sm text-slate-300">{contact.classification}</p>
+                  </div>
+                  <div className="flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.2em]">
+                    {contact.isAlerted ? <span className="rounded-full bg-rose-400/15 px-2.5 py-1 text-rose-100">Alert</span> : null}
+                    <span className="rounded-full bg-black/20 px-2.5 py-1 text-slate-200">{contact.lastSeen}</span>
+                  </div>
+                </div>
+
+                <p className="mt-4 text-sm leading-6 text-slate-300">{contact.summary}</p>
+
+                <div className="mt-4 flex flex-wrap gap-2 text-xs uppercase tracking-[0.18em] text-slate-300">
+                  <span className="rounded-full bg-black/20 px-2.5 py-1">{contact.altitude.toLocaleString()} ft</span>
+                  <span className="rounded-full bg-black/20 px-2.5 py-1">{contact.speed} kt</span>
+                  <span className="rounded-full bg-black/20 px-2.5 py-1">{contact.heading}</span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/radar-console/radar-console-header.tsx
+++ b/src/components/radar-console/radar-console-header.tsx
@@ -1,0 +1,74 @@
+import type { AlertMarker } from "@/app/radar-console/mock-data";
+
+type RadarConsoleHeaderProps = {
+  focusedSector: string | null;
+  heartbeat: string;
+  markers: AlertMarker[];
+  scopeCount: number;
+  sweepStatus: string;
+  watchCount: number;
+};
+
+const toneClasses = {
+  steady: "border-emerald-400/30 bg-emerald-400/10 text-emerald-100",
+  watch: "border-amber-300/30 bg-amber-300/10 text-amber-100",
+  critical: "border-rose-400/30 bg-rose-400/10 text-rose-100",
+};
+
+export function RadarConsoleHeader({
+  focusedSector,
+  heartbeat,
+  markers,
+  scopeCount,
+  sweepStatus,
+  watchCount,
+}: RadarConsoleHeaderProps) {
+  return (
+    <header className="rounded-[2rem] border border-cyan-300/15 bg-slate-950/75 p-5 text-slate-100 shadow-[0_24px_80px_-44px_rgba(34,211,238,0.6)] backdrop-blur">
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-3">
+          <p className="text-xs uppercase tracking-[0.4em] text-cyan-300/70">Radar console</p>
+          <div className="flex flex-wrap items-center gap-3">
+            <h1 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Synthetic sector sweep</h1>
+            <span className="rounded-full border border-cyan-300/25 bg-cyan-300/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.25em] text-cyan-100">
+              {sweepStatus}
+            </span>
+          </div>
+          <p className="max-w-2xl text-sm text-slate-300">
+            {focusedSector ? `${focusedSector} is pinned for the current pass.` : "The console is sampling all four sectors on this pass."} Heartbeat {heartbeat}.
+          </p>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-3">
+          <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+            <p className="text-xs uppercase tracking-[0.25em] text-slate-400">Tracks in scope</p>
+            <p className="mt-2 text-3xl font-semibold text-white">{scopeCount}</p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+            <p className="text-xs uppercase tracking-[0.25em] text-slate-400">Watch tags</p>
+            <p className="mt-2 text-3xl font-semibold text-white">{watchCount}</p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+            <p className="text-xs uppercase tracking-[0.25em] text-slate-400">Heartbeat</p>
+            <p className="mt-2 text-2xl font-semibold text-white">{heartbeat}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-5 flex flex-wrap gap-3">
+        {markers.map((marker) => (
+          <div
+            key={marker.id}
+            className={`min-w-48 flex-1 rounded-2xl border px-4 py-3 ${toneClasses[marker.tone]}`}
+          >
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-sm font-medium uppercase tracking-[0.18em]">{marker.label}</p>
+              <span className="rounded-full bg-black/20 px-2.5 py-1 text-xs font-semibold">{marker.count}</span>
+            </div>
+            <p className="mt-2 text-sm text-current/85">{marker.detail}</p>
+          </div>
+        ))}
+      </div>
+    </header>
+  );
+}

--- a/src/components/radar-console/radar-console-shell.test.tsx
+++ b/src/components/radar-console/radar-console-shell.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { RadarConsoleShell } from "./radar-console-shell";
+
+describe("RadarConsoleShell", () => {
+  it("shows the filtered empty state when a quiet sector is focused in alert-only mode", () => {
+    render(<RadarConsoleShell />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Focus Sector Vanta/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Show alert contacts only/i }));
+
+    expect(screen.getByText(/No alert-marked contacts remain in Sector Vanta/i)).toBeInTheDocument();
+  });
+
+  it("updates the inspector and tracks local alert toggles", () => {
+    render(<RadarConsoleShell />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Meridian-5/i }));
+
+    const inspector = screen.getByLabelText(/Contact inspector/i);
+    expect(within(inspector).getByRole("heading", { name: /Meridian-5/i })).toBeInTheDocument();
+
+    fireEvent.click(within(inspector).getByRole("button", { name: /Enable Flag intercept/i }));
+    expect(within(inspector).getByRole("button", { name: /Disable Flag intercept/i })).toHaveAttribute("aria-pressed", "true");
+
+    fireEvent.click(within(inspector).getByRole("button", { name: /Toggle note Thermal bloom/i }));
+    expect(within(inspector).getByRole("button", { name: /Toggle note Thermal bloom/i })).toHaveAttribute("aria-pressed", "true");
+  });
+});

--- a/src/components/radar-console/radar-console-shell.tsx
+++ b/src/components/radar-console/radar-console-shell.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { startTransition, useEffect, useEffectEvent, useState } from "react";
+
+import {
+  alertMarkers,
+  contacts,
+  inspectorDetails,
+  radarHeartbeatSeed,
+  sectors,
+} from "@/app/radar-console/mock-data";
+import { ContactInspector } from "./contact-inspector";
+import { ContactList } from "./contact-list";
+import { RadarConsoleHeader } from "./radar-console-header";
+import { SectorGrid } from "./sector-grid";
+
+const heartbeatFormatter = new Intl.DateTimeFormat("en-US", {
+  hour: "2-digit",
+  hour12: false,
+  minute: "2-digit",
+  second: "2-digit",
+  timeZone: "UTC",
+});
+const heartbeatStepMs = 4000;
+
+function toggleId(items: string[], id: string) {
+  return items.includes(id) ? items.filter((item) => item !== id) : [...items, id];
+}
+
+function buildScopedId(contactId: string, itemId: string) {
+  return `${contactId}:${itemId}`;
+}
+
+function filterContacts(focusedSectorId: string | null, alertsOnly: boolean) {
+  return contacts.filter((contact) => {
+    if (focusedSectorId && contact.sectorId !== focusedSectorId) return false;
+    return !alertsOnly || contact.isAlerted;
+  });
+}
+
+export function RadarConsoleShell() {
+  const [focusedSectorId, setFocusedSectorId] = useState<string | null>(null);
+  const [selectedContactId, setSelectedContactId] = useState<string | null>(contacts[0]?.id ?? null);
+  const [alertsOnly, setAlertsOnly] = useState(false);
+  const [activeAlertKeys, setActiveAlertKeys] = useState<string[]>([]);
+  const [activeNoteKeys, setActiveNoteKeys] = useState<string[]>([]);
+  const [heartbeatTick, setHeartbeatTick] = useState(0);
+
+  const tickHeartbeat = useEffectEvent(() => {
+    setHeartbeatTick((value) => value + 1);
+  });
+
+  useEffect(() => {
+    const timerId = window.setInterval(() => tickHeartbeat(), heartbeatStepMs);
+    return () => window.clearInterval(timerId);
+  }, []);
+
+  const focusedSector = sectors.find((sector) => sector.id === focusedSectorId) ?? null;
+  const visibleContacts = filterContacts(focusedSectorId, alertsOnly);
+  const selectedContact = visibleContacts.find((contact) => contact.id === selectedContactId) ?? null;
+  const selectedDetail = inspectorDetails.find((detail) => detail.contactId === selectedContact?.id) ?? null;
+  const activeAlertIds = selectedContact
+    ? activeAlertKeys
+        .filter((id) => id.startsWith(`${selectedContact.id}:`))
+        .map((id) => id.split(":")[1] ?? id)
+    : [];
+  const activeNoteIds = selectedContact
+    ? activeNoteKeys
+        .filter((id) => id.startsWith(`${selectedContact.id}:`))
+        .map((id) => id.split(":")[1] ?? id)
+    : [];
+  const watchCount = visibleContacts.filter((contact) => contact.tone !== "steady").length;
+  const heartbeat = heartbeatFormatter.format(
+    new Date(new Date(radarHeartbeatSeed).getTime() + heartbeatTick * heartbeatStepMs),
+  );
+  const sweepStatus = focusedSector
+    ? `${focusedSector.label} focus`
+    : alertsOnly
+      ? "Alert-only pass"
+      : sectors.some((sector) => sector.tone === "critical")
+        ? "Priority sweep"
+        : "Nominal sweep";
+
+  const syncSelection = (nextSectorId: string | null, nextAlertsOnly: boolean) => {
+    const nextVisibleContacts = filterContacts(nextSectorId, nextAlertsOnly);
+    setSelectedContactId((current) =>
+      nextVisibleContacts.some((contact) => contact.id === current)
+        ? current
+        : nextVisibleContacts[0]?.id ?? null,
+    );
+  };
+
+  const handleToggleSectorFocus = (sectorId: string) => {
+    startTransition(() => {
+      const nextSectorId = focusedSectorId === sectorId ? null : sectorId;
+      setFocusedSectorId(nextSectorId);
+      syncSelection(nextSectorId, alertsOnly);
+    });
+  };
+
+  const handleToggleAlertsOnly = () => {
+    startTransition(() => {
+      const nextAlertsOnly = !alertsOnly;
+      setAlertsOnly(nextAlertsOnly);
+      syncSelection(focusedSectorId, nextAlertsOnly);
+    });
+  };
+
+  const handleSelectContact = (contactId: string) => {
+    startTransition(() => {
+      setSelectedContactId((current) => (current === contactId ? null : contactId));
+    });
+  };
+
+  const handleToggleAlert = (alertId: string) => {
+    if (!selectedContact) return;
+    setActiveAlertKeys((items) => toggleId(items, buildScopedId(selectedContact.id, alertId)));
+  };
+
+  const handleToggleNote = (noteId: string) => {
+    if (!selectedContact) return;
+    setActiveNoteKeys((items) => toggleId(items, buildScopedId(selectedContact.id, noteId)));
+  };
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(6,182,212,0.18),_transparent_32%),radial-gradient(circle_at_bottom_right,_rgba(245,158,11,0.14),_transparent_26%),linear-gradient(160deg,_#020617_0%,_#06121f_45%,_#0f172a_100%)] px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <RadarConsoleHeader
+          focusedSector={focusedSector?.label ?? null}
+          heartbeat={heartbeat}
+          markers={alertMarkers}
+          scopeCount={visibleContacts.length}
+          sweepStatus={sweepStatus}
+          watchCount={watchCount}
+        />
+
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.9fr)]">
+          <div className="space-y-6">
+            <SectorGrid focusedSectorId={focusedSectorId} onToggleFocus={handleToggleSectorFocus} sectors={sectors} />
+            <ContactList
+              alertsOnly={alertsOnly}
+              contacts={visibleContacts}
+              focusedSector={focusedSector?.label ?? null}
+              onSelectContact={handleSelectContact}
+              onToggleAlertsOnly={handleToggleAlertsOnly}
+              selectedContactId={selectedContactId}
+            />
+          </div>
+
+          <ContactInspector
+            activeAlertIds={activeAlertIds}
+            activeNoteIds={activeNoteIds}
+            contact={selectedContact}
+            detail={selectedDetail}
+            onClearSelection={() => setSelectedContactId(null)}
+            onToggleAlert={handleToggleAlert}
+            onToggleNote={handleToggleNote}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/radar-console/sector-grid.tsx
+++ b/src/components/radar-console/sector-grid.tsx
@@ -1,0 +1,67 @@
+import type { SectorSummary } from "@/app/radar-console/mock-data";
+
+type SectorGridProps = {
+  focusedSectorId: string | null;
+  onToggleFocus: (sectorId: string) => void;
+  sectors: SectorSummary[];
+};
+
+const sectorToneClasses = {
+  clear: "border-emerald-300/15 bg-emerald-300/10 text-emerald-100",
+  watch: "border-amber-300/20 bg-amber-300/10 text-amber-100",
+  critical: "border-rose-400/20 bg-rose-400/10 text-rose-100",
+};
+
+export function SectorGrid({ focusedSectorId, onToggleFocus, sectors }: SectorGridProps) {
+  return (
+    <section className="rounded-[2rem] border border-cyan-300/15 bg-slate-950/70 p-5 text-slate-100 backdrop-blur">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-[0.35em] text-cyan-300/70">Sector grid</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">Focus controls</h2>
+        </div>
+        <p className="max-w-xs text-right text-sm text-slate-400">Pin a sector to narrow the contact stack without leaving this route.</p>
+      </div>
+
+      <div className="mt-5 grid gap-4 md:grid-cols-2">
+        {sectors.map((sector) => {
+          const isFocused = focusedSectorId === sector.id;
+
+          return (
+            <article
+              key={sector.id}
+              className={`rounded-[1.6rem] border p-4 transition ${sectorToneClasses[sector.tone]} ${isFocused ? "ring-1 ring-cyan-300/60" : ""}`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.28em] text-current/75">{sector.corridor}</p>
+                  <h3 className="mt-2 text-xl font-semibold text-white">{sector.label}</h3>
+                </div>
+                <span className="rounded-full bg-black/20 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.22em]">
+                  {sector.readiness}
+                </span>
+              </div>
+
+              <div className="mt-4 grid grid-cols-2 gap-3 text-sm text-current/85">
+                <div className="rounded-2xl bg-black/20 px-3 py-2"><span className="block text-xs uppercase tracking-[0.18em] text-current/65">Contacts</span>{sector.contactCount}</div>
+                <div className="rounded-2xl bg-black/20 px-3 py-2"><span className="block text-xs uppercase tracking-[0.18em] text-current/65">Alerts</span>{sector.alertCount}</div>
+                <div className="rounded-2xl bg-black/20 px-3 py-2"><span className="block text-xs uppercase tracking-[0.18em] text-current/65">Coverage</span>{sector.sweepCoverage}%</div>
+                <div className="rounded-2xl bg-black/20 px-3 py-2"><span className="block text-xs uppercase tracking-[0.18em] text-current/65">Drift</span>{sector.driftDelta} ms</div>
+              </div>
+
+              <button
+                type="button"
+                aria-pressed={isFocused}
+                aria-label={isFocused ? `Release focus for ${sector.label}` : `Focus ${sector.label}`}
+                onClick={() => onToggleFocus(sector.id)}
+                className="mt-4 w-full rounded-2xl border border-white/15 bg-black/20 px-4 py-3 text-sm font-medium text-white transition hover:border-cyan-200/40 hover:bg-black/30"
+              >
+                {isFocused ? "Release focus" : "Focus sector"}
+              </button>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/radar-console` app route with feature-local mock data only
- build a responsive radar console shell with sector focus controls, contact cards, alert markers, and a local inspector
- cover the main console interactions with a focused Vitest case

## Validation
- npm run typecheck
- npm run lint
- npm test
- npm run build

Closes #25