### PR TITLE
feat: add dispatch center route

### DIFF
--- a/src/app/dispatch-center/mock-data.ts
+++ b/src/app/dispatch-center/mock-data.ts
@@ -1,0 +1,57 @@
+export const bucketOrder = ["intake", "dispatch", "hold"] as const;
+export type BucketId = (typeof bucketOrder)[number];
+export type QueueId = "priority" | "recovery" | "returns";
+export type DispatchPriority = "critical" | "watch" | "steady";
+export type QueueDefinition = { id: QueueId; label: string; detail: string; serviceTarget: string; windowLabel: string };
+export type OperatorRecord = { id: string; name: string; focus: string; capacity: number; shift: string };
+export type DispatchAssignment = {
+  id: string; title: string; location: string; queueId: QueueId; bucketId: BucketId; operatorId: string;
+  priority: DispatchPriority; etaLabel: string; ageMinutes: number; note: string;
+};
+export type WorkloadTotals = { openAssignments: number; readyCount: number; holdCount: number };
+export type DispatchCenterSnapshot = {
+  shiftLabel: string; shiftWindow: string; lastUpdated: string; queues: QueueDefinition[];
+  operators: OperatorRecord[]; assignments: DispatchAssignment[]; workloadTotals: WorkloadTotals;
+};
+
+const queues: QueueDefinition[] = [
+  { id: "priority", label: "Priority Response", detail: "Escalated field calls that need a near-immediate reroute or operator handoff.", serviceTarget: "Target under 15 min", windowLabel: "Rapid" },
+  { id: "recovery", label: "Route Recovery", detail: "Work dropped from live routes because of timing slips, access holds, or asset conflicts.", serviceTarget: "Re-sequence inside 30 min", windowLabel: "Flex" },
+  { id: "returns", label: "Returns Lane", detail: "Return trips and callbacks grouped for low-friction reassignment before end of shift.", serviceTarget: "Close before shift handoff", windowLabel: "Later" },
+];
+
+const operators: OperatorRecord[] = [
+  { id: "op-mika", name: "Mika Solis", focus: "Downtown core", capacity: 4, shift: "12:00-20:00" },
+  { id: "op-jordan", name: "Jordan Hale", focus: "Airport ring", capacity: 3, shift: "11:30-19:30" },
+  { id: "op-priya", name: "Priya Nori", focus: "North loop", capacity: 4, shift: "12:00-20:00" },
+  { id: "op-sera", name: "Sera Quinn", focus: "Returns + overflow", capacity: 3, shift: "13:00-21:00" },
+];
+
+const assignments: DispatchAssignment[] = [
+  { id: "asg-101", title: "Generator restart", location: "Tower A", queueId: "priority", bucketId: "intake", operatorId: "op-mika", priority: "critical", etaLabel: "12 min", ageMinutes: 9, note: "Badge access needs reconfirmation." },
+  { id: "asg-102", title: "Cold-chain pickup", location: "South Dock", queueId: "priority", bucketId: "dispatch", operatorId: "op-jordan", priority: "critical", etaLabel: "18 min", ageMinutes: 14, note: "Vehicle staged and waiting for release." },
+  { id: "asg-103", title: "Relay route rebuild", location: "Airport feeder", queueId: "recovery", bucketId: "dispatch", operatorId: "op-priya", priority: "watch", etaLabel: "27 min", ageMinutes: 22, note: "Route trimmed after a missed handoff." },
+  { id: "asg-104", title: "Return label swap", location: "Harbor clinic", queueId: "returns", bucketId: "hold", operatorId: "op-sera", priority: "steady", etaLabel: "41 min", ageMinutes: 36, note: "Waiting on corrected manifest." },
+  { id: "asg-105", title: "Overnight spillover", location: "North annex", queueId: "recovery", bucketId: "intake", operatorId: "op-priya", priority: "watch", etaLabel: "34 min", ageMinutes: 17, note: "Reassign after lift-gate slot opens." },
+  { id: "asg-106", title: "Customer callback", location: "Maple district", queueId: "returns", bucketId: "dispatch", operatorId: "op-sera", priority: "steady", etaLabel: "55 min", ageMinutes: 24, note: "Window confirmed with recipient." },
+  { id: "asg-107", title: "Battery relay", location: "Gate 6", queueId: "priority", bucketId: "hold", operatorId: "op-jordan", priority: "watch", etaLabel: "20 min", ageMinutes: 19, note: "Courier is waiting on hazmat seal." },
+  { id: "asg-108", title: "Same-route merge", location: "Riverside block", queueId: "recovery", bucketId: "dispatch", operatorId: "op-mika", priority: "steady", etaLabel: "29 min", ageMinutes: 11, note: "Can move once two stops are merged." },
+  { id: "asg-109", title: "Return tote recovery", location: "Union market", queueId: "returns", bucketId: "intake", operatorId: "op-sera", priority: "watch", etaLabel: "47 min", ageMinutes: 13, note: "Tote scan mismatch flagged for review." },
+];
+
+export function calculateWorkloadTotals(items: DispatchAssignment[]): WorkloadTotals {
+  return { openAssignments: items.length, readyCount: items.filter((item) => item.bucketId === "dispatch").length, holdCount: items.filter((item) => item.bucketId === "hold").length };
+}
+
+export function buildDispatchCenterSnapshot(): DispatchCenterSnapshot {
+  const clonedAssignments = assignments.map((assignment) => ({ ...assignment }));
+  return {
+    shiftLabel: "Swing Shift",
+    shiftWindow: "12:00-20:00 local",
+    lastUpdated: "Local sync 08:14",
+    queues: queues.map((queue) => ({ ...queue })),
+    operators: operators.map((operator) => ({ ...operator })),
+    assignments: clonedAssignments,
+    workloadTotals: calculateWorkloadTotals(clonedAssignments),
+  };
+}

--- a/src/app/dispatch-center/page.tsx
+++ b/src/app/dispatch-center/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { buildDispatchCenterSnapshot } from "./mock-data";
+import { DispatchCenterShell } from "@/components/dispatch-center/dispatch-center-shell";
+
+export const metadata: Metadata = {
+  title: "Dispatch Center | API Test",
+  description: "Isolated dispatch board with queue buckets, operator load cards, and local drawer state.",
+};
+
+export default function DispatchCenterPage() {
+  return <DispatchCenterShell initialSnapshot={buildDispatchCenterSnapshot()} />;
+}

--- a/src/components/dispatch-center/assignment-buckets.tsx
+++ b/src/components/dispatch-center/assignment-buckets.tsx
@@ -1,0 +1,102 @@
+import type { DispatchAssignment, OperatorRecord, QueueDefinition, QueueId } from "@/app/dispatch-center/mock-data";
+
+type AssignmentBucketsProps = {
+  assignments: DispatchAssignment[]; onMoveAssignment: (assignmentId: string, direction: -1 | 1) => void;
+  onQueueFilterChange: (filter: QueueId | "all") => void; onSelectAssignment: (assignmentId: string) => void;
+  operators: OperatorRecord[]; queueCounts: Record<QueueId, number>; queueFilter: QueueId | "all"; queues: QueueDefinition[];
+  selectedAssignmentId: string | null; selectedOperatorId: string | null;
+};
+
+const bucketMeta = [
+  { id: "intake", label: "Intake", detail: "Fresh queue drops and newly recovered work." },
+  { id: "dispatch", label: "Ready Board", detail: "Operator-confirmed work waiting for release." },
+  { id: "hold", label: "Hold Bucket", detail: "Paused items waiting on access, stock, or approval." },
+] as const;
+const priorityTone = { critical: "border-amber-300/25 bg-amber-300/10 text-amber-100", watch: "border-sky-300/25 bg-sky-300/10 text-sky-100", steady: "border-emerald-300/25 bg-emerald-300/10 text-emerald-100" };
+
+export function AssignmentBuckets({
+  assignments, onMoveAssignment, onQueueFilterChange, onSelectAssignment, operators, queueCounts, queueFilter, queues, selectedAssignmentId, selectedOperatorId,
+}: AssignmentBucketsProps) {
+  const operatorMap = Object.fromEntries(operators.map((operator) => [operator.id, operator.name]));
+  const queueLabelMap = Object.fromEntries(queues.map((queue) => [queue.id, queue.label]));
+  const filteredAssignments = assignments.filter((assignment) => queueFilter === "all" || assignment.queueId === queueFilter);
+
+  return (
+    <section className="rounded-[2rem] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.9),rgba(2,6,23,0.94))] p-5 shadow-[0_22px_80px_rgba(0,0,0,0.34)] sm:p-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Assignment board</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">Queue buckets with local movement controls</h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-300">Filter by queue, select a card to sync the drawer, and move items between buckets without leaving this route.</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button className={`rounded-full px-3 py-2 text-sm transition ${queueFilter === "all" ? "bg-white text-slate-950" : "border border-white/12 bg-white/5 text-slate-200 hover:bg-white/10"}`} onClick={() => onQueueFilterChange("all")} type="button">
+            All queues · {assignments.length}
+          </button>
+          {queues.map((queue) => (
+            <button
+              className={`rounded-full px-3 py-2 text-sm transition ${queueFilter === queue.id ? "bg-sky-200 text-slate-950" : "border border-white/12 bg-white/5 text-slate-200 hover:bg-white/10"}`}
+              key={queue.id}
+              onClick={() => onQueueFilterChange(queue.id)}
+              type="button"
+            >
+              {queue.label} · {queueCounts[queue.id]}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-6 grid gap-4 xl:grid-cols-3">
+        {bucketMeta.map((bucket, index) => {
+          const bucketAssignments = filteredAssignments.filter((assignment) => assignment.bucketId === bucket.id);
+          return (
+            <article className="rounded-[1.75rem] border border-white/10 bg-white/[0.03] p-4" key={bucket.id}>
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-lg font-semibold text-white">{bucket.label}</p>
+                  <p className="mt-1 text-sm leading-6 text-slate-400">{bucket.detail}</p>
+                </div>
+                <span className="rounded-full border border-white/12 px-3 py-1 text-xs uppercase tracking-[0.22em] text-slate-300">{bucketAssignments.length}</span>
+              </div>
+
+              <div className="mt-4 space-y-3">
+                {bucketAssignments.length > 0 ? bucketAssignments.map((assignment) => {
+                  const isSelected = selectedAssignmentId === assignment.id;
+                  const isDimmed = Boolean(selectedOperatorId && assignment.operatorId !== selectedOperatorId);
+                  return (
+                    <div className={`rounded-[1.5rem] border p-4 transition ${isSelected ? "border-sky-300/30 bg-sky-300/10" : "border-white/10 bg-white/5"} ${isDimmed ? "opacity-55" : ""}`} key={assignment.id}>
+                      <button className="w-full text-left" onClick={() => onSelectAssignment(assignment.id)} type="button">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className={`rounded-full border px-3 py-1 text-[11px] font-medium uppercase tracking-[0.24em] ${priorityTone[assignment.priority]}`}>{assignment.priority}</span>
+                          <span className="rounded-full border border-white/12 px-3 py-1 text-[11px] uppercase tracking-[0.24em] text-slate-300">{queueLabelMap[assignment.queueId]}</span>
+                        </div>
+                        <h3 className="mt-3 text-lg font-semibold text-white">{assignment.title}</h3>
+                        <p className="mt-1 text-sm text-slate-300">{assignment.location}</p>
+                        <p className="mt-3 text-sm leading-6 text-slate-400">{assignment.note}</p>
+                      </button>
+                      <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+                        <div className="text-sm text-slate-300">
+                          <p>{operatorMap[assignment.operatorId]}</p>
+                          <p className="text-slate-500">ETA {assignment.etaLabel}</p>
+                        </div>
+                        <div className="flex gap-2">
+                          <button className="rounded-full border border-white/12 bg-white/5 px-3 py-2 text-sm text-slate-200 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40" disabled={index === 0} onClick={() => onMoveAssignment(assignment.id, -1)} type="button">Back</button>
+                          <button className="rounded-full bg-sky-200 px-3 py-2 text-sm font-medium text-slate-950 transition hover:bg-sky-100 disabled:cursor-not-allowed disabled:opacity-40" disabled={index === bucketMeta.length - 1} onClick={() => onMoveAssignment(assignment.id, 1)} type="button">Advance</button>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                }) : (
+                  <div className="rounded-[1.5rem] border border-dashed border-white/12 bg-white/[0.02] p-5 text-center">
+                    <p className="text-sm font-semibold uppercase tracking-[0.26em] text-slate-400">Zero state</p>
+                    <p className="mt-3 text-sm leading-6 text-slate-300">{queueFilter === "all" ? "This bucket is clear right now." : "The active queue filter leaves this bucket empty."}</p>
+                  </div>
+                )}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/dispatch-center/dispatch-center-header.tsx
+++ b/src/components/dispatch-center/dispatch-center-header.tsx
@@ -1,0 +1,71 @@
+import type { QueueId, WorkloadTotals } from "@/app/dispatch-center/mock-data";
+
+type DispatchCenterHeaderProps = {
+  lastUpdated: string; onSelectQueue: (queueId: QueueId) => void;
+  queueSummaries: Array<{ id: QueueId; label: string; serviceTarget: string; windowLabel: string; total: number; dispatchCount: number; holdCount: number; oldestMinutes: number }>;
+  selectedQueueId: QueueId | null; shiftLabel: string; shiftWindow: string; workloadTotals: WorkloadTotals;
+};
+
+const queueTone = { priority: "border-amber-300/25 bg-amber-300/10 text-amber-50", recovery: "border-sky-300/25 bg-sky-300/10 text-sky-50", returns: "border-emerald-300/25 bg-emerald-300/10 text-emerald-50" };
+
+export function DispatchCenterHeader({ lastUpdated, onSelectQueue, queueSummaries, selectedQueueId, shiftLabel, shiftWindow, workloadTotals }: DispatchCenterHeaderProps) {
+  return (
+    <header className="rounded-[2rem] border border-white/10 bg-[linear-gradient(135deg,rgba(15,23,42,0.94),rgba(17,24,39,0.88))] p-6 shadow-[0_28px_100px_rgba(0,0,0,0.42)] sm:p-8">
+      <div className="flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
+        <div className="max-w-3xl">
+          <div className="flex flex-wrap items-center gap-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.35em] text-sky-300">Dispatch Center</p>
+            <span className="rounded-full border border-sky-300/25 bg-sky-300/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] text-sky-100">{shiftLabel}</span>
+          </div>
+          <h1 className="mt-4 text-4xl font-semibold tracking-tight text-white sm:text-5xl">Assignment buckets, queue pressure, and operator load on one isolated route.</h1>
+          <p className="mt-4 max-w-2xl text-sm leading-6 text-slate-300 sm:text-base">Move items across local buckets, open queue detail without touching shared state, and watch the header totals react as the board shifts.</p>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-3 xl:w-[25rem]">
+          <div className="rounded-3xl border border-white/10 bg-white/5 p-4 text-white">
+            <p className="text-sm text-slate-300">Open board</p>
+            <p className="mt-2 text-3xl font-semibold">{workloadTotals.openAssignments}</p>
+            <p className="mt-1 text-sm text-slate-400">{shiftWindow}</p>
+          </div>
+          <div className="rounded-3xl border border-sky-300/20 bg-sky-300/10 p-4 text-sky-50">
+            <p className="text-sm text-sky-100/80">Ready to move</p>
+            <p className="mt-2 text-3xl font-semibold">{workloadTotals.readyCount}</p>
+            <p className="mt-1 text-sm text-sky-100/80">Dispatch-ready cards</p>
+          </div>
+          <div className="rounded-3xl border border-rose-300/20 bg-rose-300/10 p-4 text-rose-50">
+            <p className="text-sm text-rose-100/80">Hold review</p>
+            <p className="mt-2 text-3xl font-semibold">{workloadTotals.holdCount}</p>
+            <p className="mt-1 text-sm text-rose-100/80">{lastUpdated}</p>
+          </div>
+        </div>
+      </div>
+      <div className="mt-6 grid gap-3 lg:grid-cols-3">
+        {queueSummaries.map((queue) => (
+          <button
+            className={`rounded-[1.75rem] border p-5 text-left transition hover:-translate-y-0.5 hover:bg-white/10 ${selectedQueueId === queue.id ? "border-white/20 bg-white/10" : "border-white/10 bg-white/[0.04]"}`}
+            key={queue.id}
+            onClick={() => onSelectQueue(queue.id)}
+            type="button"
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-lg font-semibold text-white">{queue.label}</p>
+                <p className="mt-1 text-sm text-slate-400">{queue.serviceTarget}</p>
+              </div>
+              <span className={`rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-[0.24em] ${queueTone[queue.id]}`}>{queue.windowLabel}</span>
+            </div>
+            <div className="mt-5 flex items-end justify-between gap-4">
+              <div>
+                <p className="text-3xl font-semibold text-white">{queue.total}</p>
+                <p className="mt-1 text-sm text-slate-400">{queue.oldestMinutes} min oldest item</p>
+              </div>
+              <div className="text-right text-sm text-slate-300">
+                <p>{queue.dispatchCount} ready</p>
+                <p>{queue.holdCount} on hold</p>
+              </div>
+            </div>
+          </button>
+        ))}
+      </div>
+    </header>
+  );
+}

--- a/src/components/dispatch-center/dispatch-center-shell.tsx
+++ b/src/components/dispatch-center/dispatch-center-shell.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { startTransition, useState } from "react";
+import { bucketOrder, calculateWorkloadTotals, type DispatchCenterSnapshot, type QueueId } from "@/app/dispatch-center/mock-data";
+import { AssignmentBuckets } from "./assignment-buckets";
+import { DispatchCenterHeader } from "./dispatch-center-header";
+import { OperatorLoadGrid } from "./operator-load-grid";
+import { QueueDetailDrawer } from "./queue-detail-drawer";
+
+type DispatchCenterShellProps = { initialSnapshot: DispatchCenterSnapshot };
+
+export function DispatchCenterShell({ initialSnapshot }: DispatchCenterShellProps) {
+  const [assignments, setAssignments] = useState(initialSnapshot.assignments);
+  const [queueFilter, setQueueFilter] = useState<QueueId | "all">("all");
+  const [selectedQueueId, setSelectedQueueId] = useState<QueueId | null>(null);
+  const [selectedAssignmentId, setSelectedAssignmentId] = useState<string | null>(null);
+  const [selectedOperatorId, setSelectedOperatorId] = useState<string | null>(null);
+
+  const workloadTotals = calculateWorkloadTotals(assignments);
+  const selectedAssignment = assignments.find((assignment) => assignment.id === selectedAssignmentId) ?? null;
+  const queueSummaries = initialSnapshot.queues.map((queue) => {
+    const queueAssignments = assignments.filter((assignment) => assignment.queueId === queue.id);
+    return {
+      ...queue,
+      total: queueAssignments.length,
+      dispatchCount: queueAssignments.filter((assignment) => assignment.bucketId === "dispatch").length,
+      holdCount: queueAssignments.filter((assignment) => assignment.bucketId === "hold").length,
+      oldestMinutes: queueAssignments.reduce((max, assignment) => Math.max(max, assignment.ageMinutes), 0),
+    };
+  });
+  const queueCounts = queueSummaries.reduce<Record<QueueId, number>>((counts, queue) => ({ ...counts, [queue.id]: queue.total }), { priority: 0, recovery: 0, returns: 0 });
+
+  function handleMoveAssignment(assignmentId: string, direction: -1 | 1) {
+    startTransition(() => setAssignments((current) => current.map((assignment) => {
+      if (assignment.id !== assignmentId) return assignment;
+      const nextBucket = bucketOrder[bucketOrder.indexOf(assignment.bucketId) + direction];
+      return nextBucket ? { ...assignment, bucketId: nextBucket } : assignment;
+    })));
+  }
+
+  function handleQueueFilterChange(nextFilter: QueueId | "all") {
+    startTransition(() => {
+      setQueueFilter(nextFilter);
+      if (nextFilter !== "all" && selectedAssignment?.queueId !== nextFilter) setSelectedAssignmentId(null);
+    });
+  }
+
+  function handleSelectAssignment(assignmentId: string) {
+    const assignment = assignments.find((item) => item.id === assignmentId);
+    if (!assignment) return;
+    startTransition(() => {
+      setSelectedAssignmentId((current) => (current === assignmentId ? null : assignmentId));
+      setSelectedQueueId(assignment.queueId);
+      setSelectedOperatorId(assignment.operatorId);
+    });
+  }
+
+  function handleSelectQueue(queueId: QueueId) {
+    startTransition(() => {
+      setSelectedQueueId((current) => (current === queueId ? null : queueId));
+      if (selectedAssignment && selectedAssignment.queueId !== queueId) setSelectedAssignmentId(null);
+    });
+  }
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(56,189,248,0.16),transparent_30%),radial-gradient(circle_at_top_right,rgba(251,146,60,0.14),transparent_24%),linear-gradient(180deg,#07111f_0%,#0f172a_58%,#111827_100%)] px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <DispatchCenterHeader
+          lastUpdated={initialSnapshot.lastUpdated}
+          onSelectQueue={handleSelectQueue}
+          queueSummaries={queueSummaries}
+          selectedQueueId={selectedQueueId}
+          shiftLabel={initialSnapshot.shiftLabel}
+          shiftWindow={initialSnapshot.shiftWindow}
+          workloadTotals={workloadTotals}
+        />
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.55fr)_minmax(21rem,0.9fr)]">
+          <div className="space-y-6">
+            <AssignmentBuckets
+              assignments={assignments}
+              onMoveAssignment={handleMoveAssignment}
+              onQueueFilterChange={handleQueueFilterChange}
+              onSelectAssignment={handleSelectAssignment}
+              operators={initialSnapshot.operators}
+              queueCounts={queueCounts}
+              queueFilter={queueFilter}
+              queues={initialSnapshot.queues}
+              selectedAssignmentId={selectedAssignmentId}
+              selectedOperatorId={selectedOperatorId}
+            />
+            <OperatorLoadGrid
+              assignments={assignments}
+              onSelectOperator={(operatorId) => startTransition(() => setSelectedOperatorId((current) => (current === operatorId ? null : operatorId)))}
+              operators={initialSnapshot.operators}
+              selectedOperatorId={selectedOperatorId}
+            />
+          </div>
+          <QueueDetailDrawer
+            assignments={assignments}
+            onClearSelection={() => startTransition(() => { setSelectedAssignmentId(null); setSelectedQueueId(null); })}
+            onSelectAssignment={handleSelectAssignment}
+            operators={initialSnapshot.operators}
+            queues={initialSnapshot.queues}
+            selectedAssignmentId={selectedAssignmentId}
+            selectedOperatorId={selectedOperatorId}
+            selectedQueueId={selectedQueueId}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/dispatch-center/operator-load-grid.tsx
+++ b/src/components/dispatch-center/operator-load-grid.tsx
@@ -1,0 +1,53 @@
+import type { DispatchAssignment, OperatorRecord } from "@/app/dispatch-center/mock-data";
+
+type OperatorLoadGridProps = { assignments: DispatchAssignment[]; onSelectOperator: (operatorId: string) => void; operators: OperatorRecord[]; selectedOperatorId: string | null };
+
+export function OperatorLoadGrid({ assignments, onSelectOperator, operators, selectedOperatorId }: OperatorLoadGridProps) {
+  return (
+    <section className="rounded-[2rem] border border-white/10 bg-[linear-gradient(180deg,rgba(17,24,39,0.9),rgba(2,6,23,0.96))] p-5 shadow-[0_22px_80px_rgba(0,0,0,0.34)] sm:p-6">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Operator load</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">Capacity view by active dispatcher</h2>
+        </div>
+        <p className="text-sm text-slate-400">Select a card to spotlight that operator on the board.</p>
+      </div>
+
+      <div className="mt-5 grid gap-4 md:grid-cols-2">
+        {operators.map((operator) => {
+          const operatorAssignments = assignments.filter((assignment) => assignment.operatorId === operator.id);
+          const utilization = Math.round((operatorAssignments.length / operator.capacity) * 100);
+          const readyCount = operatorAssignments.filter((assignment) => assignment.bucketId === "dispatch").length;
+          const holdCount = operatorAssignments.filter((assignment) => assignment.bucketId === "hold").length;
+          const isSelected = selectedOperatorId === operator.id;
+
+          return (
+            <button className={`rounded-[1.75rem] border p-5 text-left transition hover:-translate-y-0.5 ${isSelected ? "border-sky-300/25 bg-sky-300/10" : "border-white/10 bg-white/[0.04] hover:bg-white/[0.08]"}`} key={operator.id} onClick={() => onSelectOperator(operator.id)} type="button">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="text-lg font-semibold text-white">{operator.name}</p>
+                  <p className="mt-1 text-sm text-slate-400">{operator.focus}</p>
+                </div>
+                <span className="rounded-full border border-white/12 px-3 py-1 text-xs uppercase tracking-[0.22em] text-slate-300">{operator.shift}</span>
+              </div>
+              <div className="mt-5 flex items-end justify-between gap-4">
+                <div>
+                  <p className="text-3xl font-semibold text-white">{operatorAssignments.length}</p>
+                  <p className="mt-1 text-sm text-slate-400">Assigned against {operator.capacity} slots</p>
+                </div>
+                <div className="text-right text-sm text-slate-300">
+                  <p>{readyCount} ready</p>
+                  <p>{holdCount} on hold</p>
+                </div>
+              </div>
+              <div className="mt-4 h-2 rounded-full bg-white/10">
+                <div className="h-full rounded-full bg-[linear-gradient(90deg,#38bdf8,#f59e0b)]" style={{ width: `${Math.min(utilization, 100)}%` }} />
+              </div>
+              <p className="mt-3 text-sm text-slate-400">{utilization}% utilized</p>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/dispatch-center/queue-detail-drawer.tsx
+++ b/src/components/dispatch-center/queue-detail-drawer.tsx
@@ -1,0 +1,93 @@
+import type { DispatchAssignment, OperatorRecord, QueueDefinition, QueueId } from "@/app/dispatch-center/mock-data";
+
+type QueueDetailDrawerProps = {
+  assignments: DispatchAssignment[]; onClearSelection: () => void; onSelectAssignment: (assignmentId: string) => void;
+  operators: OperatorRecord[]; queues: QueueDefinition[]; selectedAssignmentId: string | null; selectedOperatorId: string | null; selectedQueueId: QueueId | null;
+};
+
+export function QueueDetailDrawer({
+  assignments, onClearSelection, onSelectAssignment, operators, queues, selectedAssignmentId, selectedOperatorId, selectedQueueId,
+}: QueueDetailDrawerProps) {
+  const selectedQueue = queues.find((queue) => queue.id === selectedQueueId) ?? null;
+  const queueAssignments = selectedQueue ? assignments.filter((assignment) => assignment.queueId === selectedQueue.id) : [];
+  const queueOperators = operators.filter((operator) => queueAssignments.some((assignment) => assignment.operatorId === operator.id));
+  const nextUp = [...queueAssignments].sort((left, right) => right.ageMinutes - left.ageMinutes).slice(0, 3);
+
+  return (
+    <aside className="rounded-[2rem] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.92),rgba(2,6,23,0.98))] p-5 shadow-[0_22px_80px_rgba(0,0,0,0.42)] sm:p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Queue detail</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">{selectedQueue ? selectedQueue.label : "No queue selected"}</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-300">{selectedQueue ? selectedQueue.detail : "Use a queue card in the header or any assignment card on the board to open a local detail drawer."}</p>
+        </div>
+        {selectedQueue ? <button className="rounded-full border border-white/12 bg-white/5 px-3 py-2 text-sm text-slate-200 transition hover:bg-white/10" onClick={onClearSelection} type="button">Close</button> : null}
+      </div>
+
+      {!selectedQueue ? (
+        <div className="mt-6 rounded-[1.75rem] border border-dashed border-white/12 bg-white/[0.03] p-6 text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-400">Waiting on selection</p>
+          <p className="mt-3 text-sm leading-6 text-slate-300">The drawer stays empty until you choose a queue, which gives the route an explicit deselected state.</p>
+        </div>
+      ) : (
+        <>
+          <div className="mt-6 grid gap-3 sm:grid-cols-3">
+            <div className="rounded-3xl border border-white/10 bg-white/5 p-4">
+              <p className="text-sm text-slate-400">Queue load</p>
+              <p className="mt-2 text-3xl font-semibold text-white">{queueAssignments.length}</p>
+              <p className="mt-1 text-sm text-slate-400">{selectedQueue.serviceTarget}</p>
+            </div>
+            <div className="rounded-3xl border border-sky-300/20 bg-sky-300/10 p-4">
+              <p className="text-sm text-sky-100/80">Ready now</p>
+              <p className="mt-2 text-3xl font-semibold text-sky-50">{queueAssignments.filter((assignment) => assignment.bucketId === "dispatch").length}</p>
+              <p className="mt-1 text-sm text-sky-100/80">{selectedQueue.windowLabel} window</p>
+            </div>
+            <div className="rounded-3xl border border-rose-300/20 bg-rose-300/10 p-4">
+              <p className="text-sm text-rose-100/80">Blocked</p>
+              <p className="mt-2 text-3xl font-semibold text-rose-50">{queueAssignments.filter((assignment) => assignment.bucketId === "hold").length}</p>
+              <p className="mt-1 text-sm text-rose-100/80">Needs local review</p>
+            </div>
+          </div>
+
+          <section className="mt-6 rounded-[1.75rem] border border-white/10 bg-white/[0.04] p-5">
+            <div>
+              <p className="text-lg font-semibold text-white">Next to move</p>
+              <p className="mt-1 text-sm text-slate-400">Oldest queue items surfaced for quick review.</p>
+            </div>
+            <div className="mt-4 space-y-3">
+              {nextUp.map((assignment) => (
+                <button className={`w-full rounded-[1.5rem] border p-4 text-left transition ${selectedAssignmentId === assignment.id ? "border-sky-300/25 bg-sky-300/10" : "border-white/10 bg-white/5 hover:bg-white/10"}`} key={assignment.id} onClick={() => onSelectAssignment(assignment.id)} type="button">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <p className="text-base font-semibold text-white">{assignment.title}</p>
+                      <p className="mt-1 text-sm text-slate-400">{assignment.location}</p>
+                    </div>
+                    <span className="rounded-full border border-white/12 px-3 py-1 text-xs uppercase tracking-[0.22em] text-slate-300">{assignment.ageMinutes} min</span>
+                  </div>
+                  <p className="mt-3 text-sm leading-6 text-slate-300">{assignment.note}</p>
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section className="mt-6 rounded-[1.75rem] border border-white/10 bg-white/[0.04] p-5">
+            <p className="text-lg font-semibold text-white">Staffed by</p>
+            <div className="mt-4 space-y-3">
+              {queueOperators.map((operator) => (
+                <div className={`rounded-[1.5rem] border p-4 ${selectedOperatorId === operator.id ? "border-sky-300/25 bg-sky-300/10" : "border-white/10 bg-white/5"}`} key={operator.id}>
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-base font-semibold text-white">{operator.name}</p>
+                      <p className="mt-1 text-sm text-slate-400">{operator.focus}</p>
+                    </div>
+                    <span className="rounded-full border border-white/12 px-3 py-1 text-xs uppercase tracking-[0.22em] text-slate-300">{operator.shift}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        </>
+      )}
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/dispatch-center` app route with feature-local mock data
- build a client-side dispatch board with queue filters, bucket movement controls, and operator load cards
- add a queue detail drawer with deselected and zero-state handling, keeping all state inside the feature

## Testing
- npm run lint -- src/app/dispatch-center src/components/dispatch-center
- npm run typecheck
- npm run build

Closes #24