### PR TITLE
feat: add isolated scenario board route

### DIFF
--- a/src/app/scenario-board/mock-data.ts
+++ b/src/app/scenario-board/mock-data.ts
@@ -1,0 +1,51 @@
+export type OutcomeImpact = "contained" | "elevated" | "severe"
+export type ScenarioPlaybook = { id: string; title: string; intent: string; lead: string; cadence: string; checkpoint: string }
+export type ScenarioAssumption = { id: string; label: string; note: string; status: "validated" | "watch" | "fragile"; initiallyActive: boolean }
+export type ScenarioOutcome = { id: string; title: string; note: string; impact: OutcomeImpact; probability: "low" | "medium" | "high"; playbookIds: string[]; assumptionIds: string[] }
+export type ActionPrompt = { id: string; title: string; detail: string; owner: string; window: string; playbookIds: string[]; cueIds: string[] }
+export type ScenarioRecord = {
+  id: string
+  name: string
+  summary: string
+  horizon: string
+  signal: string
+  mode: string
+  playbooks: ScenarioPlaybook[]
+  assumptions: ScenarioAssumption[]
+  outcomes: ScenarioOutcome[]
+  prompts: ActionPrompt[]
+}
+
+export const scenarioBoardScenario: ScenarioRecord = {
+  id: "atlas-freeze",
+  name: "Atlas Supplier Freeze",
+  summary: "A customs hold on the Atlas line is forcing the team to rebalance margin, support load, and premium promises in a 72 hour window.",
+  horizon: "72 hour response window",
+  signal: "Ports signal: amber",
+  mode: "Containment draft",
+  playbooks: [
+    { id: "reroute", title: "Reroute premium loads", intent: "Preserve top-tier accounts with alternate lanes and temporary surcharge cover.", lead: "Ops desk", cadence: "Every 2 hours", checkpoint: "Needs surge carrier quotes by 14:00." },
+    { id: "buffer", title: "Buffer with partial kits", intent: "Ship what is ready now, then recover fill-rate with substitution logic.", lead: "Fulfillment", cadence: "Shift change", checkpoint: "Bundle rules need finance sign-off before launch." },
+    { id: "pause", title: "Pause low-margin drops", intent: "Hold the least resilient lanes to protect support and working capital.", lead: "Commercial", cadence: "Daily reset", checkpoint: "Account managers need exception scripts at open." },
+  ],
+  assumptions: [
+    { id: "supplier-window", label: "Hold clears within 36 hours", note: "Broker team still expects a short release.", status: "validated", initiallyActive: true },
+    { id: "carrier-capacity", label: "Backup carrier capacity stays above 18%", note: "Spot quotes remain available but narrow.", status: "watch", initiallyActive: true },
+    { id: "support-script", label: "Support scripts absorb ETA changes", note: "New macros lower handle time on exceptions.", status: "validated", initiallyActive: true },
+    { id: "surcharge-credit", label: "Finance approves temporary credits", note: "Approval has not landed for margin relief.", status: "fragile", initiallyActive: false },
+  ],
+  outcomes: [
+    { id: "vip-green", title: "VIP orders stay green", note: "Priority accounts land inside promised windows.", impact: "contained", probability: "high", playbookIds: ["reroute"], assumptionIds: ["carrier-capacity", "support-script"] },
+    { id: "margin-slip", title: "Margin slips but churn holds", note: "Credits buy retention while finance watches the week.", impact: "elevated", probability: "medium", playbookIds: ["reroute", "buffer"], assumptionIds: ["surcharge-credit"] },
+    { id: "kit-backlog", title: "Kit substitutions create short backlogs", note: "Partial kits protect revenue but slow downstream assembly.", impact: "elevated", probability: "high", playbookIds: ["buffer"], assumptionIds: ["supplier-window"] },
+    { id: "wholesale-stop", title: "Wholesale queues hard stop", note: "Lower-priority drops stack behind premium lanes.", impact: "severe", probability: "medium", playbookIds: ["pause"], assumptionIds: ["supplier-window"] },
+    { id: "support-surge", title: "Support volume doubles overnight", note: "Inbound delay notices trigger a secondary staffing problem.", impact: "severe", probability: "high", playbookIds: ["reroute", "pause"], assumptionIds: ["support-script"] },
+    { id: "friday-recovery", title: "Recovery sprint clears backlog by Friday", note: "The board can pivot back to normal cadence if enough levers hold.", impact: "contained", probability: "low", playbookIds: ["reroute", "buffer", "pause"], assumptionIds: ["supplier-window", "carrier-capacity", "surcharge-credit"] },
+  ],
+  prompts: [
+    { id: "quote-window", title: "Lock surge carrier quotes", detail: "Close quotes before afternoon rate drift widens the reroute plan.", owner: "Ops desk", window: "Next 90 min", playbookIds: ["reroute"], cueIds: ["carrier-capacity"] },
+    { id: "credit-copy", title: "Draft margin-protection copy", detail: "Align finance and account messaging before credits go live.", owner: "Revenue ops", window: "This afternoon", playbookIds: ["reroute", "buffer"], cueIds: ["surcharge-credit"] },
+    { id: "kit-logic", title: "Publish substitution rules", detail: "Give floor leads the first approved bundle combinations and a red-line list.", owner: "Fulfillment", window: "Before shift handoff", playbookIds: ["buffer"], cueIds: ["supplier-window"] },
+    { id: "freeze-brief", title: "Prep low-margin pause brief", detail: "Sequence the accounts that need a proactive pause note before the stop hits.", owner: "Commercial", window: "By 09:00 tomorrow", playbookIds: ["pause"], cueIds: ["support-script"] },
+  ],
+}

--- a/src/app/scenario-board/page.tsx
+++ b/src/app/scenario-board/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next"
+import { scenarioBoardScenario } from "./mock-data"
+import { ScenarioBoardShell } from "@/components/scenario-board/scenario-board-shell"
+
+export const metadata: Metadata = {
+  title: "Scenario Board | API Test",
+  description: "Mock scenario board with local playbooks, assumptions, and an outcome matrix.",
+}
+
+export default function ScenarioBoardPage() {
+  return <ScenarioBoardShell scenario={scenarioBoardScenario} />
+}

--- a/src/components/scenario-board/action-prompt-panel.tsx
+++ b/src/components/scenario-board/action-prompt-panel.tsx
@@ -1,0 +1,42 @@
+import type { ActionPrompt } from "@/app/scenario-board/mock-data"
+
+type ActionPromptPanelProps = {
+  activeAssumptionIds: string[]
+  prompts: ActionPrompt[]
+  selectedPlaybookTitle: string | null
+}
+
+export function ActionPromptPanel({ activeAssumptionIds, prompts, selectedPlaybookTitle }: ActionPromptPanelProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-stone-200 bg-white p-5 shadow-[0_18px_60px_rgba(38,23,22,0.08)] sm:p-6">
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">Action prompts</p>
+        <h2 className="mt-1 text-2xl font-semibold tracking-tight text-stone-900">{selectedPlaybookTitle ? `Moves for ${selectedPlaybookTitle}` : "Action prompts"}</h2>
+      </div>
+      {!selectedPlaybookTitle ? (
+        <div className="mt-5 rounded-[1.5rem] border border-dashed border-stone-300 bg-stone-50 px-5 py-8 text-center text-sm leading-6 text-stone-600">Choose a playbook to reveal the next prompts and operating cues.</div>
+      ) : (
+        <div className="mt-5 space-y-3">
+          {prompts.map((prompt) => {
+            const isReady = prompt.cueIds.every((id) => activeAssumptionIds.includes(id))
+            return (
+              <div key={prompt.id} className="rounded-[1.35rem] border border-stone-200 bg-stone-50 p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-stone-900">{prompt.title}</p>
+                    <p className="mt-2 text-sm leading-6 text-stone-600">{prompt.detail}</p>
+                  </div>
+                  <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${isReady ? "bg-teal-100 text-teal-700" : "bg-rose-100 text-rose-700"}`}>{isReady ? "Ready" : "Hold"}</span>
+                </div>
+                <div className="mt-4 flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-stone-500">
+                  <span className="rounded-full bg-white px-2.5 py-1">{prompt.owner}</span>
+                  <span className="rounded-full bg-white px-2.5 py-1">{prompt.window}</span>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/scenario-board/assumption-panel.tsx
+++ b/src/components/scenario-board/assumption-panel.tsx
@@ -1,0 +1,47 @@
+import type { ScenarioAssumption } from "@/app/scenario-board/mock-data"
+
+type AssumptionPanelProps = {
+  activeAssumptionIds: string[]
+  assumptions: ScenarioAssumption[]
+  onReset: () => void
+  onToggleAssumption: (assumptionId: string) => void
+}
+
+const statusStyles = {
+  fragile: "border-rose-200 bg-rose-50 text-rose-700",
+  validated: "border-teal-200 bg-teal-50 text-teal-700",
+  watch: "border-amber-200 bg-amber-50 text-amber-700",
+} as const
+
+export function AssumptionPanel({ activeAssumptionIds, assumptions, onReset, onToggleAssumption }: AssumptionPanelProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-stone-200 bg-white p-5 shadow-[0_18px_60px_rgba(38,23,22,0.08)] sm:p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">Assumptions</p>
+          <h2 className="mt-1 text-2xl font-semibold tracking-tight text-stone-900">Toggle what still holds</h2>
+        </div>
+        <button className="rounded-full border border-stone-200 px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] text-stone-600 transition hover:border-stone-300 hover:text-stone-900" onClick={onReset} type="button">Restore baseline</button>
+      </div>
+      <div className="mt-5 space-y-3">
+        {assumptions.map((assumption) => {
+          const isActive = activeAssumptionIds.includes(assumption.id)
+          return (
+            <button key={assumption.id} aria-pressed={isActive} className={`w-full rounded-[1.35rem] border p-4 text-left transition ${isActive ? "border-stone-900 bg-stone-950 text-stone-50" : "border-stone-200 bg-stone-50 text-stone-800 hover:border-stone-300"}`} onClick={() => onToggleAssumption(assumption.id)} type="button">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold">{assumption.label}</p>
+                  <p className={`mt-2 text-sm leading-6 ${isActive ? "text-stone-300" : "text-stone-600"}`}>{assumption.note}</p>
+                </div>
+                <div className="flex flex-col items-end gap-2">
+                  <span className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${isActive ? "border-white/10 bg-white/10 text-white" : statusStyles[assumption.status]}`}>{assumption.status}</span>
+                  <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${isActive ? "bg-orange-400/20 text-orange-100" : "bg-stone-200 text-stone-600"}`}>{isActive ? "Included" : "Excluded"}</span>
+                </div>
+              </div>
+            </button>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/components/scenario-board/outcome-matrix.tsx
+++ b/src/components/scenario-board/outcome-matrix.tsx
@@ -1,0 +1,75 @@
+import type { OutcomeImpact, ScenarioOutcome } from "@/app/scenario-board/mock-data"
+
+type OutcomeMatrixProps = {
+  impactFilter: "all" | OutcomeImpact
+  onImpactFilterChange: (impact: "all" | OutcomeImpact) => void
+  outcomes: ScenarioOutcome[]
+  selectedPlaybookTitle: string | null
+}
+
+const impactColumns: { id: OutcomeImpact; label: string; tone: string }[] = [
+  { id: "contained", label: "Contained", tone: "bg-teal-50 text-teal-700" },
+  { id: "elevated", label: "Elevated", tone: "bg-amber-50 text-amber-700" },
+  { id: "severe", label: "Severe", tone: "bg-rose-50 text-rose-700" },
+]
+
+const probabilityRows = [
+  { id: "high", label: "High probability" },
+  { id: "medium", label: "Medium probability" },
+  { id: "low", label: "Low probability" },
+] as const
+
+export function OutcomeMatrix({ impactFilter, onImpactFilterChange, outcomes, selectedPlaybookTitle }: OutcomeMatrixProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-stone-200 bg-white p-5 shadow-[0_18px_60px_rgba(38,23,22,0.08)] sm:p-6">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">Outcome matrix</p>
+          <h2 className="mt-1 text-2xl font-semibold tracking-tight text-stone-900">{selectedPlaybookTitle ? `Projected spread for ${selectedPlaybookTitle}` : "Projected spread"}</h2>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button className={`rounded-full px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] transition ${impactFilter === "all" ? "bg-stone-900 text-white" : "bg-stone-100 text-stone-600 hover:bg-stone-200"}`} onClick={() => onImpactFilterChange("all")} type="button">All outcomes</button>
+          {impactColumns.map((column) => (
+            <button key={column.id} className={`rounded-full px-3 py-2 text-xs font-semibold uppercase tracking-[0.18em] transition ${impactFilter === column.id ? "bg-stone-900 text-white" : "bg-stone-100 text-stone-600 hover:bg-stone-200"}`} onClick={() => onImpactFilterChange(column.id)} type="button">{column.label}</button>
+          ))}
+        </div>
+      </div>
+      {!selectedPlaybookTitle ? (
+        <div className="mt-5 rounded-[1.5rem] border border-dashed border-stone-300 bg-stone-50 px-5 py-10 text-center text-sm leading-6 text-stone-600">Select a playbook card to project the matrix. Clearing the active card intentionally gives this route a zero-state view.</div>
+      ) : outcomes.length === 0 ? (
+        <div className="mt-5 rounded-[1.5rem] border border-dashed border-stone-300 bg-stone-50 px-5 py-10 text-center text-sm leading-6 text-stone-600">No outcomes remain for this playbook under the current assumption mix. Re-enable a fragile assumption or switch the impact focus.</div>
+      ) : (
+        <div className="mt-5 overflow-x-auto">
+          <div className="grid min-w-[48rem] grid-cols-[10rem_repeat(3,minmax(0,1fr))] gap-3">
+            <div />
+            {impactColumns.map((column) => <div key={column.id} className={`rounded-2xl px-4 py-3 text-center text-sm font-semibold ${column.tone}`}>{column.label}</div>)}
+            {probabilityRows.map((row) => (
+              <div key={row.id} className="contents">
+                <div className="rounded-2xl border border-stone-200 bg-stone-50 px-4 py-4 text-sm font-semibold text-stone-700">{row.label}</div>
+                {impactColumns.map((column) => {
+                  const cellOutcomes = outcomes.filter((outcome) => outcome.probability === row.id && outcome.impact === column.id)
+                  return (
+                    <div key={`${row.id}-${column.id}`} className="rounded-2xl border border-stone-200 bg-[#fcfaf7] p-4">
+                      {cellOutcomes.length === 0 ? (
+                        <p className="text-sm text-stone-400">No live branch.</p>
+                      ) : (
+                        <div className="space-y-3">
+                          {cellOutcomes.map((outcome) => (
+                            <div key={outcome.id} className="rounded-xl border border-stone-200 bg-white px-3 py-3">
+                              <p className="text-sm font-semibold text-stone-900">{outcome.title}</p>
+                              <p className="mt-1 text-sm leading-6 text-stone-600">{outcome.note}</p>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/components/scenario-board/playbook-card-grid.tsx
+++ b/src/components/scenario-board/playbook-card-grid.tsx
@@ -1,0 +1,39 @@
+import type { ScenarioPlaybook } from "@/app/scenario-board/mock-data"
+
+type PlaybookCardGridProps = {
+  onSelectPlaybook: (playbookId: string) => void
+  playbooks: ScenarioPlaybook[]
+  selectedPlaybookId: string
+}
+
+export function PlaybookCardGrid({ onSelectPlaybook, playbooks, selectedPlaybookId }: PlaybookCardGridProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-stone-200 bg-[#f8f2eb] p-5 shadow-[0_18px_60px_rgba(38,23,22,0.08)] sm:p-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">Playbook cards</p>
+          <h2 className="mt-1 text-2xl font-semibold tracking-tight text-stone-900">Pick the operating posture</h2>
+        </div>
+        <p className="text-sm text-stone-600">Tap the active card again to clear it and trigger the zero-state.</p>
+      </div>
+      <div className="mt-5 grid gap-4 lg:grid-cols-3">
+        {playbooks.map((playbook) => {
+          const isSelected = playbook.id === selectedPlaybookId
+          return (
+            <button key={playbook.id} aria-pressed={isSelected} className={`rounded-[1.5rem] border p-4 text-left transition ${isSelected ? "border-stone-900 bg-stone-950 text-stone-50 shadow-[0_18px_40px_rgba(17,24,39,0.22)]" : "border-stone-200 bg-white text-stone-900 hover:-translate-y-0.5 hover:border-stone-300"}`} onClick={() => onSelectPlaybook(playbook.id)} type="button">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold">{playbook.title}</p>
+                  <p className={`mt-1 text-xs uppercase tracking-[0.22em] ${isSelected ? "text-orange-200" : "text-stone-500"}`}>{playbook.lead}</p>
+                </div>
+                <span className={`rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${isSelected ? "bg-white/10 text-white" : "bg-stone-100 text-stone-600"}`}>{playbook.cadence}</span>
+              </div>
+              <p className={`mt-4 text-sm leading-6 ${isSelected ? "text-stone-200" : "text-stone-600"}`}>{playbook.intent}</p>
+              <div className={`mt-4 rounded-2xl border px-3 py-3 text-sm ${isSelected ? "border-white/10 bg-white/5 text-stone-100" : "border-stone-200 bg-stone-50 text-stone-700"}`}>{playbook.checkpoint}</div>
+            </button>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/components/scenario-board/scenario-board-header.tsx
+++ b/src/components/scenario-board/scenario-board-header.tsx
@@ -1,0 +1,53 @@
+import type { ScenarioRecord } from "@/app/scenario-board/mock-data"
+
+type ScenarioBoardHeaderProps = {
+  activeAssumptionCount: number
+  scenario: ScenarioRecord
+  selectedPlaybookTitle: string | null
+  visibleOutcomeCount: number
+}
+
+export function ScenarioBoardHeader({ activeAssumptionCount, scenario, selectedPlaybookTitle, visibleOutcomeCount }: ScenarioBoardHeaderProps) {
+  return (
+    <section className="overflow-hidden rounded-[2rem] border border-white/10 bg-[#1d1311]/80 text-stone-50 shadow-[0_24px_80px_rgba(18,10,7,0.36)] backdrop-blur">
+      <div className="grid gap-6 px-5 py-6 sm:px-6 lg:grid-cols-[minmax(0,1.3fr)_minmax(300px,0.9fr)] lg:px-8">
+        <div className="space-y-4">
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="rounded-full border border-orange-400/30 bg-orange-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.28em] text-orange-200">Scenario board</span>
+            <span className="rounded-full border border-teal-400/30 bg-teal-400/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-teal-100">{scenario.mode}</span>
+          </div>
+          <div>
+            <h1 className="max-w-3xl text-3xl font-semibold tracking-tight text-white sm:text-4xl">{scenario.name}</h1>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-stone-300 sm:text-base">{scenario.summary}</p>
+          </div>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+            <p className="text-xs uppercase tracking-[0.24em] text-stone-400">Watch window</p>
+            <p className="mt-2 text-sm font-medium text-white">{scenario.horizon}</p>
+          </div>
+          <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+            <p className="text-xs uppercase tracking-[0.24em] text-stone-400">Signal</p>
+            <p className="mt-2 text-sm font-medium text-white">{scenario.signal}</p>
+          </div>
+          <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+            <p className="text-xs uppercase tracking-[0.24em] text-stone-400">Active playbook</p>
+            <p className="mt-2 text-sm font-medium text-white">{selectedPlaybookTitle ?? "No playbook selected"}</p>
+          </div>
+          <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+            <p className="text-xs uppercase tracking-[0.24em] text-stone-400">Visible outcomes</p>
+            <p className="mt-2 text-3xl font-semibold text-white">{visibleOutcomeCount}</p>
+          </div>
+          <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+            <p className="text-xs uppercase tracking-[0.24em] text-stone-400">Live assumptions</p>
+            <p className="mt-2 text-3xl font-semibold text-white">{activeAssumptionCount}</p>
+          </div>
+          <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+            <p className="text-xs uppercase tracking-[0.24em] text-stone-400">Playbooks in scene</p>
+            <p className="mt-2 text-3xl font-semibold text-white">{scenario.playbooks.length}</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/scenario-board/scenario-board-shell.test.tsx
+++ b/src/components/scenario-board/scenario-board-shell.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { scenarioBoardScenario } from "@/app/scenario-board/mock-data";
+
+import { ScenarioBoardShell } from "./scenario-board-shell";
+
+describe("ScenarioBoardShell", () => {
+  it("shows a zero-state when the active playbook is cleared", () => {
+    render(<ScenarioBoardShell scenario={scenarioBoardScenario} />);
+
+    expect(screen.getByText("VIP orders stay green")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /reroute premium loads/i }),
+    );
+
+    expect(
+      screen.getByText(/Select a playbook card to project the matrix/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Choose a playbook to reveal the next prompts/i),
+    ).toBeInTheDocument();
+  });
+
+  it("reacts to fragile assumption toggles and baseline reset", () => {
+    render(<ScenarioBoardShell scenario={scenarioBoardScenario} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /buffer with partial kits/i }),
+    );
+
+    expect(
+      screen.queryByText("Margin slips but churn holds"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /finance approves temporary credits/i }),
+    );
+
+    expect(
+      screen.getByText("Margin slips but churn holds"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /restore baseline/i }));
+
+    expect(
+      screen.queryByText("Margin slips but churn holds"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("filters matrix cells by impact focus", () => {
+    render(<ScenarioBoardShell scenario={scenarioBoardScenario} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Severe" }));
+
+    expect(
+      screen.getByText("Support volume doubles overnight"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("VIP orders stay green")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Contained" }));
+
+    expect(screen.getByText("VIP orders stay green")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Support volume doubles overnight"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("updates prompt readiness when a cue assumption is enabled", () => {
+    render(<ScenarioBoardShell scenario={scenarioBoardScenario} />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /buffer with partial kits/i }),
+    );
+
+    expect(screen.getByText("Draft margin-protection copy")).toBeInTheDocument();
+    expect(screen.getByText("Hold")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /finance approves temporary credits/i }),
+    );
+
+    expect(screen.queryByText("Hold")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Ready")).toHaveLength(2);
+  });
+});

--- a/src/components/scenario-board/scenario-board-shell.tsx
+++ b/src/components/scenario-board/scenario-board-shell.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import { startTransition, useState } from "react"
+import type { OutcomeImpact, ScenarioRecord } from "@/app/scenario-board/mock-data"
+import { ActionPromptPanel } from "./action-prompt-panel"
+import { AssumptionPanel } from "./assumption-panel"
+import { OutcomeMatrix } from "./outcome-matrix"
+import { PlaybookCardGrid } from "./playbook-card-grid"
+import { ScenarioBoardHeader } from "./scenario-board-header"
+
+type ScenarioBoardShellProps = { scenario: ScenarioRecord }
+
+function getBaselineAssumptions(scenario: ScenarioRecord) {
+  return scenario.assumptions.filter((assumption) => assumption.initiallyActive).map((assumption) => assumption.id)
+}
+
+export function ScenarioBoardShell({ scenario }: ScenarioBoardShellProps) {
+  const [selectedPlaybookId, setSelectedPlaybookId] = useState(scenario.playbooks[0]?.id ?? "")
+  const [activeAssumptionIds, setActiveAssumptionIds] = useState(getBaselineAssumptions(scenario))
+  const [impactFilter, setImpactFilter] = useState<"all" | OutcomeImpact>("all")
+  const selectedPlaybook = scenario.playbooks.find((playbook) => playbook.id === selectedPlaybookId) ?? null
+  const visibleOutcomes = scenario.outcomes.filter((outcome) => selectedPlaybookId.length > 0 && outcome.playbookIds.includes(selectedPlaybookId) && outcome.assumptionIds.every((id) => activeAssumptionIds.includes(id)) && (impactFilter === "all" || outcome.impact === impactFilter))
+  const visiblePrompts = scenario.prompts.filter((prompt) => selectedPlaybookId.length > 0 && prompt.playbookIds.includes(selectedPlaybookId))
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(249,115,22,0.14),transparent_28%),radial-gradient(circle_at_right,rgba(15,118,110,0.16),transparent_32%),linear-gradient(180deg,#140d09_0%,#261716_40%,#f5efe8_40.1%,#f5efe8_100%)] px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <ScenarioBoardHeader activeAssumptionCount={activeAssumptionIds.length} scenario={scenario} selectedPlaybookTitle={selectedPlaybook?.title ?? null} visibleOutcomeCount={visibleOutcomes.length} />
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.85fr)]">
+          <div className="space-y-6">
+            <PlaybookCardGrid onSelectPlaybook={(playbookId) => startTransition(() => setSelectedPlaybookId((current) => current === playbookId ? "" : playbookId))} playbooks={scenario.playbooks} selectedPlaybookId={selectedPlaybookId} />
+            <OutcomeMatrix impactFilter={impactFilter} onImpactFilterChange={(nextFilter) => startTransition(() => setImpactFilter(nextFilter))} outcomes={visibleOutcomes} selectedPlaybookTitle={selectedPlaybook?.title ?? null} />
+          </div>
+          <div className="space-y-6">
+            <AssumptionPanel activeAssumptionIds={activeAssumptionIds} assumptions={scenario.assumptions} onReset={() => startTransition(() => setActiveAssumptionIds(getBaselineAssumptions(scenario)))} onToggleAssumption={(assumptionId) => startTransition(() => setActiveAssumptionIds((current) => current.includes(assumptionId) ? current.filter((id) => id !== assumptionId) : [...current, assumptionId]))} />
+            <ActionPromptPanel activeAssumptionIds={activeAssumptionIds} prompts={visiblePrompts} selectedPlaybookTitle={selectedPlaybook?.title ?? null} />
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- add an isolated `/scenario-board` app route with feature-local mock data and metadata
- build a client-side scenario board shell with playbook selection, assumption toggles, outcome matrix filters, and prompt cards
- add a feature-local test covering zero-state, assumption reset, and matrix/prompt interactions

## Testing
- npm run lint
- npm run typecheck
- npm run test -- src/components/scenario-board/scenario-board-shell.test.tsx
- npm run build

Closes #29