### PR TITLE
feat: add lab notebook templates and comparison workflow

### DIFF
--- a/src/app/lab-notebook/notebook-data.ts
+++ b/src/app/lab-notebook/notebook-data.ts
@@ -1,17 +1,140 @@
 export type ExperimentStatus = "active" | "watch" | "stabilizing" | "archived";
 export type StatusFilter = ExperimentStatus | "all";
 export type ObservationSection = "notes" | "flags" | "timeline";
+export type BoardLaneId = "intake" | "compare" | "review";
+export type RunState = "planned" | "running" | "review" | "complete";
+export type RunMetricId = "signal" | "variance" | "cycle" | "watchFlags";
+export type ComparisonView = "summary" | "detail";
+export type ReviewDecisionId = "promote" | "rerun" | "hold";
 
-export type NotebookStatus = { label: string; phase: string; syncLabel: string; lastEntrySummary: string };
-export type StatusOption = { id: StatusFilter; label: string };
-export type MilestoneTag = { id: string; label: string; tone: "sky" | "amber" | "emerald" | "rose" };
-export type Experiment = {
-  id: string; title: string; lead: string; status: ExperimentStatus; summary: string; focus: string;
-  window: string; progressValue: number; progressLabel: string; sampleCount: number; lastEntry: string; milestoneIds: string[];
+export type NotebookStatus = {
+  label: string;
+  phase: string;
+  syncLabel: string;
+  lastEntrySummary: string;
 };
+
+export type StatusOption = { id: StatusFilter; label: string };
+export type MilestoneTag = {
+  id: string;
+  label: string;
+  tone: "sky" | "amber" | "emerald" | "rose";
+};
+
+export type BoardLane = {
+  id: BoardLaneId;
+  label: string;
+  description: string;
+  emphasis: string;
+};
+
+export type ExperimentTemplate = {
+  id: string;
+  name: string;
+  category: string;
+  summary: string;
+  objective: string;
+  cadence: string;
+  defaultLead: string;
+  defaultBoardLaneId: BoardLaneId;
+  checkpointMilestoneIds: string[];
+  compareHint: string;
+  reviewPrompts: string[];
+  boardNotes: string[];
+};
+
+export type Experiment = {
+  id: string;
+  title: string;
+  lead: string;
+  status: ExperimentStatus;
+  templateId: string;
+  summary: string;
+  focus: string;
+  window: string;
+  progressValue: number;
+  progressLabel: string;
+  sampleCount: number;
+  lastEntry: string;
+  milestoneIds: string[];
+  boardLaneId: BoardLaneId;
+  comparisonRunIds: string[];
+  recommendation: string;
+  boardNote: string;
+};
+
+export type RunMetrics = Record<RunMetricId, number>;
+
+export type ExperimentRun = {
+  id: string;
+  experimentId: string;
+  label: string;
+  state: RunState;
+  startedAt: string;
+  operator: string;
+  setup: string;
+  summary: string;
+  focus: string;
+  detail: string;
+  decisionNote: string;
+  highlights: string[];
+  metrics: RunMetrics;
+};
+
 export type ObservationEntry = {
-  id: string; experimentId: string; section: ObservationSection; headline: string; snippet: string;
-  detail: string; capturedAt: string; recorder: string; milestoneId?: string;
+  id: string;
+  experimentId: string;
+  runId: string;
+  section: ObservationSection;
+  headline: string;
+  snippet: string;
+  detail: string;
+  capturedAt: string;
+  recorder: string;
+  milestoneId?: string;
+};
+
+export type ReviewHelper = {
+  id: string;
+  label: string;
+  description: string;
+  defaultChecked: boolean;
+};
+
+export type OutcomeReview = {
+  id: string;
+  experimentId: string;
+  templateId: string;
+  headline: string;
+  summary: string;
+  recommendedDecision: ReviewDecisionId;
+  owner: string;
+  dueWindow: string;
+  helperChecklist: ReviewHelper[];
+  prompts: string[];
+};
+
+export type ReviewDecisionOption = {
+  id: ReviewDecisionId;
+  label: string;
+  boardLaneId: BoardLaneId;
+  status: ExperimentStatus;
+  recommendation: string;
+  summary: string;
+};
+
+export type ComparisonMetric = {
+  id: RunMetricId;
+  label: string;
+  unit: string;
+  better: "higher" | "lower";
+};
+
+export type ExperimentBundle = {
+  experiment: Experiment;
+  runs: ExperimentRun[];
+  observationEntries: ObservationEntry[];
+  outcomeReview: OutcomeReview;
 };
 
 export const notebookStatus: NotebookStatus = {
@@ -22,80 +145,768 @@ export const notebookStatus: NotebookStatus = {
 };
 
 export const statusOptions: StatusOption[] = [
-  { id: "all", label: "All cards" }, { id: "active", label: "Active" }, { id: "watch", label: "Watch" },
-  { id: "stabilizing", label: "Stabilizing" }, { id: "archived", label: "Archived" },
+  { id: "all", label: "All cards" },
+  { id: "active", label: "Active" },
+  { id: "watch", label: "Watch" },
+  { id: "stabilizing", label: "Stabilizing" },
+  { id: "archived", label: "Archived" },
 ];
 
 export const milestoneTags: MilestoneTag[] = [
-  { id: "capture", label: "Signal capture", tone: "sky" }, { id: "mix", label: "Ratio swap", tone: "amber" },
-  { id: "stability", label: "Stability gate", tone: "emerald" }, { id: "variance", label: "Variance watch", tone: "rose" },
+  { id: "capture", label: "Signal capture", tone: "sky" },
+  { id: "mix", label: "Ratio swap", tone: "amber" },
+  { id: "stability", label: "Stability gate", tone: "emerald" },
+  { id: "variance", label: "Variance watch", tone: "rose" },
+];
+
+export const boardLanes: BoardLane[] = [
+  {
+    id: "intake",
+    label: "Template intake",
+    description: "Draft boards, setup notes, and paired runs waiting for a first comparison pass.",
+    emphasis: "Seeded from templates",
+  },
+  {
+    id: "compare",
+    label: "Active comparison",
+    description: "Experiments with enough recorded runs to compare in summary and detail without leaving the notebook.",
+    emphasis: "Multi-run analysis",
+  },
+  {
+    id: "review",
+    label: "Outcome review",
+    description: "Boards prepared for verdicts, handoff notes, and the next board move after a comparison cycle.",
+    emphasis: "Review helpers ready",
+  },
+];
+
+export const comparisonMetrics: ComparisonMetric[] = [
+  { id: "signal", label: "Signal score", unit: "pts", better: "higher" },
+  { id: "variance", label: "Variance", unit: "%", better: "lower" },
+  { id: "cycle", label: "Cycle time", unit: "min", better: "lower" },
+  { id: "watchFlags", label: "Watch flags", unit: "", better: "lower" },
+];
+
+export const reviewDecisionOptions: ReviewDecisionOption[] = [
+  {
+    id: "promote",
+    label: "Promote to review lane",
+    boardLaneId: "review",
+    status: "stabilizing",
+    recommendation: "Promote the strongest run and package the comparison for handoff review.",
+    summary: "Move the card into the review lane with the selected runs attached as the comparison set.",
+  },
+  {
+    id: "rerun",
+    label: "Schedule rerun",
+    boardLaneId: "intake",
+    status: "watch",
+    recommendation: "Schedule another paired run before promoting this board beyond intake.",
+    summary: "Return the card to intake with a fresh baseline and candidate run to gather better evidence.",
+  },
+  {
+    id: "hold",
+    label: "Hold on comparison lane",
+    boardLaneId: "compare",
+    status: "watch",
+    recommendation: "Keep the card in active comparison until another clean pass closes the open watch items.",
+    summary: "Stay in the comparison lane while the team logs more evidence from the selected template.",
+  },
+];
+
+export const experimentTemplates: ExperimentTemplate[] = [
+  {
+    id: "assay-ratio",
+    name: "Assay ratio sweep",
+    category: "Catalyst assay",
+    summary: "Designed for solvent-ratio experiments that need quick variance checks before the evening review window.",
+    objective: "Compare ratio swaps side by side and capture which tray holds the cleanest signal.",
+    cadence: "Pair every two pulls",
+    defaultLead: "Dr. Lin Mora",
+    defaultBoardLaneId: "compare",
+    checkpointMilestoneIds: ["capture", "mix", "stability"],
+    compareHint: "Compare post-swap runs against the baseline and keep the warm-up handoff visible.",
+    reviewPrompts: [
+      "Did the ratio change hold for at least two clean pulls?",
+      "Can the strongest tray advance without a new late-cycle spike?",
+      "Is there enough evidence to package the assay for the stability review lane?",
+    ],
+    boardNotes: [
+      "Keep the final tray handoff under the watch threshold before promoting.",
+      "Attach both the baseline and candidate runs to the review summary.",
+    ],
+  },
+  {
+    id: "thermal-recovery",
+    name: "Thermal recovery ladder",
+    category: "Cooldown loop",
+    summary: "A template for pulse-based thermal experiments where the recovery curve must be compared after each shield adjustment.",
+    objective: "Track whether cooldown timing improves across paired shield or dwell changes.",
+    cadence: "Compare every pulse set",
+    defaultLead: "Ira Sol",
+    defaultBoardLaneId: "compare",
+    checkpointMilestoneIds: ["capture", "variance"],
+    compareHint: "Use the paired runs to compare the recovery delay, total cycle time, and watch flags before escalation.",
+    reviewPrompts: [
+      "Did the cooldown rise move later in the cycle across more than one run?",
+      "Are manual-watch steps still required after the new shield setting?",
+      "Should the next board move be another rerun or a promotion into outcome review?",
+    ],
+    boardNotes: [
+      "Any run with a repeated pulse-three spike stays visible on the compare lane.",
+      "Include a manual-watch owner before promoting the notebook card.",
+    ],
+  },
+  {
+    id: "reagent-ladder",
+    name: "Reagent ladder validation",
+    category: "Noise reduction",
+    summary: "A template for ladder and rung validation work where teams need repeatable comparisons before closing a stability gate.",
+    objective: "Confirm the updated ladder removes lower-band noise and earns a clean validation repeat.",
+    cadence: "Compare validation passes",
+    defaultLead: "M. Ortega",
+    defaultBoardLaneId: "review",
+    checkpointMilestoneIds: ["mix", "stability"],
+    compareHint: "Compare the validation passes with the lower rung in focus and keep the review prompts attached to the board.",
+    reviewPrompts: [
+      "Did the lower rung hold across consecutive validation passes?",
+      "Can the board move into outcome review without another ladder adjustment?",
+      "Which notes must stay attached for the final handoff?",
+    ],
+    boardNotes: [
+      "Review cards should carry the best pass and the prior repeat for context.",
+      "If the lower rung slips, move the board back to intake with a new ladder setup.",
+    ],
+  },
 ];
 
 export const experiments: Experiment[] = [
   {
-    id: "vector-12", title: "Vector 12 catalyst assay", lead: "Dr. Lin Mora", status: "active",
+    id: "vector-12",
+    title: "Vector 12 catalyst assay",
+    lead: "Dr. Lin Mora",
+    status: "active",
+    templateId: "assay-ratio",
     summary: "Comparing solvent ratios across four trays to tighten signal consistency before the next review window.",
-    focus: "Tray C retained the strongest read without the late-cycle spike.", window: "Next readout in 42 min",
-    progressValue: 72, progressLabel: "Run 6 of 8", sampleCount: 24,
-    lastEntry: "Signal tightened after the second ratio swap and held across the last two pulls.", milestoneIds: ["capture", "mix", "stability"],
+    focus: "Tray C retained the strongest read without the late-cycle spike.",
+    window: "Next readout in 42 min",
+    progressValue: 72,
+    progressLabel: "Run 6 of 8",
+    sampleCount: 24,
+    lastEntry: "Signal tightened after the second ratio swap and held across the last two pulls.",
+    milestoneIds: ["capture", "mix", "stability"],
+    boardLaneId: "compare",
+    comparisonRunIds: ["v12-run-5", "v12-run-6"],
+    recommendation: "Promote the strongest run and package the comparison for handoff review.",
+    boardNote: "Assay ratio sweep template is attached to every active run on this board.",
   },
   {
-    id: "amber-04", title: "Amber 04 thermal loop", lead: "Ira Sol", status: "watch",
+    id: "amber-04",
+    title: "Amber 04 thermal loop",
+    lead: "Ira Sol",
+    status: "watch",
+    templateId: "thermal-recovery",
     summary: "Following an intermittent rise in coil temperature during the cooldown band after each third pulse.",
-    focus: "Thermal recovery is stable until pulse three, then slips outside the preferred curve.", window: "Manual watch until 19:40",
-    progressValue: 46, progressLabel: "Pulse set 3", sampleCount: 18,
-    lastEntry: "Cooldown lag reappeared on the final pulse set with a shorter plateau than yesterday.", milestoneIds: ["variance", "capture"],
+    focus: "Thermal recovery is stable until pulse three, then slips outside the preferred curve.",
+    window: "Manual watch until 19:40",
+    progressValue: 46,
+    progressLabel: "Pulse set 3",
+    sampleCount: 18,
+    lastEntry: "Cooldown lag reappeared on the final pulse set with a shorter plateau than yesterday.",
+    milestoneIds: ["variance", "capture"],
+    boardLaneId: "compare",
+    comparisonRunIds: ["a04-run-2", "a04-run-3"],
+    recommendation: "Schedule another paired run before promoting this board beyond intake.",
+    boardNote: "Thermal recovery ladder keeps the manual-watch owner and cooldown prompt visible in compare view.",
   },
   {
-    id: "north-arc", title: "North Arc reagent ladder", lead: "M. Ortega", status: "stabilizing",
+    id: "north-arc",
+    title: "North Arc reagent ladder",
+    lead: "M. Ortega",
+    status: "stabilizing",
+    templateId: "reagent-ladder",
     summary: "Verifying whether the updated reagent ladder reduces noise in the lower-band observations.",
-    focus: "The middle rung is now steady, but the lower rung still needs one more clean repeat.", window: "Review checkpoint at 20:15",
-    progressValue: 88, progressLabel: "Validation pass", sampleCount: 31,
-    lastEntry: "The lower rung cleared one repeat without drift and now needs a second confirmation.", milestoneIds: ["mix", "stability"],
+    focus: "The middle rung is now steady, but the lower rung still needs one more clean repeat.",
+    window: "Review checkpoint at 20:15",
+    progressValue: 88,
+    progressLabel: "Validation pass",
+    sampleCount: 31,
+    lastEntry: "The lower rung cleared one repeat without drift and now needs a second confirmation.",
+    milestoneIds: ["mix", "stability"],
+    boardLaneId: "review",
+    comparisonRunIds: ["na-run-1", "na-run-2"],
+    recommendation: "Promote the strongest run and package the comparison for handoff review.",
+    boardNote: "Reagent ladder validation boards stay template-aware even inside the outcome review lane.",
+  },
+];
+
+export const experimentRuns: ExperimentRun[] = [
+  {
+    id: "v12-run-4",
+    experimentId: "vector-12",
+    label: "Run 4 baseline",
+    state: "complete",
+    startedAt: "17:08",
+    operator: "L. Mora",
+    setup: "28% solvent baseline, tray order A-D",
+    summary: "The baseline closed with a broad spread and a warm handoff on the final tray.",
+    focus: "Use this as the comparison floor for the ratio swap runs.",
+    detail: "Run 4 showed the old baseline clearly: the spread widened after the fourth pull and Tray D warmed during the handoff.",
+    decisionNote: "Keep as the baseline reference only; do not promote without the ratio swap pair.",
+    highlights: [
+      "Tray C held a cleaner mid-band than Tray D.",
+      "Late-cycle spike returned on the final pull.",
+    ],
+    metrics: { signal: 82, variance: 6.1, cycle: 38, watchFlags: 2 },
+  },
+  {
+    id: "v12-run-5",
+    experimentId: "vector-12",
+    label: "Run 5 ratio swap",
+    state: "complete",
+    startedAt: "17:46",
+    operator: "A. Pike",
+    setup: "24% solvent candidate, shortened transfer dwell",
+    summary: "The ratio swap narrowed the spread and removed one of the late-cycle deviations.",
+    focus: "Compare directly against Run 6 to confirm the gain holds across consecutive pulls.",
+    detail: "Run 5 introduced the shorter dwell setting and a lower solvent percentage. The result was a tighter spread but one tray still heated during transfer.",
+    decisionNote: "Strong candidate for comparison, but still needs a second clean pass to clear the watch note.",
+    highlights: [
+      "Variance dropped below five percent for the first time tonight.",
+      "Transfer warm-up held under three minutes on all but the last tray.",
+    ],
+    metrics: { signal: 87, variance: 4.2, cycle: 35, watchFlags: 1 },
+  },
+  {
+    id: "v12-run-6",
+    experimentId: "vector-12",
+    label: "Run 6 follow-up",
+    state: "review",
+    startedAt: "18:18",
+    operator: "L. Mora",
+    setup: "24% solvent candidate, repeated handoff",
+    summary: "The follow-up confirmed the ratio swap and tightened the spread even further.",
+    focus: "Best signal score so far; likely promotion candidate for the review lane.",
+    detail: "Run 6 repeated the ratio swap and held the improved spread while trimming another minute from the cycle. Only one watch flag remained in the tray handoff.",
+    decisionNote: "Promote with Run 5 as the comparison pair if the handoff note is documented.",
+    highlights: [
+      "Signal score improved again on the strongest tray.",
+      "Second consecutive pull stayed within the local stability band.",
+    ],
+    metrics: { signal: 89, variance: 3.2, cycle: 34, watchFlags: 1 },
+  },
+  {
+    id: "a04-run-1",
+    experimentId: "amber-04",
+    label: "Pulse set 1 baseline",
+    state: "complete",
+    startedAt: "16:44",
+    operator: "I. Sol",
+    setup: "Default shield, standard dwell",
+    summary: "Baseline pulse set still spiked immediately after the third pulse.",
+    focus: "Use this run to measure whether the shield adjustments actually delay the thermal rise.",
+    detail: "The baseline run hit the upper bound almost immediately after the third pulse, with no delay from the previous shield pattern.",
+    decisionNote: "Keep as the recovery floor; not stable enough for promotion.",
+    highlights: [
+      "Pulse three exceeded the watch curve by a wide margin.",
+      "Cooldown recovery was noisy during the final minute.",
+    ],
+    metrics: { signal: 69, variance: 7.4, cycle: 52, watchFlags: 3 },
+  },
+  {
+    id: "a04-run-2",
+    experimentId: "amber-04",
+    label: "Pulse set 2 shield swap",
+    state: "running",
+    startedAt: "17:22",
+    operator: "R. Vale",
+    setup: "Shield plate B, standard dwell",
+    summary: "The spike moved later in the cycle but still crossed the watch threshold.",
+    focus: "Compare against the next pulse set to see whether the delay is repeatable.",
+    detail: "Shield plate B delayed the spike by about twenty seconds. The cooldown curve still crossed the threshold, but it did so later than the baseline.",
+    decisionNote: "Keep in compare view until another run shows the same delay.",
+    highlights: [
+      "Delayed spike without removing the threshold breach.",
+      "Cycle time fell slightly compared with the baseline.",
+    ],
+    metrics: { signal: 73, variance: 6.3, cycle: 49, watchFlags: 2 },
+  },
+  {
+    id: "a04-run-3",
+    experimentId: "amber-04",
+    label: "Pulse set 3 short dwell",
+    state: "review",
+    startedAt: "18:03",
+    operator: "I. Sol",
+    setup: "Shield plate B, shortened dwell",
+    summary: "The shorter dwell trimmed the cycle again, but the pulse-three spike persisted in a smaller window.",
+    focus: "Best candidate so far, though the board still needs another rerun before review.",
+    detail: "The shorter dwell helped the recovery timing and compressed the cooldown cycle, but the remaining spike means manual watch is still required.",
+    decisionNote: "Use as the leading candidate, but schedule another paired run before promotion.",
+    highlights: [
+      "Cycle time improved without introducing a new anomaly.",
+      "Manual-watch requirement remains because the spike is still present.",
+    ],
+    metrics: { signal: 76, variance: 5.7, cycle: 47, watchFlags: 2 },
+  },
+  {
+    id: "na-run-1",
+    experimentId: "north-arc",
+    label: "Validation pass A",
+    state: "complete",
+    startedAt: "17:11",
+    operator: "M. Ortega",
+    setup: "Updated ladder, lower rung retuned",
+    summary: "The first validation pass cleared the lower rung once without edge noise.",
+    focus: "Compare this pass against the confirmation run before closing the stability gate.",
+    detail: "Pass A removed the edge noise and gave the team the first clean lower-band repeat after the ladder update.",
+    decisionNote: "Strong pass; needs a matching confirmation before closure.",
+    highlights: [
+      "Middle rung stayed quiet through the full cycle.",
+      "Lower-band noise cleared on the first repeat.",
+    ],
+    metrics: { signal: 84, variance: 3.6, cycle: 31, watchFlags: 1 },
+  },
+  {
+    id: "na-run-2",
+    experimentId: "north-arc",
+    label: "Validation pass B",
+    state: "review",
+    startedAt: "17:55",
+    operator: "N. Hsu",
+    setup: "Updated ladder, repeated lower rung confirmation",
+    summary: "The confirmation pass matched the lower-band stability and is ready for outcome review.",
+    focus: "Best confirmation set for a review-lane handoff.",
+    detail: "Pass B matched the first clean validation run while lowering the remaining noise floor. This gives the board a credible outcome review package.",
+    decisionNote: "Promote with Pass A attached as supporting context.",
+    highlights: [
+      "Lower rung stayed inside the preferred band across the full pass.",
+      "Noise floor improved again on the repeated ladder setup.",
+    ],
+    metrics: { signal: 86, variance: 2.9, cycle: 30, watchFlags: 0 },
   },
 ];
 
 export const observationEntries: ObservationEntry[] = [
   {
-    id: "v12-note-1", experimentId: "vector-12", section: "notes", headline: "Ratio swap narrowed the spread",
-    snippet: "Cycle six closed to a 3.2% variance after the solvent ratio moved down four points.",
-    detail: "Tray C and Tray D converged within the same tolerance band after the swap, which did not happen in the previous two runs.",
-    capturedAt: "18:12", recorder: "L. Mora", milestoneId: "mix",
+    id: "v12-note-1",
+    experimentId: "vector-12",
+    runId: "v12-run-5",
+    section: "notes",
+    headline: "Ratio swap narrowed the spread",
+    snippet: "Run 5 closed to a 4.2% variance after the solvent ratio moved down four points.",
+    detail: "Tray C and Tray D converged within the same tolerance band after the swap, which did not happen in the baseline run.",
+    capturedAt: "17:58",
+    recorder: "L. Mora",
+    milestoneId: "mix",
   },
   {
-    id: "v12-flag-1", experimentId: "vector-12", section: "flags", headline: "Watch the final tray handoff",
+    id: "v12-note-2",
+    experimentId: "vector-12",
+    runId: "v12-run-6",
+    section: "notes",
+    headline: "Follow-up pull held the gain",
+    snippet: "Run 6 repeated the ratio swap and kept the variance just above three percent.",
+    detail: "The follow-up pull held the new ratio and kept the tray spread inside the local stability band for a second straight cycle.",
+    capturedAt: "18:27",
+    recorder: "A. Pike",
+    milestoneId: "stability",
+  },
+  {
+    id: "v12-flag-1",
+    experimentId: "vector-12",
+    runId: "v12-run-6",
+    section: "flags",
+    headline: "Watch the final tray handoff",
     snippet: "The last tray still warms faster than the others during the transfer interval.",
     detail: "If the handoff warm-up exceeds three minutes again, pause the next pull and repeat the transfer with the shorter dwell setting.",
-    capturedAt: "18:25", recorder: "A. Pike", milestoneId: "variance",
+    capturedAt: "18:31",
+    recorder: "A. Pike",
+    milestoneId: "variance",
   },
   {
-    id: "v12-time-1", experimentId: "vector-12", section: "timeline", headline: "Stability gate cleared",
-    snippet: "Two consecutive pulls stayed within the notebook target band after the ratio change.",
-    detail: "That clears the local stability gate and keeps the assay on track for the final review window tonight.",
-    capturedAt: "18:31", recorder: "L. Mora", milestoneId: "stability",
+    id: "v12-time-1",
+    experimentId: "vector-12",
+    runId: "v12-run-5",
+    section: "timeline",
+    headline: "Baseline pair attached",
+    snippet: "Run 5 is now attached as the baseline candidate for the comparison workflow.",
+    detail: "That gives the notebook a clean baseline-to-candidate pair for the summary view and the detailed review cards.",
+    capturedAt: "18:03",
+    recorder: "L. Mora",
+    milestoneId: "capture",
   },
   {
-    id: "a04-note-1", experimentId: "amber-04", section: "notes", headline: "Thermal rise stayed late",
-    snippet: "Pulse three still drifted high, but the rise started twenty seconds later than the earlier run.",
+    id: "v12-time-2",
+    experimentId: "vector-12",
+    runId: "v12-run-6",
+    section: "timeline",
+    headline: "Stability gate queued",
+    snippet: "Run 6 cleared the local gate and queued the outcome review helper set.",
+    detail: "With two runs in context, the board can move into the review lane as soon as the transfer note is confirmed.",
+    capturedAt: "18:34",
+    recorder: "L. Mora",
+    milestoneId: "stability",
+  },
+  {
+    id: "a04-note-1",
+    experimentId: "amber-04",
+    runId: "a04-run-2",
+    section: "notes",
+    headline: "Thermal rise stayed late",
+    snippet: "Pulse set 2 still drifted high, but the rise started twenty seconds later than the earlier run.",
     detail: "That delay suggests the shield is helping, though not enough to remove the deviation completely.",
-    capturedAt: "17:58", recorder: "I. Sol", milestoneId: "capture",
+    capturedAt: "17:41",
+    recorder: "I. Sol",
+    milestoneId: "capture",
   },
   {
-    id: "a04-flag-1", experimentId: "amber-04", section: "flags", headline: "Hold for manual watch",
+    id: "a04-note-2",
+    experimentId: "amber-04",
+    runId: "a04-run-3",
+    section: "notes",
+    headline: "Short dwell improved the cycle",
+    snippet: "Pulse set 3 cut another two minutes without adding a new anomaly.",
+    detail: "The shorter dwell tightened the cycle and preserved the delayed spike, but the loop still needs a cleaner pass before promotion.",
+    capturedAt: "18:09",
+    recorder: "R. Vale",
+  },
+  {
+    id: "a04-flag-1",
+    experimentId: "amber-04",
+    runId: "a04-run-3",
+    section: "flags",
+    headline: "Hold for manual watch",
     snippet: "Leave this loop under operator watch until another cooldown cycle clears without a spike.",
-    detail: "The notebook should stay on the watch filter until the recovery curve stays under the upper bound for two consecutive pulse sets.",
-    capturedAt: "18:05", recorder: "R. Vale", milestoneId: "variance",
+    detail: "The board should stay visible on the compare lane until the recovery curve stays under the upper bound for two consecutive pulse sets.",
+    capturedAt: "18:12",
+    recorder: "R. Vale",
+    milestoneId: "variance",
   },
   {
-    id: "na-note-1", experimentId: "north-arc", section: "notes", headline: "Lower rung nearly steady",
+    id: "a04-time-1",
+    experimentId: "amber-04",
+    runId: "a04-run-2",
+    section: "timeline",
+    headline: "Manual-watch owner attached",
+    snippet: "The template board now carries the watch owner and escalation note in comparison view.",
+    detail: "That keeps the run context visible during review so the next decision can send the board to intake or keep it in compare.",
+    capturedAt: "17:48",
+    recorder: "I. Sol",
+  },
+  {
+    id: "na-note-1",
+    experimentId: "north-arc",
+    runId: "na-run-1",
+    section: "notes",
+    headline: "Lower rung nearly steady",
     snippet: "The lower rung held cleanly through one repeat with no edge noise in the final band.",
     detail: "A matching repeat would let the team close this ladder as stable and move the notebook card out of active handling.",
-    capturedAt: "17:42", recorder: "M. Ortega", milestoneId: "stability",
+    capturedAt: "17:33",
+    recorder: "M. Ortega",
+    milestoneId: "stability",
   },
   {
-    id: "na-time-1", experimentId: "north-arc", section: "timeline", headline: "Validation pass queued",
-    snippet: "The second confirmation run is staged for the 20:15 checkpoint with the revised reagent ladder.",
-    detail: "If the lower rung holds again, the notebook can promote the card from stabilizing to complete in the next review cycle.",
-    capturedAt: "17:49", recorder: "N. Hsu", milestoneId: "mix",
+    id: "na-note-2",
+    experimentId: "north-arc",
+    runId: "na-run-2",
+    section: "notes",
+    headline: "Confirmation pass matched the first result",
+    snippet: "Validation pass B stayed inside the target band and lowered the residual noise floor.",
+    detail: "The confirmation run backed up the first clean pass and gave the board enough evidence for the outcome review helpers.",
+    capturedAt: "18:02",
+    recorder: "N. Hsu",
+    milestoneId: "mix",
+  },
+  {
+    id: "na-flag-1",
+    experimentId: "north-arc",
+    runId: "na-run-2",
+    section: "flags",
+    headline: "Carry forward the lower-band note",
+    snippet: "Keep the lower-rung noise note attached during the final handoff even though the latest pass cleared it.",
+    detail: "That note explains why both validation passes are attached to the review lane and why the ladder setup should remain visible after promotion.",
+    capturedAt: "18:06",
+    recorder: "M. Ortega",
+    milestoneId: "variance",
+  },
+  {
+    id: "na-time-1",
+    experimentId: "north-arc",
+    runId: "na-run-2",
+    section: "timeline",
+    headline: "Validation pass queued for review",
+    snippet: "The second confirmation run is staged for the 20:15 checkpoint with the updated ladder package.",
+    detail: "If the board keeps both passes attached, the notebook can promote the lane and complete the review without another ladder change.",
+    capturedAt: "18:08",
+    recorder: "N. Hsu",
+    milestoneId: "stability",
   },
 ];
+
+export const outcomeReviews: OutcomeReview[] = [
+  {
+    id: "review-vector-12",
+    experimentId: "vector-12",
+    templateId: "assay-ratio",
+    headline: "Package the ratio sweep for tonight's stability review.",
+    summary: "Run 5 and Run 6 form a clean comparison pair, but the transfer handoff note still needs explicit confirmation.",
+    recommendedDecision: "promote",
+    owner: "L. Mora",
+    dueWindow: "Outcome desk at 19:10",
+    helperChecklist: [
+      {
+        id: "vector-helper-1",
+        label: "Attach two comparison runs",
+        description: "Keep both the baseline candidate and the follow-up run attached to the board.",
+        defaultChecked: true,
+      },
+      {
+        id: "vector-helper-2",
+        label: "Review the tray handoff note",
+        description: "Confirm the final tray transfer stayed under the local watch threshold.",
+        defaultChecked: false,
+      },
+      {
+        id: "vector-helper-3",
+        label: "Draft the review summary",
+        description: "Prepare the stability gate summary for the wider team.",
+        defaultChecked: true,
+      },
+    ],
+    prompts: [
+      "Which run becomes the lead example in the review handoff?",
+      "Does the handoff note require one more operator comment before promotion?",
+    ],
+  },
+  {
+    id: "review-amber-04",
+    experimentId: "amber-04",
+    templateId: "thermal-recovery",
+    headline: "Decide whether the thermal loop needs another rerun or can stay in comparison.",
+    summary: "The latest pulse set is better, but the board still carries a manual-watch flag and does not yet have a clean cooldown repeat.",
+    recommendedDecision: "rerun",
+    owner: "R. Vale",
+    dueWindow: "Manual watch check-in at 19:40",
+    helperChecklist: [
+      {
+        id: "amber-helper-1",
+        label: "Compare at least two pulse sets",
+        description: "Keep the shield swap and short-dwell runs visible in the comparison set.",
+        defaultChecked: true,
+      },
+      {
+        id: "amber-helper-2",
+        label: "Assign a watch owner",
+        description: "Carry the operator watch owner into the board summary.",
+        defaultChecked: true,
+      },
+      {
+        id: "amber-helper-3",
+        label: "Clear one cooldown cycle",
+        description: "Wait for a full pulse set that clears without the pulse-three spike.",
+        defaultChecked: false,
+      },
+    ],
+    prompts: [
+      "Does the delayed spike justify another rerun with the same shield setting?",
+      "Would a hold decision keep the right level of operator attention on the board?",
+    ],
+  },
+  {
+    id: "review-north-arc",
+    experimentId: "north-arc",
+    templateId: "reagent-ladder",
+    headline: "Close the ladder validation with both confirmation passes attached.",
+    summary: "The pair of validation runs is strong enough for the outcome review lane, provided the lower-band note stays attached.",
+    recommendedDecision: "promote",
+    owner: "M. Ortega",
+    dueWindow: "Review checkpoint at 20:15",
+    helperChecklist: [
+      {
+        id: "north-helper-1",
+        label: "Keep both validation passes attached",
+        description: "Attach the original clean pass and the confirmation pass together.",
+        defaultChecked: true,
+      },
+      {
+        id: "north-helper-2",
+        label: "Preserve the lower-band note",
+        description: "Carry forward why the validation pair matters in the final handoff.",
+        defaultChecked: true,
+      },
+      {
+        id: "north-helper-3",
+        label: "Confirm the final gate owner",
+        description: "Make sure the closing reviewer is assigned before the board leaves the notebook.",
+        defaultChecked: false,
+      },
+    ],
+    prompts: [
+      "Is any additional ladder evidence required, or is the pair enough for closure?",
+      "What context must remain visible after the board leaves the notebook route?",
+    ],
+  },
+];
+
+const draftMetricSeeds: Record<string, { signal: number; variance: number; cycle: number }> = {
+  "assay-ratio": { signal: 84, variance: 4.9, cycle: 36 },
+  "thermal-recovery": { signal: 74, variance: 5.9, cycle: 48 },
+  "reagent-ladder": { signal: 82, variance: 3.8, cycle: 32 },
+};
+
+export function createExperimentBundleFromTemplate(
+  template: ExperimentTemplate,
+  sequence: number,
+): ExperimentBundle {
+  const experimentId = `${template.id}-draft-${sequence}`;
+  const baselineRunId = `${experimentId}-baseline`;
+  const candidateRunId = `${experimentId}-candidate`;
+  const seed = draftMetricSeeds[template.id] ?? { signal: 80, variance: 5.1, cycle: 38 };
+
+  const experiment: Experiment = {
+    id: experimentId,
+    title: `${template.name} draft ${sequence}`,
+    lead: template.defaultLead,
+    status: "active",
+    templateId: template.id,
+    summary: `Local draft seeded from the ${template.name.toLowerCase()} template so the team can start a paired comparison without leaving the notebook.`,
+    focus: `Draft board is tracking ${template.objective.toLowerCase()}.`,
+    window: "Template kickoff queued for the next bench opening",
+    progressValue: 18,
+    progressLabel: "Draft setup",
+    sampleCount: 12,
+    lastEntry: "Template draft opened with baseline and candidate runs ready for a local comparison pass.",
+    milestoneIds: template.checkpointMilestoneIds,
+    boardLaneId: "intake",
+    comparisonRunIds: [baselineRunId, candidateRunId],
+    recommendation: "Keep the draft on intake until the paired runs are compared and documented.",
+    boardNote: `${template.name} board notes stay attached from the moment the draft is created.`,
+  };
+
+  const runs: ExperimentRun[] = [
+    {
+      id: baselineRunId,
+      experimentId,
+      label: "Baseline run",
+      state: "planned",
+      startedAt: "Queued",
+      operator: template.defaultLead,
+      setup: "Baseline setup copied from the selected template",
+      summary: "The draft baseline run is parked and waiting for the first capture window.",
+      focus: "Use this run as the floor for the candidate comparison.",
+      detail: `This baseline run inherits the ${template.name.toLowerCase()} template defaults so the team can capture a first reference point quickly.`,
+      decisionNote: "Keep in intake until the candidate run lands beside it.",
+      highlights: [
+        "Baseline run is already attached to the notebook card.",
+        "Template checkpoints remain visible in the intake lane.",
+      ],
+      metrics: {
+        signal: seed.signal,
+        variance: seed.variance,
+        cycle: seed.cycle,
+        watchFlags: 2,
+      },
+    },
+    {
+      id: candidateRunId,
+      experimentId,
+      label: "Candidate run",
+      state: "planned",
+      startedAt: "Queued",
+      operator: template.defaultLead,
+      setup: "Candidate setup copied from the selected template",
+      summary: "The draft candidate run is staged to pair against the baseline once the bench opens.",
+      focus: "Use this run to prove the first improvement before the board leaves intake.",
+      detail: `This candidate run mirrors the ${template.name.toLowerCase()} board notes so the team can compare two runs immediately after creation.`,
+      decisionNote: "Promote to compare only after both intake runs are recorded.",
+      highlights: [
+        "Candidate run is attached to the same template-aware board.",
+        "Outcome prompts are prepared before the first observation is captured.",
+      ],
+      metrics: {
+        signal: seed.signal + 3,
+        variance: Number((seed.variance - 0.8).toFixed(1)),
+        cycle: Math.max(seed.cycle - 2, 24),
+        watchFlags: 1,
+      },
+    },
+  ];
+
+  const observationEntries: ObservationEntry[] = [
+    {
+      id: `${experimentId}-note-1`,
+      experimentId,
+      runId: baselineRunId,
+      section: "notes",
+      headline: "Draft notebook board created",
+      snippet: `The ${template.name.toLowerCase()} template seeded a fresh intake board with paired runs attached.`,
+      detail: "The notebook now carries template notes, paired comparison runs, and the first outcome prompts without touching shared state.",
+      capturedAt: "Queued",
+      recorder: template.defaultLead,
+      milestoneId: template.checkpointMilestoneIds[0],
+    },
+    {
+      id: `${experimentId}-flag-1`,
+      experimentId,
+      runId: candidateRunId,
+      section: "flags",
+      headline: "Candidate run still needs a first capture",
+      snippet: "Keep the card in intake until the candidate run records its first pass.",
+      detail: "The board should not leave the intake lane until both runs have data and the team can compare them side by side.",
+      capturedAt: "Queued",
+      recorder: template.defaultLead,
+      milestoneId: template.checkpointMilestoneIds.at(-1),
+    },
+    {
+      id: `${experimentId}-time-1`,
+      experimentId,
+      runId: candidateRunId,
+      section: "timeline",
+      headline: "Outcome prompts loaded",
+      snippet: "The review helpers and next-board actions are staged as soon as the draft is created.",
+      detail: "That keeps the notebook aligned with the template before any runs move into comparison or review.",
+      capturedAt: "Queued",
+      recorder: template.defaultLead,
+    },
+  ];
+
+  const outcomeReview: OutcomeReview = {
+    id: `${experimentId}-review`,
+    experimentId,
+    templateId: template.id,
+    headline: `Guide the first board move for ${template.name.toLowerCase()}.`,
+    summary: "Draft outcome helpers are available immediately so the team can decide whether the next move is compare, rerun, or promotion.",
+    recommendedDecision: "hold",
+    owner: template.defaultLead,
+    dueWindow: "After the first paired run capture",
+    helperChecklist: [
+      {
+        id: `${experimentId}-helper-1`,
+        label: "Keep both draft runs attached",
+        description: "The comparison workflow only unlocks once both runs remain attached to the board.",
+        defaultChecked: true,
+      },
+      {
+        id: `${experimentId}-helper-2`,
+        label: "Capture the first template note",
+        description: "Add the opening notebook note before moving the board beyond intake.",
+        defaultChecked: false,
+      },
+      {
+        id: `${experimentId}-helper-3`,
+        label: "Carry forward template prompts",
+        description: "Keep the template review prompts visible when the board starts comparing runs.",
+        defaultChecked: true,
+      },
+    ],
+    prompts: template.reviewPrompts,
+  };
+
+  return {
+    experiment,
+    runs,
+    observationEntries,
+    outcomeReview,
+  };
+}

--- a/src/app/lab-notebook/page.tsx
+++ b/src/app/lab-notebook/page.tsx
@@ -2,13 +2,39 @@ import type { Metadata } from "next";
 
 import { LabNotebookShell } from "@/components/lab-notebook/lab-notebook-shell";
 
-import { experiments, milestoneTags, notebookStatus, observationEntries, statusOptions } from "./notebook-data";
+import {
+  boardLanes,
+  comparisonMetrics,
+  experimentRuns,
+  experimentTemplates,
+  experiments,
+  milestoneTags,
+  notebookStatus,
+  observationEntries,
+  outcomeReviews,
+  reviewDecisionOptions,
+  statusOptions,
+} from "./notebook-data";
 
 export const metadata: Metadata = {
   title: "Lab Notebook | API Test",
-  description: "Mock notebook workspace with experiment cards, status filters, and an observation drawer.",
+  description: "Mock notebook workspace with experiment templates, multi-run comparison, and outcome review helpers.",
 };
 
 export default function LabNotebookPage() {
-  return <LabNotebookShell experiments={experiments} milestoneTags={milestoneTags} notebookStatus={notebookStatus} observationEntries={observationEntries} statusOptions={statusOptions} />;
+  return (
+    <LabNotebookShell
+      boardLanes={boardLanes}
+      comparisonMetrics={comparisonMetrics}
+      experimentRuns={experimentRuns}
+      experimentTemplates={experimentTemplates}
+      experiments={experiments}
+      milestoneTags={milestoneTags}
+      notebookStatus={notebookStatus}
+      observationEntries={observationEntries}
+      outcomeReviews={outcomeReviews}
+      reviewDecisionOptions={reviewDecisionOptions}
+      statusOptions={statusOptions}
+    />
+  );
 }

--- a/src/components/lab-notebook/experiment-board.tsx
+++ b/src/components/lab-notebook/experiment-board.tsx
@@ -1,14 +1,20 @@
 import type {
+  BoardLane,
   Experiment,
+  ExperimentRun,
   ExperimentStatus,
+  ExperimentTemplate,
   MilestoneTag,
 } from "@/app/lab-notebook/notebook-data";
 
 type ExperimentBoardProps = {
+  boardLanes: BoardLane[];
   experiments: Experiment[];
   milestoneTagsById: Record<string, MilestoneTag>;
   onSelect: (experimentId: string) => void;
+  runsByExperimentId: Record<string, ExperimentRun[]>;
   selectedExperimentId: string | null;
+  templatesById: Record<string, ExperimentTemplate>;
 };
 
 const statusClasses: Record<ExperimentStatus, string> = {
@@ -16,6 +22,12 @@ const statusClasses: Record<ExperimentStatus, string> = {
   watch: "border-rose-700/15 bg-rose-500/10 text-rose-900",
   stabilizing: "border-sky-700/15 bg-sky-500/10 text-sky-900",
   archived: "border-stone-900/10 bg-stone-300/30 text-stone-700",
+};
+
+const laneClasses = {
+  compare: "border-sky-900/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.9),rgba(239,246,255,0.82))]",
+  intake: "border-amber-900/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.92),rgba(254,243,199,0.78))]",
+  review: "border-emerald-900/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.92),rgba(220,252,231,0.76))]",
 };
 
 const toneClasses = {
@@ -26,85 +38,147 @@ const toneClasses = {
 };
 
 export function ExperimentBoard({
+  boardLanes,
   experiments,
   milestoneTagsById,
   onSelect,
+  runsByExperimentId,
   selectedExperimentId,
+  templatesById,
 }: ExperimentBoardProps) {
   if (experiments.length === 0) {
     return (
       <section className="rounded-[2rem] border border-dashed border-stone-900/15 bg-white/70 p-8 text-center shadow-[0_20px_70px_rgba(120,53,15,0.1)]">
         <p className="text-xs font-semibold uppercase tracking-[0.34em] text-stone-500">Zero state</p>
-        <h2 className="mt-3 text-2xl font-semibold tracking-[-0.03em] text-stone-950">No experiment cards match the current filter.</h2>
-        <p className="mt-3 text-sm leading-6 text-stone-600">This notebook keeps the empty state local. Switch back to active, watch, or stabilizing cards to reopen the workspace.</p>
+        <h2 className="mt-3 text-2xl font-semibold tracking-[-0.03em] text-stone-950">No experiment cards match the current template or status filter.</h2>
+        <p className="mt-3 text-sm leading-6 text-stone-600">Switch filters or create a new board from one of the templates to reopen the notebook workspace.</p>
       </section>
     );
   }
 
   return (
-    <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-1">
-      {experiments.map((experiment) => {
-        const isSelected = experiment.id === selectedExperimentId;
+    <section aria-label="Template-aware experiment board" className="space-y-4">
+      {boardLanes.map((lane) => {
+        const laneExperiments = experiments.filter((experiment) => experiment.boardLaneId === lane.id);
+
+        if (laneExperiments.length === 0) {
+          return null;
+        }
 
         return (
           <article
-            className={`rounded-[2rem] border p-5 shadow-[0_22px_80px_rgba(120,53,15,0.12)] transition ${
-              isSelected
-                ? "border-stone-950 bg-[linear-gradient(135deg,rgba(255,251,235,0.98),rgba(254,240,138,0.74))]"
-                : "border-stone-900/10 bg-white/82 hover:border-stone-900/20"
-            }`}
-            key={experiment.id}
+            className={`rounded-[2rem] border p-5 shadow-[0_22px_80px_rgba(120,53,15,0.12)] ${laneClasses[lane.id]}`}
+            key={lane.id}
           >
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-stone-500">{experiment.lead}</p>
-                <h2 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-stone-950">{experiment.title}</h2>
+                <p className="text-xs font-semibold uppercase tracking-[0.32em] text-stone-500">{lane.emphasis}</p>
+                <h2 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-stone-950">{lane.label}</h2>
+                <p className="mt-2 max-w-3xl text-sm leading-6 text-stone-700">{lane.description}</p>
               </div>
-              <span className={`rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] ${statusClasses[experiment.status]}`}>{experiment.status}</span>
+              <span className="rounded-full border border-stone-900/10 bg-white/70 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-600">{laneExperiments.length} cards</span>
             </div>
 
-            <p className="mt-3 text-sm leading-6 text-stone-700">{experiment.summary}</p>
-            <div className="mt-4 flex flex-wrap gap-2">
-              {experiment.milestoneIds.map((milestoneId) => {
-                const milestone = milestoneTagsById[milestoneId];
+            <div className="mt-5 grid gap-4 xl:grid-cols-2">
+              {laneExperiments.map((experiment) => {
+                const isSelected = experiment.id === selectedExperimentId;
+                const template = templatesById[experiment.templateId];
+                const runs = runsByExperimentId[experiment.id] ?? [];
 
-                return milestone ? (
-                  <span className={`rounded-full border px-3 py-1 text-xs font-medium ${toneClasses[milestone.tone]}`} key={milestone.id}>
-                    {milestone.label}
-                  </span>
-                ) : null;
+                return (
+                  <article
+                    className={`rounded-[1.9rem] border p-5 transition ${
+                      isSelected
+                        ? "border-stone-950 bg-[linear-gradient(135deg,rgba(255,251,235,0.98),rgba(255,255,255,0.92))] shadow-[0_24px_80px_rgba(120,53,15,0.18)]"
+                        : "border-stone-900/10 bg-white/78 hover:border-stone-900/20"
+                    }`}
+                    key={experiment.id}
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-stone-500">{experiment.lead}</p>
+                        <h3 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-stone-950">{experiment.title}</h3>
+                      </div>
+                      <span className={`rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] ${statusClasses[experiment.status]}`}>{experiment.status}</span>
+                    </div>
+
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      <span className="rounded-full border border-stone-900/10 bg-stone-100/70 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-stone-700">
+                        {template?.name ?? "Template"}
+                      </span>
+                      <span className="rounded-full border border-stone-900/10 bg-white/70 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-600">
+                        {runs.length} runs attached
+                      </span>
+                      <span className="rounded-full border border-stone-900/10 bg-white/70 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-600">
+                        {experiment.comparisonRunIds.length} in compare set
+                      </span>
+                    </div>
+
+                    <p className="mt-4 text-sm leading-6 text-stone-700">{experiment.summary}</p>
+
+                    <div className="mt-4 grid gap-3 md:grid-cols-2">
+                      <div className="rounded-[1.35rem] bg-stone-100/70 p-4">
+                        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">Template objective</p>
+                        <p className="mt-2 text-sm leading-6 text-stone-700">{template?.objective ?? experiment.focus}</p>
+                      </div>
+                      <div className="rounded-[1.35rem] bg-stone-100/70 p-4">
+                        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">Board note</p>
+                        <p className="mt-2 text-sm leading-6 text-stone-700">{experiment.boardNote}</p>
+                      </div>
+                    </div>
+
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      {experiment.milestoneIds.map((milestoneId) => {
+                        const milestone = milestoneTagsById[milestoneId];
+
+                        return milestone ? (
+                          <span className={`rounded-full border px-3 py-1 text-xs font-medium ${toneClasses[milestone.tone]}`} key={milestone.id}>
+                            {milestone.label}
+                          </span>
+                        ) : null;
+                      })}
+                    </div>
+
+                    <div className="mt-5 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
+                      <div>
+                        <div className="flex items-center justify-between text-sm text-stone-700">
+                          <span className="font-medium">{experiment.progressLabel}</span>
+                          <span>{experiment.progressValue}%</span>
+                        </div>
+                        <div className="mt-2 h-2 rounded-full bg-stone-200">
+                          <div className="h-full rounded-full bg-stone-950" style={{ width: `${experiment.progressValue}%` }} />
+                        </div>
+                      </div>
+                      <span className="rounded-full border border-stone-900/10 bg-stone-100/75 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-600">
+                        {experiment.sampleCount} samples
+                      </span>
+                    </div>
+
+                    <div className="mt-5 grid gap-3 text-sm text-stone-700 sm:grid-cols-2">
+                      <div className="rounded-[1.35rem] bg-white/65 p-4">
+                        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">Run focus</p>
+                        <p className="mt-2 leading-6">{experiment.focus}</p>
+                      </div>
+                      <div className="rounded-[1.35rem] bg-white/65 p-4">
+                        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">Next board move</p>
+                        <p className="mt-2 leading-6">{experiment.recommendation}</p>
+                      </div>
+                    </div>
+
+                    <div className="mt-5 flex flex-wrap items-center justify-between gap-3">
+                      <p className="max-w-xl text-sm leading-6 text-stone-700">{experiment.window}</p>
+                      <button
+                        aria-label={`Open notebook: ${experiment.title}`}
+                        className="rounded-full bg-stone-950 px-4 py-2 text-sm text-stone-50 transition hover:bg-stone-800"
+                        onClick={() => onSelect(experiment.id)}
+                        type="button"
+                      >
+                        {isSelected ? "Focused in notebook" : "Focus notebook"}
+                      </button>
+                    </div>
+                  </article>
+                );
               })}
-            </div>
-
-            <div className="mt-5 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center">
-              <div>
-                <div className="flex items-center justify-between text-sm text-stone-700">
-                  <span className="font-medium">{experiment.progressLabel}</span>
-                  <span>{experiment.progressValue}%</span>
-                </div>
-                <div className="mt-2 h-2 rounded-full bg-stone-200">
-                  <div className="h-full rounded-full bg-stone-950" style={{ width: `${experiment.progressValue}%` }} />
-                </div>
-              </div>
-              <span className="rounded-full border border-stone-900/10 bg-stone-100/75 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-600">{experiment.sampleCount} samples</span>
-            </div>
-
-            <div className="mt-5 grid gap-3 text-sm text-stone-700 sm:grid-cols-2">
-              <div className="rounded-[1.35rem] bg-stone-100/70 p-4">
-                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">Focus</p>
-                <p className="mt-2 leading-6">{experiment.focus}</p>
-              </div>
-              <div className="rounded-[1.35rem] bg-stone-100/70 p-4">
-                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">Next window</p>
-                <p className="mt-2 leading-6">{experiment.window}</p>
-              </div>
-            </div>
-
-            <div className="mt-5 flex flex-wrap items-center justify-between gap-3">
-              <p className="max-w-xl text-sm leading-6 text-stone-700">{experiment.lastEntry}</p>
-              <button className="rounded-full bg-stone-950 px-4 py-2 text-sm text-stone-50 transition hover:bg-stone-800" onClick={() => onSelect(experiment.id)} type="button">
-                {isSelected ? "Focused in drawer" : "Open in drawer"}
-              </button>
             </div>
           </article>
         );

--- a/src/components/lab-notebook/lab-notebook-header.tsx
+++ b/src/components/lab-notebook/lab-notebook-header.tsx
@@ -1,14 +1,24 @@
 import type { NotebookStatus } from "@/app/lab-notebook/notebook-data";
 
 type LabNotebookHeaderProps = {
-  activeCount: number; flaggedCount: number; lastEntrySummary: string; notebookStatus: NotebookStatus; visibleCount: number;
+  activeCount: number;
+  comparedRunCount: number;
+  flaggedCount: number;
+  lastEntrySummary: string;
+  notebookStatus: NotebookStatus;
+  selectedExperimentTitle: string | null;
+  selectedTemplateLabel: string;
+  visibleCount: number;
 };
 
 export function LabNotebookHeader({
   activeCount,
+  comparedRunCount,
   flaggedCount,
   lastEntrySummary,
   notebookStatus,
+  selectedExperimentTitle,
+  selectedTemplateLabel,
   visibleCount,
 }: LabNotebookHeaderProps) {
   return (
@@ -18,15 +28,20 @@ export function LabNotebookHeader({
         <div className="mt-3 flex flex-wrap items-center gap-3">
           <span className="rounded-full border border-emerald-700/15 bg-emerald-600/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-emerald-900">{notebookStatus.label}</span>
           <span className="rounded-full border border-stone-900/10 bg-white/65 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-600">{notebookStatus.phase}</span>
+          <span className="rounded-full border border-stone-900/10 bg-white/65 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-600">{selectedTemplateLabel}</span>
         </div>
-        <h1 className="mt-4 max-w-2xl text-4xl font-semibold tracking-[-0.04em] text-stone-950 sm:text-5xl">Experiment cards anchored to a local observation notebook.</h1>
-        <p className="mt-4 max-w-2xl text-sm leading-6 text-stone-700">Every card, filter, milestone tag, and drawer interaction lives only inside this route, mirroring a notebook workspace without touching shared app state.</p>
+        <h1 className="mt-4 max-w-2xl text-4xl font-semibold tracking-[-0.04em] text-stone-950 sm:text-5xl">Template-aware experiment boards with local multi-run review.</h1>
+        <p className="mt-4 max-w-2xl text-sm leading-6 text-stone-700">Templates, board lanes, comparison runs, and review helpers all stay local to this route so the notebook can model a fuller research workflow without touching shared app state.</p>
+        <div className="mt-5 rounded-[1.4rem] border border-stone-900/10 bg-white/65 p-4 text-sm text-stone-700">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">Current focus</p>
+          <p className="mt-2 leading-6">{selectedExperimentTitle ?? "Pick a card or create a draft from a template to focus the notebook."}</p>
+        </div>
       </article>
       <article className="rounded-[2rem] border border-stone-900/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.96),rgba(41,37,36,0.94))] p-6 text-stone-100 shadow-[0_28px_90px_rgba(15,23,42,0.28)]">
         <p className="text-xs font-semibold uppercase tracking-[0.32em] text-amber-200/75">{notebookStatus.syncLabel}</p>
         <h2 className="mt-3 text-2xl font-semibold tracking-[-0.03em]">Last-entry summary</h2>
         <p className="mt-3 text-sm leading-6 text-stone-300">{lastEntrySummary}</p>
-        <div className="mt-5 grid grid-cols-3 gap-3 text-center">
+        <div className="mt-5 grid grid-cols-2 gap-3 text-center sm:grid-cols-4">
           <div className="rounded-[1.4rem] border border-white/10 bg-white/5 px-3 py-4">
             <p className="text-2xl font-semibold">{visibleCount}</p>
             <p className="mt-1 text-xs uppercase tracking-[0.24em] text-stone-400">Visible cards</p>
@@ -38,6 +53,10 @@ export function LabNotebookHeader({
           <div className="rounded-[1.4rem] border border-white/10 bg-white/5 px-3 py-4">
             <p className="text-2xl font-semibold">{flaggedCount}</p>
             <p className="mt-1 text-xs uppercase tracking-[0.24em] text-stone-400">Watch notes</p>
+          </div>
+          <div className="rounded-[1.4rem] border border-white/10 bg-white/5 px-3 py-4">
+            <p className="text-2xl font-semibold">{comparedRunCount}</p>
+            <p className="mt-1 text-xs uppercase tracking-[0.24em] text-stone-400">Runs in compare</p>
           </div>
         </div>
       </article>

--- a/src/components/lab-notebook/lab-notebook-shell.test.tsx
+++ b/src/components/lab-notebook/lab-notebook-shell.test.tsx
@@ -1,0 +1,142 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  boardLanes,
+  comparisonMetrics,
+  experimentRuns,
+  experimentTemplates,
+  experiments,
+  milestoneTags,
+  notebookStatus,
+  observationEntries,
+  outcomeReviews,
+  reviewDecisionOptions,
+  statusOptions,
+} from "@/app/lab-notebook/notebook-data";
+import { LabNotebookShell } from "./lab-notebook-shell";
+
+function renderNotebook() {
+  render(
+    <LabNotebookShell
+      boardLanes={boardLanes}
+      comparisonMetrics={comparisonMetrics}
+      experimentRuns={experimentRuns}
+      experimentTemplates={experimentTemplates}
+      experiments={experiments}
+      milestoneTags={milestoneTags}
+      notebookStatus={notebookStatus}
+      observationEntries={observationEntries}
+      outcomeReviews={outcomeReviews}
+      reviewDecisionOptions={reviewDecisionOptions}
+      statusOptions={statusOptions}
+    />,
+  );
+}
+
+describe("LabNotebookShell", () => {
+  it("filters by template and creates a new notebook board from the selected template", () => {
+    renderNotebook();
+    const board = screen.getByLabelText("Template-aware experiment board");
+
+    fireEvent.click(screen.getByLabelText("Select template: Thermal recovery ladder"));
+
+    expect(
+      within(board).getByText("Amber 04 thermal loop", { selector: "h3" }),
+    ).toBeInTheDocument();
+    expect(
+      within(board).queryByText("Vector 12 catalyst assay", { selector: "h3" }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Create notebook from template: Thermal recovery ladder"));
+
+    expect(
+      within(board).getByText("Thermal recovery ladder draft 2", { selector: "h3" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Keep the draft on intake until the paired runs are compared and documented.",
+      ),
+    ).toBeInTheDocument();
+  }, 10_000);
+
+  it("compares multiple runs in summary and detail views", () => {
+    renderNotebook();
+
+    const comparisonPanel = screen.getByLabelText("Run comparison panel");
+
+    expect(within(comparisonPanel).getByText("Average signal")).toBeInTheDocument();
+    expect(
+      within(comparisonPanel).getByRole("checkbox", { name: "Select Run 5 ratio swap" }),
+    ).toBeChecked();
+    expect(
+      within(comparisonPanel).getByRole("checkbox", { name: "Select Run 6 follow-up" }),
+    ).toBeChecked();
+
+    fireEvent.click(
+      within(comparisonPanel).getByRole("checkbox", { name: "Select Run 4 baseline" }),
+    );
+    fireEvent.click(
+      within(comparisonPanel).getByRole("button", { name: "Detail view" }),
+    );
+
+    expect(
+      within(comparisonPanel).getByText(
+        "The baseline closed with a broad spread and a warm handoff on the final tray.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(comparisonPanel).getByText(
+        "The follow-up confirmed the ratio swap and tightened the spread even further.",
+      ),
+    ).toBeInTheDocument();
+  }, 10_000);
+
+  it("filters observation entries by the currently selected run set", () => {
+    renderNotebook();
+
+    const comparisonPanel = screen.getByLabelText("Run comparison panel");
+    const observationDrawer = screen.getByLabelText("Observation drawer");
+
+    expect(
+      within(observationDrawer).getByText("Ratio swap narrowed the spread"),
+    ).toBeInTheDocument();
+    expect(
+      within(observationDrawer).getByText("Follow-up pull held the gain"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      within(comparisonPanel).getByRole("checkbox", { name: "Select Run 5 ratio swap" }),
+    );
+
+    expect(
+      within(observationDrawer).queryByText("Ratio swap narrowed the spread"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(observationDrawer).getByText("Follow-up pull held the gain"),
+    ).toBeInTheDocument();
+  }, 10_000);
+
+  it("updates the board context when review helpers and decisions change", () => {
+    renderNotebook();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open notebook: Amber 04 thermal loop" }),
+    );
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "Toggle helper: Clear one cooldown cycle" }),
+    );
+    expect(screen.getByText("3 of 3 ready")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Hold on comparison lane/i }),
+    );
+
+    expect(
+      screen.getByText(
+        "Thermal recovery ladder is currently sending this board toward compare.",
+      ),
+    ).toBeInTheDocument();
+  }, 10_000);
+});

--- a/src/components/lab-notebook/lab-notebook-shell.tsx
+++ b/src/components/lab-notebook/lab-notebook-shell.tsx
@@ -1,73 +1,196 @@
 "use client";
 
-import { startTransition, useState } from "react";
+import { startTransition, useDeferredValue, useState } from "react";
 
 import type {
+  BoardLane,
+  ComparisonMetric,
+  ComparisonView,
   Experiment,
+  ExperimentRun,
+  ExperimentTemplate,
   MilestoneTag,
   NotebookStatus,
   ObservationEntry,
   ObservationSection,
+  OutcomeReview,
+  ReviewDecisionId,
+  ReviewDecisionOption,
   StatusFilter,
   StatusOption,
 } from "@/app/lab-notebook/notebook-data";
+import { createExperimentBundleFromTemplate } from "@/app/lab-notebook/notebook-data";
 import { ExperimentBoard } from "./experiment-board";
 import { LabNotebookHeader } from "./lab-notebook-header";
 import { ObservationDrawer } from "./observation-drawer";
+import { OutcomeReviewPanel } from "./outcome-review-panel";
+import { RunComparisonPanel } from "./run-comparison-panel";
 import { StatusFilterBar } from "./status-filter-bar";
+import { TemplateGallery } from "./template-gallery";
 
 type LabNotebookShellProps = {
-  experiments: Experiment[]; milestoneTags: MilestoneTag[]; notebookStatus: NotebookStatus;
-  observationEntries: ObservationEntry[]; statusOptions: StatusOption[];
+  boardLanes: BoardLane[];
+  comparisonMetrics: ComparisonMetric[];
+  experimentRuns: ExperimentRun[];
+  experimentTemplates: ExperimentTemplate[];
+  experiments: Experiment[];
+  milestoneTags: MilestoneTag[];
+  notebookStatus: NotebookStatus;
+  observationEntries: ObservationEntry[];
+  outcomeReviews: OutcomeReview[];
+  reviewDecisionOptions: ReviewDecisionOption[];
+  statusOptions: StatusOption[];
 };
 
 function matchesStatus(experiment: Experiment, filter: StatusFilter) {
   return filter === "all" || experiment.status === filter;
 }
 
+function matchesTemplate(experiment: Experiment, templateId: string | null) {
+  return templateId === null || experiment.templateId === templateId;
+}
+
+function getDefaultRunIds(experiment: Experiment | null, runs: ExperimentRun[]) {
+  if (!experiment) {
+    return [];
+  }
+
+  if (experiment.comparisonRunIds.length > 0) {
+    return experiment.comparisonRunIds;
+  }
+
+  return runs.filter((run) => run.experimentId === experiment.id).slice(0, 2).map((run) => run.id);
+}
+
 export function LabNotebookShell({
+  boardLanes,
+  comparisonMetrics,
+  experimentRuns,
+  experimentTemplates,
   experiments,
   milestoneTags,
   notebookStatus,
   observationEntries,
+  outcomeReviews,
+  reviewDecisionOptions,
   statusOptions,
 }: LabNotebookShellProps) {
+  const [allExperiments, setAllExperiments] = useState(experiments);
+  const [allRuns, setAllRuns] = useState(experimentRuns);
+  const [allObservationEntries, setAllObservationEntries] = useState(observationEntries);
+  const [allOutcomeReviews, setAllOutcomeReviews] = useState(outcomeReviews);
   const [selectedFilter, setSelectedFilter] = useState<StatusFilter>("all");
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null);
   const [selectedExperimentId, setSelectedExperimentId] = useState<string | null>(experiments[0]?.id ?? null);
   const [drawerSection, setDrawerSection] = useState<ObservationSection>("notes");
+  const [comparisonView, setComparisonView] = useState<ComparisonView>("summary");
   const [expandedEntryId, setExpandedEntryId] = useState<string | null>(null);
-  const visibleExperiments = experiments.filter((experiment) => matchesStatus(experiment, selectedFilter));
-  const selectedExperiment = visibleExperiments.find((experiment) => experiment.id === selectedExperimentId) ?? null;
-  const selectedEntries = observationEntries.filter((entry) => entry.experimentId === selectedExperimentId);
+  const [selectedRunIds, setSelectedRunIds] = useState<string[]>(
+    getDefaultRunIds(experiments[0] ?? null, experimentRuns),
+  );
+  const [reviewDecisionByExperimentId, setReviewDecisionByExperimentId] = useState<Record<string, ReviewDecisionId>>(
+    () => Object.fromEntries(outcomeReviews.map((review) => [review.experimentId, review.recommendedDecision])),
+  );
+  const [checkedHelpersByReviewId, setCheckedHelpersByReviewId] = useState<Record<string, string[]>>(
+    () =>
+      Object.fromEntries(
+        outcomeReviews.map((review) => [
+          review.id,
+          review.helperChecklist.filter((helper) => helper.defaultChecked).map((helper) => helper.id),
+        ]),
+      ),
+  );
+  const deferredFilter = useDeferredValue(selectedFilter);
+  const deferredTemplateId = useDeferredValue(selectedTemplateId);
+  const visibleExperiments = allExperiments.filter(
+    (experiment) => matchesStatus(experiment, deferredFilter) && matchesTemplate(experiment, deferredTemplateId),
+  );
+  const selectedExperiment = allExperiments.find((experiment) => experiment.id === selectedExperimentId) ?? null;
+  const selectedTemplate = selectedExperiment
+    ? experimentTemplates.find((template) => template.id === selectedExperiment.templateId) ?? null
+    : selectedTemplateId
+      ? experimentTemplates.find((template) => template.id === selectedTemplateId) ?? null
+      : null;
+  const selectedExperimentRuns = allRuns.filter((run) => run.experimentId === selectedExperimentId);
+  const selectedRuns = selectedExperimentRuns.filter((run) => selectedRunIds.includes(run.id));
+  const selectedEntries = allObservationEntries.filter(
+    (entry) =>
+      entry.experimentId === selectedExperimentId
+      && (selectedRunIds.length === 0 || selectedRunIds.includes(entry.runId)),
+  );
+  const selectedReview = allOutcomeReviews.find((review) => review.experimentId === selectedExperimentId) ?? null;
   const lastEntrySummary = selectedExperiment?.lastEntry ?? notebookStatus.lastEntrySummary;
-  const activeCount = experiments.filter((experiment) => experiment.status === "active").length;
-  const flaggedCount = observationEntries.filter((entry) => entry.section === "flags").length;
+  const activeCount = allExperiments.filter((experiment) => experiment.status === "active").length;
+  const flaggedCount = allObservationEntries.filter((entry) => entry.section === "flags").length;
+  const selectedTemplateLabel = selectedTemplate ? `${selectedTemplate.name} template` : "All templates";
   const counts = {
-    all: experiments.length,
-    active: experiments.filter((experiment) => experiment.status === "active").length,
-    watch: experiments.filter((experiment) => experiment.status === "watch").length,
-    stabilizing: experiments.filter((experiment) => experiment.status === "stabilizing").length,
-    archived: experiments.filter((experiment) => experiment.status === "archived").length,
+    all: allExperiments.length,
+    active: allExperiments.filter((experiment) => experiment.status === "active").length,
+    watch: allExperiments.filter((experiment) => experiment.status === "watch").length,
+    stabilizing: allExperiments.filter((experiment) => experiment.status === "stabilizing").length,
+    archived: allExperiments.filter((experiment) => experiment.status === "archived").length,
   } as Record<StatusFilter, number>;
   const milestoneTagsById = Object.fromEntries(milestoneTags.map((tag) => [tag.id, tag])) as Record<string, MilestoneTag>;
+  const runsById = Object.fromEntries(allRuns.map((run) => [run.id, run])) as Record<string, ExperimentRun>;
+  const runsByExperimentId = Object.fromEntries(
+    allExperiments.map((experiment) => [
+      experiment.id,
+      allRuns.filter((run) => run.experimentId === experiment.id),
+    ]),
+  ) as Record<string, ExperimentRun[]>;
+  const templatesById = Object.fromEntries(
+    experimentTemplates.map((template) => [template.id, template]),
+  ) as Record<string, ExperimentTemplate>;
+  const reviewDecisionOptionsById = Object.fromEntries(
+    reviewDecisionOptions.map((option) => [option.id, option]),
+  ) as Record<string, ReviewDecisionOption>;
+  const countsByTemplateId = Object.fromEntries(
+    experimentTemplates.map((template) => [
+      template.id,
+      allExperiments.filter((experiment) => experiment.templateId === template.id).length,
+    ]),
+  ) as Record<string, number>;
+
+  const syncSelection = (nextExperiments: Experiment[], nextTemplateId: string | null, nextFilter: StatusFilter) => {
+    const nextVisible = nextExperiments.filter(
+      (experiment) => matchesStatus(experiment, nextFilter) && matchesTemplate(experiment, nextTemplateId),
+    );
+
+    if (!nextVisible.some((experiment) => experiment.id === selectedExperimentId)) {
+      const fallback = nextVisible[0] ?? null;
+      setSelectedExperimentId(fallback?.id ?? null);
+      setSelectedRunIds(getDefaultRunIds(fallback, allRuns));
+    }
+  };
 
   const handleFilterChange = (filter: StatusFilter) => {
     startTransition(() => {
       setSelectedFilter(filter);
       setExpandedEntryId(null);
-
-      const nextVisible = experiments.filter((experiment) => matchesStatus(experiment, filter));
-      if (!nextVisible.some((experiment) => experiment.id === selectedExperimentId)) {
-        setSelectedExperimentId(nextVisible[0]?.id ?? null);
-      }
+      syncSelection(allExperiments, selectedTemplateId, filter);
     });
   };
+
+  const handleTemplateChange = (templateId: string | null) => {
+    startTransition(() => {
+      setSelectedTemplateId(templateId);
+      setExpandedEntryId(null);
+      syncSelection(allExperiments, templateId, selectedFilter);
+    });
+  };
+
   const handleSelectExperiment = (experimentId: string) => {
+    const experiment = allExperiments.find((item) => item.id === experimentId) ?? null;
+
     startTransition(() => {
       setSelectedExperimentId(experimentId);
+      setSelectedRunIds(getDefaultRunIds(experiment, allRuns));
+      setDrawerSection("notes");
+      setComparisonView("summary");
       setExpandedEntryId(null);
     });
   };
+
   const handleSectionChange = (section: ObservationSection) => {
     startTransition(() => {
       setDrawerSection(section);
@@ -81,33 +204,174 @@ export function LabNotebookShell({
     });
   };
 
+  const handleToggleRun = (runId: string) => {
+    startTransition(() => {
+      setSelectedRunIds((current) => {
+        if (current.includes(runId)) {
+          return current.filter((id) => id !== runId);
+        }
+
+        const next = [...current, runId];
+        return next.length > 3 ? next.slice(next.length - 3) : next;
+      });
+      setExpandedEntryId(null);
+    });
+  };
+
+  const handleCreateFromTemplate = (templateId: string) => {
+    const template = templatesById[templateId];
+
+    if (!template) {
+      return;
+    }
+
+    const nextSequence = (countsByTemplateId[templateId] ?? 0) + 1;
+    const bundle = createExperimentBundleFromTemplate(template, nextSequence);
+    const nextExperiments = [bundle.experiment, ...allExperiments];
+    const nextRuns = [...bundle.runs, ...allRuns];
+
+    startTransition(() => {
+      setAllExperiments(nextExperiments);
+      setAllRuns(nextRuns);
+      setAllObservationEntries((current) => [...bundle.observationEntries, ...current]);
+      setAllOutcomeReviews((current) => [bundle.outcomeReview, ...current]);
+      setReviewDecisionByExperimentId((current) => ({
+        ...current,
+        [bundle.experiment.id]: bundle.outcomeReview.recommendedDecision,
+      }));
+      setCheckedHelpersByReviewId((current) => ({
+        ...current,
+        [bundle.outcomeReview.id]: bundle.outcomeReview.helperChecklist
+          .filter((helper) => helper.defaultChecked)
+          .map((helper) => helper.id),
+      }));
+      setSelectedTemplateId(templateId);
+      setSelectedFilter("all");
+      setSelectedExperimentId(bundle.experiment.id);
+      setSelectedRunIds(getDefaultRunIds(bundle.experiment, nextRuns));
+      setDrawerSection("notes");
+      setComparisonView("summary");
+      setExpandedEntryId(null);
+    });
+  };
+
+  const handleToggleHelper = (helperId: string) => {
+    if (!selectedReview) {
+      return;
+    }
+
+    startTransition(() => {
+      setCheckedHelpersByReviewId((current) => {
+        const existing = current[selectedReview.id] ?? [];
+
+        return {
+          ...current,
+          [selectedReview.id]: existing.includes(helperId)
+            ? existing.filter((id) => id !== helperId)
+            : [...existing, helperId],
+        };
+      });
+    });
+  };
+
+  const handleSelectDecision = (decisionId: ReviewDecisionId) => {
+    if (!selectedExperiment) {
+      return;
+    }
+
+    const decision = reviewDecisionOptionsById[decisionId];
+
+    if (!decision) {
+      return;
+    }
+
+    startTransition(() => {
+      setReviewDecisionByExperimentId((current) => ({
+        ...current,
+        [selectedExperiment.id]: decisionId,
+      }));
+      setAllExperiments((current) =>
+        current.map((experiment) =>
+          experiment.id === selectedExperiment.id
+            ? {
+                ...experiment,
+                boardLaneId: decision.boardLaneId,
+                status: decision.status,
+                recommendation: decision.recommendation,
+                boardNote: `${selectedTemplate?.name ?? "Template"} is currently sending this board toward ${decision.boardLaneId}.`,
+              }
+            : experiment,
+        ),
+      );
+    });
+  };
+
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(251,191,36,0.12),transparent_30%),radial-gradient(circle_at_right,rgba(20,184,166,0.1),transparent_24%),linear-gradient(180deg,#fefce8_0%,#fffbeb_34%,#f8fafc_100%)] px-4 py-6 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-7xl space-y-6">
         <LabNotebookHeader
           activeCount={activeCount}
+          comparedRunCount={selectedRuns.length}
           flaggedCount={flaggedCount}
           lastEntrySummary={lastEntrySummary}
           notebookStatus={notebookStatus}
+          selectedExperimentTitle={selectedExperiment?.title ?? null}
+          selectedTemplateLabel={selectedTemplateLabel}
           visibleCount={visibleExperiments.length}
         />
+        <TemplateGallery
+          countsByTemplateId={countsByTemplateId}
+          onCreateFromTemplate={handleCreateFromTemplate}
+          onSelectTemplate={handleTemplateChange}
+          selectedTemplateId={selectedTemplateId}
+          templates={experimentTemplates}
+        />
         <StatusFilterBar counts={counts} onChange={handleFilterChange} selectedFilter={selectedFilter} statusOptions={statusOptions} />
-        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.25fr)_minmax(22rem,0.88fr)]">
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.3fr)_minmax(22rem,0.95fr)]">
           <ExperimentBoard
+            boardLanes={boardLanes}
             experiments={visibleExperiments}
             milestoneTagsById={milestoneTagsById}
             onSelect={handleSelectExperiment}
+            runsByExperimentId={runsByExperimentId}
             selectedExperimentId={selectedExperimentId}
+            templatesById={templatesById}
           />
-          <ObservationDrawer
-            entries={selectedEntries}
-            expandedEntryId={expandedEntryId}
-            experiment={selectedExperiment}
-            milestoneTagsById={milestoneTagsById}
-            onExpandEntry={handleExpandEntry}
-            onSectionChange={handleSectionChange}
-            section={drawerSection}
-          />
+          <div className="space-y-6">
+            <RunComparisonPanel
+              comparisonMetrics={comparisonMetrics}
+              comparisonView={comparisonView}
+              experiment={selectedExperiment}
+              onChangeComparisonView={setComparisonView}
+              onToggleRun={handleToggleRun}
+              runs={selectedExperimentRuns}
+              selectedRunIds={selectedRunIds}
+              template={selectedTemplate}
+            />
+            <ObservationDrawer
+              entries={selectedEntries}
+              expandedEntryId={expandedEntryId}
+              experiment={selectedExperiment}
+              milestoneTagsById={milestoneTagsById}
+              onExpandEntry={handleExpandEntry}
+              onSectionChange={handleSectionChange}
+              runsById={runsById}
+              section={drawerSection}
+              selectedRuns={selectedRuns}
+              template={selectedTemplate}
+            />
+            <OutcomeReviewPanel
+              activeDecisionId={selectedExperiment ? reviewDecisionByExperimentId[selectedExperiment.id] ?? null : null}
+              checkedHelperIds={selectedReview ? checkedHelpersByReviewId[selectedReview.id] ?? [] : []}
+              decisionOptions={reviewDecisionOptions}
+              experiment={selectedExperiment}
+              onSelectDecision={handleSelectDecision}
+              onToggleHelper={handleToggleHelper}
+              review={selectedReview}
+              selectedRuns={selectedRuns}
+              template={selectedTemplate}
+            />
+          </div>
         </div>
       </div>
     </main>

--- a/src/components/lab-notebook/observation-drawer.tsx
+++ b/src/components/lab-notebook/observation-drawer.tsx
@@ -1,5 +1,7 @@
 import type {
   Experiment,
+  ExperimentRun,
+  ExperimentTemplate,
   MilestoneTag,
   ObservationEntry,
   ObservationSection,
@@ -12,7 +14,10 @@ type ObservationDrawerProps = {
   milestoneTagsById: Record<string, MilestoneTag>;
   onExpandEntry: (entryId: string) => void;
   onSectionChange: (section: ObservationSection) => void;
+  runsById: Record<string, ExperimentRun>;
   section: ObservationSection;
+  selectedRuns: ExperimentRun[];
+  template: ExperimentTemplate | null;
 };
 
 const sectionLabels: Record<ObservationSection, string> = {
@@ -35,7 +40,10 @@ export function ObservationDrawer({
   milestoneTagsById,
   onExpandEntry,
   onSectionChange,
+  runsById,
   section,
+  selectedRuns,
+  template,
 }: ObservationDrawerProps) {
   const sectionEntries = entries.filter((entry) => entry.section === section);
   const counts = {
@@ -45,14 +53,17 @@ export function ObservationDrawer({
   };
 
   return (
-    <aside className="rounded-[2rem] border border-stone-900/10 bg-[linear-gradient(180deg,rgba(12,10,9,0.96),rgba(41,37,36,0.97))] p-5 text-stone-100 shadow-[0_28px_90px_rgba(15,23,42,0.3)] sm:p-6">
+    <aside
+      aria-label="Observation drawer"
+      className="rounded-[2rem] border border-stone-900/10 bg-[linear-gradient(180deg,rgba(12,10,9,0.96),rgba(41,37,36,0.97))] p-5 text-stone-100 shadow-[0_28px_90px_rgba(15,23,42,0.3)] sm:p-6"
+    >
       <div className="flex items-start justify-between gap-4">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.32em] text-amber-200/75">Observation drawer</p>
           <h2 className="mt-2 text-2xl font-semibold tracking-[-0.03em]">{experiment ? experiment.title : "Choose an experiment"}</h2>
           <p className="mt-2 text-sm leading-6 text-stone-300">
             {experiment
-              ? `${experiment.window}. Local sections switch between notebook notes, watch items, and milestone timing.`
+              ? `${template?.name ?? "Template"} is filtering notes through ${selectedRuns.length > 0 ? `${selectedRuns.length} selected runs` : "all attached runs"}.`
               : "Select an experiment card to open the drawer. Until then, the notebook keeps this region in a local waiting state."}
           </p>
         </div>
@@ -75,6 +86,16 @@ export function ObservationDrawer({
         ))}
       </div>
 
+      {selectedRuns.length > 0 ? (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {selectedRuns.map((run) => (
+            <span className="rounded-full border border-white/12 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-300" key={run.id}>
+              {run.label}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
       {!experiment ? (
         <div className="mt-5 rounded-[1.75rem] border border-dashed border-white/12 bg-white/[0.04] p-6 text-center">
           <p className="text-xs font-semibold uppercase tracking-[0.32em] text-stone-400">Waiting on selection</p>
@@ -83,13 +104,14 @@ export function ObservationDrawer({
       ) : sectionEntries.length === 0 ? (
         <div className="mt-5 rounded-[1.75rem] border border-dashed border-white/12 bg-white/[0.04] p-6 text-center">
           <p className="text-xs font-semibold uppercase tracking-[0.32em] text-stone-400">Section clear</p>
-          <h3 className="mt-3 text-xl font-semibold">No {sectionLabels[section].toLowerCase()} are parked for this experiment.</h3>
-          <p className="mt-3 text-sm leading-6 text-stone-300">The drawer stays open, but this section is empty. Switch sections or return to another card if you want a fuller observation trail.</p>
+          <h3 className="mt-3 text-xl font-semibold">No {sectionLabels[section].toLowerCase()} are parked for this experiment and run set.</h3>
+          <p className="mt-3 text-sm leading-6 text-stone-300">The drawer stays open, but the currently selected runs do not have entries in this section. Switch sections or change the comparison set for more context.</p>
         </div>
       ) : (
         <div className="mt-5 space-y-3">
           {sectionEntries.map((entry) => {
             const milestone = entry.milestoneId ? milestoneTagsById[entry.milestoneId] : undefined;
+            const run = runsById[entry.runId];
             const isExpanded = expandedEntryId === entry.id;
 
             return (
@@ -97,8 +119,13 @@ export function ObservationDrawer({
                 <div className="flex flex-wrap items-center gap-2">
                   <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-300">{entry.capturedAt}</span>
                   <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-300">{entry.recorder}</span>
+                  {run ? (
+                    <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-300">{run.label}</span>
+                  ) : null}
                   {milestone ? (
-                    <span className={`rounded-full border px-3 py-1 text-xs font-medium ${toneClasses[milestone.tone]}`}>{milestone.label}</span>
+                    <span className={`rounded-full border px-3 py-1 text-xs font-medium ${toneClasses[milestone.tone]}`} key={milestone.id}>
+                      {milestone.label}
+                    </span>
                   ) : null}
                 </div>
                 <h3 className="mt-3 text-lg font-semibold">{entry.headline}</h3>

--- a/src/components/lab-notebook/outcome-review-panel.tsx
+++ b/src/components/lab-notebook/outcome-review-panel.tsx
@@ -1,0 +1,161 @@
+import type {
+  Experiment,
+  ExperimentRun,
+  ExperimentTemplate,
+  OutcomeReview,
+  ReviewDecisionId,
+  ReviewDecisionOption,
+} from "@/app/lab-notebook/notebook-data";
+
+type OutcomeReviewPanelProps = {
+  activeDecisionId: ReviewDecisionId | null;
+  checkedHelperIds: string[];
+  decisionOptions: ReviewDecisionOption[];
+  experiment: Experiment | null;
+  onSelectDecision: (decisionId: ReviewDecisionId) => void;
+  onToggleHelper: (helperId: string) => void;
+  review: OutcomeReview | null;
+  selectedRuns: ExperimentRun[];
+  template: ExperimentTemplate | null;
+};
+
+export function OutcomeReviewPanel({
+  activeDecisionId,
+  checkedHelperIds,
+  decisionOptions,
+  experiment,
+  onSelectDecision,
+  onToggleHelper,
+  review,
+  selectedRuns,
+  template,
+}: OutcomeReviewPanelProps) {
+  const activeDecision = decisionOptions.find((option) => option.id === activeDecisionId) ?? null;
+
+  return (
+    <section className="rounded-[2rem] border border-stone-900/10 bg-[linear-gradient(180deg,rgba(12,10,9,0.96),rgba(41,37,36,0.97))] p-5 text-stone-100 shadow-[0_28px_90px_rgba(15,23,42,0.3)] sm:p-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-amber-200/75">Outcome review</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-[-0.03em]">{experiment ? experiment.title : "Choose an experiment"}</h2>
+          <p className="mt-2 text-sm leading-6 text-stone-300">
+            {experiment
+              ? `${template?.name ?? "Template"} review helpers keep the board move, evidence checklist, and selected runs in one panel.`
+              : "Focus a board card to unlock the review checklist and next-lane actions."}
+          </p>
+        </div>
+        {review ? (
+          <span className="rounded-full border border-white/12 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-300">
+            {review.dueWindow}
+          </span>
+        ) : null}
+      </div>
+
+      {!experiment || !review ? (
+        <div className="mt-5 rounded-[1.75rem] border border-dashed border-white/12 bg-white/[0.04] p-6 text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-stone-400">Waiting on review context</p>
+          <p className="mt-3 text-sm leading-6 text-stone-300">Once a board is focused, this panel will stage the checklist, run context, and recommended board move.</p>
+        </div>
+      ) : (
+        <>
+          <div className="mt-5 rounded-[1.5rem] border border-white/10 bg-white/[0.05] p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-400">{review.owner}</p>
+            <h3 className="mt-2 text-xl font-semibold">{review.headline}</h3>
+            <p className="mt-2 text-sm leading-6 text-stone-300">{review.summary}</p>
+          </div>
+
+          <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(15rem,0.7fr)]">
+            <div className="space-y-3">
+              <div className="rounded-[1.45rem] border border-white/10 bg-white/[0.05] p-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-400">Checklist</p>
+                  <span className="rounded-full border border-white/12 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-300">
+                    {checkedHelperIds.length} of {review.helperChecklist.length} ready
+                  </span>
+                </div>
+                <div className="mt-4 space-y-3">
+                  {review.helperChecklist.map((helper) => {
+                    const checked = checkedHelperIds.includes(helper.id);
+
+                    return (
+                      <label className="flex gap-3 rounded-[1.2rem] border border-white/10 bg-white/[0.04] p-3" key={helper.id}>
+                        <input
+                          aria-label={`Toggle helper: ${helper.label}`}
+                          checked={checked}
+                          className="mt-1 size-4 rounded border-stone-400 text-stone-50 focus:ring-amber-200"
+                          onChange={() => onToggleHelper(helper.id)}
+                          type="checkbox"
+                        />
+                        <span>
+                          <span className="block text-sm font-semibold text-stone-100">{helper.label}</span>
+                          <span className="mt-1 block text-sm leading-6 text-stone-300">{helper.description}</span>
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className="rounded-[1.45rem] border border-white/10 bg-white/[0.05] p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-400">Review prompts</p>
+                <div className="mt-4 space-y-2">
+                  {review.prompts.map((prompt) => (
+                    <p className="rounded-[1.1rem] border border-white/10 bg-white/[0.04] px-3 py-3 text-sm leading-6 text-stone-300" key={prompt}>
+                      {prompt}
+                    </p>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              <div className="rounded-[1.45rem] border border-white/10 bg-white/[0.05] p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-400">Selected runs</p>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {selectedRuns.length > 0 ? (
+                    selectedRuns.map((run) => (
+                      <span className="rounded-full border border-white/12 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-200" key={run.id}>
+                        {run.label}
+                      </span>
+                    ))
+                  ) : (
+                    <span className="text-sm leading-6 text-stone-300">Choose one or more runs in comparison view to attach them to the review decision.</span>
+                  )}
+                </div>
+              </div>
+
+              <div className="rounded-[1.45rem] border border-white/10 bg-white/[0.05] p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-400">Next board move</p>
+                <div className="mt-4 space-y-2">
+                  {decisionOptions.map((option) => (
+                    <button
+                      className={`w-full rounded-[1.1rem] border px-4 py-3 text-left text-sm transition ${
+                        activeDecisionId === option.id
+                          ? "border-amber-200/40 bg-amber-300/10 text-stone-50"
+                          : "border-white/10 bg-white/[0.04] text-stone-200 hover:bg-white/[0.08]"
+                      }`}
+                      key={option.id}
+                      onClick={() => onSelectDecision(option.id)}
+                      type="button"
+                    >
+                      <span className="block font-semibold">{option.label}</span>
+                      <span className="mt-1 block leading-6 text-stone-300">{option.summary}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="rounded-[1.45rem] border border-emerald-300/20 bg-emerald-400/10 p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-emerald-100">Active recommendation</p>
+                <p className="mt-2 text-lg font-semibold text-white">{activeDecision?.label ?? "No decision selected"}</p>
+                <p className="mt-2 text-sm leading-6 text-emerald-50/90">
+                  {activeDecision?.recommendation ?? "Pick a board move to update the lane placement and recommendation on the focused experiment card."}
+                </p>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/components/lab-notebook/run-comparison-panel.tsx
+++ b/src/components/lab-notebook/run-comparison-panel.tsx
@@ -1,0 +1,259 @@
+import type {
+  ComparisonMetric,
+  ComparisonView,
+  Experiment,
+  ExperimentRun,
+  ExperimentTemplate,
+} from "@/app/lab-notebook/notebook-data";
+
+type RunComparisonPanelProps = {
+  comparisonMetrics: ComparisonMetric[];
+  comparisonView: ComparisonView;
+  experiment: Experiment | null;
+  onChangeComparisonView: (view: ComparisonView) => void;
+  onToggleRun: (runId: string) => void;
+  runs: ExperimentRun[];
+  selectedRunIds: string[];
+  template: ExperimentTemplate | null;
+};
+
+function formatMetric(metric: ComparisonMetric, value: number) {
+  if (metric.id === "variance") {
+    return `${value.toFixed(1)}${metric.unit}`;
+  }
+
+  return metric.unit.length > 0 ? `${value}${metric.unit}` : `${value}`;
+}
+
+function getBestRun(runs: ExperimentRun[], metric: ComparisonMetric) {
+  if (runs.length === 0) {
+    return null;
+  }
+
+  return runs.reduce((best, run) => {
+    if (!best) {
+      return run;
+    }
+
+    const currentValue = run.metrics[metric.id];
+    const bestValue = best.metrics[metric.id];
+
+    if (metric.better === "higher") {
+      return currentValue > bestValue ? run : best;
+    }
+
+    return currentValue < bestValue ? run : best;
+  }, runs[0] ?? null);
+}
+
+export function RunComparisonPanel({
+  comparisonMetrics,
+  comparisonView,
+  experiment,
+  onChangeComparisonView,
+  onToggleRun,
+  runs,
+  selectedRunIds,
+  template,
+}: RunComparisonPanelProps) {
+  const selectedRuns = runs.filter((run) => selectedRunIds.includes(run.id));
+  const averageSignal = selectedRuns.length > 0
+    ? Math.round(
+        (selectedRuns.reduce((total, run) => total + run.metrics.signal, 0) / selectedRuns.length) * 10,
+      ) / 10
+    : 0;
+  const lowestVariance = selectedRuns.length > 0
+    ? Math.min(...selectedRuns.map((run) => run.metrics.variance))
+    : null;
+  const totalWatchFlags = selectedRuns.reduce((total, run) => total + run.metrics.watchFlags, 0);
+
+  return (
+    <section
+      aria-label="Run comparison panel"
+      className="rounded-[2rem] border border-stone-900/10 bg-white/82 p-5 shadow-[0_24px_90px_rgba(120,53,15,0.12)]"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-stone-500">Run comparison</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-stone-950">
+            {experiment ? experiment.title : "Choose an experiment"}
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-stone-600">
+            {experiment
+              ? `${template?.name ?? "Template"} keeps the summary and detail views anchored to the selected run set.`
+              : "Select a board card to compare multiple runs in summary and detail without leaving the notebook."}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {(["summary", "detail"] as ComparisonView[]).map((view) => (
+            <button
+              className={`rounded-full px-4 py-2 text-sm transition ${
+                comparisonView === view
+                  ? "bg-stone-950 text-stone-50"
+                  : "border border-stone-900/10 bg-stone-100/80 text-stone-700 hover:bg-stone-200/80"
+              }`}
+              key={view}
+              onClick={() => onChangeComparisonView(view)}
+              type="button"
+            >
+              {view === "summary" ? "Summary view" : "Detail view"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {!experiment ? (
+        <div className="mt-5 rounded-[1.75rem] border border-dashed border-stone-900/12 bg-stone-100/60 p-6 text-center">
+          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-stone-500">Waiting on selection</p>
+          <p className="mt-3 text-sm leading-6 text-stone-600">Once a board card is focused, this panel will let you choose a run set and inspect the comparison from summary to detail.</p>
+        </div>
+      ) : (
+        <>
+          <div className="mt-5 grid gap-3 lg:grid-cols-3">
+            {runs.map((run) => {
+              const isSelected = selectedRunIds.includes(run.id);
+
+              return (
+                <label
+                  className={`cursor-pointer rounded-[1.45rem] border p-4 transition ${
+                    isSelected
+                      ? "border-stone-950 bg-[linear-gradient(135deg,rgba(255,251,235,0.96),rgba(254,249,195,0.82))]"
+                      : "border-stone-900/10 bg-stone-50/80 hover:border-stone-900/20"
+                  }`}
+                  key={run.id}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">{run.startedAt}</p>
+                      <h3 className="mt-2 text-lg font-semibold text-stone-950">{run.label}</h3>
+                    </div>
+                    <input
+                      aria-label={`Select ${run.label}`}
+                      checked={isSelected}
+                      className="mt-1 size-4 rounded border-stone-400 text-stone-950 focus:ring-stone-500"
+                      onChange={() => onToggleRun(run.id)}
+                      type="checkbox"
+                    />
+                  </div>
+                  <p className="mt-2 text-sm leading-6 text-stone-700">{run.summary}</p>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <span className="rounded-full border border-stone-900/10 bg-white/70 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-600">{run.state}</span>
+                    <span className="rounded-full border border-stone-900/10 bg-white/70 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-600">{run.operator}</span>
+                  </div>
+                </label>
+              );
+            })}
+          </div>
+
+          {comparisonView === "summary" ? (
+            selectedRuns.length < 2 ? (
+              <div className="mt-5 rounded-[1.75rem] border border-dashed border-stone-900/12 bg-stone-100/60 p-6 text-center">
+                <p className="text-xs font-semibold uppercase tracking-[0.32em] text-stone-500">Summary locked</p>
+                <p className="mt-3 text-sm leading-6 text-stone-600">Select at least two runs to unlock the summary comparison view for this board.</p>
+              </div>
+            ) : (
+              <div className="mt-5 space-y-4">
+                <div className="grid gap-3 md:grid-cols-3">
+                  <article className="rounded-[1.5rem] border border-stone-900/10 bg-[linear-gradient(180deg,rgba(255,251,235,0.95),rgba(255,255,255,0.92))] p-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">Average signal</p>
+                    <p className="mt-2 text-3xl font-semibold text-stone-950">{averageSignal} pts</p>
+                    <p className="mt-2 text-sm leading-6 text-stone-600">Across {selectedRuns.length} runs in the current comparison set.</p>
+                  </article>
+                  <article className="rounded-[1.5rem] border border-stone-900/10 bg-[linear-gradient(180deg,rgba(239,246,255,0.92),rgba(255,255,255,0.9))] p-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">Lowest variance</p>
+                    <p className="mt-2 text-3xl font-semibold text-stone-950">
+                      {lowestVariance !== null ? `${lowestVariance.toFixed(1)}%` : "N/A"}
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-stone-600">Use the detailed view to inspect which run is holding the cleanest spread.</p>
+                  </article>
+                  <article className="rounded-[1.5rem] border border-stone-900/10 bg-[linear-gradient(180deg,rgba(220,252,231,0.92),rgba(255,255,255,0.9))] p-4">
+                    <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">Watch flags</p>
+                    <p className="mt-2 text-3xl font-semibold text-stone-950">{totalWatchFlags}</p>
+                    <p className="mt-2 text-sm leading-6 text-stone-600">Carry these flags forward into the outcome review helper set.</p>
+                  </article>
+                </div>
+
+                <div className="grid gap-3 xl:grid-cols-2">
+                  {comparisonMetrics.map((metric) => {
+                    const bestRun = getBestRun(selectedRuns, metric);
+
+                    return (
+                      <article className="rounded-[1.5rem] border border-stone-900/10 bg-white/70 p-4" key={metric.id}>
+                        <div className="flex items-start justify-between gap-4">
+                          <div>
+                            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">{metric.label}</p>
+                            <p className="mt-2 text-sm leading-6 text-stone-600">
+                              {metric.better === "higher" ? "Higher is better" : "Lower is better"} for this comparison metric.
+                            </p>
+                          </div>
+                          <span className="rounded-full border border-stone-900/10 bg-stone-100/80 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-600">
+                            {bestRun ? bestRun.label : "No run"}
+                          </span>
+                        </div>
+                        <div className="mt-4 space-y-2">
+                          {selectedRuns.map((run) => (
+                            <div className="flex items-center justify-between rounded-[1.1rem] bg-stone-100/80 px-3 py-3 text-sm text-stone-700" key={run.id}>
+                              <span>{run.label}</span>
+                              <span className="font-semibold">{formatMetric(metric, run.metrics[metric.id])}</span>
+                            </div>
+                          ))}
+                        </div>
+                      </article>
+                    );
+                  })}
+                </div>
+              </div>
+            )
+          ) : selectedRuns.length === 0 ? (
+            <div className="mt-5 rounded-[1.75rem] border border-dashed border-stone-900/12 bg-stone-100/60 p-6 text-center">
+              <p className="text-xs font-semibold uppercase tracking-[0.32em] text-stone-500">No runs selected</p>
+              <p className="mt-3 text-sm leading-6 text-stone-600">Pick at least one run to open the detailed comparison cards.</p>
+            </div>
+          ) : (
+            <div className="mt-5 grid gap-4 xl:grid-cols-2">
+              {selectedRuns.map((run) => (
+                <article className="rounded-[1.6rem] border border-stone-900/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.96),rgba(248,250,252,0.88))] p-5" key={run.id}>
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">{run.startedAt}</p>
+                      <h3 className="mt-2 text-xl font-semibold text-stone-950">{run.label}</h3>
+                    </div>
+                    <span className="rounded-full border border-stone-900/10 bg-stone-100/80 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-600">{run.state}</span>
+                  </div>
+                  <p className="mt-3 text-sm leading-6 text-stone-700">{run.detail}</p>
+
+                  <div className="mt-4 grid grid-cols-2 gap-3">
+                    {comparisonMetrics.map((metric) => (
+                      <div className="rounded-[1.15rem] bg-stone-100/70 p-3" key={metric.id}>
+                        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-stone-500">{metric.label}</p>
+                        <p className="mt-2 text-lg font-semibold text-stone-950">{formatMetric(metric, run.metrics[metric.id])}</p>
+                      </div>
+                    ))}
+                  </div>
+
+                  <div className="mt-4 rounded-[1.25rem] bg-stone-100/70 p-4 text-sm text-stone-700">
+                    <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">Setup</p>
+                    <p className="mt-2 leading-6">{run.setup}</p>
+                  </div>
+
+                  <div className="mt-4 space-y-2">
+                    {run.highlights.map((highlight) => (
+                      <p className="rounded-[1.1rem] border border-stone-900/10 bg-white/70 px-3 py-3 text-sm leading-6 text-stone-700" key={highlight}>
+                        {highlight}
+                      </p>
+                    ))}
+                  </div>
+
+                  <div className="mt-4 rounded-[1.25rem] border border-stone-900/10 bg-stone-950 px-4 py-4 text-sm leading-6 text-stone-100">
+                    <p className="text-xs font-semibold uppercase tracking-[0.24em] text-amber-200/75">Decision note</p>
+                    <p className="mt-2">{run.decisionNote}</p>
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/components/lab-notebook/status-filter-bar.tsx
+++ b/src/components/lab-notebook/status-filter-bar.tsx
@@ -15,7 +15,7 @@ export function StatusFilterBar({
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.32em] text-stone-500">Status filters</p>
-          <p className="mt-2 text-sm text-stone-600">Filter the notebook without leaving the route or mutating any shared workspace.</p>
+          <p className="mt-2 text-sm text-stone-600">Filter the notebook board after template selection without leaving the route or mutating any shared workspace.</p>
         </div>
         <div className="flex flex-wrap gap-2">
           {statusOptions.map((option) => (

--- a/src/components/lab-notebook/template-gallery.tsx
+++ b/src/components/lab-notebook/template-gallery.tsx
@@ -1,0 +1,120 @@
+import type { ExperimentTemplate } from "@/app/lab-notebook/notebook-data";
+
+type TemplateGalleryProps = {
+  countsByTemplateId: Record<string, number>;
+  onCreateFromTemplate: (templateId: string) => void;
+  onSelectTemplate: (templateId: string | null) => void;
+  selectedTemplateId: string | null;
+  templates: ExperimentTemplate[];
+};
+
+export function TemplateGallery({
+  countsByTemplateId,
+  onCreateFromTemplate,
+  onSelectTemplate,
+  selectedTemplateId,
+  templates,
+}: TemplateGalleryProps) {
+  return (
+    <section className="rounded-[2rem] border border-stone-900/10 bg-white/80 p-5 shadow-[0_22px_80px_rgba(120,53,15,0.12)]">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-stone-500">Experiment templates</p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-stone-950">Select an existing template or create a fresh notebook board from one.</h2>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-stone-600">Template cards keep the planning notes, compare guidance, and review prompts close to the board so teams can move from setup to outcome review inside one route.</p>
+        </div>
+        <button
+          className={`rounded-full px-4 py-2 text-sm transition ${
+            selectedTemplateId === null
+              ? "bg-stone-950 text-stone-50"
+              : "border border-stone-900/10 bg-stone-100/80 text-stone-700 hover:bg-stone-200/80"
+          }`}
+          onClick={() => onSelectTemplate(null)}
+          type="button"
+        >
+          Show all templates
+        </button>
+      </div>
+
+      <div className="mt-5 grid gap-4 xl:grid-cols-3">
+        {templates.map((template) => {
+          const isSelected = selectedTemplateId === template.id;
+
+          return (
+            <article
+              className={`rounded-[1.85rem] border p-5 transition ${
+                isSelected
+                  ? "border-stone-950 bg-[linear-gradient(135deg,rgba(255,251,235,0.98),rgba(254,249,195,0.8))] shadow-[0_22px_80px_rgba(120,53,15,0.16)]"
+                  : "border-stone-900/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.96),rgba(248,250,252,0.88))] hover:border-stone-900/20"
+              }`}
+              key={template.id}
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.28em] text-stone-500">{template.category}</p>
+                  <h3 className="mt-2 text-2xl font-semibold tracking-[-0.03em] text-stone-950">{template.name}</h3>
+                </div>
+                <span className="rounded-full border border-stone-900/10 bg-white/70 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-600">
+                  {countsByTemplateId[template.id] ?? 0} boards
+                </span>
+              </div>
+
+              <p className="mt-4 text-sm leading-6 text-stone-700">{template.summary}</p>
+
+              <div className="mt-4 grid gap-3">
+                <div className="rounded-[1.35rem] bg-stone-100/70 p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">Objective</p>
+                  <p className="mt-2 text-sm leading-6 text-stone-700">{template.objective}</p>
+                </div>
+                <div className="rounded-[1.35rem] bg-stone-100/70 p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-stone-500">Comparison hint</p>
+                  <p className="mt-2 text-sm leading-6 text-stone-700">{template.compareHint}</p>
+                </div>
+              </div>
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                <span className="rounded-full border border-stone-900/10 bg-white/70 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-600">
+                  {template.cadence}
+                </span>
+                <span className="rounded-full border border-stone-900/10 bg-white/70 px-3 py-1 text-xs uppercase tracking-[0.22em] text-stone-600">
+                  {template.checkpointMilestoneIds.length} checkpoints
+                </span>
+              </div>
+
+              <div className="mt-4 space-y-2 text-sm text-stone-700">
+                {template.boardNotes.map((note) => (
+                  <p className="rounded-[1.15rem] border border-stone-900/10 bg-white/60 px-3 py-3 leading-6" key={note}>
+                    {note}
+                  </p>
+                ))}
+              </div>
+
+              <div className="mt-5 flex flex-wrap gap-3">
+                <button
+                  aria-label={`Select template: ${template.name}`}
+                  className={`rounded-full px-4 py-2 text-sm transition ${
+                    isSelected
+                      ? "bg-stone-950 text-stone-50"
+                      : "border border-stone-900/10 bg-white/70 text-stone-700 hover:bg-stone-100"
+                  }`}
+                  onClick={() => onSelectTemplate(template.id)}
+                  type="button"
+                >
+                  {isSelected ? "Template selected" : "Select template"}
+                </button>
+                <button
+                  aria-label={`Create notebook from template: ${template.name}`}
+                  className="rounded-full border border-stone-900/10 bg-stone-100/80 px-4 py-2 text-sm text-stone-700 transition hover:bg-stone-200/80"
+                  onClick={() => onCreateFromTemplate(template.id)}
+                  type="button"
+                >
+                  Create notebook board
+                </button>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add experiment templates and local template-driven board creation to the lab notebook
- add template-aware board lanes, multi-run summary/detail comparison, and richer outcome review helpers
- add notebook interaction tests for template selection, comparison flows, observation context, and review actions

## Testing
- npm run typecheck
- npx eslint src/app/lab-notebook/page.tsx src/app/lab-notebook/notebook-data.ts src/components/lab-notebook --max-warnings=0
- npx vitest run src/components/lab-notebook/lab-notebook-shell.test.tsx

## Notes
- Full `npm test` still fails in unrelated pre-existing suites: `mission-briefing`, `scenario-board`, and `signal-lab` timeout tests.

Closes #72