### PR TITLE
feat: add isolated status board route

### DIFF
--- a/src/app/status-board/mock-data.ts
+++ b/src/app/status-board/mock-data.ts
@@ -1,0 +1,78 @@
+export type BoardTone = "healthy" | "watch" | "degraded" | "failover";
+export type ChecklistPhase = "Stabilize" | "Reroute" | "Validate";
+export type StatusBoardSummary = { id: string; label: string; value: string; note: string; tone: BoardTone };
+export type StatusBoardRegion = { id: string; name: string; code: string; city: string; status: BoardTone; latencyMs: number; latencyDeltaMs: number; trafficShare: number; incidents: number; summary: string };
+export type StatusBoardDependency = { id: string; service: string; owner: string; status: BoardTone; primaryRegion: string; backupRegion: string; regionIds: string[]; p95LatencyMs: number; errorRate: number; since: string };
+export type FailoverChecklistItem = { id: string; title: string; owner: string; phase: ChecklistPhase; detail: string; required: boolean; defaultDone: boolean };
+export type StatusBoardSnapshot = { boardState: string; environment: string; lastUpdated: Date; summaryCards: StatusBoardSummary[]; regions: StatusBoardRegion[]; dependencies: StatusBoardDependency[]; checklist: FailoverChecklistItem[] };
+
+type RegionRow = readonly [string, string, string, string, BoardTone, number, number, number, number, string];
+type DependencyRow = readonly [string, string, string, BoardTone, string, string, string[], number, number, string];
+type ChecklistRow = readonly [string, string, string, ChecklistPhase, string, boolean, boolean];
+
+const regionRows: RegionRow[] = [
+  ["us-east", "US East", "IAD", "Ashburn", "healthy", 46, -5, 42, 0, "Primary ingress and token minting remain inside latency targets."],
+  ["eu-west", "EU West", "DUB", "Dublin", "watch", 68, 11, 24, 1, "Cache pressure is contained, but replay traffic is still elevated."],
+  ["ap-south", "AP South", "BOM", "Mumbai", "healthy", 61, 3, 18, 0, "Background queue replay has settled without affecting customer APIs."],
+  ["sa-east", "SA East", "GRU", "Sao Paulo", "failover", 94, 18, 16, 2, "Backup replicas are warm while writes remain pinned to the secondary lane."],
+];
+const dependencyRows: DependencyRow[] = [
+  ["edge-api", "Edge API", "Platform", "healthy", "IAD", "DUB", ["us-east", "eu-west"], 118, 0.19, "14m"],
+  ["auth-mesh", "Auth Mesh", "Identity", "degraded", "DUB", "IAD", ["us-east", "eu-west", "sa-east"], 183, 1.62, "37m"],
+  ["session-cache", "Session Cache", "Runtime", "failover", "GRU", "IAD", ["us-east", "sa-east"], 209, 0.84, "52m"],
+  ["payments-queue", "Payments Queue", "Ledger", "watch", "BOM", "IAD", ["ap-south", "us-east"], 144, 0.47, "19m"],
+  ["notification-fanout", "Notification Fanout", "Comms", "healthy", "IAD", "BOM", ["us-east", "ap-south", "eu-west"], 101, 0.11, "8m"],
+];
+const checklistRows: ChecklistRow[] = [
+  ["freeze-routing", "Freeze cross-region routing changes", "Platform", "Stabilize", "Pause automation before capacity shifts widen blast radius.", true, true],
+  ["confirm-capacity", "Confirm backup capacity reservations", "Infrastructure", "Stabilize", "Verify spare compute headroom is held in the backup region.", true, true],
+  ["pin-stateful-writes", "Pin stateful writes to the safest region", "Data", "Reroute", "Keep write-heavy paths on the most stable replica set until lag clears.", true, false],
+  ["drain-cold-lanes", "Drain cold lanes before promoting traffic", "Network", "Reroute", "Empty stale edge queues so retries do not arrive out of order.", false, false],
+  ["verify-health-checks", "Validate public health checks from backup ingress", "SRE", "Validate", "Confirm probe locations outside the primary region can still pass end to end.", true, false],
+  ["note-handover", "Log handover owner and rollback gate", "Incident", "Validate", "Record who can revert traffic and the metric needed to close the drill.", false, true],
+];
+
+const baseRegions = regionRows.map(([id, name, code, city, status, latencyMs, latencyDeltaMs, trafficShare, incidents, summary]) => ({ id, name, code, city, status, latencyMs, latencyDeltaMs, trafficShare, incidents, summary }));
+const baseDependencies = dependencyRows.map(([id, service, owner, status, primaryRegion, backupRegion, regionIds, p95LatencyMs, errorRate, since]) => ({ id, service, owner, status, primaryRegion, backupRegion, regionIds, p95LatencyMs, errorRate, since }));
+const baseChecklist = checklistRows.map(([id, title, owner, phase, detail, required, defaultDone]) => ({ id, title, owner, phase, detail, required, defaultDone }));
+const swingMetric = (cycle: number, seed: number, step: number) => (((cycle + seed) % 3) - 1) * step;
+
+export function buildStatusBoardSnapshot(cycle: number, now: Date): StatusBoardSnapshot {
+  const regions = baseRegions.map((region, index) => ({
+    ...region,
+    status: region.id === "sa-east" && cycle % 2 === 1 ? "watch" : region.status,
+    latencyMs: region.latencyMs + swingMetric(cycle, index + 1, 4),
+    latencyDeltaMs: region.latencyDeltaMs + swingMetric(cycle, index + 4, 3),
+  }));
+  const dependencies = baseDependencies.map((dependency, index) => ({
+    ...dependency,
+    status:
+      dependency.id === "auth-mesh" && cycle % 2 === 1
+        ? "watch"
+        : dependency.id === "session-cache" && cycle % 3 === 2
+          ? "watch"
+          : dependency.status,
+    p95LatencyMs: dependency.p95LatencyMs + swingMetric(cycle, index + 2, 6),
+    errorRate: Number((dependency.errorRate + swingMetric(cycle, index + 6, 0.08)).toFixed(2)),
+  }));
+  const elevatedRegions = regions.filter((region) => region.status !== "healthy").length;
+  const attentionDependencies = dependencies.filter((dependency) => dependency.status !== "healthy").length;
+  const primaryTrafficShare = regions.filter((region) => region.status !== "failover").reduce((sum, region) => sum + region.trafficShare, 0);
+  const completedCount = baseChecklist.filter((item) => item.defaultDone).length;
+  const requiredOutstanding = baseChecklist.filter((item) => item.required && !item.defaultDone).length;
+
+  return {
+    boardState: elevatedRegions > 1 ? "Regional failover watch" : "Regional posture nominal",
+    environment: "Production mirror",
+    lastUpdated: new Date(now.getTime() + cycle * 60_000),
+    summaryCards: [
+      { id: "regional-slo", label: "Regions within target", value: `${regions.length - elevatedRegions}/${regions.length}`, note: `${elevatedRegions} elevated regional lanes`, tone: elevatedRegions > 1 ? "watch" : "healthy" },
+      { id: "traffic", label: "Traffic on primary path", value: `${primaryTrafficShare}%`, note: `${100 - primaryTrafficShare}% pinned to backup lanes`, tone: primaryTrafficShare < 90 ? "watch" : "healthy" },
+      { id: "dependencies", label: "Dependencies needing action", value: String(attentionDependencies), note: `${dependencies.filter((item) => item.status === "failover").length} in assisted failover`, tone: attentionDependencies > 2 ? "degraded" : "watch" },
+      { id: "checklist", label: "Checklist pre-cleared", value: `${completedCount}/${baseChecklist.length}`, note: `${requiredOutstanding} required steps still open`, tone: requiredOutstanding === 0 ? "healthy" : "watch" },
+    ],
+    regions,
+    dependencies,
+    checklist: baseChecklist,
+  };
+}

--- a/src/app/status-board/page.tsx
+++ b/src/app/status-board/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+
+import { buildStatusBoardSnapshot } from "./mock-data";
+import { StatusBoardShell } from "@/components/status-board/status-board-shell";
+
+export const metadata: Metadata = {
+  title: "Status Board | API Test",
+  description:
+    "Mock service status board with regional health cards, dependency status, and a failover checklist.",
+};
+
+export default function StatusBoardPage() {
+  return (
+    <StatusBoardShell
+      initialSnapshot={buildStatusBoardSnapshot(0, new Date())}
+    />
+  );
+}

--- a/src/components/status-board/dependency-table.tsx
+++ b/src/components/status-board/dependency-table.tsx
@@ -1,0 +1,95 @@
+import type { BoardTone, StatusBoardDependency } from "@/app/status-board/mock-data";
+
+type DependencyTableProps = {
+  dependencies: StatusBoardDependency[];
+  filterOptions: { count: number; id: string; label: string }[];
+  onFilterChange: (filterId: string) => void;
+  selectedFilter: string;
+  selectedRegionCount: number;
+};
+
+const toneClasses = {
+  healthy: "border-emerald-200 bg-emerald-500/12 text-emerald-900",
+  watch: "border-amber-200 bg-amber-400/15 text-amber-900",
+  degraded: "border-rose-200 bg-rose-500/12 text-rose-900",
+  failover: "border-cyan-200 bg-cyan-500/12 text-cyan-900",
+} satisfies Record<BoardTone, string>;
+
+export function DependencyTable({
+  dependencies,
+  filterOptions,
+  onFilterChange,
+  selectedFilter,
+  selectedRegionCount,
+}: DependencyTableProps) {
+  return (
+    <section className="rounded-[28px] border border-slate-200 bg-white/78 p-5 shadow-[0_18px_50px_rgba(15,23,42,0.08)] backdrop-blur md:p-6">
+      <div className="flex flex-col gap-4">
+        <div>
+          <p className="text-sm font-medium uppercase tracking-[0.22em] text-slate-500">Dependency health</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">Regional dependency coverage</h2>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {filterOptions.map((option) => {
+            const isActive = selectedFilter === option.id;
+            return (
+              <button
+                className={`rounded-full border px-4 py-2 text-sm font-medium transition ${isActive ? "border-slate-950 bg-slate-950 text-slate-50" : "border-slate-300 bg-white text-slate-700 hover:border-slate-950 hover:text-slate-950"}`}
+                key={option.id}
+                onClick={() => onFilterChange(option.id)}
+                type="button"
+              >
+                {option.label} · {option.count}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      {selectedRegionCount === 0 ? (
+        <div className="mt-6 rounded-[24px] border border-dashed border-slate-300 bg-slate-50 p-8 text-center">
+          <p className="text-lg font-semibold text-slate-950">Select at least one region to inspect dependency coverage.</p>
+          <p className="mt-2 text-sm leading-6 text-slate-600">Clear filters only when you want a deliberate zero-state. The table repopulates as soon as a regional card is active again.</p>
+        </div>
+      ) : dependencies.length === 0 ? (
+        <div className="mt-6 rounded-[24px] border border-dashed border-slate-300 bg-slate-50 p-8 text-center">
+          <p className="text-lg font-semibold text-slate-950">No dependencies match the current state filter.</p>
+          <p className="mt-2 text-sm leading-6 text-slate-600">Switch the status chips above or widen the regional selection to compare a broader failover surface.</p>
+        </div>
+      ) : (
+        <div className="mt-6 overflow-hidden rounded-[24px] border border-slate-200">
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-slate-200">
+              <thead className="bg-slate-950 text-left text-xs uppercase tracking-[0.22em] text-slate-300">
+                <tr>
+                  <th className="px-4 py-3 font-medium">Service</th>
+                  <th className="px-4 py-3 font-medium">Status</th>
+                  <th className="px-4 py-3 font-medium">Primary</th>
+                  <th className="px-4 py-3 font-medium">Backup</th>
+                  <th className="px-4 py-3 font-medium">p95</th>
+                  <th className="px-4 py-3 font-medium">Error rate</th>
+                  <th className="px-4 py-3 font-medium">Since</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200 bg-white">
+                {dependencies.map((dependency) => (
+                  <tr className="align-top text-sm text-slate-700" key={dependency.id}>
+                    <td className="px-4 py-4">
+                      <p className="font-semibold text-slate-950">{dependency.service}</p>
+                      <p className="mt-1 text-xs uppercase tracking-[0.22em] text-slate-500">{dependency.owner}</p>
+                    </td>
+                    <td className="px-4 py-4"><span className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] ${toneClasses[dependency.status]}`}>{dependency.status}</span></td>
+                    <td className="px-4 py-4">{dependency.primaryRegion}</td>
+                    <td className="px-4 py-4">{dependency.backupRegion}</td>
+                    <td className="px-4 py-4">{dependency.p95LatencyMs} ms</td>
+                    <td className="px-4 py-4">{dependency.errorRate.toFixed(2)}%</td>
+                    <td className="px-4 py-4">{dependency.since}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/status-board/failover-checklist.tsx
+++ b/src/components/status-board/failover-checklist.tsx
@@ -1,0 +1,73 @@
+import type { FailoverChecklistItem } from "@/app/status-board/mock-data";
+
+type FailoverChecklistProps = {
+  completedCount: number;
+  items: FailoverChecklistItem[];
+  onReset: () => void;
+  onToggleItem: (itemId: string) => void;
+  onToggleOpenOnly: () => void;
+  showOpenOnly: boolean;
+  toggledIds: string[];
+  totalCount: number;
+};
+
+export function FailoverChecklist({
+  completedCount,
+  items,
+  onReset,
+  onToggleItem,
+  onToggleOpenOnly,
+  showOpenOnly,
+  toggledIds,
+  totalCount,
+}: FailoverChecklistProps) {
+  return (
+    <section className="rounded-[28px] border border-slate-200 bg-slate-950 p-5 text-slate-100 shadow-[0_20px_50px_rgba(15,23,42,0.2)] md:p-6">
+      <div className="flex flex-col gap-4">
+        <div>
+          <p className="text-sm font-medium uppercase tracking-[0.22em] text-slate-400">Failover checklist</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight">Operator handoff</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-300">{completedCount} of {totalCount} checklist steps complete</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button className={`rounded-full border px-4 py-2 text-sm font-medium transition ${showOpenOnly ? "border-cyan-200 bg-cyan-300 text-slate-950" : "border-slate-700 text-slate-200 hover:border-slate-400"}`} onClick={onToggleOpenOnly} type="button">{showOpenOnly ? "Showing open only" : "Show open only"}</button>
+          <button className="rounded-full border border-slate-700 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-slate-400" onClick={onReset} type="button">Reset defaults</button>
+        </div>
+      </div>
+      {items.length === 0 ? (
+        <div className="mt-6 rounded-[24px] border border-dashed border-slate-700 bg-slate-900/70 p-8 text-center">
+          <p className="text-lg font-semibold">No open checklist items remain.</p>
+          <p className="mt-2 text-sm leading-6 text-slate-300">Every visible step is cleared for this snapshot. Reset defaults to rehearse the failover path again.</p>
+        </div>
+      ) : (
+        <ul className="mt-6 space-y-3">
+          {items.map((item) => {
+            const checked = toggledIds.includes(item.id);
+            return (
+              <li className="rounded-[24px] border border-slate-800 bg-slate-900/75 p-4" key={item.id}>
+                <label className="flex cursor-pointer items-start gap-4">
+                  <input
+                    aria-label={item.title}
+                    checked={checked}
+                    className="mt-1 h-4 w-4 rounded border-slate-500 bg-slate-950 text-cyan-300"
+                    onChange={() => onToggleItem(item.id)}
+                    type="checkbox"
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="flex flex-wrap items-center gap-2">
+                      <span className="text-base font-semibold text-slate-50">{item.title}</span>
+                      <span className="rounded-full border border-slate-700 px-2 py-1 text-[11px] uppercase tracking-[0.22em] text-slate-300">{item.phase}</span>
+                      {item.required ? <span className="rounded-full border border-amber-300/25 bg-amber-400/10 px-2 py-1 text-[11px] uppercase tracking-[0.22em] text-amber-200">Required</span> : null}
+                    </span>
+                    <span className="mt-2 block text-sm leading-6 text-slate-300">{item.detail}</span>
+                    <span className="mt-2 block text-xs uppercase tracking-[0.22em] text-slate-500">Owner · {item.owner}</span>
+                  </span>
+                </label>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/status-board/regional-health-grid.tsx
+++ b/src/components/status-board/regional-health-grid.tsx
@@ -1,0 +1,78 @@
+import type { StatusBoardRegion } from "@/app/status-board/mock-data";
+
+type RegionalHealthGridProps = {
+  onClearAll: () => void;
+  onSelectAll: () => void;
+  onToggleRegion: (regionId: string) => void;
+  regions: StatusBoardRegion[];
+  selectedRegionIds: string[];
+};
+
+const toneClasses = {
+  healthy: "border-emerald-200 bg-emerald-500/12 text-emerald-900",
+  watch: "border-amber-200 bg-amber-400/15 text-amber-900",
+  degraded: "border-rose-200 bg-rose-500/12 text-rose-900",
+  failover: "border-cyan-200 bg-cyan-500/12 text-cyan-900",
+} satisfies Record<StatusBoardRegion["status"], string>;
+const formatDelta = (delta: number) => `${delta >= 0 ? "+" : ""}${delta} ms`;
+
+export function RegionalHealthGrid({
+  onClearAll,
+  onSelectAll,
+  onToggleRegion,
+  regions,
+  selectedRegionIds,
+}: RegionalHealthGridProps) {
+  return (
+    <section className="rounded-[28px] border border-slate-200 bg-white/75 p-5 shadow-[0_18px_50px_rgba(15,23,42,0.08)] backdrop-blur md:p-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-sm font-medium uppercase tracking-[0.22em] text-slate-500">Regional health</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">Filter dependencies by active geography</h2>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button className="rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-950 hover:text-slate-950" onClick={onSelectAll} type="button">Select all regions</button>
+          <button className="rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-950 hover:text-slate-950" onClick={onClearAll} type="button">Clear all regions</button>
+        </div>
+      </div>
+      <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {regions.map((region) => {
+          const isSelected = selectedRegionIds.includes(region.id);
+          return (
+            <button
+              aria-label={`Toggle region ${region.name}`}
+              aria-pressed={isSelected}
+              className={`rounded-[24px] border p-4 text-left transition ${isSelected ? "border-slate-950 bg-slate-950 text-slate-50 shadow-[0_18px_35px_rgba(15,23,42,0.18)]" : "border-slate-200 bg-slate-50/85 text-slate-950 hover:border-slate-400"}`}
+              key={region.id}
+              onClick={() => onToggleRegion(region.id)}
+              type="button"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.24em] text-current/60">{region.code} · {region.city}</p>
+                  <h3 className="mt-2 text-xl font-semibold">{region.name}</h3>
+                </div>
+                <span className={`rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] ${isSelected ? "border-white/20 bg-white/10 text-slate-50" : toneClasses[region.status]}`}>{region.status}</span>
+              </div>
+              <div className="mt-5 grid grid-cols-2 gap-3">
+                <div className="rounded-2xl bg-black/5 p-3">
+                  <p className="text-xs uppercase tracking-[0.22em] text-current/60">p95 latency</p>
+                  <p className="mt-2 text-2xl font-semibold">{region.latencyMs} ms</p>
+                </div>
+                <div className="rounded-2xl bg-black/5 p-3">
+                  <p className="text-xs uppercase tracking-[0.22em] text-current/60">Delta</p>
+                  <p className="mt-2 text-2xl font-semibold">{formatDelta(region.latencyDeltaMs)}</p>
+                </div>
+              </div>
+              <div className="mt-4 flex items-center justify-between text-sm text-current/70">
+                <span>{region.trafficShare}% traffic share</span>
+                <span>{region.incidents} active incidents</span>
+              </div>
+              <p className="mt-4 text-sm leading-6 text-current/72">{region.summary}</p>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/status-board/status-board-header.tsx
+++ b/src/components/status-board/status-board-header.tsx
@@ -1,0 +1,55 @@
+type StatusBoardHeaderProps = {
+  boardState: string;
+  environment: string;
+  isRefreshing: boolean;
+  lastUpdated: Date;
+  onRefresh: () => void;
+  selectedRegionCount: number;
+  summaryCount: number;
+};
+
+const timestampFormatter = new Intl.DateTimeFormat("en-US", {
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+});
+
+export function StatusBoardHeader({
+  boardState,
+  environment,
+  isRefreshing,
+  lastUpdated,
+  onRefresh,
+  selectedRegionCount,
+  summaryCount,
+}: StatusBoardHeaderProps) {
+  return (
+    <section className="rounded-[28px] border border-white/60 bg-white/80 p-5 shadow-[0_18px_50px_rgba(15,23,42,0.12)] backdrop-blur md:p-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="rounded-full border border-emerald-600/20 bg-emerald-500/12 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-emerald-900">{environment}</span>
+            <span className="rounded-full border border-slate-300 bg-slate-950 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-slate-50">{boardState}</span>
+          </div>
+          <div>
+            <p className="text-sm font-medium uppercase tracking-[0.22em] text-slate-500">Status Board</p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">Regional health and failover posture</h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-600 sm:text-base">Review regional latency, scope dependency impact, and clear the operator checklist before widening traffic away from the primary path.</p>
+          </div>
+        </div>
+        <div className="rounded-3xl border border-slate-200 bg-slate-950 p-4 text-slate-100 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]">
+          <p className="text-xs uppercase tracking-[0.22em] text-slate-400">Refresh state</p>
+          <p className="mt-2 text-sm font-medium">Last updated {timestampFormatter.format(lastUpdated)}</p>
+          <p className="mt-1 text-sm text-slate-300">{selectedRegionCount} regions selected across {summaryCount} summary lanes</p>
+          <button
+            className="mt-4 inline-flex min-h-11 items-center justify-center rounded-full bg-cyan-300 px-4 text-sm font-semibold text-slate-950 transition hover:bg-cyan-200 disabled:cursor-not-allowed disabled:bg-cyan-100"
+            onClick={onRefresh}
+            type="button"
+          >
+            {isRefreshing ? "Refreshing snapshot..." : "Refresh snapshot"}
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/status-board/status-board-shell.tsx
+++ b/src/components/status-board/status-board-shell.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { startTransition, useState, useTransition } from "react";
+
+import {
+  buildStatusBoardSnapshot,
+  type BoardTone,
+  type StatusBoardSnapshot,
+} from "@/app/status-board/mock-data";
+import { DependencyTable } from "./dependency-table";
+import { FailoverChecklist } from "./failover-checklist";
+import { RegionalHealthGrid } from "./regional-health-grid";
+import { StatusBoardHeader } from "./status-board-header";
+
+type StatusBoardShellProps = { initialSnapshot: StatusBoardSnapshot };
+type DependencyFilter = "all" | BoardTone;
+
+const filterLabels: Record<DependencyFilter, string> = {
+  all: "All dependencies",
+  healthy: "Healthy",
+  watch: "Watch",
+  degraded: "Degraded",
+  failover: "Failover",
+};
+const summaryToneClasses: Record<BoardTone, string> = {
+  healthy: "border-emerald-200 bg-emerald-500/8",
+  watch: "border-amber-200 bg-amber-400/10",
+  degraded: "border-rose-200 bg-rose-500/10",
+  failover: "border-cyan-200 bg-cyan-500/10",
+};
+const toggleId = (items: string[], id: string) =>
+  items.includes(id) ? items.filter((item) => item !== id) : [...items, id];
+const defaultChecklistIds = (snapshot: StatusBoardSnapshot) =>
+  snapshot.checklist.filter((item) => item.defaultDone).map((item) => item.id);
+
+export function StatusBoardShell({ initialSnapshot }: StatusBoardShellProps) {
+  const [snapshot, setSnapshot] = useState(initialSnapshot);
+  const [cycle, setCycle] = useState(0);
+  const [selectedRegionIds, setSelectedRegionIds] = useState(initialSnapshot.regions.map((region) => region.id));
+  const [selectedFilter, setSelectedFilter] = useState<DependencyFilter>("all");
+  const [completedChecklistIds, setCompletedChecklistIds] = useState(defaultChecklistIds(initialSnapshot));
+  const [showOpenOnly, setShowOpenOnly] = useState(false);
+  const [isRefreshing, startRefreshTransition] = useTransition();
+
+  const scopedDependencies = snapshot.dependencies.filter((dependency) => dependency.regionIds.some((regionId) => selectedRegionIds.includes(regionId)));
+  const visibleDependencies = scopedDependencies.filter((dependency) => selectedFilter === "all" || dependency.status === selectedFilter);
+  const visibleChecklistItems = showOpenOnly ? snapshot.checklist.filter((item) => !completedChecklistIds.includes(item.id)) : snapshot.checklist;
+  const filterOptions = (Object.keys(filterLabels) as DependencyFilter[]).map((id) => ({
+    id,
+    label: filterLabels[id],
+    count: id === "all" ? scopedDependencies.length : scopedDependencies.filter((item) => item.status === id).length,
+  }));
+
+  function refreshSnapshot() {
+    const nextCycle = cycle + 1;
+    startRefreshTransition(() => {
+      setCycle(nextCycle);
+      setSnapshot(buildStatusBoardSnapshot(nextCycle, new Date()));
+    });
+  }
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(34,211,238,0.16),_transparent_28%),radial-gradient(circle_at_bottom_right,_rgba(59,130,246,0.12),_transparent_32%),linear-gradient(180deg,_#f8fbff_0%,_#eef4ff_40%,_#f8fafc_100%)] px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <StatusBoardHeader boardState={snapshot.boardState} environment={snapshot.environment} isRefreshing={isRefreshing} lastUpdated={snapshot.lastUpdated} onRefresh={refreshSnapshot} selectedRegionCount={selectedRegionIds.length} summaryCount={snapshot.summaryCards.length} />
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {snapshot.summaryCards.map((card) => (
+            <article className={`rounded-[24px] border p-4 shadow-[0_18px_40px_rgba(15,23,42,0.08)] backdrop-blur ${summaryToneClasses[card.tone]}`} key={card.id}>
+              <p className="text-xs uppercase tracking-[0.24em] text-slate-500">{card.label}</p>
+              <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">{card.value}</p>
+              <p className="mt-2 text-sm leading-6 text-slate-600">{card.note}</p>
+            </article>
+          ))}
+        </section>
+        <RegionalHealthGrid
+          onClearAll={() => startTransition(() => setSelectedRegionIds([]))}
+          onSelectAll={() => startTransition(() => setSelectedRegionIds(snapshot.regions.map((region) => region.id)))}
+          onToggleRegion={(regionId) => startTransition(() => setSelectedRegionIds((current) => toggleId(current, regionId)))}
+          regions={snapshot.regions}
+          selectedRegionIds={selectedRegionIds}
+        />
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(320px,0.9fr)]">
+          <DependencyTable dependencies={visibleDependencies} filterOptions={filterOptions} onFilterChange={(filterId) => startTransition(() => setSelectedFilter(filterId as DependencyFilter))} selectedFilter={selectedFilter} selectedRegionCount={selectedRegionIds.length} />
+          <FailoverChecklist
+            completedCount={completedChecklistIds.length}
+            items={visibleChecklistItems}
+            onReset={() => startTransition(() => { setCompletedChecklistIds(defaultChecklistIds(snapshot)); setShowOpenOnly(false); })}
+            onToggleItem={(itemId) => startTransition(() => setCompletedChecklistIds((current) => toggleId(current, itemId)))}
+            onToggleOpenOnly={() => startTransition(() => setShowOpenOnly((current) => !current))}
+            showOpenOnly={showOpenOnly}
+            toggledIds={completedChecklistIds}
+            totalCount={snapshot.checklist.length}
+          />
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add an isolated `/status-board` route with feature-local mock data and metadata
- render regional health cards, dependency status filtering, and a client-side failover checklist
- keep the implementation scoped to `src/app/status-board/**` and `src/components/status-board/**`

## Verification
- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Issue
Closes #22