### PR TITLE
feat: add isolated crew roster route

### DIFF
--- a/src/app/crew-roster/mock-data.ts
+++ b/src/app/crew-roster/mock-data.ts
@@ -1,0 +1,47 @@
+export type CrewRoleId = "navigation" | "systems" | "medical" | "security";
+export type ReadinessId = "ready" | "steady" | "recovery";
+export type RotationState = "active" | "handoff" | "staged";
+export type CrewRole = { id: CrewRoleId; label: string; shortLabel: string };
+export type ReadinessState = { id: ReadinessId; label: string; summary: string };
+export type CrewTeam = { id: string; name: string; bay: string; mission: string; watch: string; cadence: string; tags: string[] };
+export type CrewMember = { id: string; name: string; callsign: string; teamId: CrewTeam["id"]; roleId: CrewRoleId; readinessId: ReadinessId; specialty: string; note: string };
+export type DutyRotation = { id: string; label: string; window: string; teamId: CrewTeam["id"]; state: RotationState; objective: string; handoff: string; leadId: CrewMember["id"]; supportIds: CrewMember["id"][]; notes: string[] };
+
+export const crewRoles: CrewRole[] = [
+  { id: "navigation", label: "Navigation", shortLabel: "Nav" },
+  { id: "systems", label: "Systems", shortLabel: "Sys" },
+  { id: "medical", label: "Medical", shortLabel: "Med" },
+  { id: "security", label: "Security", shortLabel: "Sec" },
+];
+export const readinessStates: ReadinessState[] = [
+  { id: "ready", label: "Ready", summary: "Cleared for current watch" },
+  { id: "steady", label: "Steady", summary: "On console with reduced load" },
+  { id: "recovery", label: "Recovery", summary: "Off-peak support only" },
+];
+export const crewTeams: CrewTeam[] = [
+  { id: "atlas", name: "Atlas Flight", bay: "Dock A-3", mission: "Launch deck routing, escort windows, and queue sequencing.", watch: "Blue watch", cadence: "00:00-06:00 UTC", tags: ["Launch deck", "Priority cargo"] },
+  { id: "beacon", name: "Beacon Relay", bay: "Med Ring 2", mission: "Passenger stabilisation, corridor relays, and infirmary handoffs.", watch: "Gold watch", cadence: "02:00-08:00 UTC", tags: ["Med relay", "Inbound triage"] },
+  { id: "cinder", name: "Cinder Span", bay: "Engine Spine", mission: "Coolant balance, reactor trim, and systems fault isolation.", watch: "Red watch", cadence: "04:00-10:00 UTC", tags: ["Coolant grid", "Maintenance lock"] },
+  { id: "drift", name: "Drift Guard", bay: "Outer Lock 5", mission: "Perimeter escort, deck sweeps, and access control coverage.", watch: "Slate watch", cadence: "06:00-12:00 UTC", tags: ["Perimeter", "Visitor screening"] },
+];
+export const crewMembers: CrewMember[] = [
+  { id: "mara-quin", name: "Mara Quin", callsign: "Keel", teamId: "atlas", roleId: "navigation", readinessId: "ready", specialty: "Orbital docking", note: "Holding launch queue." },
+  { id: "ivo-senn", name: "Ivo Senn", callsign: "Latch", teamId: "atlas", roleId: "systems", readinessId: "steady", specialty: "Thruster trim", note: "Balancing gate pressure." },
+  { id: "talia-reed", name: "Talia Reed", callsign: "Ward", teamId: "atlas", roleId: "security", readinessId: "ready", specialty: "Escort lanes", note: "Covering cargo escort." },
+  { id: "lena-osei", name: "Lena Osei", callsign: "Pulse", teamId: "beacon", roleId: "medical", readinessId: "ready", specialty: "Rapid triage", note: "Lead for med ring handoff." },
+  { id: "jules-park", name: "Jules Park", callsign: "Kite", teamId: "beacon", roleId: "navigation", readinessId: "steady", specialty: "Shuttle relay", note: "Holding corridor routing." },
+  { id: "orin-vale", name: "Orin Vale", callsign: "Flux", teamId: "beacon", roleId: "systems", readinessId: "recovery", specialty: "Cabin telemetry", note: "On reduced console load." },
+  { id: "sora-keene", name: "Sora Keene", callsign: "Ember", teamId: "cinder", roleId: "systems", readinessId: "ready", specialty: "Reactor trim", note: "Lead on coolant pulse." },
+  { id: "dev-malik", name: "Dev Malik", callsign: "Hush", teamId: "cinder", roleId: "security", readinessId: "steady", specialty: "Access rings", note: "Watching maintenance lock." },
+  { id: "mira-ilyan", name: "Mira Ilyan", callsign: "Suture", teamId: "cinder", roleId: "medical", readinessId: "ready", specialty: "Fatigue recovery", note: "Supporting rest corridor." },
+  { id: "noor-hale", name: "Noor Hale", callsign: "Harbor", teamId: "drift", roleId: "security", readinessId: "ready", specialty: "Gate screening", note: "Lead for outer lock checks." },
+  { id: "ezra-pike", name: "Ezra Pike", callsign: "Span", teamId: "drift", roleId: "navigation", readinessId: "ready", specialty: "Approach vectors", note: "Tracking escort windows." },
+  { id: "cass-wynn", name: "Cass Wynn", callsign: "Rivet", teamId: "drift", roleId: "systems", readinessId: "steady", specialty: "Sensor sweep", note: "Monitoring gate mesh." },
+];
+export const dutyRotations: DutyRotation[] = [
+  { id: "north-span", label: "North Span Watch", window: "04:00-06:00 UTC", teamId: "atlas", state: "active", objective: "Keep launch deck sequencing stable while freight escorts clear Dock A.", handoff: "Transfer to Beacon corridor when passenger surge reaches gate three.", leadId: "mara-quin", supportIds: ["ivo-senn", "talia-reed"], notes: ["Cargo escort staggered by six minutes.", "Throttle handoff stays on manual confirmation."] },
+  { id: "triage-loop", label: "Triage Loop", window: "05:30-07:30 UTC", teamId: "beacon", state: "handoff", objective: "Stabilise inbound passenger flow and keep med ring relay below two-minute dwell.", handoff: "Rotate cabin telemetry to Cinder once infirmary intake drops under twelve.", leadId: "lena-osei", supportIds: ["jules-park", "orin-vale"], notes: ["Medical kits already staged at ring two.", "Reduced load on systems console remains in effect."] },
+  { id: "coolant-pulse", label: "Coolant Pulse", window: "07:00-09:00 UTC", teamId: "cinder", state: "staged", objective: "Balance reactor draw before maintenance crews reopen the engine spine.", handoff: "Release lock only after sensor delta stays flat for two consecutive scans.", leadId: "sora-keene", supportIds: ["dev-malik", "mira-ilyan"], notes: ["Security stays posted on maintenance lock.", "Recovery corridor remains open for technical crews."] },
+  { id: "outer-lantern", label: "Outer Lantern", window: "08:30-10:30 UTC", teamId: "drift", state: "staged", objective: "Sweep perimeter lanes and hold visitor screening coverage through arrivals peak.", handoff: "Promote to live watch if gate five queue exceeds threshold.", leadId: "noor-hale", supportIds: ["ezra-pike", "cass-wynn"], notes: ["Escort lane two is reserved for diplomatic arrivals.", "Sensor mesh refresh remains on ten-minute cadence."] },
+];
+export const rosterSummary = { cycleLabel: "Cycle 7 / Dockside Rotation", activeRotationId: "north-span", handoffAt: "05:45 UTC", readinessNote: "Nine crew cleared for active coverage across four isolated teams." };

--- a/src/app/crew-roster/page.tsx
+++ b/src/app/crew-roster/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import {
+  crewMembers,
+  crewRoles,
+  crewTeams,
+  dutyRotations,
+  readinessStates,
+  rosterSummary,
+} from "./mock-data";
+import { CrewRosterShell } from "@/components/crew-roster/crew-roster-shell";
+
+export const metadata: Metadata = {
+  title: "Crew Roster | API Test",
+  description: "Mock crew roster with role filters, team cards, readiness indicators, and duty rotation details.",
+};
+
+export default function CrewRosterPage() {
+  return <CrewRosterShell members={crewMembers} readinessStates={readinessStates} roles={crewRoles} rotations={dutyRotations} summary={rosterSummary} teams={crewTeams} />;
+}

--- a/src/components/crew-roster/crew-roster-header.tsx
+++ b/src/components/crew-roster/crew-roster-header.tsx
@@ -1,0 +1,44 @@
+type CrewRosterHeaderProps = {
+  activeRotationLabel: string; cycleLabel: string; handoffAt: string; readinessNote: string; readyCount: number;
+  selectedRoleLabel: string; totalCrew: number; totalTeams: number; visibleCrewCount: number; visibleTeamsCount: number;
+};
+
+export function CrewRosterHeader({
+  activeRotationLabel, cycleLabel, handoffAt, readinessNote, readyCount,
+  selectedRoleLabel, totalCrew, totalTeams, visibleCrewCount, visibleTeamsCount,
+}: CrewRosterHeaderProps) {
+  return (
+    <section className="overflow-hidden rounded-[2rem] border border-amber-200/15 bg-[linear-gradient(140deg,rgba(120,53,15,0.36),rgba(15,23,42,0.92)_42%,rgba(17,24,39,0.96)_100%)] px-6 py-7 shadow-2xl shadow-slate-950/30">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1.35fr)_minmax(18rem,0.95fr)] lg:px-2">
+        <div className="space-y-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.42em] text-amber-200/80">Crew Roster</p>
+          <h1 className="max-w-3xl font-[family-name:Georgia,Times,serif] text-4xl font-semibold tracking-tight text-white sm:text-5xl">Team cards, role coverage, and duty handoffs in one isolated watch board.</h1>
+          <p className="max-w-2xl text-sm leading-7 text-slate-300 sm:text-base">Narrow the roster by specialty, inspect readiness at the team level, and open a local rotation card for handoff notes without touching any shared route state.</p>
+          <div className="flex flex-wrap gap-3 text-sm text-slate-200">
+            <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1.5">{cycleLabel}</span>
+            <span className="rounded-full border border-amber-300/25 bg-amber-200/10 px-3 py-1.5">Active watch: {activeRotationLabel}</span>
+            <span className="rounded-full border border-sky-300/20 bg-sky-300/10 px-3 py-1.5">Handoff at {handoffAt}</span>
+            <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1.5">Focus: {selectedRoleLabel}</span>
+          </div>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
+          <div className="rounded-[1.5rem] border border-white/10 bg-white/8 px-4 py-4 backdrop-blur">
+            <p className="text-sm text-slate-300">Crew listed</p>
+            <p className="mt-2 text-3xl font-semibold text-white">{totalCrew}</p>
+            <p className="mt-1 text-xs text-slate-400">{visibleCrewCount} in current filter</p>
+          </div>
+          <div className="rounded-[1.5rem] border border-emerald-300/20 bg-emerald-300/10 px-4 py-4">
+            <p className="text-sm text-emerald-100">Ready now</p>
+            <p className="mt-2 text-3xl font-semibold text-white">{readyCount}</p>
+            <p className="mt-1 text-xs text-emerald-100/80">{readinessNote}</p>
+          </div>
+          <div className="rounded-[1.5rem] border border-sky-300/20 bg-sky-300/10 px-4 py-4">
+            <p className="text-sm text-sky-100">Teams in view</p>
+            <p className="mt-2 text-3xl font-semibold text-white">{visibleTeamsCount}/{totalTeams}</p>
+            <p className="mt-1 text-xs text-sky-100/80">Desktop and mobile-safe layout</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/crew-roster/crew-roster-shell.tsx
+++ b/src/components/crew-roster/crew-roster-shell.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { startTransition, useState } from "react";
+import type {
+  CrewMember,
+  CrewRole,
+  CrewRoleId,
+  CrewTeam,
+  DutyRotation,
+  ReadinessState,
+} from "@/app/crew-roster/mock-data";
+import { CrewRosterHeader } from "./crew-roster-header";
+import { CrewTeamCardGrid } from "./crew-team-card-grid";
+import { DutyRotationPanel } from "./duty-rotation-panel";
+import { RoleFilterBar } from "./role-filter-bar";
+
+type CrewRosterShellProps = {
+  members: CrewMember[]; readinessStates: ReadinessState[]; roles: CrewRole[]; rotations: DutyRotation[];
+  summary: { activeRotationId: string; cycleLabel: string; handoffAt: string; readinessNote: string };
+  teams: CrewTeam[];
+};
+
+function teamMatchesRole(teamId: string, members: CrewMember[], selectedRoleId: CrewRoleId | "all") {
+  return selectedRoleId === "all" || members.some((member) => member.teamId === teamId && member.roleId === selectedRoleId);
+}
+
+export function CrewRosterShell({
+  members, readinessStates, roles, rotations, summary, teams,
+}: CrewRosterShellProps) {
+  const [selectedRoleId, setSelectedRoleId] = useState<CrewRoleId | "all">("all");
+  const [selectedRotationId, setSelectedRotationId] = useState<string | null>(null);
+  const roleCounts: Record<CrewRoleId, number> = { navigation: 0, systems: 0, medical: 0, security: 0 };
+  for (const member of members) roleCounts[member.roleId] += 1;
+  const visibleTeams = teams.filter((team) => teamMatchesRole(team.id, members, selectedRoleId));
+  const visibleTeamIds = new Set(visibleTeams.map((team) => team.id));
+  const visibleRotations = rotations.filter((rotation) => visibleTeamIds.has(rotation.teamId));
+  const activeRotation = rotations.find((rotation) => rotation.id === summary.activeRotationId) ?? rotations[0];
+  const selectedRoleLabel = selectedRoleId === "all" ? "All roles" : (roles.find((role) => role.id === selectedRoleId)?.label ?? "All roles");
+  const readyCount = members.filter((member) => member.readinessId === "ready").length;
+  const visibleCrewCount = members.filter((member) => selectedRoleId === "all" || member.roleId === selectedRoleId).length;
+
+  const handleRoleSelect = (nextRoleId: CrewRoleId | "all") => {
+    const nextVisibleTeamIds = new Set(teams.filter((team) => teamMatchesRole(team.id, members, nextRoleId)).map((team) => team.id));
+    startTransition(() => {
+      setSelectedRoleId(nextRoleId);
+      if (selectedRotationId && !rotations.some((rotation) => rotation.id === selectedRotationId && nextVisibleTeamIds.has(rotation.teamId))) {
+        setSelectedRotationId(null);
+      }
+    });
+  };
+
+  const handleRotationSelect = (rotationId: string) => startTransition(() => setSelectedRotationId((current) => (current === rotationId ? null : rotationId)));
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(251,191,36,0.14),transparent_28%),linear-gradient(180deg,#09090b_0%,#0f172a_46%,#111827_100%)] px-4 py-6 text-slate-100 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <CrewRosterHeader activeRotationLabel={activeRotation?.label ?? "No active lane"} cycleLabel={summary.cycleLabel} handoffAt={summary.handoffAt} readinessNote={summary.readinessNote} readyCount={readyCount} selectedRoleLabel={selectedRoleLabel} totalCrew={members.length} totalTeams={teams.length} visibleCrewCount={visibleCrewCount} visibleTeamsCount={visibleTeams.length} />
+        <section className="grid gap-6 xl:grid-cols-[minmax(0,1.5fr)_minmax(320px,0.92fr)]">
+          <div className="space-y-5">
+            <RoleFilterBar onSelectRole={handleRoleSelect} roles={roles} roleCounts={roleCounts} selectedRoleId={selectedRoleId} totalCrewCount={members.length} visibleCrewCount={visibleCrewCount} visibleTeamsCount={visibleTeams.length} />
+            <CrewTeamCardGrid members={members} readinessStates={readinessStates} rotations={visibleRotations} selectedRoleId={selectedRoleId} teams={visibleTeams} />
+          </div>
+          <DutyRotationPanel members={members} onClearSelection={() => setSelectedRotationId(null)} onSelectRotation={handleRotationSelect} rotations={visibleRotations} selectedRoleId={selectedRoleId} selectedRotationId={selectedRotationId} teams={teams} />
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/components/crew-roster/crew-team-card-grid.tsx
+++ b/src/components/crew-roster/crew-team-card-grid.tsx
@@ -1,0 +1,32 @@
+import type {
+  CrewMember,
+  CrewRoleId,
+  CrewTeam,
+  DutyRotation,
+  ReadinessState,
+} from "@/app/crew-roster/mock-data";
+import { CrewTeamCard } from "./crew-team-card";
+
+type CrewTeamCardGridProps = {
+  members: CrewMember[]; readinessStates: ReadinessState[]; rotations: DutyRotation[];
+  selectedRoleId: CrewRoleId | "all"; teams: CrewTeam[];
+};
+
+export function CrewTeamCardGrid({
+  members, readinessStates, rotations, selectedRoleId, teams,
+}: CrewTeamCardGridProps) {
+  return (
+    <section className="grid gap-4 lg:grid-cols-2">
+      {teams.map((team) => (
+        <CrewTeamCard
+          key={team.id}
+          members={members.filter((member) => member.teamId === team.id)}
+          readinessStates={readinessStates}
+          rotation={rotations.find((rotation) => rotation.teamId === team.id) ?? null}
+          selectedRoleId={selectedRoleId}
+          team={team}
+        />
+      ))}
+    </section>
+  );
+}

--- a/src/components/crew-roster/crew-team-card.tsx
+++ b/src/components/crew-roster/crew-team-card.tsx
@@ -1,0 +1,90 @@
+import type {
+  CrewMember,
+  CrewRoleId,
+  CrewTeam,
+  DutyRotation,
+  ReadinessState,
+} from "@/app/crew-roster/mock-data";
+
+const readinessChipClass = {
+  ready: "border-emerald-300/25 bg-emerald-300/10 text-emerald-100",
+  steady: "border-amber-300/25 bg-amber-300/10 text-amber-100",
+  recovery: "border-rose-300/25 bg-rose-300/10 text-rose-100",
+} as const;
+
+const rotationStateClass = {
+  active: "border-emerald-300/25 bg-emerald-300/10 text-emerald-100",
+  handoff: "border-amber-300/25 bg-amber-300/10 text-amber-100",
+  staged: "border-sky-300/25 bg-sky-300/10 text-sky-100",
+} as const;
+const roleLabel = { navigation: "Nav", systems: "Sys", medical: "Med", security: "Sec" } as const;
+
+type CrewTeamCardProps = {
+  members: CrewMember[];
+  readinessStates: ReadinessState[];
+  rotation: DutyRotation | null;
+  selectedRoleId: CrewRoleId | "all";
+  team: CrewTeam;
+};
+
+export function CrewTeamCard({
+  members,
+  readinessStates,
+  rotation,
+  selectedRoleId,
+  team,
+}: CrewTeamCardProps) {
+  const visibleMembers = members.filter((member) => selectedRoleId === "all" || member.roleId === selectedRoleId);
+
+  return (
+    <article className="rounded-[1.75rem] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.92),rgba(15,23,42,0.72))] p-5 shadow-xl shadow-slate-950/15">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-amber-200/70">{team.watch}</p>
+          <h3 className="mt-2 text-2xl font-semibold text-white">{team.name}</h3>
+          <p className="mt-1 text-sm text-slate-400">{team.bay} · {team.cadence}</p>
+        </div>
+        {rotation ? <span className={`rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-[0.22em] ${rotationStateClass[rotation.state]}`}>{rotation.state}</span> : null}
+      </div>
+      <p className="mt-4 text-sm leading-6 text-slate-300">{team.mission}</p>
+      <div className="mt-4 flex flex-wrap gap-2">
+        {team.tags.map((tag) => (
+          <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-200" key={tag}>{tag}</span>
+        ))}
+      </div>
+      <div className="mt-5 flex flex-wrap gap-2">
+        {readinessStates.map((state) => {
+          const count = visibleMembers.filter((member) => member.readinessId === state.id).length;
+          if (count === 0) return null;
+          return (
+            <span className={`rounded-full border px-3 py-1 text-xs font-medium ${readinessChipClass[state.id]}`} key={state.id}>
+              {count} {state.label}
+            </span>
+          );
+        })}
+      </div>
+      <ul className="mt-5 space-y-3">
+        {visibleMembers.map((member) => {
+          const readiness = readinessStates.find((state) => state.id === member.readinessId);
+          return (
+            <li className="flex items-start justify-between gap-3 rounded-2xl border border-white/8 bg-white/4 px-4 py-3" key={member.id}>
+              <div>
+                <p className="font-medium text-white">{member.name}</p>
+                <p className="mt-1 text-xs uppercase tracking-[0.24em] text-slate-400">{member.callsign} · {roleLabel[member.roleId]}</p>
+                <p className="mt-2 text-sm text-slate-300">{member.note}</p>
+              </div>
+              <div className="text-right">
+                <span className={`rounded-full border px-3 py-1 text-xs font-medium ${readinessChipClass[member.readinessId]}`}>{readiness?.label}</span>
+                <p className="mt-2 text-xs text-slate-400">{member.specialty}</p>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+      <div className="mt-5 flex items-center justify-between text-sm text-slate-400">
+        <span>Showing {visibleMembers.length} of {members.length} crew</span>
+        <span>{rotation?.label ?? "Rotation pending"}</span>
+      </div>
+    </article>
+  );
+}

--- a/src/components/crew-roster/duty-rotation-panel.tsx
+++ b/src/components/crew-roster/duty-rotation-panel.tsx
@@ -1,0 +1,100 @@
+import type {
+  CrewMember,
+  CrewRoleId,
+  CrewTeam,
+  DutyRotation,
+} from "@/app/crew-roster/mock-data";
+
+const rotationStateClass = {
+  active: "border-emerald-300/25 bg-emerald-300/10 text-emerald-100",
+  handoff: "border-amber-300/25 bg-amber-300/10 text-amber-100",
+  staged: "border-sky-300/25 bg-sky-300/10 text-sky-100",
+} as const;
+const roleLabel = { navigation: "navigation", systems: "systems", medical: "medical", security: "security" } as const;
+
+type DutyRotationPanelProps = {
+  members: CrewMember[]; onClearSelection: () => void; onSelectRotation: (rotationId: string) => void;
+  rotations: DutyRotation[]; selectedRoleId: CrewRoleId | "all"; selectedRotationId: string | null; teams: CrewTeam[];
+};
+
+export function DutyRotationPanel({
+  members, onClearSelection, onSelectRotation, rotations, selectedRoleId, selectedRotationId, teams,
+}: DutyRotationPanelProps) {
+  const scopeLabel = selectedRoleId === "all" ? "all roles" : roleLabel[selectedRoleId];
+  const selectedRotation = rotations.find((rotation) => rotation.id === selectedRotationId) ?? null;
+  const selectedTeam = teams.find((team) => team.id === selectedRotation?.teamId) ?? null;
+  const selectedCrew = selectedRotation
+    ? members.filter((member) => member.teamId === selectedRotation.teamId && (selectedRoleId === "all" || member.roleId === selectedRoleId))
+    : [];
+
+  return (
+    <aside className="rounded-[1.75rem] border border-white/10 bg-slate-950/60 p-5 shadow-xl shadow-slate-950/15 backdrop-blur">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-amber-200/70">Duty Rotation</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">Highlight the next handoff lane.</h2>
+        </div>
+        <button className="rounded-full border border-white/10 px-3 py-1.5 text-sm text-slate-300 transition hover:border-white/20 hover:bg-white/5" onClick={onClearSelection} type="button">Clear</button>
+      </div>
+      <div className="mt-5 space-y-3">
+        {rotations.map((rotation) => {
+          const team = teams.find((entry) => entry.id === rotation.teamId);
+          const matchingCrew = members.filter((member) => member.teamId === rotation.teamId && (selectedRoleId === "all" || member.roleId === selectedRoleId));
+
+          return (
+            <button className={`w-full rounded-[1.5rem] border p-4 text-left transition ${selectedRotationId === rotation.id ? "border-amber-300/40 bg-amber-200/10 shadow-lg shadow-amber-950/10" : "border-white/10 bg-white/5 hover:border-white/20 hover:bg-white/8"}`} key={rotation.id} onClick={() => onSelectRotation(rotation.id)} type="button">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-white">{rotation.label}</p>
+                  <p className="mt-1 text-sm text-slate-400">{team?.name} · {rotation.window}</p>
+                </div>
+                <span className={`rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-[0.22em] ${rotationStateClass[rotation.state]}`}>{rotation.state}</span>
+              </div>
+              <p className="mt-3 text-sm leading-6 text-slate-300">{matchingCrew.length} crew visible for {scopeLabel}.</p>
+            </button>
+          );
+        })}
+      </div>
+      {selectedRotation && selectedTeam ? (
+        <div className="mt-5 rounded-[1.5rem] border border-white/10 bg-[linear-gradient(180deg,rgba(56,189,248,0.12),rgba(15,23,42,0.4))] p-5">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs uppercase tracking-[0.22em] text-slate-200">{selectedTeam.name}</span>
+            <span className={`rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-[0.22em] ${rotationStateClass[selectedRotation.state]}`}>{selectedRotation.state}</span>
+          </div>
+          <h3 className="mt-4 text-xl font-semibold text-white">{selectedRotation.objective}</h3>
+          <p className="mt-3 text-sm leading-6 text-slate-300">Handoff note: {selectedRotation.handoff}</p>
+          <div className="mt-5">
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-400">Crew on this lane</p>
+            {selectedCrew.length > 0 ? (
+              <ul className="mt-3 space-y-3">
+                {selectedCrew.map((member) => (
+                  <li className="rounded-2xl border border-white/10 bg-white/6 px-4 py-3" key={member.id}>
+                    <p className="font-medium text-white">{member.name}</p>
+                    <p className="mt-1 text-xs uppercase tracking-[0.22em] text-slate-400">{member.callsign} · {roleLabel[member.roleId]}</p>
+                    <p className="mt-2 text-sm text-slate-300">{member.specialty}</p>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="mt-3 rounded-2xl border border-dashed border-white/15 bg-white/4 px-4 py-5 text-sm leading-6 text-slate-300">
+                {selectedRoleId === "all" ? "No crew are assigned to this rotation right now." : `No ${scopeLabel} crew are assigned to this rotation right now.`} Clear the filter to restore the full lane.
+              </p>
+            )}
+          </div>
+          <div className="mt-5">
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-400">Handoff checkpoints</p>
+            <ul className="mt-3 space-y-2 text-sm text-slate-300">
+              {selectedRotation.notes.map((note) => <li className="rounded-2xl border border-white/8 bg-white/4 px-4 py-3" key={note}>{note}</li>)}
+            </ul>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-5 rounded-[1.5rem] border border-dashed border-white/15 bg-white/4 px-5 py-8 text-center">
+          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-400">No lane selected</p>
+          <h3 className="mt-3 text-2xl font-semibold text-white">Choose a rotation card to inspect the crew handoff.</h3>
+          <p className="mt-3 text-sm leading-6 text-slate-300">Deselecting returns this empty state so the panel can stay local to the route without forcing a shared default focus.</p>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/components/crew-roster/role-filter-bar.tsx
+++ b/src/components/crew-roster/role-filter-bar.tsx
@@ -1,0 +1,34 @@
+import type { CrewRole, CrewRoleId } from "@/app/crew-roster/mock-data";
+
+type RoleFilterBarProps = {
+  onSelectRole: (roleId: CrewRoleId | "all") => void; roles: CrewRole[]; roleCounts: Record<CrewRoleId, number>;
+  selectedRoleId: CrewRoleId | "all"; totalCrewCount: number; visibleCrewCount: number; visibleTeamsCount: number;
+};
+
+export function RoleFilterBar({
+  onSelectRole, roles, roleCounts, selectedRoleId, totalCrewCount, visibleCrewCount, visibleTeamsCount,
+}: RoleFilterBarProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-white/10 bg-slate-950/55 p-4 shadow-xl shadow-slate-950/15 backdrop-blur sm:p-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-amber-200/70">Role Filters</p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">Spotlight a specialty without leaving the roster board.</h2>
+        </div>
+        <p className="text-sm text-slate-300">Showing {visibleCrewCount} crew across {visibleTeamsCount} visible teams.</p>
+      </div>
+      <div className="mt-4 flex flex-wrap gap-2">
+        <button className={`rounded-full px-4 py-2 text-sm font-medium transition ${selectedRoleId === "all" ? "bg-amber-300 text-slate-950" : "border border-white/10 bg-white/5 text-slate-200 hover:border-amber-200/30 hover:bg-white/10"}`} onClick={() => onSelectRole("all")} type="button">
+          All roles
+          <span className="ml-2 text-xs opacity-70">{totalCrewCount}</span>
+        </button>
+        {roles.map((role) => (
+          <button className={`rounded-full px-4 py-2 text-sm font-medium transition ${selectedRoleId === role.id ? "bg-sky-300 text-slate-950" : "border border-white/10 bg-white/5 text-slate-200 hover:border-sky-200/30 hover:bg-white/10"}`} key={role.id} onClick={() => onSelectRole(role.id)} type="button">
+            {role.label}
+            <span className="ml-2 text-xs opacity-70">{roleCounts[role.id]}</span>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/crew-roster` app route with local mock roster data and metadata
- render role-filtered team cards with readiness chips and watch summaries
- add a client-side duty rotation panel with highlight and deselection empty states

## Verification
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #30