### PR TITLE
feat: add archive vault snapshot diff explorer and export queue

### DIFF
--- a/src/app/archive-vault/archive-vault-data.test.ts
+++ b/src/app/archive-vault/archive-vault-data.test.ts
@@ -1,16 +1,49 @@
 import { describe, expect, it } from "vitest";
-import { findComparisonSummary } from "./archive-vault-data";
+import {
+  advanceExportQueueStatus,
+  createExportQueueEntry,
+  findComparisonSummary,
+  findSnapshotRecord,
+} from "./archive-vault-data";
 
 describe("archive vault comparison summaries", () => {
-  it("returns seeded summaries for curated pairs", () => {
-    expect(findComparisonSummary("helix-171", "kestrel-176")?.risk).toBe(
-      "High drift risk",
+  it("returns seeded summaries with detailed change records", () => {
+    const summary = findComparisonSummary("helix-171", "kestrel-176");
+
+    expect(summary?.risk).toBe("High drift risk");
+    expect(summary?.recordChanges.some((change) => change.severity === "high")).toBe(
+      true,
     );
+    expect(summary?.exportArtifacts).toContain("checksum mismatch brief");
   });
 
   it("derives fallback summaries for ad hoc selections", () => {
-    expect(findComparisonSummary("aurelia-204", "helix-171")?.alignment).toContain(
-      "% field overlap",
-    );
+    const summary = findComparisonSummary("aurelia-204", "helix-171");
+
+    expect(summary?.alignment).toContain("% field overlap");
+    expect(summary?.recordChanges).toHaveLength(4);
+    expect(summary?.timeline).toHaveLength(3);
+  });
+
+  it("creates export queue entries for reviewed comparisons", () => {
+    const summary = findComparisonSummary("ember-198", "quartz-159");
+    const records = [
+      findSnapshotRecord("ember-198"),
+      findSnapshotRecord("quartz-159"),
+    ].flatMap((record) => (record ? [record] : []));
+
+    expect(summary).not.toBeNull();
+
+    const entry = createExportQueueEntry(summary!, records);
+
+    expect(entry.label).toBe("Ember Registry vs Quartz Session Tape");
+    expect(entry.status).toBe("queued");
+    expect(entry.artifacts).toContain("masking variance appendix");
+  });
+
+  it("advances queue states until ready", () => {
+    expect(advanceExportQueueStatus("queued")).toBe("packaging");
+    expect(advanceExportQueueStatus("packaging")).toBe("ready");
+    expect(advanceExportQueueStatus("ready")).toBe("ready");
   });
 });

--- a/src/app/archive-vault/archive-vault-data.ts
+++ b/src/app/archive-vault/archive-vault-data.ts
@@ -16,6 +16,47 @@ export type SnapshotRecord = {
   summary: string;
   notes: string[];
   highlights: Array<{ label: string; value: string }>;
+  lineage: string;
+  retentionWindow: string;
+  checksumStatus: string;
+  exportTarget: string;
+  reviewLane: string;
+};
+
+export type ComparisonMetricTone = "stable" | "watch" | "risk";
+
+export type ComparisonMetric = {
+  label: string;
+  leftValue: string;
+  rightValue: string;
+  delta: string;
+  tone: ComparisonMetricTone;
+};
+
+export type ComparisonRecordChangeType = "added" | "removed" | "changed" | "watch";
+export type ComparisonRecordChangeSeverity = "low" | "medium" | "high";
+
+export type ComparisonRecordChange = {
+  id: string;
+  recordLabel: string;
+  area: string;
+  changeType: ComparisonRecordChangeType;
+  severity: ComparisonRecordChangeSeverity;
+  summary: string;
+  leftValue: string;
+  rightValue: string;
+  impact: string;
+  reviewerAction: string;
+};
+
+export type ComparisonTimelineEventTone = "baseline" | "handoff" | "action" | "alert";
+
+export type ComparisonTimelineEvent = {
+  id: string;
+  at: string;
+  lane: string;
+  summary: string;
+  tone: ComparisonTimelineEventTone;
 };
 
 export type ComparisonSummary = {
@@ -25,102 +66,827 @@ export type ComparisonSummary = {
   risk: string;
   shift: string;
   recommendation: string;
+  reviewLane: string;
+  queueSummary: string;
+  leftFocus: string;
+  rightFocus: string;
+  metrics: ComparisonMetric[];
+  recordChanges: ComparisonRecordChange[];
+  timeline: ComparisonTimelineEvent[];
+  exportArtifacts: string[];
 };
 
-export const archiveTags = ["legal hold", "pii mesh", "geo drift", "consent", "checksum drift", "retention", "delta burst"] as const;
+export type ExportQueueStatus = "queued" | "packaging" | "ready";
+
+export type ExportQueueEntry = {
+  id: string;
+  comparisonKey: string;
+  pair: [string, string];
+  label: string;
+  status: ExportQueueStatus;
+  requestedBy: string;
+  requestedAt: string;
+  destination: string;
+  reviewLane: string;
+  note: string;
+  artifacts: string[];
+};
+
+export const archiveTags = [
+  "legal hold",
+  "pii mesh",
+  "geo drift",
+  "consent",
+  "checksum drift",
+  "retention",
+  "delta burst",
+] as const;
+
 export const snapshotRecords: SnapshotRecord[] = [
   {
-    id: "aurelia-204", label: "Aurelia Ledger", cluster: "vault-eu-west / stripe mirror", status: "sealed", owner: "Ops Nine", region: "Frankfurt",
-    capturedAt: "2026-04-17 08:32 UTC", records: 184_221, delta: 2, confidence: 97, tags: ["legal hold", "retention", "pii mesh"],
+    id: "aurelia-204",
+    label: "Aurelia Ledger",
+    cluster: "vault-eu-west / stripe mirror",
+    status: "sealed",
+    owner: "Ops Nine",
+    region: "Frankfurt",
+    capturedAt: "2026-04-17 08:32 UTC",
+    records: 184_221,
+    delta: 2,
+    confidence: 97,
+    tags: ["legal hold", "retention", "pii mesh"],
     summary: "Baseline ledger preserved ahead of policy expiration sweep.",
-    notes: ["Checksum drift absent across all sealed shards.", "Retention lock survives regional replay."],
-    highlights: [{ label: "Coverage", value: "99.2% fields indexed" }, { label: "Retention", value: "Locked until Q1 FY27" }, { label: "Replay gap", value: "14 minutes" }],
+    notes: [
+      "Checksum drift absent across all sealed shards.",
+      "Retention lock survives regional replay.",
+    ],
+    highlights: [
+      { label: "Coverage", value: "99.2% fields indexed" },
+      { label: "Retention", value: "Locked until Q1 FY27" },
+      { label: "Replay gap", value: "14 minutes" },
+    ],
+    lineage: "Quarter-end seal after policy expiration sweep.",
+    retentionWindow: "Locked until Q1 FY27",
+    checksumStatus: "No variance across sealed shards",
+    exportTarget: "legal-hold review package",
+    reviewLane: "baseline audit lane",
   },
   {
-    id: "ember-198", label: "Ember Registry", cluster: "vault-us-central / event cache", status: "review", owner: "Delta Cell", region: "Iowa",
-    capturedAt: "2026-04-18 03:10 UTC", records: 142_908, delta: 11, confidence: 88, tags: ["delta burst", "consent", "retention"],
+    id: "ember-198",
+    label: "Ember Registry",
+    cluster: "vault-us-central / event cache",
+    status: "review",
+    owner: "Delta Cell",
+    region: "Iowa",
+    capturedAt: "2026-04-18 03:10 UTC",
+    records: 142_908,
+    delta: 11,
+    confidence: 88,
+    tags: ["delta burst", "consent", "retention"],
     summary: "Consent revocations spiked after a backfilled subscriber import.",
-    notes: ["Two collections crossed expected delta thresholds.", "Reviewer handoff pending for consent anomalies."],
-    highlights: [{ label: "Coverage", value: "94.5% fields indexed" }, { label: "Retention", value: "Freeze pending" }, { label: "Replay gap", value: "42 minutes" }],
+    notes: [
+      "Two collections crossed expected delta thresholds.",
+      "Reviewer handoff pending for consent anomalies.",
+    ],
+    highlights: [
+      { label: "Coverage", value: "94.5% fields indexed" },
+      { label: "Retention", value: "Freeze pending" },
+      { label: "Replay gap", value: "42 minutes" },
+    ],
+    lineage: "Subscriber import landed after the last approved consent freeze.",
+    retentionWindow: "Freeze pending",
+    checksumStatus: "Consent index drift across two collections",
+    exportTarget: "consent anomaly digest",
+    reviewLane: "subscriber remediation lane",
   },
   {
-    id: "helix-171", label: "Helix Notes", cluster: "vault-us-east / health stream", status: "active", owner: "Pulse Desk", region: "Virginia",
-    capturedAt: "2026-04-19 01:42 UTC", records: 208_554, delta: 6, confidence: 91, tags: ["pii mesh", "consent", "checksum drift"],
+    id: "helix-171",
+    label: "Helix Notes",
+    cluster: "vault-us-east / health stream",
+    status: "active",
+    owner: "Pulse Desk",
+    region: "Virginia",
+    capturedAt: "2026-04-19 01:42 UTC",
+    records: 208_554,
+    delta: 6,
+    confidence: 91,
+    tags: ["pii mesh", "consent", "checksum drift"],
     summary: "Live notes mirror remains stable with a narrow checksum variance.",
-    notes: ["Consent rollups landed before the latest mirror cut.", "Variance stays inside automated reconciliation limits."],
-    highlights: [{ label: "Coverage", value: "96.7% fields indexed" }, { label: "Retention", value: "Rolling 180-day band" }, { label: "Replay gap", value: "9 minutes" }],
+    notes: [
+      "Consent rollups landed before the latest mirror cut.",
+      "Variance stays inside automated reconciliation limits.",
+    ],
+    highlights: [
+      { label: "Coverage", value: "96.7% fields indexed" },
+      { label: "Retention", value: "Rolling 180-day band" },
+      { label: "Replay gap", value: "9 minutes" },
+    ],
+    lineage: "Reference health snapshot captured before the regional failback window.",
+    retentionWindow: "Rolling 180-day band",
+    checksumStatus: "Variance under automated tolerance",
+    exportTarget: "health replay package",
+    reviewLane: "clinical drift lane",
   },
   {
-    id: "kestrel-176", label: "Kestrel Claims", cluster: "vault-ap-south / claims replica", status: "drift", owner: "Skylark Queue", region: "Mumbai",
-    capturedAt: "2026-04-18 19:04 UTC", records: 96_411, delta: 18, confidence: 79, tags: ["geo drift", "delta burst", "checksum drift"],
+    id: "kestrel-176",
+    label: "Kestrel Claims",
+    cluster: "vault-ap-south / claims replica",
+    status: "drift",
+    owner: "Skylark Queue",
+    region: "Mumbai",
+    capturedAt: "2026-04-18 19:04 UTC",
+    records: 96_411,
+    delta: 18,
+    confidence: 79,
+    tags: ["geo drift", "delta burst", "checksum drift"],
     summary: "Claims replica shows broad field drift after a regional failback.",
-    notes: ["Checksum mismatch clusters around adjudication notes.", "Geo rebalance duplicated one retention bucket."],
-    highlights: [{ label: "Coverage", value: "89.1% fields indexed" }, { label: "Retention", value: "Dual-window mismatch" }, { label: "Replay gap", value: "1 hour 16 minutes" }],
+    notes: [
+      "Checksum mismatch clusters around adjudication notes.",
+      "Geo rebalance duplicated one retention bucket.",
+    ],
+    highlights: [
+      { label: "Coverage", value: "89.1% fields indexed" },
+      { label: "Retention", value: "Dual-window mismatch" },
+      { label: "Replay gap", value: "1 hour 16 minutes" },
+    ],
+    lineage: "Replica recovered during an AP-south failback with duplicated retention residue.",
+    retentionWindow: "Dual-window mismatch",
+    checksumStatus: "Mismatch on adjudication note segments",
+    exportTarget: "claims drift incident bundle",
+    reviewLane: "regional failback lane",
   },
   {
-    id: "orbit-164", label: "Orbit Permissions", cluster: "vault-ca-east / auth graph", status: "sealed", owner: "Northwatch", region: "Montreal",
-    capturedAt: "2026-04-16 12:18 UTC", records: 121_733, delta: 4, confidence: 95, tags: ["legal hold", "consent", "retention"],
+    id: "orbit-164",
+    label: "Orbit Permissions",
+    cluster: "vault-ca-east / auth graph",
+    status: "sealed",
+    owner: "Northwatch",
+    region: "Montreal",
+    capturedAt: "2026-04-16 12:18 UTC",
+    records: 121_733,
+    delta: 4,
+    confidence: 95,
+    tags: ["legal hold", "consent", "retention"],
     summary: "Permissions archive sealed before entitlement pruning was applied.",
-    notes: ["Role tombstones remain linked to the final approval window.", "Consent history is complete but cold-stored."],
-    highlights: [{ label: "Coverage", value: "98.1% fields indexed" }, { label: "Retention", value: "Locked until legal release" }, { label: "Replay gap", value: "21 minutes" }],
+    notes: [
+      "Role tombstones remain linked to the final approval window.",
+      "Consent history is complete but cold-stored.",
+    ],
+    highlights: [
+      { label: "Coverage", value: "98.1% fields indexed" },
+      { label: "Retention", value: "Locked until legal release" },
+      { label: "Replay gap", value: "21 minutes" },
+    ],
+    lineage: "Seal taken while entitlement residue was still attached to the auth graph.",
+    retentionWindow: "Locked until legal release",
+    checksumStatus: "Stable checksum graph with entitlement residue",
+    exportTarget: "entitlement review packet",
+    reviewLane: "baseline audit lane",
   },
   {
-    id: "quartz-159", label: "Quartz Session Tape", cluster: "vault-us-west / edge replay", status: "review", owner: "Signal Array", region: "Oregon",
-    capturedAt: "2026-04-19 05:27 UTC", records: 77_942, delta: 9, confidence: 86, tags: ["geo drift", "pii mesh", "consent"],
+    id: "quartz-159",
+    label: "Quartz Session Tape",
+    cluster: "vault-us-west / edge replay",
+    status: "review",
+    owner: "Signal Array",
+    region: "Oregon",
+    capturedAt: "2026-04-19 05:27 UTC",
+    records: 77_942,
+    delta: 9,
+    confidence: 86,
+    tags: ["geo drift", "pii mesh", "consent"],
     summary: "Session tape needs manual review after cross-region masking drift.",
-    notes: ["Edge replay produced new tokenization gaps.", "Masking rules differ between west and south replicas."],
-    highlights: [{ label: "Coverage", value: "93.3% fields indexed" }, { label: "Retention", value: "30-day forensic window" }, { label: "Replay gap", value: "37 minutes" }],
+    notes: [
+      "Edge replay produced new tokenization gaps.",
+      "Masking rules differ between west and south replicas.",
+    ],
+    highlights: [
+      { label: "Coverage", value: "93.3% fields indexed" },
+      { label: "Retention", value: "30-day forensic window" },
+      { label: "Replay gap", value: "37 minutes" },
+    ],
+    lineage: "Cross-region masking divergence surfaced after the latest replay bundle.",
+    retentionWindow: "30-day forensic window",
+    checksumStatus: "Masking variance across replay shards",
+    exportTarget: "masking variance appendix",
+    reviewLane: "consent remediation lane",
   },
 ];
 
 export const comparisonSummaries: ComparisonSummary[] = [
   {
-    pair: ["aurelia-204", "orbit-164"], verdict: "Both sealed archives hold steady and differ mostly in consent lineage depth.",
-    alignment: "88% field overlap", risk: "Low drift risk",
+    pair: ["aurelia-204", "orbit-164"],
+    verdict: "Both sealed archives hold steady and differ mostly in consent lineage depth.",
+    alignment: "88% field overlap",
+    risk: "Low drift risk",
     shift: "Orbit keeps more entitlement residue; Aurelia keeps stronger PII indexing.",
     recommendation: "Use this pair when reviewers need a calm baseline before drift triage.",
+    reviewLane: "baseline audit lane",
+    queueSummary: "Low-noise diff package fit for policy sign-off exports.",
+    leftFocus: "Aurelia preserves stronger PII index coverage and the faster replay baseline.",
+    rightFocus: "Orbit keeps entitlement residue and colder consent lineage for legal follow-up.",
+    metrics: [
+      {
+        label: "Indexed fields",
+        leftValue: "99.2%",
+        rightValue: "98.1%",
+        delta: "Aurelia +1.1%",
+        tone: "stable",
+      },
+      {
+        label: "Replay gap",
+        leftValue: "14 minutes",
+        rightValue: "21 minutes",
+        delta: "Orbit +7 min lag",
+        tone: "watch",
+      },
+      {
+        label: "Retention lock",
+        leftValue: "Q1 FY27",
+        rightValue: "Legal release",
+        delta: "Orbit uses external release gate",
+        tone: "watch",
+      },
+    ],
+    recordChanges: [
+      {
+        id: "aurelia-orbit-consent-lineage",
+        recordLabel: "Consent lineage map",
+        area: "Identity graph",
+        changeType: "changed",
+        severity: "low",
+        summary: "Orbit preserves entitlement tombstones that Aurelia already collapsed into sealed lineage.",
+        leftValue: "Collapsed lineage after final approval",
+        rightValue: "Entitlement residue retained until legal release",
+        impact: "Reviewers see more historical permission residue on Orbit exports.",
+        reviewerAction: "Use Orbit when sign-off needs entitlement ancestry.",
+      },
+      {
+        id: "aurelia-orbit-replay-gap",
+        recordLabel: "Replay completion lag",
+        area: "Recovery log",
+        changeType: "changed",
+        severity: "low",
+        summary: "Orbit trails Aurelia on replay completion despite both archives staying sealed.",
+        leftValue: "14 minutes",
+        rightValue: "21 minutes",
+        impact: "Longer replay lag widens the manual annotation window for reviewers.",
+        reviewerAction: "Keep Aurelia as the baseline for timing-sensitive approvals.",
+      },
+      {
+        id: "aurelia-orbit-retention-lock",
+        recordLabel: "Retention release gate",
+        area: "Lifecycle policy",
+        changeType: "watch",
+        severity: "medium",
+        summary: "Lock semantics differ even though both archives were sealed in calm conditions.",
+        leftValue: "Locked until Q1 FY27",
+        rightValue: "Locked until legal release",
+        impact: "Different release triggers change who can authorize the export package.",
+        reviewerAction: "Confirm the release authority in the package cover sheet.",
+      },
+    ],
+    timeline: [
+      {
+        id: "aurelia-orbit-seal",
+        at: "2026-04-16 12:18 UTC",
+        lane: "baseline audit lane",
+        summary: "Orbit sealed before entitlement pruning and kept the original approval residue.",
+        tone: "baseline",
+      },
+      {
+        id: "aurelia-orbit-policy-sweep",
+        at: "2026-04-17 08:32 UTC",
+        lane: "baseline audit lane",
+        summary: "Aurelia captured after policy sweep and preserved the stronger PII index coverage.",
+        tone: "handoff",
+      },
+      {
+        id: "aurelia-orbit-review",
+        at: "2026-04-20 09:05 UTC",
+        lane: "archive review desk",
+        summary: "Review desk approved the pair as a calm baseline for training exports.",
+        tone: "action",
+      },
+    ],
+    exportArtifacts: [
+      "field-overlap digest",
+      "consent lineage appendix",
+      "retention release checklist",
+    ],
   },
   {
-    pair: ["ember-198", "quartz-159"], verdict: "Consent-oriented review queues align, but Quartz carries wider masking variance.",
-    alignment: "72% field overlap", risk: "Moderate review risk",
+    pair: ["ember-198", "quartz-159"],
+    verdict: "Consent-oriented review queues align, but Quartz carries wider masking variance.",
+    alignment: "72% field overlap",
+    risk: "Moderate review risk",
     shift: "Masking drift clusters in session tape while Ember spikes on subscriber deltas.",
     recommendation: "Pair these when validating consent workflows against replay artifacts.",
+    reviewLane: "consent remediation lane",
+    queueSummary: "Package should include consent delta sheets before masking evidence leaves review.",
+    leftFocus: "Ember highlights subscriber backfill deltas and pending freeze decisions.",
+    rightFocus: "Quartz exposes cross-region masking gaps and tokenization exceptions.",
+    metrics: [
+      {
+        label: "Delta pressure",
+        leftValue: "11%",
+        rightValue: "9%",
+        delta: "Ember +2% subscriber churn",
+        tone: "watch",
+      },
+      {
+        label: "Indexed fields",
+        leftValue: "94.5%",
+        rightValue: "93.3%",
+        delta: "Quartz trails by 1.2%",
+        tone: "watch",
+      },
+      {
+        label: "Replay gap",
+        leftValue: "42 minutes",
+        rightValue: "37 minutes",
+        delta: "Ember +5 min lag",
+        tone: "watch",
+      },
+    ],
+    recordChanges: [
+      {
+        id: "ember-quartz-revocations",
+        recordLabel: "Subscriber revocation set",
+        area: "Consent ledger",
+        changeType: "changed",
+        severity: "medium",
+        summary: "Ember adds new revocations from imported subscriber history while Quartz stays session-bound.",
+        leftValue: "Backfilled subscriber revocations pending sign-off",
+        rightValue: "Stable session consent events with masking exceptions",
+        impact: "Review packages need both churn evidence and masking context to stay coherent.",
+        reviewerAction: "Attach the subscriber delta sheet before export.",
+      },
+      {
+        id: "ember-quartz-masking",
+        recordLabel: "Masking ruleset drift",
+        area: "Privacy masking",
+        changeType: "changed",
+        severity: "high",
+        summary: "Quartz diverges between west and south replica masking rules after replay.",
+        leftValue: "Masking stays aligned inside registry imports",
+        rightValue: "Replica mismatch on tokenization and redaction",
+        impact: "Quartz artifacts can expose different fields across regions unless annotated.",
+        reviewerAction: "Block external export until masking notes are attached.",
+      },
+      {
+        id: "ember-quartz-retention",
+        recordLabel: "Retention freeze readiness",
+        area: "Lifecycle policy",
+        changeType: "watch",
+        severity: "medium",
+        summary: "Ember has a pending freeze while Quartz stays inside a fixed forensic window.",
+        leftValue: "Freeze pending",
+        rightValue: "30-day forensic window",
+        impact: "Packaging destination and reviewer SLA differ by snapshot.",
+        reviewerAction: "Route approval through the consent remediation lane.",
+      },
+      {
+        id: "ember-quartz-geo-annotations",
+        recordLabel: "Regional masking appendix",
+        area: "Replay annotations",
+        changeType: "added",
+        severity: "low",
+        summary: "Quartz adds cross-region masking annotations that Ember does not carry.",
+        leftValue: "No regional appendix",
+        rightValue: "West vs south masking note bundle",
+        impact: "The queue needs an extra appendix to explain why the same session fields diverge.",
+        reviewerAction: "Export the regional masking appendix whenever Quartz is in the pair.",
+      },
+    ],
+    timeline: [
+      {
+        id: "ember-quartz-import",
+        at: "2026-04-18 03:10 UTC",
+        lane: "subscriber remediation lane",
+        summary: "Ember captured the imported subscriber revocations before the freeze decision landed.",
+        tone: "baseline",
+      },
+      {
+        id: "ember-quartz-replay",
+        at: "2026-04-19 05:27 UTC",
+        lane: "consent remediation lane",
+        summary: "Quartz replay surfaced a masking split between west and south replicas.",
+        tone: "alert",
+      },
+      {
+        id: "ember-quartz-handoff",
+        at: "2026-04-20 06:50 UTC",
+        lane: "archive review desk",
+        summary: "Review desk combined both snapshots for consent workflow validation and export prep.",
+        tone: "handoff",
+      },
+      {
+        id: "ember-quartz-queue",
+        at: "2026-04-20 07:18 UTC",
+        lane: "consent remediation lane",
+        summary: "Queue package moved to masking appendix assembly before release review.",
+        tone: "action",
+      },
+    ],
+    exportArtifacts: [
+      "consent delta digest",
+      "masking variance appendix",
+      "reviewer handoff memo",
+    ],
   },
   {
-    pair: ["helix-171", "kestrel-176"], verdict: "Helix offers a stable live reference for a replica already slipping into drift.",
-    alignment: "64% field overlap", risk: "High drift risk",
+    pair: ["helix-171", "kestrel-176"],
+    verdict: "Helix offers a stable live reference for a replica already slipping into drift.",
+    alignment: "64% field overlap",
+    risk: "High drift risk",
     shift: "Kestrel widens checksum and regional variance far beyond Helix tolerance.",
     recommendation: "Start with checksum mismatches, then inspect geo rebalance behavior.",
+    reviewLane: "regional drift escalation lane",
+    queueSummary: "Queue only after checksum drift evidence and failback notes are attached.",
+    leftFocus: "Helix stays inside tolerance and acts as the clean reference snapshot.",
+    rightFocus: "Kestrel shows failback drift concentrated around adjudication notes.",
+    metrics: [
+      {
+        label: "Drift delta",
+        leftValue: "6%",
+        rightValue: "18%",
+        delta: "Kestrel +12% variance",
+        tone: "risk",
+      },
+      {
+        label: "Confidence",
+        leftValue: "91%",
+        rightValue: "79%",
+        delta: "12% spread",
+        tone: "risk",
+      },
+      {
+        label: "Replay gap",
+        leftValue: "9 minutes",
+        rightValue: "1 hour 16 minutes",
+        delta: "Kestrel +67 min lag",
+        tone: "risk",
+      },
+    ],
+    recordChanges: [
+      {
+        id: "helix-kestrel-checksum",
+        recordLabel: "Adjudication note checksum",
+        area: "Claims narrative",
+        changeType: "changed",
+        severity: "high",
+        summary: "Kestrel duplicates checksum segments after regional failback while Helix stays stable.",
+        leftValue: "Stable note hash ladder",
+        rightValue: "Mismatch clusters around adjudication notes",
+        impact: "Narrative fields cannot be trusted until the failback duplication is explained.",
+        reviewerAction: "Keep this issue in the package lead summary.",
+      },
+      {
+        id: "helix-kestrel-geo",
+        recordLabel: "Geo rebalance residue",
+        area: "Regional routing",
+        changeType: "added",
+        severity: "high",
+        summary: "Failback introduced a second retention bucket in Kestrel and widened regional drift.",
+        leftValue: "Single active region band",
+        rightValue: "Duplicate AP-south retention bucket",
+        impact: "Reviewers need region lineage evidence to understand why row counts diverged.",
+        reviewerAction: "Attach regional failback logs before export.",
+      },
+      {
+        id: "helix-kestrel-consent",
+        recordLabel: "Consent rollup alignment",
+        area: "Consent aggregates",
+        changeType: "watch",
+        severity: "medium",
+        summary: "Helix completed rollups before mirror cut while Kestrel replayed mid-failback.",
+        leftValue: "Consent rollups sealed before capture",
+        rightValue: "Consent rollups interleaved with failback replay",
+        impact: "Aggregate counts diverge even when row totals still look plausible.",
+        reviewerAction: "Compare aggregate consent totals before approval.",
+      },
+      {
+        id: "helix-kestrel-replay",
+        recordLabel: "Replay recovery lag",
+        area: "Recovery log",
+        changeType: "changed",
+        severity: "high",
+        summary: "Kestrel trails Helix by more than an hour on replay completion.",
+        leftValue: "9 minutes",
+        rightValue: "1 hour 16 minutes",
+        impact: "Exported packages could omit late-arriving replay annotations without an exception note.",
+        reviewerAction: "Wait for replay recovery evidence or export an explicit exception notice.",
+      },
+    ],
+    timeline: [
+      {
+        id: "helix-kestrel-failback",
+        at: "2026-04-18 19:04 UTC",
+        lane: "regional failback lane",
+        summary: "Kestrel recovered during AP-south failback and duplicated one retention bucket.",
+        tone: "alert",
+      },
+      {
+        id: "helix-kestrel-reference",
+        at: "2026-04-19 01:42 UTC",
+        lane: "clinical drift lane",
+        summary: "Helix captured a stable reference state before the failback residue could spread.",
+        tone: "baseline",
+      },
+      {
+        id: "helix-kestrel-triage",
+        at: "2026-04-20 08:22 UTC",
+        lane: "regional drift escalation lane",
+        summary: "Triage moved the pair into checksum-first review after replay lag widened.",
+        tone: "handoff",
+      },
+      {
+        id: "helix-kestrel-export",
+        at: "2026-04-20 09:40 UTC",
+        lane: "archive review desk",
+        summary: "Queue guidance requires checksum evidence and failback logs before export.",
+        tone: "action",
+      },
+    ],
+    exportArtifacts: [
+      "checksum mismatch brief",
+      "regional failback appendix",
+      "replay recovery exception form",
+    ],
   },
 ];
 
-function pairKey(leftId: string, rightId: string) {
+export const exportQueueEntries: ExportQueueEntry[] = [
+  {
+    id: "pkg-aurelia-204-orbit-164",
+    comparisonKey: "aurelia-204::orbit-164",
+    pair: ["aurelia-204", "orbit-164"],
+    label: "Aurelia Ledger vs Orbit Permissions",
+    status: "ready",
+    requestedBy: "Ops Nine",
+    requestedAt: "2026-04-19 22:05 UTC",
+    destination: "baseline audit lane -> legal-hold review package",
+    reviewLane: "baseline audit lane",
+    note: "Low-noise baseline bundle approved for training exports.",
+    artifacts: [
+      "field-overlap digest",
+      "consent lineage appendix",
+      "retention release checklist",
+    ],
+  },
+  {
+    id: "pkg-ember-198-quartz-159",
+    comparisonKey: "ember-198::quartz-159",
+    pair: ["ember-198", "quartz-159"],
+    label: "Ember Registry vs Quartz Session Tape",
+    status: "packaging",
+    requestedBy: "Mara Holt",
+    requestedAt: "2026-04-20 07:18 UTC",
+    destination: "consent remediation lane -> privacy review bundle",
+    reviewLane: "consent remediation lane",
+    note: "Awaiting masking appendix before export sign-off.",
+    artifacts: [
+      "consent delta digest",
+      "masking variance appendix",
+      "reviewer handoff memo",
+    ],
+  },
+];
+
+const exportQueueStatusOrder: ExportQueueStatus[] = ["queued", "packaging", "ready"];
+
+function getHighlightValue(record: SnapshotRecord, label: string) {
+  return record.highlights.find((highlight) => highlight.label === label)?.value ?? "Unavailable";
+}
+
+function metricTone(
+  spread: number,
+  watchCutoff: number,
+  riskCutoff: number,
+): ComparisonMetricTone {
+  if (spread >= riskCutoff) return "risk";
+  if (spread >= watchCutoff) return "watch";
+  return "stable";
+}
+
+function changeSeverity(
+  spread: number,
+  watchCutoff: number,
+  riskCutoff: number,
+): ComparisonRecordChangeSeverity {
+  if (spread >= riskCutoff) return "high";
+  if (spread >= watchCutoff) return "medium";
+  return "low";
+}
+
+function buildFallbackRecordChanges(
+  left: SnapshotRecord,
+  right: SnapshotRecord,
+  sharedTags: string[],
+  deltaGap: number,
+  confidenceGap: number,
+): ComparisonRecordChange[] {
+  const comparisonKey = buildComparisonKey(left.id, right.id);
+
+  return [
+    {
+      id: `${comparisonKey}-coverage`,
+      recordLabel: "Coverage profile",
+      area: "Field catalog",
+      changeType: deltaGap >= 8 ? "changed" : "watch",
+      severity: changeSeverity(confidenceGap, 5, 10),
+      summary: `Coverage and confidence diverge between ${left.label} and ${right.label}.`,
+      leftValue: getHighlightValue(left, "Coverage"),
+      rightValue: getHighlightValue(right, "Coverage"),
+      impact: "Reviewers need the field coverage spread before exporting a side-by-side package.",
+      reviewerAction: sharedTags.length
+        ? `Validate the shared focus tags first: ${sharedTags.join(", ")}.`
+        : "No shared tags were found, so inspect structure before comparing semantics.",
+    },
+    {
+      id: `${comparisonKey}-retention`,
+      recordLabel: "Retention controls",
+      area: "Lifecycle policy",
+      changeType: left.retentionWindow === right.retentionWindow ? "watch" : "changed",
+      severity: changeSeverity(deltaGap, 4, 9),
+      summary: "Retention release rules differ across the selected snapshots.",
+      leftValue: left.retentionWindow,
+      rightValue: right.retentionWindow,
+      impact: "Different release gates affect who can authorize the export queue handoff.",
+      reviewerAction: "Confirm the approval owner before sending the package downstream.",
+    },
+    {
+      id: `${comparisonKey}-checksum`,
+      recordLabel: "Checksum posture",
+      area: "Integrity signals",
+      changeType: left.checksumStatus === right.checksumStatus ? "watch" : "changed",
+      severity: changeSeverity(deltaGap + confidenceGap, 10, 18),
+      summary: "Checksum posture shifted enough to justify an explicit reviewer note.",
+      leftValue: left.checksumStatus,
+      rightValue: right.checksumStatus,
+      impact: "Checksum differences change how much trust reviewers can place in the record deltas.",
+      reviewerAction: "Attach integrity notes when the pair moves into the export queue.",
+    },
+    {
+      id: `${comparisonKey}-replay`,
+      recordLabel: "Replay recovery lag",
+      area: "Recovery log",
+      changeType: "changed",
+      severity: changeSeverity(deltaGap, 5, 10),
+      summary: "Replay lag changed between the two snapshots and can affect review completeness.",
+      leftValue: getHighlightValue(left, "Replay gap"),
+      rightValue: getHighlightValue(right, "Replay gap"),
+      impact: "Late replay completion can leave annotations out of an exported review package.",
+      reviewerAction: "Verify replay notes before marking the comparison export-ready.",
+    },
+  ];
+}
+
+function buildFallbackTimeline(
+  left: SnapshotRecord,
+  right: SnapshotRecord,
+  deltaGap: number,
+): ComparisonTimelineEvent[] {
+  const comparisonKey = buildComparisonKey(left.id, right.id);
+
+  return [
+    {
+      id: `${comparisonKey}-left-capture`,
+      at: left.capturedAt,
+      lane: left.reviewLane,
+      summary: `${left.label} captured with ${left.delta}% drift and ${left.confidence}% confidence.`,
+      tone: "baseline",
+    },
+    {
+      id: `${comparisonKey}-right-capture`,
+      at: right.capturedAt,
+      lane: right.reviewLane,
+      summary: `${right.label} captured with ${right.delta}% drift and ${right.confidence}% confidence.`,
+      tone: deltaGap >= 8 ? "alert" : "handoff",
+    },
+    {
+      id: `${comparisonKey}-queue-guidance`,
+      at: "2026-04-20 10:12 UTC",
+      lane: "archive review desk",
+      summary: deltaGap >= 8
+        ? "Escalate this ad hoc pair before queueing any export bundle."
+        : "Pair is eligible for a lightweight export review package once notes are attached.",
+      tone: "action",
+    },
+  ];
+}
+
+export function buildComparisonKey(leftId: string, rightId: string) {
   return [leftId, rightId].sort().join("::");
+}
+
+export function findSnapshotRecord(recordId: string) {
+  return snapshotRecords.find((record) => record.id === recordId) ?? null;
 }
 
 export function findComparisonSummary(
   leftId: string,
   rightId: string,
 ): ComparisonSummary | null {
-  const explicit = comparisonSummaries.find((summary) => pairKey(...summary.pair) === pairKey(leftId, rightId));
+  const explicit = comparisonSummaries.find((summary) => buildComparisonKey(...summary.pair) === buildComparisonKey(leftId, rightId));
   if (explicit) return explicit;
-  const left = snapshotRecords.find((record) => record.id === leftId);
-  const right = snapshotRecords.find((record) => record.id === rightId);
+
+  const left = findSnapshotRecord(leftId);
+  const right = findSnapshotRecord(rightId);
+
   if (!left || !right) return null;
+
   const sharedTags = left.tags.filter((tag) => right.tags.includes(tag));
-  const driftGap = Math.abs(left.delta - right.delta);
-  const overlap = Math.max(58, 92 - driftGap * 3);
+  const deltaGap = Math.abs(left.delta - right.delta);
+  const confidenceGap = Math.abs(left.confidence - right.confidence);
+  const overlap = Math.max(58, 92 - deltaGap * 3);
 
   return {
-    pair: [leftId, rightId] as [string, string],
-    verdict: driftGap > 8
+    pair: [left.id, right.id],
+    verdict: deltaGap > 8
       ? "Variance is wide enough to treat this pair as an active drift investigation."
       : "The pair is close enough for a fast reviewer handoff and side-by-side scan.",
     alignment: `${overlap}% field overlap`,
-    risk: driftGap > 8 ? "Escalate drift review" : "Watch in daily review",
-    shift: sharedTags.length ? `Shared focus tags: ${sharedTags.join(", ")}.` : "No shared focus tags; compare structure before comparing semantics.",
-    recommendation: driftGap > 8
+    risk: deltaGap > 8 ? "Escalate drift review" : "Watch in daily review",
+    shift: sharedTags.length
+      ? `Shared focus tags: ${sharedTags.join(", ")}.`
+      : "No shared focus tags; compare structure before comparing semantics.",
+    recommendation: deltaGap > 8
       ? "Inspect replay gap and checksum confidence before approving archival use."
       : "Use this pair as a quick confidence check for neighboring archive states.",
+    reviewLane: deltaGap > 8 ? "drift escalation lane" : "daily archive review lane",
+    queueSummary: deltaGap > 8
+      ? "Queue only after replay and checksum evidence are attached."
+      : "Low-friction ad hoc pair; attach coverage and retention notes before export.",
+    leftFocus: `${left.label} captured in ${left.reviewLane} with ${left.delta}% drift.`,
+    rightFocus: `${right.label} captured in ${right.reviewLane} with ${right.delta}% drift.`,
+    metrics: [
+      {
+        label: "Record span",
+        leftValue: left.records.toLocaleString(),
+        rightValue: right.records.toLocaleString(),
+        delta: `${Math.abs(left.records - right.records).toLocaleString()} row gap`,
+        tone: metricTone(Math.abs(left.records - right.records), 25_000, 75_000),
+      },
+      {
+        label: "Drift delta",
+        leftValue: `${left.delta}%`,
+        rightValue: `${right.delta}%`,
+        delta: `${deltaGap}% gap`,
+        tone: metricTone(deltaGap, 5, 10),
+      },
+      {
+        label: "Confidence",
+        leftValue: `${left.confidence}%`,
+        rightValue: `${right.confidence}%`,
+        delta: `${confidenceGap}% spread`,
+        tone: metricTone(confidenceGap, 5, 10),
+      },
+      {
+        label: "Replay gap",
+        leftValue: getHighlightValue(left, "Replay gap"),
+        rightValue: getHighlightValue(right, "Replay gap"),
+        delta: "Compare replay lag before export",
+        tone: metricTone(deltaGap, 5, 10),
+      },
+    ],
+    recordChanges: buildFallbackRecordChanges(left, right, sharedTags, deltaGap, confidenceGap),
+    timeline: buildFallbackTimeline(left, right, deltaGap),
+    exportArtifacts: sharedTags.length
+      ? [`${sharedTags[0]} diff digest`, "coverage comparison sheet", "reviewer handoff memo"]
+      : ["coverage comparison sheet", "retention release note", "reviewer handoff memo"],
+  };
+}
+
+export function advanceExportQueueStatus(status: ExportQueueStatus): ExportQueueStatus {
+  const currentIndex = exportQueueStatusOrder.indexOf(status);
+  return exportQueueStatusOrder[Math.min(currentIndex + 1, exportQueueStatusOrder.length - 1)] ?? status;
+}
+
+export function createExportQueueEntry(
+  summary: ComparisonSummary,
+  records: SnapshotRecord[],
+): ExportQueueEntry {
+  const comparisonKey = buildComparisonKey(...summary.pair);
+  const label = records.length === 2
+    ? `${records[0].label} vs ${records[1].label}`
+    : summary.pair.join(" vs ");
+  const destination = records.length === 2
+    ? `${records[0].exportTarget} -> ${records[1].exportTarget}`
+    : `${summary.reviewLane} -> review package`;
+
+  return {
+    id: `pkg-${comparisonKey.replace(/::/g, "-")}`,
+    comparisonKey,
+    pair: summary.pair,
+    label,
+    status: "queued",
+    requestedBy: "Archive review desk",
+    requestedAt: "2026-04-20 10:48 UTC",
+    destination,
+    reviewLane: summary.reviewLane,
+    note: summary.queueSummary,
+    artifacts: summary.exportArtifacts,
   };
 }

--- a/src/app/archive-vault/page.tsx
+++ b/src/app/archive-vault/page.tsx
@@ -3,7 +3,7 @@ import { ArchiveVaultShell } from "@/components/archive-vault/archive-vault-shel
 
 export const metadata: Metadata = {
   title: "Archive Vault",
-  description: "Mock snapshot browser with local compare and detail panels.",
+  description: "Mock snapshot diff explorer with local review exports and queue state.",
 };
 
 export default function ArchiveVaultPage() {

--- a/src/components/archive-vault/archive-vault-filters.tsx
+++ b/src/components/archive-vault/archive-vault-filters.tsx
@@ -48,7 +48,7 @@ export function ArchiveVaultFilters({
           </strong>
           <span>client-side matches</span>
           {hasFilters ? (
-            <button onClick={onReset} type="button">
+            <button className={styles.ghostButton} onClick={onReset} type="button">
               Reset
             </button>
           ) : null}

--- a/src/components/archive-vault/archive-vault-shell.test.tsx
+++ b/src/components/archive-vault/archive-vault-shell.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ArchiveVaultShell } from "./archive-vault-shell";
+
+describe("ArchiveVaultShell", () => {
+  it("shows record-level diff details for selected snapshot pairs", () => {
+    render(<ArchiveVaultShell />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Select Aurelia Ledger for compare" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Select Orbit Permissions for compare" }),
+    );
+
+    expect(
+      screen.getByText(
+        "Both sealed archives hold steady and differ mostly in consent lineage depth.",
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Inspect diff for Consent lineage map" }),
+    );
+
+    const inspector = screen.getByLabelText("Selected diff detail");
+    expect(
+      within(inspector).getByText("Entitlement residue retained until legal release"),
+    ).toBeInTheDocument();
+    expect(within(inspector).getByText("Identity graph")).toBeInTheDocument();
+  });
+
+  it("requires review before queueing a comparison package", () => {
+    render(<ArchiveVaultShell />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Select Helix Notes for compare" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Select Kestrel Claims for compare" }),
+    );
+
+    const queueButton = screen.getByRole("button", { name: "Queue review package" });
+    expect(queueButton).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark comparison reviewed" }));
+
+    expect(queueButton).toBeEnabled();
+
+    fireEvent.click(queueButton);
+
+    const exportPanel = screen.getByLabelText("Export queue");
+    expect(
+      within(exportPanel).getByText("Helix Notes vs Kestrel Claims"),
+    ).toBeInTheDocument();
+    expect(within(exportPanel).getByText("queued")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Queued for export" }),
+    ).toBeDisabled();
+  });
+
+  it("advances seeded queue packages through their export states", () => {
+    render(<ArchiveVaultShell />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Advance package Ember Registry vs Quartz Session Tape",
+      }),
+    );
+
+    const exportPanel = screen.getByLabelText("Export queue");
+    const queueCard = within(exportPanel)
+      .getByText("Ember Registry vs Quartz Session Tape")
+      .closest("article");
+
+    expect(queueCard).not.toBeNull();
+    expect(within(queueCard!).getByText("ready")).toBeInTheDocument();
+    expect(
+      within(queueCard!).getByRole("button", {
+        name: "Export package ready Ember Registry vs Quartz Session Tape",
+      }),
+    ).toBeDisabled();
+  });
+});

--- a/src/components/archive-vault/archive-vault-shell.tsx
+++ b/src/components/archive-vault/archive-vault-shell.tsx
@@ -1,18 +1,33 @@
 "use client";
 
-import { startTransition, useDeferredValue, useState } from "react";
+import { startTransition, useDeferredValue, useEffect, useState } from "react";
 import {
+  advanceExportQueueStatus,
   archiveStatuses,
   archiveTags,
+  buildComparisonKey,
+  createExportQueueEntry,
+  exportQueueEntries,
   findComparisonSummary,
   snapshotRecords,
   type ArchiveStatus,
+  type ExportQueueEntry,
 } from "@/app/archive-vault/archive-vault-data";
 import { ArchiveVaultFilters } from "./archive-vault-filters";
 import styles from "./archive-vault.module.css";
+import { ComparisonDetailPanel } from "./comparison-detail-panel";
 import { CompareSummaryPanel } from "./compare-summary-panel";
+import { ExportQueuePanel } from "./export-queue-panel";
 import { RecordDetailPanel } from "./record-detail-panel";
 import { SnapshotList } from "./snapshot-list";
+
+const initialReviewedPairs = exportQueueEntries.reduce<Record<string, boolean>>(
+  (state, entry) => {
+    state[entry.comparisonKey] = true;
+    return state;
+  },
+  {},
+);
 
 export function ArchiveVaultShell() {
   const [query, setQuery] = useState("");
@@ -20,10 +35,28 @@ export function ArchiveVaultShell() {
   const [tagFilter, setTagFilter] = useState<string>("all");
   const [focusedRecordId, setFocusedRecordId] = useState<string | null>(snapshotRecords[0]?.id ?? null);
   const [compareIds, setCompareIds] = useState<string[]>([]);
+  const [selectedChangeId, setSelectedChangeId] = useState<string | null>(null);
+  const [reviewedPairs, setReviewedPairs] = useState<Record<string, boolean>>(
+    () => initialReviewedPairs,
+  );
+  const [exportQueue, setExportQueue] = useState<ExportQueueEntry[]>(
+    () => [...exportQueueEntries],
+  );
   const deferredQuery = useDeferredValue(query).trim().toLowerCase();
 
   const visibleRecords = snapshotRecords.filter((record) => {
-    const haystack = [record.label, record.cluster, record.owner, record.region, record.summary, ...record.tags].join(" ").toLowerCase();
+    const haystack = [
+      record.label,
+      record.cluster,
+      record.owner,
+      record.region,
+      record.summary,
+      record.lineage,
+      record.exportTarget,
+      record.reviewLane,
+      record.checksumStatus,
+      ...record.tags,
+    ].join(" ").toLowerCase();
 
     return (
       (!deferredQuery || haystack.includes(deferredQuery)) &&
@@ -32,29 +65,100 @@ export function ArchiveVaultShell() {
     );
   });
 
-  const activeRecordId = focusedRecordId && visibleRecords.some((record) => record.id === focusedRecordId) ? focusedRecordId : visibleRecords[0]?.id ?? null;
+  const activeRecordId = focusedRecordId && visibleRecords.some((record) => record.id === focusedRecordId)
+    ? focusedRecordId
+    : visibleRecords[0]?.id ?? null;
   const visibleCompareIds = compareIds.filter((id) => visibleRecords.some((record) => record.id === id));
   const activeRecord = snapshotRecords.find((record) => record.id === activeRecordId) ?? null;
   const comparedRecords = visibleCompareIds.flatMap((id) => {
     const match = snapshotRecords.find((record) => record.id === id);
     return match ? [match] : [];
   });
-  const comparison = comparedRecords.length === 2 ? findComparisonSummary(comparedRecords[0].id, comparedRecords[1].id) : null;
+  const comparison = comparedRecords.length === 2
+    ? findComparisonSummary(comparedRecords[0].id, comparedRecords[1].id)
+    : null;
+  const activeComparisonKey = comparison ? buildComparisonKey(...comparison.pair) : null;
   const hasFilters = query.trim().length > 0 || statusFilters.length > 0 || tagFilter !== "all";
+  const reviewedCount = Object.values(reviewedPairs).filter(Boolean).length;
+  const readyCount = exportQueue.filter((entry) => entry.status === "ready").length;
+  const activeQueueEntry = activeComparisonKey
+    ? exportQueue.find((entry) => entry.comparisonKey === activeComparisonKey) ?? null
+    : null;
+  const isReviewed = activeComparisonKey ? reviewedPairs[activeComparisonKey] ?? false : false;
+
+  useEffect(() => {
+    if (!comparison) {
+      setSelectedChangeId(null);
+      return;
+    }
+
+    if (!comparison.recordChanges.some((change) => change.id === selectedChangeId)) {
+      setSelectedChangeId(comparison.recordChanges[0]?.id ?? null);
+    }
+  }, [comparison, selectedChangeId]);
+
+  function resetFilters() {
+    startTransition(() => {
+      setQuery("");
+      setStatusFilters([]);
+      setTagFilter("all");
+    });
+  }
 
   function toggleStatus(status: ArchiveStatus) {
-    startTransition(() => setStatusFilters((current) => current.includes(status) ? current.filter((value) => value !== status) : [...current, status]));
+    startTransition(() => {
+      setStatusFilters((current) => current.includes(status)
+        ? current.filter((value) => value !== status)
+        : [...current, status]);
+    });
   }
 
   function toggleCompare(recordId: string) {
-    setCompareIds((current) => {
-      const visibleSelection = current.filter((id) => visibleRecords.some((record) => record.id === id));
+    startTransition(() => {
+      setCompareIds((current) => {
+        const visibleSelection = current.filter((id) => visibleRecords.some((record) => record.id === id));
 
-      if (visibleSelection.includes(recordId)) return visibleSelection.filter((value) => value !== recordId);
-      if (visibleSelection.length < 2) return [...visibleSelection, recordId];
-      return [visibleSelection[1], recordId];
+        if (visibleSelection.includes(recordId)) {
+          return visibleSelection.filter((value) => value !== recordId);
+        }
+
+        if (visibleSelection.length < 2) return [...visibleSelection, recordId];
+        return [visibleSelection[1], recordId];
+      });
+      setFocusedRecordId(recordId);
     });
-    setFocusedRecordId(recordId);
+  }
+
+  function markComparisonReviewed() {
+    if (!activeComparisonKey) return;
+
+    startTransition(() => {
+      setReviewedPairs((current) => current[activeComparisonKey]
+        ? current
+        : { ...current, [activeComparisonKey]: true });
+    });
+  }
+
+  function queueComparison() {
+    if (!comparison || !activeComparisonKey || !isReviewed || activeQueueEntry) return;
+
+    startTransition(() => {
+      setExportQueue((current) => {
+        if (current.some((entry) => entry.comparisonKey === activeComparisonKey)) {
+          return current;
+        }
+
+        return [createExportQueueEntry(comparison, comparedRecords), ...current];
+      });
+    });
+  }
+
+  function advanceQueueEntry(entryId: string) {
+    startTransition(() => {
+      setExportQueue((current) => current.map((entry) => entry.id === entryId
+        ? { ...entry, status: advanceExportQueueStatus(entry.status) }
+        : entry));
+    });
   }
 
   return (
@@ -63,10 +167,10 @@ export function ArchiveVaultShell() {
         <div>
           <p className={styles.eyebrow}>Archive Vault</p>
           <h1 className={styles.title}>
-            Snapshot browser for sealed records, review queues, and drift-ready comparisons.
+            Snapshot diff explorer for sealed baselines, drift investigations, and queued review exports.
           </h1>
           <p className={styles.intro}>
-            Everything on this route is mock and local: search, filters, detail state, and pairwise compare summaries never leave the client.
+            Compare two saved snapshots, inspect record-level deltas, mark the review complete, and stage export packages without leaving the client.
           </p>
         </div>
         <div className={styles.heroStats}>
@@ -75,11 +179,19 @@ export function ArchiveVaultShell() {
             <strong>{snapshotRecords.length}</strong>
           </div>
           <div className={styles.statCard}>
-            <span>Sealed</span>
-            <strong>{snapshotRecords.filter((record) => record.status === "sealed").length}</strong>
+            <span>Reviewed pairs</span>
+            <strong>{reviewedCount}</strong>
           </div>
           <div className={styles.statCard}>
-            <span>Drift Watch</span>
+            <span>Queue packages</span>
+            <strong>{exportQueue.length}</strong>
+          </div>
+          <div className={styles.statCard}>
+            <span>Ready exports</span>
+            <strong>{readyCount}</strong>
+          </div>
+          <div className={styles.statCard}>
+            <span>Drift watch</span>
             <strong>{snapshotRecords.filter((record) => record.status === "drift").length}</strong>
           </div>
         </div>
@@ -91,7 +203,7 @@ export function ArchiveVaultShell() {
         activeTag={tagFilter}
         hasFilters={hasFilters}
         onQueryChange={(value) => startTransition(() => setQuery(value))}
-        onReset={() => startTransition(() => { setQuery(""); setStatusFilters([]); setTagFilter("all"); })}
+        onReset={resetFilters}
         onTagChange={(value) => startTransition(() => setTagFilter(value))}
         onToggleStatus={toggleStatus}
         resultCount={visibleRecords.length}
@@ -101,19 +213,43 @@ export function ArchiveVaultShell() {
       />
 
       <div className={styles.workspace}>
-        <SnapshotList
-          activeRecordId={activeRecordId}
-          compareIds={visibleCompareIds}
-          hasFilters={hasFilters}
-          onActivate={setFocusedRecordId}
-          onResetFilters={() => startTransition(() => { setQuery(""); setStatusFilters([]); setTagFilter("all"); })}
-          onToggleCompare={toggleCompare}
-          records={visibleRecords}
-        />
+        <section className={styles.primaryColumn}>
+          <SnapshotList
+            activeRecordId={activeRecordId}
+            compareIds={visibleCompareIds}
+            hasFilters={hasFilters}
+            onActivate={setFocusedRecordId}
+            onClearCompare={() => startTransition(() => setCompareIds([]))}
+            onResetFilters={resetFilters}
+            onToggleCompare={toggleCompare}
+            records={visibleRecords}
+          />
+          <ComparisonDetailPanel
+            onSelectChange={setSelectedChangeId}
+            selectedChangeId={selectedChangeId}
+            summary={comparison}
+          />
+        </section>
 
         <aside className={styles.sideRail}>
-          <RecordDetailPanel isCompared={visibleCompareIds.includes(activeRecord?.id ?? "")} record={activeRecord} />
-          <CompareSummaryPanel records={comparedRecords} summary={comparison} />
+          <CompareSummaryPanel
+            isQueued={Boolean(activeQueueEntry)}
+            onMarkReviewed={markComparisonReviewed}
+            onQueue={queueComparison}
+            records={comparedRecords}
+            reviewed={isReviewed}
+            summary={comparison}
+          />
+          <RecordDetailPanel
+            comparison={comparison}
+            isCompared={visibleCompareIds.includes(activeRecord?.id ?? "")}
+            record={activeRecord}
+          />
+          <ExportQueuePanel
+            activeComparisonKey={activeComparisonKey}
+            entries={exportQueue}
+            onAdvance={advanceQueueEntry}
+          />
         </aside>
       </div>
     </main>

--- a/src/components/archive-vault/archive-vault.module.css
+++ b/src/components/archive-vault/archive-vault.module.css
@@ -1,84 +1,653 @@
-.shell { padding: 2rem; }
-.hero, .filters, .listPanel, .sidePanel {
-  border: 1px solid rgba(93, 68, 44, 0.12);
-  border-radius: 1.75rem;
-  background: rgba(255, 251, 245, 0.9);
-  box-shadow: 0 20px 48px rgba(80, 56, 36, 0.08);
+.shell {
+  --paper: rgba(255, 248, 238, 0.94);
+  --paper-strong: rgba(255, 252, 246, 0.98);
+  --line: rgba(122, 86, 56, 0.16);
+  --line-strong: rgba(85, 57, 38, 0.22);
+  --ink: #221911;
+  --muted: #6a5545;
+  --accent: #22405d;
+  --accent-soft: rgba(34, 64, 93, 0.1);
+  --warm: #a75c31;
+  --risk: #9a3f28;
+  --watch: #7c5d1b;
+  min-height: 100vh;
+  padding: 1.5rem;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at top left, rgba(175, 93, 36, 0.14), transparent 28%),
+    radial-gradient(circle at top right, rgba(47, 82, 117, 0.16), transparent 30%),
+    linear-gradient(180deg, #f4e8d6 0%, #efe1cc 46%, #ead9c4 100%);
 }
+
+.hero,
+.filters,
+.listPanel,
+.sidePanel,
+.detailPanel {
+  border: 1px solid var(--line);
+  border-radius: 1.75rem;
+  background: var(--paper);
+  box-shadow: 0 22px 50px rgba(71, 45, 23, 0.08);
+  backdrop-filter: blur(16px);
+}
+
 .hero {
   display: grid;
   gap: 1.5rem;
   margin-bottom: 1.5rem;
   padding: 1.75rem;
-  background: linear-gradient(135deg, rgba(122, 68, 36, 0.09), transparent), rgba(255, 251, 245, 0.92);
+  grid-template-columns: minmax(0, 1.35fr) minmax(18rem, 1fr);
+  background:
+    linear-gradient(125deg, rgba(167, 92, 49, 0.12), rgba(255, 248, 238, 0.12)),
+    var(--paper-strong);
 }
-.eyebrow, .panelHeader p {
+
+.eyebrow,
+.panelHeader p {
   margin: 0 0 0.45rem;
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
   font-size: 0.72rem;
-  color: #885734;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #8c5d39;
 }
-.title, .panelHeader h2, .cardHeading h3 { margin: 0; }
-.intro, .cardSummary, .emptyState p, .noteList { color: #54483f; }
-.heroStats, .workspace, .sideRail, .recordGrid, .detailGrid, .highlightList, .chipRow, .tagStrip, .comparePair, .statGrid { display: grid; gap: 0.85rem; }
-.heroStats, .recordGrid, .highlightList, .chipRow, .tagStrip, .comparePair { grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr)); }
-.workspace { grid-template-columns: minmax(0, 1.5fr) minmax(20rem, 0.9fr); align-items: start; }
-.sideRail { position: sticky; top: 1.25rem; }
-.statCard, .highlightCard, .chip, .tag, .inlineBadge, .statusBadge, .cardTop button, .filterMeta button {
-  border: 1px solid rgba(127, 92, 56, 0.18);
-  border-radius: 999px;
-  background: rgba(255, 246, 235, 0.88);
+
+.title,
+.panelHeader h2,
+.cardHeading h3,
+.changeInspector h3 {
+  margin: 0;
 }
-.statCard, .highlightCard { padding: 0.9rem 1rem; }
-.statCard span, .highlightCard span, .detailGrid dt, .statGrid dt { display: block; font-size: 0.78rem; color: #725a45; }
-.statCard strong, .highlightCard strong, .detailGrid dd, .statGrid dd { margin: 0.35rem 0 0; font-size: 1.05rem; }
-.filters, .listPanel, .sidePanel { padding: 1.25rem; }
-.filters { margin-bottom: 1.5rem; }
-.searchRow, .panelHeader, .cardTop, .filterMeta, .cardHeading {
+
+.title {
+  max-width: 12ch;
+  font-size: clamp(2rem, 5vw, 3.3rem);
+  line-height: 0.98;
+}
+
+.intro,
+.cardSummary,
+.emptyState p,
+.noteList,
+.compareHint,
+.focusCard p,
+.metricCard p,
+.queueNote,
+.lineageNote,
+.timelineItem p {
+  color: var(--muted);
+}
+
+.heroStats,
+.workspace,
+.primaryColumn,
+.sideRail,
+.recordGrid,
+.detailGrid,
+.highlightList,
+.chipRow,
+.tagStrip,
+.comparePair,
+.statGrid,
+.metricGrid,
+.compareFocusGrid,
+.artifactRow,
+.timelineList,
+.queueList {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.heroStats {
+  align-content: start;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.workspace {
+  grid-template-columns: minmax(0, 1.6fr) minmax(20rem, 0.96fr);
+  align-items: start;
+}
+
+.primaryColumn,
+.sideRail {
+  min-width: 0;
+}
+
+.sideRail {
+  position: sticky;
+  top: 1.25rem;
+}
+
+.statCard,
+.highlightCard,
+.metricCard,
+.focusCard,
+.valueCard {
+  border: 1px solid var(--line);
+  border-radius: 1.2rem;
+  padding: 0.95rem 1rem;
+  background: rgba(255, 252, 246, 0.82);
+}
+
+.statCard span,
+.highlightCard span,
+.detailGrid dt,
+.statGrid dt,
+.metricCard span,
+.focusCard span,
+.valueCard span,
+.timelineMeta span,
+.queueMeta span,
+.changeCard span,
+.inspectorLabel {
+  display: block;
+  font-size: 0.77rem;
+  color: #7a604f;
+}
+
+.statCard strong,
+.highlightCard strong,
+.detailGrid dd,
+.statGrid dd,
+.metricCard strong,
+.focusCard strong,
+.valueCard strong {
+  display: block;
+  margin-top: 0.3rem;
+  font-size: 1.02rem;
+}
+
+.filters,
+.listPanel,
+.sidePanel,
+.detailPanel {
+  padding: 1.25rem;
+}
+
+.filters {
+  margin-bottom: 1.5rem;
+}
+
+.searchRow,
+.panelHeader,
+.cardTop,
+.filterMeta,
+.cardHeading,
+.compareHeaderActions,
+.changeMeta,
+.timelineMeta {
   display: flex;
   gap: 0.75rem;
   justify-content: space-between;
   align-items: flex-start;
 }
-.searchField, .cardBody { display: grid; gap: 0.5rem; }
-.searchField { flex: 1; }
+
+.searchField,
+.cardBody {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.searchField {
+  flex: 1;
+}
+
 .searchField span {
   font-size: 0.8rem;
-  text-transform: uppercase;
   letter-spacing: 0.14em;
+  text-transform: uppercase;
   color: #725238;
 }
+
 .searchField input {
   width: 100%;
-  padding: 0.85rem 1rem;
-  border: 1px solid rgba(127, 92, 56, 0.18);
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--line);
   border-radius: 1rem;
-  background: rgba(255, 250, 244, 0.96);
+  background: rgba(255, 253, 248, 0.96);
+  color: var(--ink);
 }
-.filterMeta { align-items: center; white-space: nowrap; color: #725a45; }
-.chip, .tag, .inlineBadge, .statusBadge, .cardTop button, .filterMeta button { padding: 0.5rem 0.85rem; font-size: 0.82rem; text-transform: capitalize; }
-.chipActive, .cardActive, .inlineBadge { background: #2e3d52; color: #f7f2e9; }
-.listPanel, .sidePanel { min-width: 0; }
-.card {
+
+.filterMeta {
+  align-items: center;
+  white-space: nowrap;
+  color: #725a45;
+}
+
+.chip,
+.tag,
+.inlineBadge,
+.statusBadge,
+.ghostButton,
+.actionPrimary,
+.actionSecondary,
+.toneBadge {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  font-size: 0.82rem;
+  line-height: 1.2;
+}
+
+.chip,
+.tag,
+.inlineBadge,
+.statusBadge,
+.ghostButton,
+.actionPrimary,
+.actionSecondary {
+  padding: 0.56rem 0.9rem;
+}
+
+.chip,
+.tag,
+.inlineBadge,
+.statusBadge,
+.ghostButton {
+  background: rgba(255, 247, 236, 0.85);
+}
+
+.chip {
+  text-transform: capitalize;
+}
+
+.chipActive,
+.inlineBadge {
+  border-color: rgba(27, 54, 77, 0.26);
+  background: #243a50;
+  color: #fff6ed;
+}
+
+.ghostButton,
+.actionPrimary,
+.actionSecondary,
+.cardBody,
+.changeCard {
+  cursor: pointer;
+}
+
+.ghostButton {
+  color: #5d4637;
+}
+
+.actionPrimary {
+  border-color: rgba(27, 54, 77, 0.26);
+  background: #243a50;
+  color: #fff6ed;
+}
+
+.actionSecondary {
+  border-color: rgba(167, 92, 49, 0.24);
+  background: rgba(167, 92, 49, 0.12);
+  color: #5e3b29;
+}
+
+.actionPrimary:disabled,
+.actionSecondary:disabled,
+.ghostButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.recordGrid,
+.highlightList,
+.comparePair,
+.artifactRow {
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+}
+
+.compareShelf {
+  display: grid;
+  gap: 0.85rem;
+  margin-bottom: 1rem;
   padding: 1rem;
-  border-radius: 1.35rem;
-  border: 1px solid rgba(93, 68, 44, 0.1);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.65), rgba(250, 242, 231, 0.95));
+  border: 1px dashed rgba(109, 76, 51, 0.26);
+  border-radius: 1.2rem;
+  background: rgba(255, 251, 245, 0.72);
 }
-.cardBody { width: 100%; padding: 0; border: 0; background: transparent; text-align: left; color: inherit; }
-.cardHeading span { font-size: 0.78rem; color: #725a45; }
-.statGrid, .detailGrid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-.tag { text-align: center; }
-.statusBadge[data-tone="sealed"] { background: #dff0df; }
-.statusBadge[data-tone="review"] { background: #f6e3ba; }
-.statusBadge[data-tone="active"] { background: #dce8f6; }
-.statusBadge[data-tone="drift"] { background: #f8d1c3; }
-.compareVerdict { margin: 0; padding: 1rem; border-radius: 1rem; background: rgba(46, 61, 82, 0.08); }
-.noteList { margin: 0; padding-left: 1rem; }
-.emptyState { display: grid; gap: 0.75rem; padding: 1.25rem; border-radius: 1.1rem; background: rgba(104, 74, 47, 0.06); }
-@media (max-width: 900px) {
-  .shell { padding: 1rem; }
-  .workspace, .searchRow, .panelHeader, .cardTop, .filterMeta, .cardHeading { grid-template-columns: 1fr; display: grid; }
-  .sideRail { position: static; }
+
+.compareHint {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.card {
+  display: grid;
+  gap: 0.95rem;
+  padding: 1rem;
+  border: 1px solid rgba(111, 79, 50, 0.12);
+  border-radius: 1.35rem;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.65), rgba(250, 242, 231, 0.95)),
+    rgba(255, 255, 255, 0.32);
+}
+
+.cardActive {
+  border-color: rgba(33, 62, 90, 0.28);
+  box-shadow: inset 0 0 0 1px rgba(33, 62, 90, 0.14);
+}
+
+.cardBody {
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  color: inherit;
+}
+
+.cardHeading span {
+  font-size: 0.78rem;
+  color: #725a45;
+}
+
+.cardMeta {
+  display: flex;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+}
+
+.cardMeta span {
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(36, 58, 80, 0.08);
+  font-size: 0.75rem;
+  color: #4d5f74;
+}
+
+.statGrid,
+.detailGrid,
+.valueCompare {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.statusBadge {
+  text-transform: capitalize;
+}
+
+.statusBadge[data-tone="sealed"] {
+  background: #def0df;
+}
+
+.statusBadge[data-tone="review"] {
+  background: #f7e5bb;
+}
+
+.statusBadge[data-tone="active"] {
+  background: #dce7f5;
+}
+
+.statusBadge[data-tone="drift"] {
+  background: #f7d2c4;
+}
+
+.statusBadge[data-queue-status="queued"] {
+  background: rgba(36, 58, 80, 0.12);
+}
+
+.statusBadge[data-queue-status="packaging"] {
+  background: rgba(167, 92, 49, 0.14);
+}
+
+.statusBadge[data-queue-status="ready"] {
+  background: rgba(91, 132, 75, 0.18);
+}
+
+.compareVerdict {
+  margin: 0;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: var(--accent-soft);
+}
+
+.compareFocusGrid,
+.metricGrid {
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+}
+
+.focusCard p,
+.metricCard p,
+.queueNote,
+.lineageNote {
+  margin: 0.45rem 0 0;
+}
+
+.metricCard[data-tone="risk"] {
+  border-color: rgba(154, 63, 40, 0.22);
+  background: rgba(154, 63, 40, 0.08);
+}
+
+.metricCard[data-tone="watch"] {
+  border-color: rgba(124, 93, 27, 0.2);
+  background: rgba(124, 93, 27, 0.08);
+}
+
+.metricCard[data-tone="stable"] {
+  border-color: rgba(36, 58, 80, 0.16);
+  background: rgba(36, 58, 80, 0.06);
+}
+
+.actionRow {
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.changeGrid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.15fr);
+}
+
+.changeList {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.changeCard {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.95rem 1rem;
+  border: 1px solid var(--line);
+  border-radius: 1.2rem;
+  background: rgba(255, 252, 246, 0.76);
+  text-align: left;
+}
+
+.changeCardActive {
+  border-color: rgba(36, 58, 80, 0.26);
+  box-shadow: inset 0 0 0 1px rgba(36, 58, 80, 0.12);
+  background: rgba(240, 246, 252, 0.8);
+}
+
+.changeCard p,
+.timelineItem p {
+  margin: 0;
+}
+
+.toneBadge {
+  width: fit-content;
+  padding: 0.3rem 0.55rem;
+  background: rgba(255, 247, 236, 0.95);
+  text-transform: capitalize;
+}
+
+.toneBadge[data-severity="high"] {
+  border-color: rgba(154, 63, 40, 0.24);
+  background: rgba(154, 63, 40, 0.1);
+  color: var(--risk);
+}
+
+.toneBadge[data-severity="medium"] {
+  border-color: rgba(124, 93, 27, 0.22);
+  background: rgba(124, 93, 27, 0.1);
+  color: var(--watch);
+}
+
+.toneBadge[data-severity="low"] {
+  border-color: rgba(36, 58, 80, 0.22);
+  background: rgba(36, 58, 80, 0.08);
+  color: var(--accent);
+}
+
+.toneBadge[data-type="added"],
+.toneBadge[data-type="removed"],
+.toneBadge[data-type="changed"],
+.toneBadge[data-type="watch"] {
+  color: #6d4c37;
+}
+
+.changeInspector {
+  display: grid;
+  gap: 0.9rem;
+  padding: 1.1rem;
+  border: 1px solid var(--line-strong);
+  border-radius: 1.35rem;
+  background:
+    linear-gradient(160deg, rgba(36, 58, 80, 0.08), transparent 55%),
+    rgba(255, 252, 247, 0.92);
+}
+
+.inspectorLabel {
+  margin: 0;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.valueCard {
+  min-width: 0;
+}
+
+.timelineList {
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+}
+
+.timelineItem {
+  padding: 0.95rem 1rem;
+  border: 1px solid var(--line);
+  border-radius: 1.15rem;
+  background: rgba(255, 252, 246, 0.8);
+}
+
+.timelineItem[data-tone="alert"] {
+  border-color: rgba(154, 63, 40, 0.22);
+  background: rgba(154, 63, 40, 0.07);
+}
+
+.timelineItem[data-tone="action"] {
+  border-color: rgba(36, 58, 80, 0.2);
+  background: rgba(36, 58, 80, 0.07);
+}
+
+.timelineItem[data-tone="handoff"] {
+  border-color: rgba(124, 93, 27, 0.18);
+  background: rgba(124, 93, 27, 0.07);
+}
+
+.detailGrid {
+  gap: 0.8rem;
+}
+
+.detailGrid dd {
+  margin: 0.3rem 0 0;
+}
+
+.focusCallout {
+  padding: 0.95rem 1rem;
+  border-radius: 1.2rem;
+  background: rgba(36, 58, 80, 0.08);
+}
+
+.focusCallout span {
+  display: block;
+  font-size: 0.77rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #4d5f74;
+}
+
+.focusCallout p,
+.lineageNote {
+  margin: 0.45rem 0 0;
+}
+
+.tag {
+  text-align: center;
+}
+
+.noteList {
+  margin: 0;
+  padding-left: 1rem;
+}
+
+.emptyState {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.25rem;
+  border-radius: 1.1rem;
+  background: rgba(104, 74, 47, 0.06);
+}
+
+.queueCard {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 1.25rem;
+  background: rgba(255, 252, 246, 0.82);
+}
+
+.queueCardActive {
+  border-color: rgba(36, 58, 80, 0.24);
+  box-shadow: inset 0 0 0 1px rgba(36, 58, 80, 0.12);
+}
+
+.queueMeta {
+  display: flex;
+  gap: 0.55rem;
+  flex-wrap: wrap;
+}
+
+.queueMeta span {
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(36, 58, 80, 0.06);
+}
+
+@media (max-width: 1080px) {
+  .hero,
+  .workspace,
+  .changeGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .sideRail {
+    position: static;
+  }
+}
+
+@media (max-width: 720px) {
+  .shell {
+    padding: 1rem;
+  }
+
+  .heroStats,
+  .detailGrid,
+  .statGrid,
+  .valueCompare {
+    grid-template-columns: 1fr;
+  }
+
+  .searchRow,
+  .panelHeader,
+  .cardTop,
+  .filterMeta,
+  .cardHeading,
+  .compareHeaderActions,
+  .queueMeta {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .actionRow {
+    display: grid;
+  }
 }

--- a/src/components/archive-vault/compare-summary-panel.tsx
+++ b/src/components/archive-vault/compare-summary-panel.tsx
@@ -7,26 +7,34 @@ import styles from "./archive-vault.module.css";
 type CompareSummaryPanelProps = {
   records: SnapshotRecord[];
   summary: ComparisonSummary | null;
+  reviewed: boolean;
+  isQueued: boolean;
+  onMarkReviewed: () => void;
+  onQueue: () => void;
 };
 
 export function CompareSummaryPanel({
   records,
   summary,
+  reviewed,
+  isQueued,
+  onMarkReviewed,
+  onQueue,
 }: CompareSummaryPanelProps) {
   return (
     <section className={styles.sidePanel}>
       <div className={styles.panelHeader}>
         <div>
           <p className={styles.eyebrow}>Comparison</p>
-          <h2>Pairwise summary</h2>
+          <h2>Snapshot summary</h2>
         </div>
         <span className={styles.inlineBadge}>{records.length}/2 selected</span>
       </div>
 
       {records.length < 2 || !summary ? (
         <div className={styles.emptyState}>
-          <p>Select two snapshots to unlock overlap, drift, and compare guidance.</p>
-          {records.length === 1 ? <p>Waiting for a second pair candidate.</p> : null}
+          <p>Select two snapshots to unlock overlap, drift, record deltas, and export actions.</p>
+          {records.length === 1 ? <p>Baseline selected: {records[0].label}</p> : null}
         </div>
       ) : (
         <>
@@ -37,21 +45,66 @@ export function CompareSummaryPanel({
               </span>
             ))}
           </div>
+
           <p className={styles.compareVerdict}>{summary.verdict}</p>
-          <dl className={styles.detailGrid}>
-            <div>
-              <dt>Alignment</dt>
-              <dd>{summary.alignment}</dd>
-            </div>
-            <div>
-              <dt>Risk</dt>
-              <dd>{summary.risk}</dd>
-            </div>
-          </dl>
+
+          <div className={styles.compareFocusGrid}>
+            <article className={styles.focusCard}>
+              <span>Primary focus</span>
+              <strong>{records[0].label}</strong>
+              <p>{summary.leftFocus}</p>
+            </article>
+            <article className={styles.focusCard}>
+              <span>Secondary focus</span>
+              <strong>{records[1].label}</strong>
+              <p>{summary.rightFocus}</p>
+            </article>
+          </div>
+
+          <div className={styles.metricGrid}>
+            {summary.metrics.map((metric) => (
+              <article className={styles.metricCard} data-tone={metric.tone} key={metric.label}>
+                <span>{metric.label}</span>
+                <strong>{metric.delta}</strong>
+                <p>
+                  {metric.leftValue} vs {metric.rightValue}
+                </p>
+              </article>
+            ))}
+          </div>
+
           <ul className={styles.noteList}>
             <li>{summary.shift}</li>
             <li>{summary.recommendation}</li>
+            <li>{summary.queueSummary}</li>
           </ul>
+
+          <div className={styles.artifactRow}>
+            {summary.exportArtifacts.map((artifact) => (
+              <span className={styles.tag} key={artifact}>
+                {artifact}
+              </span>
+            ))}
+          </div>
+
+          <div className={styles.actionRow}>
+            <button
+              className={reviewed ? styles.actionSecondary : styles.actionPrimary}
+              disabled={reviewed}
+              onClick={onMarkReviewed}
+              type="button"
+            >
+              {reviewed ? "Review captured" : "Mark comparison reviewed"}
+            </button>
+            <button
+              className={styles.actionPrimary}
+              disabled={!reviewed || isQueued}
+              onClick={onQueue}
+              type="button"
+            >
+              {isQueued ? "Queued for export" : "Queue review package"}
+            </button>
+          </div>
         </>
       )}
     </section>

--- a/src/components/archive-vault/comparison-detail-panel.tsx
+++ b/src/components/archive-vault/comparison-detail-panel.tsx
@@ -1,0 +1,129 @@
+import type { ComparisonSummary } from "@/app/archive-vault/archive-vault-data";
+import styles from "./archive-vault.module.css";
+
+type ComparisonDetailPanelProps = {
+  summary: ComparisonSummary | null;
+  selectedChangeId: string | null;
+  onSelectChange: (changeId: string) => void;
+};
+
+export function ComparisonDetailPanel({
+  summary,
+  selectedChangeId,
+  onSelectChange,
+}: ComparisonDetailPanelProps) {
+  if (!summary) {
+    return (
+      <section className={styles.detailPanel}>
+        <div className={styles.panelHeader}>
+          <div>
+            <p className={styles.eyebrow}>Diff Explorer</p>
+            <h2>Record-level changes</h2>
+          </div>
+        </div>
+        <div className={styles.emptyState}>
+          <p>Select a snapshot pair to inspect field deltas, reviewer notes, and queue guidance.</p>
+        </div>
+      </section>
+    );
+  }
+
+  const activeChange = summary.recordChanges.find((change) => change.id === selectedChangeId) ?? summary.recordChanges[0];
+  const highSeverityCount = summary.recordChanges.filter((change) => change.severity === "high").length;
+  const changedCount = summary.recordChanges.filter((change) => change.changeType === "changed").length;
+
+  return (
+    <section className={styles.detailPanel}>
+      <div className={styles.panelHeader}>
+        <div>
+          <p className={styles.eyebrow}>Diff Explorer</p>
+          <h2>Record-level changes</h2>
+        </div>
+        <span className={styles.inlineBadge}>{summary.recordChanges.length} tracked</span>
+      </div>
+
+      <div className={styles.metricGrid}>
+        <article className={styles.metricCard} data-tone={highSeverityCount > 0 ? "risk" : "stable"}>
+          <span>High severity</span>
+          <strong>{highSeverityCount}</strong>
+          <p>{highSeverityCount > 0 ? "Needs escalation before export." : "No blocking diffs."}</p>
+        </article>
+        <article className={styles.metricCard} data-tone="watch">
+          <span>Direct changes</span>
+          <strong>{changedCount}</strong>
+          <p>Changed records versus passive watch items.</p>
+        </article>
+        <article className={styles.metricCard} data-tone="stable">
+          <span>Review lane</span>
+          <strong>{summary.reviewLane}</strong>
+          <p>Where the current comparison should be triaged.</p>
+        </article>
+      </div>
+
+      <div className={styles.changeGrid}>
+        <div className={styles.changeList}>
+          {summary.recordChanges.map((change) => {
+            const isActive = change.id === activeChange.id;
+
+            return (
+              <button
+                aria-label={`Inspect diff for ${change.recordLabel}`}
+                aria-pressed={isActive}
+                className={isActive ? `${styles.changeCard} ${styles.changeCardActive}` : styles.changeCard}
+                key={change.id}
+                onClick={() => onSelectChange(change.id)}
+                type="button"
+              >
+                <div className={styles.changeMeta}>
+                  <span className={styles.toneBadge} data-severity={change.severity}>
+                    {change.severity}
+                  </span>
+                  <span className={styles.toneBadge} data-type={change.changeType}>
+                    {change.changeType}
+                  </span>
+                </div>
+                <strong>{change.recordLabel}</strong>
+                <span>{change.area}</span>
+                <p>{change.summary}</p>
+              </button>
+            );
+          })}
+        </div>
+
+        <article aria-label="Selected diff detail" className={styles.changeInspector}>
+          <p className={styles.inspectorLabel}>{activeChange.area}</p>
+          <h3>{activeChange.recordLabel}</h3>
+          <p className={styles.cardSummary}>{activeChange.summary}</p>
+
+          <div className={styles.valueCompare}>
+            <div className={styles.valueCard}>
+              <span>Primary snapshot</span>
+              <strong>{activeChange.leftValue}</strong>
+            </div>
+            <div className={styles.valueCard}>
+              <span>Secondary snapshot</span>
+              <strong>{activeChange.rightValue}</strong>
+            </div>
+          </div>
+
+          <ul className={styles.noteList}>
+            <li>{activeChange.impact}</li>
+            <li>{activeChange.reviewerAction}</li>
+          </ul>
+        </article>
+      </div>
+
+      <div className={styles.timelineList}>
+        {summary.timeline.map((event) => (
+          <article className={styles.timelineItem} data-tone={event.tone} key={event.id}>
+            <div className={styles.timelineMeta}>
+              <strong>{event.at}</strong>
+              <span>{event.lane}</span>
+            </div>
+            <p>{event.summary}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/archive-vault/export-queue-panel.tsx
+++ b/src/components/archive-vault/export-queue-panel.tsx
@@ -1,0 +1,85 @@
+import type { ExportQueueEntry } from "@/app/archive-vault/archive-vault-data";
+import styles from "./archive-vault.module.css";
+
+type ExportQueuePanelProps = {
+  entries: ExportQueueEntry[];
+  activeComparisonKey: string | null;
+  onAdvance: (entryId: string) => void;
+};
+
+export function ExportQueuePanel({
+  entries,
+  activeComparisonKey,
+  onAdvance,
+}: ExportQueuePanelProps) {
+  const readyCount = entries.filter((entry) => entry.status === "ready").length;
+
+  return (
+    <section aria-label="Export queue" className={styles.sidePanel}>
+      <div className={styles.panelHeader}>
+        <div>
+          <p className={styles.eyebrow}>Export Queue</p>
+          <h2>Review packages</h2>
+        </div>
+        <span className={styles.inlineBadge}>{readyCount} ready</span>
+      </div>
+
+      {entries.length === 0 ? (
+        <div className={styles.emptyState}>
+          <p>Mark a comparison reviewed to start queueing exportable review packages.</p>
+        </div>
+      ) : (
+        <div className={styles.queueList}>
+          {entries.map((entry) => {
+            const isActive = entry.comparisonKey === activeComparisonKey;
+
+            return (
+              <article
+                className={isActive ? `${styles.queueCard} ${styles.queueCardActive}` : styles.queueCard}
+                key={entry.id}
+              >
+                <div className={styles.cardTop}>
+                  <div>
+                    <strong>{entry.label}</strong>
+                    <p className={styles.cardSummary}>{entry.destination}</p>
+                  </div>
+                  <span className={styles.statusBadge} data-queue-status={entry.status}>
+                    {entry.status}
+                  </span>
+                </div>
+
+                <div className={styles.queueMeta}>
+                  <span>{entry.requestedBy}</span>
+                  <span>{entry.requestedAt}</span>
+                  <span>{entry.reviewLane}</span>
+                </div>
+
+                <p className={styles.queueNote}>{entry.note}</p>
+
+                <div className={styles.tagStrip}>
+                  {entry.artifacts.map((artifact) => (
+                    <span className={styles.tag} key={artifact}>
+                      {artifact}
+                    </span>
+                  ))}
+                </div>
+
+                <button
+                  aria-label={entry.status === "ready"
+                    ? `Export package ready ${entry.label}`
+                    : `Advance package ${entry.label}`}
+                  className={styles.actionSecondary}
+                  disabled={entry.status === "ready"}
+                  onClick={() => onAdvance(entry.id)}
+                  type="button"
+                >
+                  {entry.status === "ready" ? "Ready to export" : "Advance package"}
+                </button>
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/archive-vault/record-detail-panel.tsx
+++ b/src/components/archive-vault/record-detail-panel.tsx
@@ -1,24 +1,35 @@
-import type { SnapshotRecord } from "@/app/archive-vault/archive-vault-data";
+import type {
+  ComparisonSummary,
+  SnapshotRecord,
+} from "@/app/archive-vault/archive-vault-data";
 import styles from "./archive-vault.module.css";
 
 type RecordDetailPanelProps = {
   record: SnapshotRecord | null;
   isCompared: boolean;
+  comparison: ComparisonSummary | null;
 };
 
 export function RecordDetailPanel({
   record,
   isCompared,
+  comparison,
 }: RecordDetailPanelProps) {
   if (!record) {
     return (
       <section className={styles.sidePanel}>
         <div className={styles.emptyState}>
-          <p>Select a snapshot to inspect ownership, retention, and replay notes.</p>
+          <p>Select a snapshot to inspect ownership, retention, checksum posture, and export targets.</p>
         </div>
       </section>
     );
   }
+
+  const compareFocus = comparison?.pair.includes(record.id)
+    ? comparison.pair[0] === record.id
+      ? comparison.leftFocus
+      : comparison.rightFocus
+    : null;
 
   return (
     <section className={styles.sidePanel}>
@@ -47,7 +58,32 @@ export function RecordDetailPanel({
           <dt>Status</dt>
           <dd>{record.status}</dd>
         </div>
+        <div>
+          <dt>Review lane</dt>
+          <dd>{record.reviewLane}</dd>
+        </div>
+        <div>
+          <dt>Retention</dt>
+          <dd>{record.retentionWindow}</dd>
+        </div>
+        <div>
+          <dt>Checksum</dt>
+          <dd>{record.checksumStatus}</dd>
+        </div>
+        <div>
+          <dt>Export target</dt>
+          <dd>{record.exportTarget}</dd>
+        </div>
       </dl>
+
+      {compareFocus ? (
+        <div className={styles.focusCallout}>
+          <span>Compare focus</span>
+          <p>{compareFocus}</p>
+        </div>
+      ) : null}
+
+      <p className={styles.lineageNote}>{record.lineage}</p>
 
       <div className={styles.highlightList}>
         {record.highlights.map((highlight) => (

--- a/src/components/archive-vault/snapshot-list.tsx
+++ b/src/components/archive-vault/snapshot-list.tsx
@@ -9,6 +9,7 @@ type SnapshotListProps = {
   onActivate: (recordId: string) => void;
   onToggleCompare: (recordId: string) => void;
   onResetFilters: () => void;
+  onClearCompare: () => void;
 };
 
 export function SnapshotList({
@@ -19,7 +20,12 @@ export function SnapshotList({
   onActivate,
   onToggleCompare,
   onResetFilters,
+  onClearCompare,
 }: SnapshotListProps) {
+  const selectedLabels = records
+    .filter((record) => compareIds.includes(record.id))
+    .map((record) => record.label);
+
   return (
     <section className={styles.listPanel}>
       <div className={styles.panelHeader}>
@@ -27,14 +33,38 @@ export function SnapshotList({
           <p className={styles.eyebrow}>Snapshot Browser</p>
           <h2>Searchable local records</h2>
         </div>
-        <span className={styles.inlineBadge}>{compareIds.length}/2 compare slots</span>
+        <div className={styles.compareHeaderActions}>
+          <span className={styles.inlineBadge}>{compareIds.length}/2 compare slots</span>
+          {compareIds.length > 0 ? (
+            <button className={styles.ghostButton} onClick={onClearCompare} type="button">
+              Clear compare
+            </button>
+          ) : null}
+        </div>
       </div>
+
+      {compareIds.length > 0 ? (
+        <div className={styles.compareShelf}>
+          <span className={styles.compareHint}>
+            {compareIds.length === 1
+              ? "Select one more snapshot to stage a diff review."
+              : "Comparison staged for record diff inspection and export queueing."}
+          </span>
+          <div className={styles.comparePair}>
+            {selectedLabels.map((label) => (
+              <span className={styles.tag} key={label}>
+                {label}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
 
       {records.length === 0 ? (
         <div className={styles.emptyState}>
           <p>No snapshots match the current search and filter state.</p>
           {hasFilters ? (
-            <button onClick={onResetFilters} type="button">
+            <button className={styles.actionSecondary} onClick={onResetFilters} type="button">
               Clear filters
             </button>
           ) : null}
@@ -47,21 +77,26 @@ export function SnapshotList({
 
             return (
               <article
-                className={
-                  isActive ? `${styles.card} ${styles.cardActive}` : styles.card
-                }
+                className={isActive ? `${styles.card} ${styles.cardActive}` : styles.card}
                 key={record.id}
               >
                 <div className={styles.cardTop}>
                   <span className={styles.statusBadge} data-tone={record.status}>
                     {record.status}
                   </span>
-                  <button onClick={() => onToggleCompare(record.id)} type="button">
+                  <button
+                    aria-label={`Select ${record.label} for compare`}
+                    aria-pressed={isCompared}
+                    className={isCompared ? styles.actionSecondary : styles.ghostButton}
+                    onClick={() => onToggleCompare(record.id)}
+                    type="button"
+                  >
                     {isCompared ? "Selected" : compareIds.length === 2 ? "Swap in" : "Compare"}
                   </button>
                 </div>
 
                 <button
+                  aria-label={`Open snapshot ${record.label}`}
                   className={styles.cardBody}
                   onClick={() => onActivate(record.id)}
                   type="button"
@@ -71,6 +106,10 @@ export function SnapshotList({
                     <span>{record.cluster}</span>
                   </div>
                   <p className={styles.cardSummary}>{record.summary}</p>
+                  <div className={styles.cardMeta}>
+                    <span>{record.reviewLane}</span>
+                    <span>{record.exportTarget}</span>
+                  </div>
                   <dl className={styles.statGrid}>
                     <div>
                       <dt>Rows</dt>
@@ -83,6 +122,10 @@ export function SnapshotList({
                     <div>
                       <dt>Trust</dt>
                       <dd>{record.confidence}%</dd>
+                    </div>
+                    <div>
+                      <dt>Replay</dt>
+                      <dd>{record.highlights.find((highlight) => highlight.label === "Replay gap")?.value}</dd>
                     </div>
                   </dl>
                 </button>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./vitest.setup.tsx"],
     css: true,
+    testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
## Summary
- expand Archive Vault snapshot data into richer comparison summaries, record-level diff details, and export queue helpers
- add a multi-panel diff explorer UI with reviewed comparison actions, queueable export packages, and deeper snapshot detail context
- cover the new comparison and queue behavior with Archive Vault data and client workflow tests

## Testing
- npm run typecheck
- npm test
- npm run lint *(hangs locally in this session with no diagnostics; CI should confirm this path)*

Closes #68