### PR TITLE
feat: add field guide authoring playbooks

### DIFF
--- a/src/app/field-guide/page.tsx
+++ b/src/app/field-guide/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import {
+  savedPlaybooks,
   procedures,
   procedureTags,
 } from "@/components/field-guide/field-guide-data";
@@ -8,10 +9,15 @@ import FieldGuideShell from "@/components/field-guide/field-guide-shell";
 
 export const metadata: Metadata = {
   title: "Field Guide | API Test",
-  description: "Search and review mock procedures with local checklist state.",
+  description:
+    "Author, review, and rehearse mock procedures with saved playbooks and local draft state.",
 };
 
 export default function FieldGuidePage() {
+  const draftCount = savedPlaybooks.filter(
+    (playbook) => playbook.status !== "Published",
+  ).length;
+
   return (
     <main className="min-h-screen px-4 py-8 sm:px-6 lg:px-8">
       <div className="mx-auto flex max-w-7xl flex-col gap-6">
@@ -22,12 +28,13 @@ export default function FieldGuidePage() {
                 Field Guide
               </p>
               <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-                Searchable mock procedures for field drills and rapid-response
-                rehearsals.
+                Draft, review, and rehearse saved playbooks beside the source
+                procedures they come from.
               </h1>
               <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
-                Review isolated mock runbooks, narrow them by team or readiness,
-                and walk through each checklist without leaving this route.
+                Review isolated mock procedures, author custom playbooks with
+                draft metadata, and preview rehearsal steps without leaving this
+                route.
               </p>
             </div>
             <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
@@ -36,14 +43,16 @@ export default function FieldGuidePage() {
                 <p className="mt-2 text-3xl font-semibold">{procedures.length}</p>
               </div>
               <div className="rounded-3xl bg-sky-100 px-5 py-4 text-sky-950">
-                <p className="text-sm text-sky-700">Local tags</p>
+                <p className="text-sm text-sky-700">Saved playbooks</p>
                 <p className="mt-2 text-3xl font-semibold">
-                  {procedureTags.length}
+                  {savedPlaybooks.length}
                 </p>
               </div>
               <div className="rounded-3xl bg-amber-100 px-5 py-4 text-amber-950">
-                <p className="text-sm text-amber-700">Checklist mode</p>
-                <p className="mt-2 text-lg font-semibold">Session-local only</p>
+                <p className="text-sm text-amber-700">Draft-ready tags</p>
+                <p className="mt-2 text-lg font-semibold">
+                  {draftCount} active drafts · {procedureTags.length} tags
+                </p>
               </div>
             </div>
           </div>

--- a/src/components/field-guide/field-guide-data.ts
+++ b/src/components/field-guide/field-guide-data.ts
@@ -14,7 +14,20 @@ export const procedureDifficulties = [
 
 export const procedureStatuses = ["Ready", "In Review", "Draft"] as const;
 
+export const playbookStatuses = ["Draft", "In Review", "Published"] as const;
+
+export const rehearsalStatuses = [
+  "Needs Revision",
+  "Ready to Rehearse",
+  "Scheduled",
+] as const;
+
+export const playbookModes = ["Custom", "Remix"] as const;
+
+export const playbookStepPhases = ["Brief", "Execute", "Verify"] as const;
+
 export const procedureTags = [
+  "briefing",
   "handoff",
   "safety",
   "cold-chain",
@@ -23,11 +36,18 @@ export const procedureTags = [
   "response",
   "rollback",
   "telemetry",
+  "verification",
+  "coordination",
+  "downtime",
 ] as const;
 
 export type ProcedureTeam = (typeof procedureTeams)[number];
 export type ProcedureDifficulty = (typeof procedureDifficulties)[number];
 export type ProcedureStatus = (typeof procedureStatuses)[number];
+export type PlaybookStatus = (typeof playbookStatuses)[number];
+export type RehearsalStatus = (typeof rehearsalStatuses)[number];
+export type PlaybookMode = (typeof playbookModes)[number];
+export type PlaybookStepPhase = (typeof playbookStepPhases)[number];
 
 export type ProcedureStep = {
   id: string;
@@ -47,16 +67,65 @@ export type Procedure = {
   location: string;
   lastUpdated: string;
   notes: string;
-  tags: readonly string[];
-  tools: readonly string[];
-  checklist: readonly ProcedureStep[];
+  tags: string[];
+  tools: string[];
+  checklist: ProcedureStep[];
 };
 
-export const procedures: readonly Procedure[] = [
+export type PlaybookStep = {
+  id: string;
+  label: string;
+  detail: string;
+  phase: PlaybookStepPhase;
+  owner: string;
+  duration: string;
+  expectedSignal: string;
+  rehearsalTip: string;
+};
+
+export type DraftMetadata = {
+  version: string;
+  owner: string;
+  reviewers: string[];
+  changeSummary: string;
+  reviewWindow: string;
+  publishWindow: string;
+  rehearsalWindow: string;
+  lastSaved: string;
+};
+
+export type SavedPlaybook = {
+  id: string;
+  sourceProcedureId: string;
+  title: string;
+  summary: string;
+  team: ProcedureTeam;
+  difficulty: ProcedureDifficulty;
+  status: PlaybookStatus;
+  rehearsalStatus: RehearsalStatus;
+  authoringMode: PlaybookMode;
+  objective: string;
+  audience: string;
+  rehearsalFocus: string;
+  duration: string;
+  cadence: string;
+  location: string;
+  lastUpdated: string;
+  lastRehearsed: string;
+  notes: string;
+  tags: string[];
+  tools: string[];
+  checkpoints: string[];
+  metadata: DraftMetadata;
+  steps: PlaybookStep[];
+};
+
+export const procedures: Procedure[] = [
   {
     id: "fiber-uplink-recovery",
     title: "Fiber Uplink Recovery",
-    summary: "Restore the rooftop uplink after packet loss spikes without dropping the backup path.",
+    summary:
+      "Restore the rooftop uplink after packet loss spikes without dropping the backup path.",
     team: "Network Ops",
     difficulty: "Advanced",
     status: "Ready",
@@ -64,19 +133,35 @@ export const procedures: readonly Procedure[] = [
     cadence: "Weekly drill",
     location: "Roof access cabinet B2",
     lastUpdated: "April 12, 2026",
-    notes: "Keep the microwave failover online until the final packet capture review is complete.",
-    tags: ["networking", "response", "rollback"],
+    notes:
+      "Keep the microwave failover online until the final packet capture review is complete and the handoff recorder signs off.",
+    tags: ["networking", "response", "rollback", "verification"],
     tools: ["Loopback tester", "Patch labels", "Spare SFP kit"],
     checklist: [
-      { id: "confirm-alert-window", label: "Confirm alert window", detail: "Cross-check NOC timestamps with the edge switch log." },
-      { id: "inspect-fiber-tray", label: "Inspect tray and jumper seating", detail: "Verify strain relief and reseat any mismatched jumper pair." },
-      { id: "validate-primary-return", label: "Validate the primary return", detail: "Capture five clean minutes of traffic before retiring failover." },
+      {
+        id: "confirm-alert-window",
+        label: "Confirm alert window",
+        detail: "Cross-check NOC timestamps with the edge switch log.",
+      },
+      {
+        id: "inspect-fiber-tray",
+        label: "Inspect tray and jumper seating",
+        detail:
+          "Verify strain relief and reseat any mismatched jumper pair before touching the live uplink.",
+      },
+      {
+        id: "validate-primary-return",
+        label: "Validate the primary return",
+        detail:
+          "Capture five clean minutes of traffic before retiring failover and closing the incident note.",
+      },
     ],
   },
   {
     id: "cold-chain-isolation",
     title: "Cold Chain Isolation",
-    summary: "Stabilize the vaccine storage loop during a compressor fault without warming bay inventory.",
+    summary:
+      "Stabilize the vaccine storage loop during a compressor fault without warming bay inventory.",
     team: "Facilities",
     difficulty: "Intermediate",
     status: "In Review",
@@ -84,19 +169,36 @@ export const procedures: readonly Procedure[] = [
     cadence: "Biweekly",
     location: "Lower level refrigeration plant",
     lastUpdated: "April 9, 2026",
-    notes: "Record ambient readings at each checkpoint so maintenance can compare drift later.",
-    tags: ["cold-chain", "safety", "maintenance"],
+    notes:
+      "Record ambient readings at each checkpoint so maintenance can compare drift later and decide whether the temporary cooling loop stays online.",
+    tags: ["cold-chain", "safety", "maintenance", "coordination"],
     tools: ["Thermal probe", "Valve key", "Insulated tags"],
     checklist: [
-      { id: "isolate-compressor-bank", label: "Isolate the flagged compressor bank", detail: "Close the bypass pair in sequence to prevent pressure rebound." },
-      { id: "stage-portable-cooling", label: "Stage portable cooling", detail: "Keep a clear aisle so inventory carts can still rotate through receiving." },
-      { id: "handoff-maintenance", label: "Handoff to maintenance", detail: "Attach the alarm code and your temperature notes to the ticket." },
+      {
+        id: "isolate-compressor-bank",
+        label: "Isolate the flagged compressor bank",
+        detail:
+          "Close the bypass pair in sequence to prevent pressure rebound while the escort keeps aisles clear.",
+      },
+      {
+        id: "stage-portable-cooling",
+        label: "Stage portable cooling",
+        detail:
+          "Keep a clear aisle so inventory carts can still rotate through receiving without blocking the service tech.",
+      },
+      {
+        id: "handoff-maintenance",
+        label: "Handoff to maintenance",
+        detail:
+          "Attach the alarm code and your temperature notes to the ticket before the maintenance lead takes over.",
+      },
     ],
   },
   {
     id: "dock-safety-sweep",
     title: "Dock Safety Sweep",
-    summary: "Run the opening safety sweep before inbound trailers are released to the dock.",
+    summary:
+      "Run the opening safety sweep before inbound trailers are released to the dock.",
     team: "Operations",
     difficulty: "Beginner",
     status: "Ready",
@@ -104,19 +206,36 @@ export const procedures: readonly Procedure[] = [
     cadence: "Daily open",
     location: "North receiving dock",
     lastUpdated: "April 15, 2026",
-    notes: "Treat blocked egress and cracked wheel stops as no-go findings until cleared.",
-    tags: ["safety", "handoff"],
+    notes:
+      "Treat blocked egress and cracked wheel stops as no-go findings until cleared by the lead and dispatch acknowledges the hold.",
+    tags: ["safety", "handoff", "briefing"],
     tools: ["Flashlight", "Barrier cones", "Dock checklist card"],
     checklist: [
-      { id: "inspect-lane-markings", label: "Inspect lane markings", detail: "Replace any missing cone set before opening a lane to a carrier." },
-      { id: "verify-egress-paths", label: "Verify egress paths", detail: "Clear staged pallets that drifted into the pedestrian route overnight." },
-      { id: "log-first-shift-brief", label: "Log the first-shift brief", detail: "Call out restricted lanes so dispatch does not assign them." },
+      {
+        id: "inspect-lane-markings",
+        label: "Inspect lane markings",
+        detail:
+          "Replace any missing cone set before opening a lane to a carrier and call out exceptions over the dock brief.",
+      },
+      {
+        id: "verify-egress-paths",
+        label: "Verify egress paths",
+        detail:
+          "Clear staged pallets that drifted into the pedestrian route overnight and tag the aisle if further cleanup is needed.",
+      },
+      {
+        id: "log-first-shift-brief",
+        label: "Log the first-shift brief",
+        detail:
+          "Call out restricted lanes so dispatch does not assign them and record the release time for the shift log.",
+      },
     ],
   },
   {
     id: "sensor-mast-hot-swap",
     title: "Sensor Mast Hot Swap",
-    summary: "Replace a weather mast payload while keeping the remote feed online for command.",
+    summary:
+      "Replace a weather mast payload while keeping the remote feed online for command.",
     team: "Platform",
     difficulty: "Advanced",
     status: "Ready",
@@ -124,19 +243,36 @@ export const procedures: readonly Procedure[] = [
     cadence: "Monthly",
     location: "Training lot mast array",
     lastUpdated: "April 11, 2026",
-    notes: "If the backup pod takes more than two minutes to register, abort and roll back.",
-    tags: ["telemetry", "maintenance", "rollback"],
+    notes:
+      "If the backup pod takes more than two minutes to register, abort and roll back before the mast team opens the mount.",
+    tags: ["telemetry", "maintenance", "rollback", "verification"],
     tools: ["Harness", "Spare pod", "Weather cap"],
     checklist: [
-      { id: "inspect-seal", label: "Inspect mast seal and tether line", detail: "Confirm the tether has no fraying before releasing the payload bracket." },
-      { id: "promote-backup-feed", label: "Promote the backup feed", detail: "Wait for two healthy telemetry pings before the physical swap." },
-      { id: "verify-calibration", label: "Verify live calibration", detail: "Compare readings to the nearby control mast for one minute." },
+      {
+        id: "inspect-seal",
+        label: "Inspect mast seal and tether line",
+        detail:
+          "Confirm the tether has no fraying before releasing the payload bracket or exposing the open connector.",
+      },
+      {
+        id: "promote-backup-feed",
+        label: "Promote the backup feed",
+        detail:
+          "Wait for two healthy telemetry pings before the physical swap and record the exact takeover time.",
+      },
+      {
+        id: "verify-calibration",
+        label: "Verify live calibration",
+        detail:
+          "Compare readings to the nearby control mast for one minute before declaring the mast ready for command.",
+      },
     ],
   },
   {
     id: "intake-downtime-handoff",
     title: "Intake Downtime Handoff",
-    summary: "Move specimen intake to a paper queue during LIS downtime and preserve custody notes.",
+    summary:
+      "Move specimen intake to a paper queue during LIS downtime and preserve custody notes.",
     team: "Lab",
     difficulty: "Intermediate",
     status: "Draft",
@@ -144,13 +280,356 @@ export const procedures: readonly Procedure[] = [
     cadence: "Quarterly rehearsal",
     location: "Specimen intake window",
     lastUpdated: "April 8, 2026",
-    notes: "Flag controlled samples separately so they receive immediate reconciliation after recovery.",
-    tags: ["handoff", "response"],
+    notes:
+      "Flag controlled samples separately so they receive immediate reconciliation after recovery and are visible to the post-downtime audit.",
+    tags: ["handoff", "response", "downtime", "coordination"],
     tools: ["Downtime packet", "Barcode labels", "Custody seals"],
     checklist: [
-      { id: "start-paper-log", label: "Start the paper accession log", detail: "Record the downtime start time before first intake." },
-      { id: "tag-priority-samples", label: "Tag STAT and controlled samples", detail: "Use red seals so the catch-up team can separate them quickly." },
-      { id: "handoff-recovery-sheet", label: "Handoff the reconciliation sheet", detail: "Pair each paper row with the matching downtime barcode." },
+      {
+        id: "start-paper-log",
+        label: "Start the paper accession log",
+        detail:
+          "Record the downtime start time before first intake and assign a runner to keep the queue moving.",
+      },
+      {
+        id: "tag-priority-samples",
+        label: "Tag STAT and controlled samples",
+        detail:
+          "Use red seals so the catch-up team can separate them quickly when the LIS recovers.",
+      },
+      {
+        id: "handoff-recovery-sheet",
+        label: "Handoff the reconciliation sheet",
+        detail:
+          "Pair each paper row with the matching downtime barcode before the post-recovery lead signs off.",
+      },
+    ],
+  },
+];
+
+export const savedPlaybooks: SavedPlaybook[] = [
+  {
+    id: "playbook-rooftop-link-recovery",
+    sourceProcedureId: "fiber-uplink-recovery",
+    title: "Rooftop Link Recovery Drill",
+    summary:
+      "A guided rehearsal for recovering the primary rooftop uplink while keeping comms, verification, and rollback ownership explicit.",
+    team: "Network Ops",
+    difficulty: "Advanced",
+    status: "Published",
+    rehearsalStatus: "Ready to Rehearse",
+    authoringMode: "Remix",
+    objective:
+      "Rehearse the failover-to-primary recovery flow with explicit NOC narration, packet verification, and rollback gates.",
+    audience:
+      "On-call network leads, incident coordinators, and field technicians rotating into rooftop access duty.",
+    rehearsalFocus:
+      "Escalation timing, packet-capture evidence, and the final call to retire failover without cutting over too early.",
+    duration: "30 min",
+    cadence: "Monthly live drill",
+    location: "Roof access cabinet B2",
+    lastUpdated: "April 18, 2026",
+    lastRehearsed: "April 16, 2026",
+    notes:
+      "Use the backup microwave path as the scenario anchor and insert a mock stakeholder interruption before the verify phase.",
+    tags: ["networking", "rollback", "verification", "coordination"],
+    tools: ["Loopback tester", "Spare SFP kit", "Packet capture sheet"],
+    checkpoints: [
+      "State who owns the live traffic path before any reseat begins.",
+      "Call out the packet-loss threshold that allows the primary link to return.",
+      "Confirm the rollback trigger before the final failover retirement.",
+    ],
+    metadata: {
+      version: "v1.0",
+      owner: "Mina Patel",
+      reviewers: ["Chris Lopez", "Tariq Sanders"],
+      changeSummary:
+        "Added a dedicated verification phase and clarified the rollback decision point for the rooftop team.",
+      reviewWindow: "April 17, 2026 10:00 UTC",
+      publishWindow: "April 18, 2026 15:30 UTC",
+      rehearsalWindow: "April 22, 2026 09:00 UTC",
+      lastSaved: "April 18, 2026 15:30 UTC",
+    },
+    steps: [
+      {
+        id: "roof-brief",
+        label: "Frame the fault window",
+        detail:
+          "Review the alert timeline, confirm the backup path is steady, and assign the rooftop lead before anyone touches the cabinet.",
+        phase: "Brief",
+        owner: "Incident coordinator",
+        duration: "5 min",
+        expectedSignal: "Failover path stable and rooftop access cleared",
+        rehearsalTip:
+          "Pause here and ask who can stop the drill if the backup path starts to degrade.",
+      },
+      {
+        id: "roof-reseat",
+        label: "Re-seat the primary optic path",
+        detail:
+          "Inspect the jumper pair, swap the questionable optic, and narrate each change to the remote watcher keeping packet captures.",
+        phase: "Execute",
+        owner: "Field technician",
+        duration: "12 min",
+        expectedSignal: "Primary interface returns with clean light levels",
+        rehearsalTip:
+          "Force the team to name the exact moment a rollback becomes safer than continuing the swap.",
+      },
+      {
+        id: "roof-verify",
+        label: "Retire failover with evidence",
+        detail:
+          "Capture five steady minutes, verify alerts have cleared, and close with the NOC before handing the site back.",
+        phase: "Verify",
+        owner: "NOC lead",
+        duration: "13 min",
+        expectedSignal: "Five minutes of clean traffic and cleared alerts",
+        rehearsalTip:
+          "Have the moderator challenge whether the evidence is strong enough to retire failover.",
+      },
+    ],
+  },
+  {
+    id: "playbook-cold-chain-tabletop",
+    sourceProcedureId: "cold-chain-isolation",
+    title: "Cold Chain Fault Tabletop",
+    summary:
+      "Draft tabletop script for compressor isolation, escort control, and temperature-note handoff during a cold-chain fault.",
+    team: "Facilities",
+    difficulty: "Intermediate",
+    status: "In Review",
+    rehearsalStatus: "Scheduled",
+    authoringMode: "Custom",
+    objective:
+      "Pressure-test the facilities response to a compressor fault while inventory movement and maintenance dispatch happen in parallel.",
+    audience:
+      "Facilities leads, receiving supervisors, and the maintenance scheduler supporting cold-chain incidents.",
+    rehearsalFocus:
+      "Aisle control, ambient-reading discipline, and the handoff from the escort role to the maintenance lead.",
+    duration: "24 min",
+    cadence: "Biweekly tabletop",
+    location: "Lower level refrigeration plant",
+    lastUpdated: "April 17, 2026",
+    lastRehearsed: "April 10, 2026",
+    notes:
+      "The draft still needs a clearer turn for the receiving lead when carts start backing up during the portable cooling stage.",
+    tags: ["cold-chain", "safety", "maintenance", "coordination"],
+    tools: ["Thermal probe", "Portable cooling cart", "Fault escalation card"],
+    checkpoints: [
+      "Assign an aisle escort before the compressor bank is touched.",
+      "Capture an ambient reading at each stage handoff.",
+      "Close with a maintenance-ready note set rather than a verbal-only summary.",
+    ],
+    metadata: {
+      version: "v0.7",
+      owner: "Ari Velasquez",
+      reviewers: ["Mona Reed", "Priya Iyer"],
+      changeSummary:
+        "Expanded the escort lane callouts and added receiving-side prompts before the final review pass.",
+      reviewWindow: "April 18, 2026 13:00 UTC",
+      publishWindow: "Pending review",
+      rehearsalWindow: "April 24, 2026 08:30 UTC",
+      lastSaved: "April 17, 2026 18:15 UTC",
+    },
+    steps: [
+      {
+        id: "cold-brief",
+        label: "Brief the escort lane",
+        detail:
+          "Review the alarm, assign a runner, and make sure inventory carts know which aisle remains open during the isolation.",
+        phase: "Brief",
+        owner: "Facilities lead",
+        duration: "6 min",
+        expectedSignal: "Escort route acknowledged by receiving and facilities",
+        rehearsalTip:
+          "Ask the room what happens if the aisle escort is unavailable halfway through the isolation.",
+      },
+      {
+        id: "cold-stage",
+        label: "Stage portable cooling and isolate",
+        detail:
+          "Walk through the bypass order, position portable cooling, and narrate how temperature notes are captured live.",
+        phase: "Execute",
+        owner: "Cooling tech",
+        duration: "10 min",
+        expectedSignal: "Temperature drift stays within the agreed tabletop threshold",
+        rehearsalTip:
+          "Insert a distraction from receiving so the team must decide whether to pause or continue the isolation.",
+      },
+      {
+        id: "cold-handoff",
+        label: "Handoff with maintenance-ready notes",
+        detail:
+          "Package the alarm code, ambient readings, and escort observations into the maintenance ticket and review the open questions.",
+        phase: "Verify",
+        owner: "Maintenance scheduler",
+        duration: "8 min",
+        expectedSignal: "Complete handoff packet acknowledged by maintenance",
+        rehearsalTip:
+          "Have the maintenance reviewer reject vague notes so the author sees where the script still needs work.",
+      },
+    ],
+  },
+  {
+    id: "playbook-downtime-intake-rehearsal",
+    sourceProcedureId: "intake-downtime-handoff",
+    title: "Specimen Intake Downtime Rehearsal",
+    summary:
+      "Draft playbook for paper logging, controlled-sample handling, and the recovery-sheet review after LIS downtime.",
+    team: "Lab",
+    difficulty: "Intermediate",
+    status: "Draft",
+    rehearsalStatus: "Needs Revision",
+    authoringMode: "Remix",
+    objective:
+      "Make downtime intake rehearsals consistent by clarifying who owns the paper log, red-seal marking, and final reconciliation sheet.",
+    audience:
+      "Specimen intake staff, lab leads, and the recovery coordinator who owns barcode reconciliation.",
+    rehearsalFocus:
+      "Queue clarity, controlled-sample separation, and the final reconciliation handoff once systems recover.",
+    duration: "20 min",
+    cadence: "Quarterly rehearsal",
+    location: "Specimen intake window",
+    lastUpdated: "April 19, 2026",
+    lastRehearsed: "Not yet rehearsed",
+    notes:
+      "Still missing a reviewer-approved closeout step for samples that arrived during the final five minutes of downtime.",
+    tags: ["downtime", "handoff", "response", "coordination"],
+    tools: ["Downtime packet", "Custody seals", "Runner clipboard"],
+    checkpoints: [
+      "Start the paper queue with a named owner and visible downtime start time.",
+      "Separate controlled samples from the general intake flow before the queue grows.",
+      "End with a reconciliation sheet the recovery coordinator can work from immediately.",
+    ],
+    metadata: {
+      version: "v0.3",
+      owner: "Devika Shah",
+      reviewers: ["Hannah Cho"],
+      changeSummary:
+        "Added a runner role, clarified sample segregation, and left the recovery closeout open for reviewer feedback.",
+      reviewWindow: "April 21, 2026 11:00 UTC",
+      publishWindow: "Pending review",
+      rehearsalWindow: "TBD after reviewer sign-off",
+      lastSaved: "April 19, 2026 20:45 UTC",
+    },
+    steps: [
+      {
+        id: "lab-brief",
+        label: "Assign the downtime runner",
+        detail:
+          "Review the outage start time, assign the paper-log owner, and place the runner where incoming samples can still be triaged.",
+        phase: "Brief",
+        owner: "Intake lead",
+        duration: "5 min",
+        expectedSignal: "Paper queue launched with visible ownership",
+        rehearsalTip:
+          "Ask who notices first if the paper log stops matching the physical queue.",
+      },
+      {
+        id: "lab-tag",
+        label: "Separate controlled and STAT samples",
+        detail:
+          "Use red seals, announce priority samples aloud, and walk through how the runner keeps the queue from mixing.",
+        phase: "Execute",
+        owner: "Runner",
+        duration: "8 min",
+        expectedSignal: "Priority samples are visibly separated and logged",
+        rehearsalTip:
+          "Introduce a late-arriving STAT sample to confirm the team keeps the same cadence under pressure.",
+      },
+      {
+        id: "lab-verify",
+        label: "Review the recovery sheet",
+        detail:
+          "Stage the reconciliation sheet, pair rows to downtime barcodes, and note the unresolved edge cases for the recovery lead.",
+        phase: "Verify",
+        owner: "Recovery coordinator",
+        duration: "7 min",
+        expectedSignal: "Recovery coordinator accepts the sheet without clarifying questions",
+        rehearsalTip:
+          "Have the reviewer point out the missing final five-minute closeout to justify the current draft status.",
+      },
+    ],
+  },
+  {
+    id: "playbook-dock-lane-reopen",
+    sourceProcedureId: "dock-safety-sweep",
+    title: "Dock Lane Reopen Review",
+    summary:
+      "Published playbook for opening-shift dock sweeps with explicit lane release language and dispatch acknowledgment.",
+    team: "Operations",
+    difficulty: "Beginner",
+    status: "Published",
+    rehearsalStatus: "Scheduled",
+    authoringMode: "Custom",
+    objective:
+      "Keep opening-shift safety sweeps consistent by making the release, restriction, and dispatch acknowledgment sequence explicit.",
+    audience:
+      "Dock leads, dispatch coordinators, and floor supervisors covering the first inbound window.",
+    rehearsalFocus:
+      "Release authority, lane restrictions, and how exceptions get carried into the first-shift brief.",
+    duration: "15 min",
+    cadence: "Weekly rehearsal",
+    location: "North receiving dock",
+    lastUpdated: "April 14, 2026",
+    lastRehearsed: "April 14, 2026",
+    notes:
+      "Works well as a starter playbook because it keeps the choreography simple while still testing release authority.",
+    tags: ["safety", "briefing", "handoff"],
+    tools: ["Barrier cones", "Release board", "Shift note card"],
+    checkpoints: [
+      "Make the first lane release audible to dispatch.",
+      "Keep restricted lanes visibly marked through the shift brief.",
+      "Log who acknowledges the release before trucks are assigned.",
+    ],
+    metadata: {
+      version: "v1.2",
+      owner: "Luis Moreno",
+      reviewers: ["Cara Bell", "Jordan Hunt"],
+      changeSummary:
+        "Tightened the dispatch acknowledgment wording and added a visible release board checkpoint.",
+      reviewWindow: "April 11, 2026 09:00 UTC",
+      publishWindow: "April 14, 2026 12:00 UTC",
+      rehearsalWindow: "April 25, 2026 07:00 UTC",
+      lastSaved: "April 14, 2026 12:00 UTC",
+    },
+    steps: [
+      {
+        id: "dock-brief",
+        label: "Set the release board",
+        detail:
+          "Mark restricted lanes, confirm cones are in place, and name the person who will call the first release to dispatch.",
+        phase: "Brief",
+        owner: "Dock lead",
+        duration: "4 min",
+        expectedSignal: "Visible release board matches the floor state",
+        rehearsalTip:
+          "Ask the group which restriction would stop the first release entirely.",
+      },
+      {
+        id: "dock-execute",
+        label: "Walk and release the safe lanes",
+        detail:
+          "Inspect egress paths, check wheel stops, and announce the safe lanes with the same language used in production.",
+        phase: "Execute",
+        owner: "Floor supervisor",
+        duration: "6 min",
+        expectedSignal: "Dispatch repeats the released lanes back without correction",
+        rehearsalTip:
+          "Insert an interrupted radio call so the release language has to be repeated cleanly.",
+      },
+      {
+        id: "dock-verify",
+        label: "Close in the first-shift brief",
+        detail:
+          "Carry any restrictions into the first-shift brief and confirm the shift log matches the release board before trucks arrive.",
+        phase: "Verify",
+        owner: "Dispatch coordinator",
+        duration: "5 min",
+        expectedSignal: "Shift log and release board stay in sync",
+        rehearsalTip:
+          "Have the moderator ask whether the log alone is enough without the release board.",
+      },
     ],
   },
 ];

--- a/src/components/field-guide/field-guide-shell.test.tsx
+++ b/src/components/field-guide/field-guide-shell.test.tsx
@@ -4,22 +4,39 @@ import { describe, expect, it } from "vitest";
 import FieldGuideShell from "@/components/field-guide/field-guide-shell";
 
 describe("FieldGuideShell", () => {
-  it("filters procedures by title or summary", () => {
+  it("filters saved playbooks and procedures with the richer library controls", () => {
     render(<FieldGuideShell />);
 
-    fireEvent.change(screen.getByLabelText("Search procedures"), {
-      target: { value: "weather mast" },
+    fireEvent.change(screen.getByLabelText("Playbook status"), {
+      target: { value: "Draft" },
+    });
+    fireEvent.change(screen.getByLabelText("Tags"), {
+      target: { value: "downtime" },
     });
 
     expect(
-      screen.getByRole("button", { name: "Open procedure: Sensor Mast Hot Swap" }),
+      screen.getByRole("button", {
+        name: "Review playbook: Specimen Intake Downtime Rehearsal",
+      }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Open procedure: Dock Safety Sweep" }),
+      screen.queryByRole("button", {
+        name: "Review playbook: Rooftop Link Recovery Drill",
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Open procedure: Intake Downtime Handoff",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: "Open procedure: Dock Safety Sweep",
+      }),
     ).not.toBeInTheDocument();
   });
 
-  it("shows an empty state when filters remove every procedure", () => {
+  it("shows a combined empty state when search removes procedures and playbooks", () => {
     render(<FieldGuideShell />);
 
     fireEvent.change(screen.getByLabelText("Search procedures"), {
@@ -27,11 +44,11 @@ describe("FieldGuideShell", () => {
     });
 
     expect(
-      screen.getByText("No procedures match the current search or filters."),
+      screen.getByText("No procedures or playbooks match the current search."),
     ).toBeInTheDocument();
   });
 
-  it("tracks checklist completion for the active procedure", () => {
+  it("tracks checklist completion for the selected procedure template", () => {
     render(<FieldGuideShell />);
 
     fireEvent.click(
@@ -46,5 +63,63 @@ describe("FieldGuideShell", () => {
 
     expect(checkbox).toBeChecked();
     expect(screen.getAllByText("1 of 3 steps complete")).toHaveLength(2);
+  });
+
+  it("authors and saves a new draft playbook", async () => {
+    render(<FieldGuideShell />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Authoring studio" }));
+    fireEvent.change(screen.getByLabelText("Playbook title"), {
+      target: { value: "Network Escalation Remix" },
+    });
+    fireEvent.change(screen.getByLabelText("Owner"), {
+      target: { value: "Jordan Hale" },
+    });
+    fireEvent.change(screen.getByLabelText("Step 1 label"), {
+      target: { value: "Stage comms bridge" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save draft" }));
+    fireEvent.click(screen.getByRole("button", { name: "Field library" }));
+
+    expect(
+      await screen.findByRole("button", {
+        name: "Review playbook: Network Escalation Remix",
+      }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Review playbook: Network Escalation Remix",
+      }),
+    );
+
+    expect(screen.getByText("Jordan Hale")).toBeInTheDocument();
+    expect(screen.getByText(/Stage comms bridge/)).toBeInTheDocument();
+  });
+
+  it("publishes a playbook and shows the authored rehearsal preview", async () => {
+    render(<FieldGuideShell />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Authoring studio" }));
+    fireEvent.change(screen.getByLabelText("Playbook title"), {
+      target: { value: "Telemetry Shadow Drill" },
+    });
+    fireEvent.change(screen.getByLabelText("Step 1 label"), {
+      target: { value: "Brief comms and observers" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add rehearsal step" }));
+    fireEvent.change(screen.getByLabelText("Step 4 label"), {
+      target: { value: "Run final moderator recap" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Publish playbook" }));
+
+    expect(
+      await screen.findByRole("button", {
+        name: "Review playbook: Telemetry Shadow Drill",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Ready to Rehearse").length).toBeGreaterThan(0);
+    expect(screen.getByText(/Brief comms and observers/)).toBeInTheDocument();
+    expect(screen.getByText(/Run final moderator recap/)).toBeInTheDocument();
   });
 });

--- a/src/components/field-guide/field-guide-shell.tsx
+++ b/src/components/field-guide/field-guide-shell.tsx
@@ -3,71 +3,209 @@
 import { startTransition, useDeferredValue, useState } from "react";
 
 import {
+  playbookStatuses,
   procedureDifficulties,
-  procedures,
   procedureStatuses,
+  procedures,
+  procedureTags,
   procedureTeams,
+  rehearsalStatuses,
+  savedPlaybooks,
+  type PlaybookStatus,
+  type SavedPlaybook,
 } from "@/components/field-guide/field-guide-data";
 import GuideFilters from "@/components/field-guide/guide-filters";
 import GuideSearch from "@/components/field-guide/guide-search";
+import PlaybookCard from "@/components/field-guide/playbook-card";
+import PlaybookEditor from "@/components/field-guide/playbook-editor";
+import PlaybookReviewPanel from "@/components/field-guide/playbook-review-panel";
 import ProcedureCard from "@/components/field-guide/procedure-card";
 import ProcedureDrawer from "@/components/field-guide/procedure-drawer";
+import {
+  advanceVersion,
+  buildDraftPlaybook,
+  clonePlaybook,
+  createEmptyStep,
+  createPlaybookId,
+  getDefaultDraftPlaybook,
+  getProcedureById,
+  getSourceProcedure,
+  parseCommaSeparatedList,
+  parseLineSeparatedList,
+} from "@/components/field-guide/field-guide-utils";
 
 type ChecklistState = Record<string, Record<string, boolean>>;
 
+type SurfaceMode = "library" | "authoring";
+
+type ReviewSelection =
+  | {
+      id: string;
+      kind: "playbook" | "procedure";
+    }
+  | null;
+
+const SAVED_TIMESTAMP = "April 20, 2026 09:00 UTC";
+const PUBLISHED_TIMESTAMP = "April 20, 2026 12:00 UTC";
+const DISPLAY_DATE = "April 20, 2026";
+
+function matchesQuery(query: string, values: string[]) {
+  if (query.length === 0) {
+    return true;
+  }
+
+  return values.some((value) => value.toLowerCase().includes(query));
+}
+
+function EmptyState({
+  body,
+  eyebrow,
+  title,
+}: {
+  body: string;
+  eyebrow: string;
+  title: string;
+}) {
+  return (
+    <div className="rounded-[1.75rem] border border-dashed border-slate-300 bg-white/80 p-8 text-center shadow-lg shadow-slate-200/40">
+      <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">
+        {eyebrow}
+      </p>
+      <h2 className="mt-3 text-2xl font-semibold text-slate-950">{title}</h2>
+      <p className="mt-3 text-sm leading-6 text-slate-600">{body}</p>
+    </div>
+  );
+}
+
 export default function FieldGuideShell() {
+  const [surfaceMode, setSurfaceMode] = useState<SurfaceMode>("library");
   const [query, setQuery] = useState("");
   const [selectedTeam, setSelectedTeam] = useState("all");
   const [selectedDifficulty, setSelectedDifficulty] = useState("all");
   const [selectedStatus, setSelectedStatus] = useState("all");
-  const [selectedProcedureId, setSelectedProcedureId] = useState<string | null>(
-    procedures[0]?.id ?? null,
+  const [selectedPlaybookStatus, setSelectedPlaybookStatus] = useState("all");
+  const [selectedTag, setSelectedTag] = useState("all");
+  const [reviewSelection, setReviewSelection] = useState<ReviewSelection>(
+    savedPlaybooks[0]
+      ? { id: savedPlaybooks[0].id, kind: "playbook" }
+      : procedures[0]
+        ? { id: procedures[0].id, kind: "procedure" }
+        : null,
   );
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [checklistState, setChecklistState] = useState<ChecklistState>({});
+  const [savedPlaybookState, setSavedPlaybookState] = useState<SavedPlaybook[]>(
+    () => savedPlaybooks.map((playbook) => clonePlaybook(playbook)),
+  );
+  const [draftPlaybook, setDraftPlaybook] = useState<SavedPlaybook>(() =>
+    getDefaultDraftPlaybook(),
+  );
 
   const deferredQuery = useDeferredValue(query);
   const normalizedQuery = deferredQuery.trim().toLowerCase();
 
   const filteredProcedures = procedures.filter((procedure) => {
-    const matchesQuery =
-      normalizedQuery.length === 0 ||
-      procedure.title.toLowerCase().includes(normalizedQuery) ||
-      procedure.summary.toLowerCase().includes(normalizedQuery);
-    const matchesTeam =
+    const queryMatch = matchesQuery(normalizedQuery, [
+      procedure.title,
+      procedure.summary,
+      procedure.notes,
+      ...procedure.tags,
+      ...procedure.tools,
+      ...procedure.checklist.map((step) => step.label),
+    ]);
+    const teamMatch =
       selectedTeam === "all" || procedure.team === selectedTeam;
-    const matchesDifficulty =
+    const difficultyMatch =
       selectedDifficulty === "all" || procedure.difficulty === selectedDifficulty;
-    const matchesStatus =
+    const statusMatch =
       selectedStatus === "all" || procedure.status === selectedStatus;
+    const tagMatch =
+      selectedTag === "all" || procedure.tags.includes(selectedTag);
 
-    return matchesQuery && matchesTeam && matchesDifficulty && matchesStatus;
+    return (
+      queryMatch &&
+      teamMatch &&
+      difficultyMatch &&
+      statusMatch &&
+      tagMatch
+    );
   });
 
-  const activeProcedureId = filteredProcedures.some(
-    (procedure) => procedure.id === selectedProcedureId,
-  )
-    ? selectedProcedureId
-    : (filteredProcedures[0]?.id ?? null);
+  const filteredPlaybooks = savedPlaybookState.filter((playbook) => {
+    const sourceProcedure = getSourceProcedure(playbook);
+    const queryMatch = matchesQuery(normalizedQuery, [
+      playbook.title,
+      playbook.summary,
+      playbook.objective,
+      playbook.audience,
+      playbook.rehearsalFocus,
+      playbook.notes,
+      playbook.metadata.owner,
+      ...playbook.metadata.reviewers,
+      ...playbook.tags,
+      ...playbook.tools,
+      ...playbook.steps.map((step) => step.label),
+      ...playbook.steps.map((step) => step.detail),
+      sourceProcedure?.title ?? "",
+    ]);
+    const teamMatch =
+      selectedTeam === "all" || playbook.team === selectedTeam;
+    const difficultyMatch =
+      selectedDifficulty === "all" || playbook.difficulty === selectedDifficulty;
+    const statusMatch =
+      selectedPlaybookStatus === "all" || playbook.status === selectedPlaybookStatus;
+    const tagMatch =
+      selectedTag === "all" || playbook.tags.includes(selectedTag);
 
-  const activeProcedure =
-    filteredProcedures.find((procedure) => procedure.id === activeProcedureId) ??
-    null;
-  const drawerIsOpen =
-    isDrawerOpen && selectedProcedureId === activeProcedureId && activeProcedure !== null;
+    return queryMatch && teamMatch && difficultyMatch && statusMatch && tagMatch;
+  });
 
   const hasActiveFilters =
     query.length > 0 ||
     selectedTeam !== "all" ||
     selectedDifficulty !== "all" ||
-    selectedStatus !== "all";
+    selectedStatus !== "all" ||
+    selectedPlaybookStatus !== "all" ||
+    selectedTag !== "all";
 
-  const handleSelectProcedure = (procedureId: string) => {
-    startTransition(() => {
-      setSelectedProcedureId(procedureId);
-      setIsDrawerOpen(true);
-    });
-  };
+  const defaultSelection: ReviewSelection = filteredPlaybooks[0]
+    ? { id: filteredPlaybooks[0].id, kind: "playbook" }
+    : filteredProcedures[0]
+      ? { id: filteredProcedures[0].id, kind: "procedure" }
+      : null;
+
+  const reviewSelectionStillVisible =
+    reviewSelection?.kind === "playbook"
+      ? filteredPlaybooks.some((playbook) => playbook.id === reviewSelection.id)
+      : filteredProcedures.some(
+          (procedure) => procedure.id === reviewSelection?.id,
+        );
+
+  const resolvedSelection =
+    reviewSelection && reviewSelectionStillVisible
+      ? reviewSelection
+      : defaultSelection;
+
+  const activePlaybook =
+    resolvedSelection?.kind === "playbook"
+      ? filteredPlaybooks.find(
+          (playbook) => playbook.id === resolvedSelection.id,
+        ) ?? null
+      : null;
+
+  const activeProcedure =
+    resolvedSelection?.kind === "procedure"
+      ? filteredProcedures.find(
+          (procedure) => procedure.id === resolvedSelection.id,
+        ) ?? null
+      : null;
+
+  const draftSourceProcedure = getProcedureById(draftPlaybook.sourceProcedureId);
+  const draftQueueCount = savedPlaybookState.filter(
+    (playbook) => playbook.status !== "Published",
+  ).length;
+  const publishedCount = savedPlaybookState.filter(
+    (playbook) => playbook.status === "Published",
+  ).length;
 
   const handleToggleStep = (procedureId: string, stepId: string) => {
     startTransition(() => {
@@ -86,72 +224,462 @@ export default function FieldGuideShell() {
     setSelectedTeam("all");
     setSelectedDifficulty("all");
     setSelectedStatus("all");
+    setSelectedPlaybookStatus("all");
+    setSelectedTag("all");
   };
 
-  return (
-    <section className="grid gap-6 lg:grid-cols-[minmax(0,1.15fr)_minmax(22rem,0.85fr)]">
-      <div className="space-y-5">
-        <GuideSearch
-          onQueryChange={setQuery}
-          query={query}
-          resultCount={filteredProcedures.length}
-          totalCount={procedures.length}
-        />
-        <GuideFilters
-          difficulties={procedureDifficulties}
-          hasActiveFilters={hasActiveFilters}
-          onClear={handleClearFilters}
-          onDifficultyChange={setSelectedDifficulty}
-          onStatusChange={setSelectedStatus}
-          onTeamChange={setSelectedTeam}
-          selectedDifficulty={selectedDifficulty}
-          selectedStatus={selectedStatus}
-          selectedTeam={selectedTeam}
-          statuses={procedureStatuses}
-          teams={procedureTeams}
-        />
-        {filteredProcedures.length > 0 ? (
-          <div className="grid gap-4 md:grid-cols-2">
-            {filteredProcedures.map((procedure) => {
-              const completedCount = procedure.checklist.filter(
-                (step) => checklistState[procedure.id]?.[step.id],
-              ).length;
+  const handleLoadDraftFromProcedure = (procedureId: string) => {
+    const procedure = getProcedureById(procedureId);
 
-              return (
-                <ProcedureCard
-                  completedCount={completedCount}
-                  isSelected={procedure.id === activeProcedureId}
-                  key={procedure.id}
-                  onSelect={handleSelectProcedure}
-                  procedure={procedure}
-                />
-              );
-            })}
-          </div>
-        ) : (
-          <div className="rounded-[1.75rem] border border-dashed border-slate-300 bg-white/80 p-8 text-center shadow-lg shadow-slate-200/40">
+    if (!procedure) {
+      return;
+    }
+
+    startTransition(() => {
+      setDraftPlaybook(buildDraftPlaybook(procedure));
+    });
+  };
+
+  const handleLoadSavedPlaybook = (playbookId: string) => {
+    const playbook =
+      savedPlaybookState.find((entry) => entry.id === playbookId) ?? null;
+
+    if (!playbook) {
+      return;
+    }
+
+    startTransition(() => {
+      setSurfaceMode("authoring");
+      setDraftPlaybook(clonePlaybook(playbook));
+      setReviewSelection({ id: playbook.id, kind: "playbook" });
+    });
+  };
+
+  const handlePersistDraft = (nextStatus: PlaybookStatus) => {
+    const sourceProcedure =
+      getProcedureById(draftPlaybook.sourceProcedureId) ?? procedures[0];
+
+    if (!sourceProcedure) {
+      return;
+    }
+
+    const existingIds = savedPlaybookState.map((playbook) => playbook.id);
+    const resolvedId = createPlaybookId(
+      draftPlaybook.title,
+      existingIds,
+      draftPlaybook.id.startsWith("draft-") ? undefined : draftPlaybook.id,
+    );
+
+    const persistedPlaybook: SavedPlaybook = {
+      ...clonePlaybook(draftPlaybook),
+      id: resolvedId,
+      sourceProcedureId: sourceProcedure.id,
+      team: sourceProcedure.team,
+      difficulty: sourceProcedure.difficulty,
+      status: nextStatus,
+      rehearsalStatus:
+        nextStatus === "Published"
+          ? "Ready to Rehearse"
+          : draftPlaybook.rehearsalStatus,
+      lastUpdated: DISPLAY_DATE,
+      metadata: {
+        ...draftPlaybook.metadata,
+        version: advanceVersion(draftPlaybook.metadata.version, nextStatus),
+        lastSaved:
+          nextStatus === "Published" ? PUBLISHED_TIMESTAMP : SAVED_TIMESTAMP,
+        publishWindow:
+          nextStatus === "Published"
+            ? PUBLISHED_TIMESTAMP
+            : draftPlaybook.metadata.publishWindow,
+      },
+    };
+
+    setSavedPlaybookState((currentPlaybooks) => {
+      if (currentPlaybooks.some((playbook) => playbook.id === resolvedId)) {
+        return currentPlaybooks.map((playbook) =>
+          playbook.id === resolvedId ? persistedPlaybook : playbook,
+        );
+      }
+
+      return [persistedPlaybook, ...currentPlaybooks];
+    });
+
+    startTransition(() => {
+      setDraftPlaybook(clonePlaybook(persistedPlaybook));
+      setReviewSelection({ id: persistedPlaybook.id, kind: "playbook" });
+
+      if (nextStatus === "Published") {
+        setSurfaceMode("library");
+      }
+    });
+  };
+
+  const visibleProcedureCount = filteredProcedures.length;
+  const visiblePlaybookCount = filteredPlaybooks.length;
+  const searchSummary = `Showing ${visibleProcedureCount} of ${procedures.length} procedures and ${visiblePlaybookCount} of ${savedPlaybookState.length} saved playbooks`;
+  const helperText =
+    "Search checks summaries, notes, reviewer names, and authored step content while all filters stay entirely client-side.";
+
+  return (
+    <section className="space-y-6">
+      <section className="rounded-[1.75rem] border border-slate-200/70 bg-white/90 p-5 shadow-lg shadow-slate-200/50">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
             <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">
-              No results
+              Field guide modes
             </p>
-            <h2 className="mt-3 text-2xl font-semibold text-slate-950">
-              No procedures match the current search or filters.
+            <h2 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">
+              Move between review and authoring without leaving the route
             </h2>
-            <p className="mt-3 text-sm leading-6 text-slate-600">
-              Clear one or more filters to reopen the mock library and restore
-              the checklist drawer.
+            <p className="mt-3 max-w-2xl text-sm leading-7 text-slate-600">
+              The library keeps published guidance visible while the authoring
+              studio supports local draft edits, reviewer metadata, and live
+              rehearsal previews.
             </p>
           </div>
-        )}
-      </div>
-      <ProcedureDrawer
-        completedSteps={
-          activeProcedure ? checklistState[activeProcedure.id] : undefined
-        }
-        isOpen={drawerIsOpen}
-        onClose={() => setIsDrawerOpen(false)}
-        onToggleStep={handleToggleStep}
-        procedure={activeProcedure}
-      />
+          <div className="inline-flex rounded-full bg-slate-100 p-1">
+            <button
+              aria-pressed={surfaceMode === "library"}
+              className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                surfaceMode === "library"
+                  ? "bg-slate-950 text-white"
+                  : "text-slate-600 hover:text-slate-950"
+              }`}
+              onClick={() => startTransition(() => setSurfaceMode("library"))}
+              type="button"
+            >
+              Field library
+            </button>
+            <button
+              aria-pressed={surfaceMode === "authoring"}
+              className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                surfaceMode === "authoring"
+                  ? "bg-slate-950 text-white"
+                  : "text-slate-600 hover:text-slate-950"
+              }`}
+              onClick={() => startTransition(() => setSurfaceMode("authoring"))}
+              type="button"
+            >
+              Authoring studio
+            </button>
+          </div>
+        </div>
+        <div className="mt-5 grid gap-4 md:grid-cols-3">
+          <div className="rounded-3xl bg-slate-950 px-5 py-4 text-slate-50">
+            <p className="text-sm text-slate-300">Saved playbooks</p>
+            <p className="mt-2 text-3xl font-semibold">{savedPlaybookState.length}</p>
+          </div>
+          <div className="rounded-3xl bg-amber-100 px-5 py-4 text-amber-950">
+            <p className="text-sm text-amber-700">Draft queue</p>
+            <p className="mt-2 text-3xl font-semibold">{draftQueueCount}</p>
+          </div>
+          <div className="rounded-3xl bg-sky-100 px-5 py-4 text-sky-950">
+            <p className="text-sm text-sky-700">Published</p>
+            <p className="mt-2 text-3xl font-semibold">{publishedCount}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(22rem,0.9fr)]">
+        <div className="space-y-5">
+          <GuideSearch
+            helperText={helperText}
+            onQueryChange={setQuery}
+            query={query}
+            resultSummary={searchSummary}
+          />
+          <GuideFilters
+            difficulties={procedureDifficulties}
+            hasActiveFilters={hasActiveFilters}
+            onClear={handleClearFilters}
+            onDifficultyChange={setSelectedDifficulty}
+            onPlaybookStatusChange={setSelectedPlaybookStatus}
+            onStatusChange={setSelectedStatus}
+            onTagChange={setSelectedTag}
+            onTeamChange={setSelectedTeam}
+            playbookStatuses={playbookStatuses}
+            selectedDifficulty={selectedDifficulty}
+            selectedPlaybookStatus={selectedPlaybookStatus}
+            selectedStatus={selectedStatus}
+            selectedTag={selectedTag}
+            selectedTeam={selectedTeam}
+            statuses={procedureStatuses}
+            tags={procedureTags}
+            teams={procedureTeams}
+          />
+
+          {surfaceMode === "library" ? (
+            <>
+              {filteredPlaybooks.length === 0 && filteredProcedures.length === 0 ? (
+                <EmptyState
+                  body="Clear one or more filters to reopen the saved playbook queue and the procedure template library."
+                  eyebrow="No results"
+                  title="No procedures or playbooks match the current search."
+                />
+              ) : null}
+
+              {filteredPlaybooks.length > 0 ? (
+                <section className="space-y-4">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">
+                        Saved playbooks
+                      </p>
+                      <p className="mt-2 text-sm leading-6 text-slate-600">
+                        Review draft and published playbooks without leaving the
+                        field guide route.
+                      </p>
+                    </div>
+                  </div>
+                  <div className="grid gap-4">
+                    {filteredPlaybooks.map((playbook) => (
+                      <PlaybookCard
+                        isSelected={resolvedSelection?.id === playbook.id}
+                        key={playbook.id}
+                        onSelect={(playbookId) =>
+                          startTransition(() =>
+                            setReviewSelection({
+                              id: playbookId,
+                              kind: "playbook",
+                            }),
+                          )
+                        }
+                        playbook={playbook}
+                        sourceTitle={
+                          getSourceProcedure(playbook)?.title ?? "Custom flow"
+                        }
+                      />
+                    ))}
+                  </div>
+                </section>
+              ) : null}
+
+              {filteredProcedures.length > 0 ? (
+                <section className="space-y-4">
+                  <div>
+                    <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">
+                      Procedure templates
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-slate-600">
+                      Use the existing procedures as source material for new
+                      playbooks or continue using the checklist view.
+                    </p>
+                  </div>
+                  <div className="grid gap-4 md:grid-cols-2">
+                    {filteredProcedures.map((procedure) => {
+                      const completedCount = procedure.checklist.filter(
+                        (step) => checklistState[procedure.id]?.[step.id],
+                      ).length;
+
+                      return (
+                        <ProcedureCard
+                          completedCount={completedCount}
+                          isSelected={resolvedSelection?.id === procedure.id}
+                          key={procedure.id}
+                          onSelect={(procedureId) =>
+                            startTransition(() =>
+                              setReviewSelection({
+                                id: procedureId,
+                                kind: "procedure",
+                              }),
+                            )
+                          }
+                          procedure={procedure}
+                        />
+                      );
+                    })}
+                  </div>
+                </section>
+              ) : null}
+            </>
+          ) : (
+            <PlaybookEditor
+              draftPlaybook={draftPlaybook}
+              onAddStep={() =>
+                setDraftPlaybook((currentPlaybook) => ({
+                  ...currentPlaybook,
+                  steps: [
+                    ...currentPlaybook.steps,
+                    createEmptyStep(currentPlaybook.steps.length),
+                  ],
+                }))
+              }
+              onCheckpointsChange={(value) =>
+                setDraftPlaybook((currentPlaybook) => ({
+                  ...currentPlaybook,
+                  checkpoints: parseLineSeparatedList(value),
+                }))
+              }
+              onCreateNew={() => handleLoadDraftFromProcedure(procedures[0]?.id ?? "")}
+              onListChange={(field, value) =>
+                setDraftPlaybook((currentPlaybook) => ({
+                  ...currentPlaybook,
+                  [field]: parseCommaSeparatedList(value),
+                }))
+              }
+              onMetadataFieldChange={(field, value) =>
+                setDraftPlaybook((currentPlaybook) => ({
+                  ...currentPlaybook,
+                  metadata: {
+                    ...currentPlaybook.metadata,
+                    [field]: value,
+                  },
+                }))
+              }
+              onPublishPlaybook={() => handlePersistDraft("Published")}
+              onRehearsalStatusChange={(status) =>
+                setDraftPlaybook((currentPlaybook) => ({
+                  ...currentPlaybook,
+                  rehearsalStatus: status,
+                }))
+              }
+              onReviewersChange={(value) =>
+                setDraftPlaybook((currentPlaybook) => ({
+                  ...currentPlaybook,
+                  metadata: {
+                    ...currentPlaybook.metadata,
+                    reviewers: parseCommaSeparatedList(value),
+                  },
+                }))
+              }
+              onSaveDraft={() =>
+                handlePersistDraft(
+                  draftPlaybook.status === "Published"
+                    ? "In Review"
+                    : draftPlaybook.status,
+                )
+              }
+              onSelectProcedure={handleLoadDraftFromProcedure}
+              onStatusChange={(status) =>
+                setDraftPlaybook((currentPlaybook) => ({
+                  ...currentPlaybook,
+                  status,
+                }))
+              }
+              onStepFieldChange={(stepId, field, value) =>
+                setDraftPlaybook((currentPlaybook) => ({
+                  ...currentPlaybook,
+                  steps: currentPlaybook.steps.map((step) =>
+                    step.id === stepId ? { ...step, [field]: value } : step,
+                  ),
+                }))
+              }
+              onStepRemove={(stepId) =>
+                setDraftPlaybook((currentPlaybook) => ({
+                  ...currentPlaybook,
+                  steps:
+                    currentPlaybook.steps.length > 1
+                      ? currentPlaybook.steps.filter((step) => step.id !== stepId)
+                      : currentPlaybook.steps,
+                }))
+              }
+              onTextFieldChange={(field, value) =>
+                setDraftPlaybook((currentPlaybook) => ({
+                  ...currentPlaybook,
+                  [field]: value,
+                }))
+              }
+              procedures={procedures}
+              rehearsalStatuses={rehearsalStatuses}
+              statuses={playbookStatuses}
+            />
+          )}
+        </div>
+
+        <div className="space-y-6">
+          {surfaceMode === "library" ? (
+            activePlaybook ? (
+              <PlaybookReviewPanel
+                playbook={activePlaybook}
+                sourceProcedure={getSourceProcedure(activePlaybook)}
+              />
+            ) : activeProcedure ? (
+              <ProcedureDrawer
+                completedSteps={checklistState[activeProcedure.id]}
+                isOpen
+                onClose={() =>
+                  startTransition(() =>
+                    setReviewSelection(
+                      filteredPlaybooks[0]
+                        ? { id: filteredPlaybooks[0].id, kind: "playbook" }
+                        : null,
+                    ),
+                  )
+                }
+                onToggleStep={handleToggleStep}
+                procedure={activeProcedure}
+              />
+            ) : (
+              <EmptyState
+                body="Clear the filters or switch to authoring mode to start a new playbook draft."
+                eyebrow="Review panel"
+                title="Nothing is currently available to review."
+              />
+            )
+          ) : (
+            <>
+              <section className="rounded-[1.75rem] border border-slate-200/70 bg-white/95 p-5 shadow-lg shadow-slate-200/40">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">
+                      Saved queue
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-slate-600">
+                      Load an existing draft or published playbook into the
+                      editor without leaving authoring mode.
+                    </p>
+                  </div>
+                  <span className="rounded-full bg-slate-950 px-3 py-1 text-xs font-semibold text-slate-50">
+                    {filteredPlaybooks.length} visible
+                  </span>
+                </div>
+                <div className="mt-4 space-y-3">
+                  {filteredPlaybooks.length > 0 ? (
+                    filteredPlaybooks.map((playbook) => (
+                      <button
+                        aria-label={`Load playbook: ${playbook.title}`}
+                        className={`w-full rounded-3xl border p-4 text-left transition ${
+                          draftPlaybook.id === playbook.id
+                            ? "border-sky-300 bg-sky-50"
+                            : "border-slate-200 bg-slate-50 hover:border-slate-300 hover:bg-white"
+                        }`}
+                        key={playbook.id}
+                        onClick={() => handleLoadSavedPlaybook(playbook.id)}
+                        type="button"
+                      >
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                          <div>
+                            <p className="text-sm font-semibold text-slate-950">
+                              {playbook.title}
+                            </p>
+                            <p className="mt-2 text-sm text-slate-600">
+                              {playbook.status} · {playbook.metadata.version}
+                            </p>
+                          </div>
+                          <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-600">
+                            {playbook.metadata.lastSaved}
+                          </span>
+                        </div>
+                      </button>
+                    ))
+                  ) : (
+                    <p className="rounded-3xl border border-dashed border-slate-300 bg-slate-50 px-4 py-5 text-sm leading-6 text-slate-600">
+                      No saved playbooks match the current filters. Clear the
+                      filters or save the current draft to refill the queue.
+                    </p>
+                  )}
+                </div>
+              </section>
+              <PlaybookReviewPanel
+                description="Live preview of the in-progress draft, including source context, metadata, and the rehearsal flow that will be saved next."
+                heading="Draft review"
+                playbook={draftPlaybook}
+                sourceProcedure={draftSourceProcedure}
+              />
+            </>
+          )}
+        </div>
+      </section>
     </section>
   );
 }

--- a/src/components/field-guide/field-guide-utils.ts
+++ b/src/components/field-guide/field-guide-utils.ts
@@ -1,0 +1,191 @@
+import {
+  type PlaybookStatus,
+  type PlaybookStep,
+  type PlaybookStepPhase,
+  type Procedure,
+  type ProcedureStep,
+  procedures,
+  savedPlaybooks,
+  type SavedPlaybook,
+} from "@/components/field-guide/field-guide-data";
+
+const PHASES: PlaybookStepPhase[] = ["Brief", "Execute", "Verify"];
+const TODAY = "April 20, 2026";
+const NOW = "April 20, 2026 09:00 UTC";
+
+function getStepPhase(index: number, total: number): PlaybookStepPhase {
+  if (index === 0) {
+    return "Brief";
+  }
+
+  if (index === total - 1) {
+    return "Verify";
+  }
+
+  return "Execute";
+}
+
+function buildSeedStep(step: ProcedureStep, index: number, total: number): PlaybookStep {
+  const phase = getStepPhase(index, total);
+
+  return {
+    id: `draft-step-${index + 1}`,
+    label: step.label,
+    detail: step.detail,
+    phase,
+    owner:
+      phase === "Brief"
+        ? "Scenario lead"
+        : phase === "Verify"
+          ? "Reviewer"
+          : "Operator",
+    duration: phase === "Execute" ? "6 min" : "4 min",
+    expectedSignal:
+      phase === "Brief"
+        ? "Owners and conditions confirmed"
+        : phase === "Verify"
+          ? "Evidence accepted and next action named"
+          : "Scenario team can advance without rework",
+    rehearsalTip:
+      phase === "Execute"
+        ? "Interrupt the step once to confirm the owner can restate the intent."
+        : "Ask the room who would block progress if this step was unclear.",
+  };
+}
+
+export function getProcedureById(procedureId: string) {
+  return procedures.find((procedure) => procedure.id === procedureId) ?? null;
+}
+
+export function getSourceProcedure(playbook: SavedPlaybook) {
+  return getProcedureById(playbook.sourceProcedureId);
+}
+
+export function buildDraftPlaybook(procedure: Procedure): SavedPlaybook {
+  return {
+    id: `draft-${procedure.id}`,
+    sourceProcedureId: procedure.id,
+    title: `${procedure.title} Playbook`,
+    summary: `Draft a rehearsal-ready version of ${procedure.title.toLowerCase()} with explicit owners and review checkpoints.`,
+    team: procedure.team,
+    difficulty: procedure.difficulty,
+    status: "Draft",
+    rehearsalStatus: "Needs Revision",
+    authoringMode: "Remix",
+    objective: `Turn ${procedure.title.toLowerCase()} into a reusable playbook for team walkthroughs and reviews.`,
+    audience: `${procedure.team} operators and reviewers`,
+    rehearsalFocus: "Owner clarity, timing, and the final verification handoff.",
+    duration: procedure.duration,
+    cadence: procedure.cadence,
+    location: procedure.location,
+    lastUpdated: TODAY,
+    lastRehearsed: "Not yet rehearsed",
+    notes: procedure.notes,
+    tags: [...procedure.tags],
+    tools: [...procedure.tools],
+    checkpoints: procedure.checklist.map(
+      (step) => `Call out completion criteria for ${step.label.toLowerCase()}.`,
+    ),
+    metadata: {
+      version: "v0.1",
+      owner: `${procedure.team} lead`,
+      reviewers: ["Safety reviewer"],
+      changeSummary: "Initial authoring draft created from the procedure template.",
+      reviewWindow: "Pending draft review",
+      publishWindow: "Not scheduled",
+      rehearsalWindow: "Schedule after reviewer sign-off",
+      lastSaved: NOW,
+    },
+    steps: procedure.checklist.map((step, index, allSteps) =>
+      buildSeedStep(step, index, allSteps.length),
+    ),
+  };
+}
+
+export function clonePlaybook(playbook: SavedPlaybook): SavedPlaybook {
+  return {
+    ...playbook,
+    tags: [...playbook.tags],
+    tools: [...playbook.tools],
+    checkpoints: [...playbook.checkpoints],
+    metadata: {
+      ...playbook.metadata,
+      reviewers: [...playbook.metadata.reviewers],
+    },
+    steps: playbook.steps.map((step) => ({ ...step })),
+  };
+}
+
+export function createEmptyStep(nextIndex: number): PlaybookStep {
+  const phase = PHASES[Math.min(nextIndex, PHASES.length - 1)] ?? "Execute";
+
+  return {
+    id: `draft-step-${nextIndex + 1}`,
+    label: "New rehearsal step",
+    detail: "Describe what the team should do and how the moderator should frame the move.",
+    phase,
+    owner: phase === "Verify" ? "Reviewer" : "Operator",
+    duration: phase === "Brief" ? "4 min" : "6 min",
+    expectedSignal: "The team can explain the next move without prompting.",
+    rehearsalTip: "Ask the room what evidence proves this step is complete.",
+  };
+}
+
+export function parseCommaSeparatedList(value: string) {
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+export function parseLineSeparatedList(value: string) {
+  return value
+    .split("\n")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+export function createPlaybookId(
+  title: string,
+  existingIds: string[],
+  currentId?: string,
+) {
+  const base =
+    title
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "custom-playbook";
+
+  const rootId = `playbook-${base}`;
+
+  if (!existingIds.includes(rootId) || currentId === rootId) {
+    return rootId;
+  }
+
+  let suffix = 2;
+  let candidate = `${rootId}-${suffix}`;
+
+  while (existingIds.includes(candidate) && currentId !== candidate) {
+    suffix += 1;
+    candidate = `${rootId}-${suffix}`;
+  }
+
+  return candidate;
+}
+
+export function advanceVersion(version: string, nextStatus: PlaybookStatus) {
+  const match = version.match(/v?(\d+)\.(\d+)/);
+  const major = match ? Number(match[1]) : 0;
+  const minor = match ? Number(match[2]) : 0;
+
+  if (nextStatus === "Published") {
+    return major === 0 ? "v1.0" : `v${major + 1}.0`;
+  }
+
+  return `v${major}.${minor + 1}`;
+}
+
+export function getDefaultDraftPlaybook() {
+  return clonePlaybook(savedPlaybooks[2] ?? buildDraftPlaybook(procedures[0]));
+}

--- a/src/components/field-guide/guide-filters.tsx
+++ b/src/components/field-guide/guide-filters.tsx
@@ -1,14 +1,20 @@
 type GuideFiltersProps = {
-  teams: readonly string[];
   difficulties: readonly string[];
+  playbookStatuses: readonly string[];
+  selectedPlaybookStatus: string;
+  selectedTag: string;
   statuses: readonly string[];
+  tags: readonly string[];
+  teams: readonly string[];
   selectedTeam: string;
   selectedDifficulty: string;
   selectedStatus: string;
   hasActiveFilters: boolean;
-  onTeamChange: (value: string) => void;
   onDifficultyChange: (value: string) => void;
+  onPlaybookStatusChange: (value: string) => void;
   onStatusChange: (value: string) => void;
+  onTagChange: (value: string) => void;
+  onTeamChange: (value: string) => void;
   onClear: () => void;
 };
 
@@ -50,14 +56,20 @@ function FilterSelect({
 export default function GuideFilters({
   teams,
   difficulties,
+  tags,
   statuses,
+  playbookStatuses,
   selectedTeam,
   selectedDifficulty,
   selectedStatus,
+  selectedTag,
+  selectedPlaybookStatus,
   hasActiveFilters,
   onTeamChange,
   onDifficultyChange,
   onStatusChange,
+  onTagChange,
+  onPlaybookStatusChange,
   onClear,
 }: GuideFiltersProps) {
   return (
@@ -80,7 +92,7 @@ export default function GuideFilters({
           Clear all
         </button>
       </div>
-      <div className="mt-5 grid gap-4 md:grid-cols-3">
+      <div className="mt-5 grid gap-4 xl:grid-cols-5">
         <FilterSelect
           id="team-filter"
           label="Teams"
@@ -101,6 +113,20 @@ export default function GuideFilters({
           onChange={onStatusChange}
           options={statuses}
           value={selectedStatus}
+        />
+        <FilterSelect
+          id="playbook-status-filter"
+          label="Playbook status"
+          onChange={onPlaybookStatusChange}
+          options={playbookStatuses}
+          value={selectedPlaybookStatus}
+        />
+        <FilterSelect
+          id="tag-filter"
+          label="Tags"
+          onChange={onTagChange}
+          options={tags}
+          value={selectedTag}
         />
       </div>
     </section>

--- a/src/components/field-guide/guide-search.tsx
+++ b/src/components/field-guide/guide-search.tsx
@@ -1,14 +1,14 @@
 type GuideSearchProps = {
+  helperText: string;
+  resultSummary: string;
   query: string;
-  resultCount: number;
-  totalCount: number;
   onQueryChange: (value: string) => void;
 };
 
 export default function GuideSearch({
+  helperText,
   query,
-  resultCount,
-  totalCount,
+  resultSummary,
   onQueryChange,
 }: GuideSearchProps) {
   return (
@@ -29,12 +29,11 @@ export default function GuideSearch({
           value={query}
         />
         <p className="text-sm text-slate-600 lg:min-w-max">
-          Showing {resultCount} of {totalCount} mock procedures
+          {resultSummary}
         </p>
       </div>
       <p className="mt-3 text-sm leading-6 text-slate-500">
-        Search checks titles and summaries only, while team, difficulty, and
-        status filters stay entirely client-side.
+        {helperText}
       </p>
     </section>
   );

--- a/src/components/field-guide/playbook-card.tsx
+++ b/src/components/field-guide/playbook-card.tsx
@@ -1,0 +1,96 @@
+import type {
+  RehearsalStatus,
+  SavedPlaybook,
+} from "@/components/field-guide/field-guide-data";
+
+type PlaybookCardProps = {
+  isSelected: boolean;
+  onSelect: (playbookId: string) => void;
+  playbook: SavedPlaybook;
+  sourceTitle: string;
+};
+
+const statusClasses = {
+  Draft: "bg-slate-200 text-slate-700",
+  "In Review": "bg-amber-100 text-amber-800",
+  Published: "bg-emerald-100 text-emerald-800",
+} as const;
+
+const rehearsalClasses: Record<RehearsalStatus, string> = {
+  "Needs Revision": "bg-rose-100 text-rose-800",
+  "Ready to Rehearse": "bg-sky-100 text-sky-900",
+  Scheduled: "bg-violet-100 text-violet-900",
+};
+
+export default function PlaybookCard({
+  isSelected,
+  onSelect,
+  playbook,
+  sourceTitle,
+}: PlaybookCardProps) {
+  return (
+    <button
+      aria-label={`Review playbook: ${playbook.title}`}
+      className={`w-full rounded-[1.75rem] border p-5 text-left shadow-lg transition ${
+        isSelected
+          ? "border-amber-300 bg-amber-50 shadow-amber-100"
+          : "border-slate-200/70 bg-white/90 shadow-slate-200/40 hover:-translate-y-0.5 hover:border-slate-300"
+      }`}
+      onClick={() => onSelect(playbook.id)}
+      type="button"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="rounded-full bg-slate-950 px-3 py-1 text-xs font-semibold text-slate-50">
+          {playbook.team}
+        </span>
+        <span
+          className={`rounded-full px-3 py-1 text-xs font-semibold ${statusClasses[playbook.status]}`}
+        >
+          {playbook.status}
+        </span>
+        <span
+          className={`rounded-full px-3 py-1 text-xs font-semibold ${rehearsalClasses[playbook.rehearsalStatus]}`}
+        >
+          {playbook.rehearsalStatus}
+        </span>
+        <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
+          {playbook.authoringMode}
+        </span>
+      </div>
+      <h2 className="mt-4 text-2xl font-semibold tracking-tight text-slate-950">
+        {playbook.title}
+      </h2>
+      <p className="mt-3 text-sm leading-6 text-slate-600">{playbook.summary}</p>
+      <dl className="mt-4 grid gap-3 text-sm text-slate-600 sm:grid-cols-2">
+        <div className="rounded-2xl bg-slate-50 px-4 py-3">
+          <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Source
+          </dt>
+          <dd className="mt-2 font-medium text-slate-900">{sourceTitle}</dd>
+        </div>
+        <div className="rounded-2xl bg-slate-50 px-4 py-3">
+          <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Focus
+          </dt>
+          <dd className="mt-2 font-medium text-slate-900">
+            {playbook.rehearsalFocus}
+          </dd>
+        </div>
+      </dl>
+      <div className="mt-4 flex flex-wrap gap-2">
+        {playbook.tags.map((tag) => (
+          <span
+            key={tag}
+            className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-600"
+          >
+            #{tag}
+          </span>
+        ))}
+      </div>
+      <div className="mt-5 flex flex-wrap items-center justify-between gap-3 text-sm text-slate-500">
+        <span>{playbook.metadata.version}</span>
+        <span>{playbook.steps.length} rehearsal steps</span>
+      </div>
+    </button>
+  );
+}

--- a/src/components/field-guide/playbook-editor.tsx
+++ b/src/components/field-guide/playbook-editor.tsx
@@ -1,0 +1,482 @@
+import type {
+  PlaybookStatus,
+  PlaybookStep,
+  RehearsalStatus,
+  Procedure,
+  SavedPlaybook,
+} from "@/components/field-guide/field-guide-data";
+
+type PlaybookTextField =
+  | "title"
+  | "summary"
+  | "objective"
+  | "audience"
+  | "rehearsalFocus"
+  | "duration"
+  | "cadence"
+  | "location"
+  | "notes";
+
+type MetadataField =
+  | "owner"
+  | "changeSummary"
+  | "reviewWindow"
+  | "publishWindow"
+  | "rehearsalWindow";
+
+type StepField =
+  | "label"
+  | "detail"
+  | "phase"
+  | "owner"
+  | "duration"
+  | "expectedSignal"
+  | "rehearsalTip";
+
+type PlaybookEditorProps = {
+  draftPlaybook: SavedPlaybook;
+  onAddStep: () => void;
+  onCheckpointsChange: (value: string) => void;
+  onCreateNew: () => void;
+  onListChange: (field: "tags" | "tools", value: string) => void;
+  onMetadataFieldChange: (field: MetadataField, value: string) => void;
+  onPublishPlaybook: () => void;
+  onReviewersChange: (value: string) => void;
+  onSaveDraft: () => void;
+  onSelectProcedure: (procedureId: string) => void;
+  onStatusChange: (status: PlaybookStatus) => void;
+  onStepFieldChange: (stepId: string, field: StepField, value: string) => void;
+  onStepRemove: (stepId: string) => void;
+  onTextFieldChange: (field: PlaybookTextField, value: string) => void;
+  onRehearsalStatusChange: (status: RehearsalStatus) => void;
+  procedures: Procedure[];
+  rehearsalStatuses: readonly RehearsalStatus[];
+  statuses: readonly PlaybookStatus[];
+};
+
+function TextInput({
+  id,
+  label,
+  onChange,
+  value,
+}: {
+  id: string;
+  label: string;
+  onChange: (value: string) => void;
+  value: string;
+}) {
+  return (
+    <label className="space-y-2" htmlFor={id}>
+      <span className="text-sm font-medium text-slate-700">{label}</span>
+      <input
+        className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-sky-500 focus:ring-4 focus:ring-sky-100"
+        id={id}
+        onChange={(event) => onChange(event.target.value)}
+        value={value}
+      />
+    </label>
+  );
+}
+
+function TextAreaInput({
+  id,
+  label,
+  onChange,
+  rows = 4,
+  value,
+}: {
+  id: string;
+  label: string;
+  onChange: (value: string) => void;
+  rows?: number;
+  value: string;
+}) {
+  return (
+    <label className="space-y-2" htmlFor={id}>
+      <span className="text-sm font-medium text-slate-700">{label}</span>
+      <textarea
+        className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm leading-6 text-slate-900 outline-none transition focus:border-sky-500 focus:ring-4 focus:ring-sky-100"
+        id={id}
+        onChange={(event) => onChange(event.target.value)}
+        rows={rows}
+        value={value}
+      />
+    </label>
+  );
+}
+
+function SelectInput<T extends string>({
+  id,
+  label,
+  onChange,
+  options,
+  value,
+}: {
+  id: string;
+  label: string;
+  onChange: (value: T) => void;
+  options: readonly T[];
+  value: T;
+}) {
+  return (
+    <label className="space-y-2" htmlFor={id}>
+      <span className="text-sm font-medium text-slate-700">{label}</span>
+      <select
+        className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-sky-500 focus:ring-4 focus:ring-sky-100"
+        id={id}
+        onChange={(event) => onChange(event.target.value as T)}
+        value={value}
+      >
+        {options.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+function StepCard({
+  index,
+  onChange,
+  onRemove,
+  step,
+}: {
+  index: number;
+  onChange: (field: StepField, value: string) => void;
+  onRemove: () => void;
+  step: PlaybookStep;
+}) {
+  return (
+    <div className="rounded-[1.5rem] border border-slate-200 bg-slate-50 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Step {index + 1}
+          </p>
+          <h3 className="mt-2 text-lg font-semibold text-slate-950">
+            {step.label}
+          </h3>
+        </div>
+        <button
+          className="rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white"
+          onClick={onRemove}
+          type="button"
+        >
+          Remove step
+        </button>
+      </div>
+      <div className="mt-4 grid gap-4 lg:grid-cols-2">
+        <TextInput
+          id={`step-${step.id}-label`}
+          label={`Step ${index + 1} label`}
+          onChange={(value) => onChange("label", value)}
+          value={step.label}
+        />
+        <SelectInput
+          id={`step-${step.id}-phase`}
+          label={`Step ${index + 1} phase`}
+          onChange={(value) => onChange("phase", value)}
+          options={["Brief", "Execute", "Verify"]}
+          value={step.phase}
+        />
+        <TextInput
+          id={`step-${step.id}-owner`}
+          label={`Step ${index + 1} owner`}
+          onChange={(value) => onChange("owner", value)}
+          value={step.owner}
+        />
+        <TextInput
+          id={`step-${step.id}-duration`}
+          label={`Step ${index + 1} duration`}
+          onChange={(value) => onChange("duration", value)}
+          value={step.duration}
+        />
+        <div className="lg:col-span-2">
+          <TextAreaInput
+            id={`step-${step.id}-detail`}
+            label={`Step ${index + 1} detail`}
+            onChange={(value) => onChange("detail", value)}
+            rows={3}
+            value={step.detail}
+          />
+        </div>
+        <TextAreaInput
+          id={`step-${step.id}-signal`}
+          label={`Step ${index + 1} expected signal`}
+          onChange={(value) => onChange("expectedSignal", value)}
+          rows={3}
+          value={step.expectedSignal}
+        />
+        <TextAreaInput
+          id={`step-${step.id}-tip`}
+          label={`Step ${index + 1} moderator tip`}
+          onChange={(value) => onChange("rehearsalTip", value)}
+          rows={3}
+          value={step.rehearsalTip}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function PlaybookEditor({
+  draftPlaybook,
+  onAddStep,
+  onCheckpointsChange,
+  onCreateNew,
+  onListChange,
+  onMetadataFieldChange,
+  onPublishPlaybook,
+  onRehearsalStatusChange,
+  onReviewersChange,
+  onSaveDraft,
+  onSelectProcedure,
+  onStatusChange,
+  onStepFieldChange,
+  onStepRemove,
+  onTextFieldChange,
+  procedures,
+  rehearsalStatuses,
+  statuses,
+}: PlaybookEditorProps) {
+  return (
+    <section className="space-y-6 rounded-[1.75rem] border border-slate-200/70 bg-white/95 p-6 shadow-lg shadow-slate-200/40">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">
+            Authoring studio
+          </p>
+          <h2 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">
+            Draft and rehearse custom playbooks
+          </h2>
+          <p className="mt-3 max-w-2xl text-sm leading-7 text-slate-600">
+            Start from a procedure template or load a saved playbook, then edit
+            metadata, reviewer context, and step choreography before saving the
+            next version.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <button
+            className="rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50"
+            onClick={onCreateNew}
+            type="button"
+          >
+            Start new playbook
+          </button>
+          <button
+            className="rounded-full border border-slate-200 bg-slate-950 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-800"
+            onClick={onSaveDraft}
+            type="button"
+          >
+            Save draft
+          </button>
+          <button
+            className="rounded-full border border-sky-200 bg-sky-100 px-4 py-2 text-sm font-medium text-sky-950 transition hover:bg-sky-200"
+            onClick={onPublishPlaybook}
+            type="button"
+          >
+            Publish playbook
+          </button>
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        <label className="space-y-2" htmlFor="source-procedure">
+          <span className="text-sm font-medium text-slate-700">
+            Source procedure
+          </span>
+          <select
+            className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 outline-none transition focus:border-sky-500 focus:ring-4 focus:ring-sky-100"
+            id="source-procedure"
+            onChange={(event) => onSelectProcedure(event.target.value)}
+            value={draftPlaybook.sourceProcedureId}
+          >
+            {procedures.map((procedure) => (
+              <option key={procedure.id} value={procedure.id}>
+                {procedure.title}
+              </option>
+            ))}
+          </select>
+        </label>
+        <SelectInput
+          id="draft-status"
+          label="Draft status"
+          onChange={onStatusChange}
+          options={statuses}
+          value={draftPlaybook.status}
+        />
+        <SelectInput
+          id="rehearsal-status"
+          label="Rehearsal status"
+          onChange={onRehearsalStatusChange}
+          options={rehearsalStatuses}
+          value={draftPlaybook.rehearsalStatus}
+        />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <TextInput
+          id="playbook-title"
+          label="Playbook title"
+          onChange={(value) => onTextFieldChange("title", value)}
+          value={draftPlaybook.title}
+        />
+        <TextInput
+          id="playbook-duration"
+          label="Duration"
+          onChange={(value) => onTextFieldChange("duration", value)}
+          value={draftPlaybook.duration}
+        />
+        <div className="lg:col-span-2">
+          <TextAreaInput
+            id="playbook-summary"
+            label="Playbook summary"
+            onChange={(value) => onTextFieldChange("summary", value)}
+            rows={3}
+            value={draftPlaybook.summary}
+          />
+        </div>
+        <TextAreaInput
+          id="playbook-objective"
+          label="Objective"
+          onChange={(value) => onTextFieldChange("objective", value)}
+          rows={3}
+          value={draftPlaybook.objective}
+        />
+        <TextAreaInput
+          id="playbook-audience"
+          label="Audience"
+          onChange={(value) => onTextFieldChange("audience", value)}
+          rows={3}
+          value={draftPlaybook.audience}
+        />
+        <TextAreaInput
+          id="rehearsal-focus"
+          label="Rehearsal focus"
+          onChange={(value) => onTextFieldChange("rehearsalFocus", value)}
+          rows={3}
+          value={draftPlaybook.rehearsalFocus}
+        />
+        <TextAreaInput
+          id="playbook-notes"
+          label="Notes"
+          onChange={(value) => onTextFieldChange("notes", value)}
+          rows={3}
+          value={draftPlaybook.notes}
+        />
+        <TextInput
+          id="playbook-cadence"
+          label="Cadence"
+          onChange={(value) => onTextFieldChange("cadence", value)}
+          value={draftPlaybook.cadence}
+        />
+        <TextInput
+          id="playbook-location"
+          label="Location"
+          onChange={(value) => onTextFieldChange("location", value)}
+          value={draftPlaybook.location}
+        />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <TextInput
+          id="draft-owner"
+          label="Owner"
+          onChange={(value) => onMetadataFieldChange("owner", value)}
+          value={draftPlaybook.metadata.owner}
+        />
+        <TextInput
+          id="reviewers"
+          label="Reviewers"
+          onChange={onReviewersChange}
+          value={draftPlaybook.metadata.reviewers.join(", ")}
+        />
+        <TextAreaInput
+          id="change-summary"
+          label="Change summary"
+          onChange={(value) => onMetadataFieldChange("changeSummary", value)}
+          rows={3}
+          value={draftPlaybook.metadata.changeSummary}
+        />
+        <TextInput
+          id="review-window"
+          label="Review window"
+          onChange={(value) => onMetadataFieldChange("reviewWindow", value)}
+          value={draftPlaybook.metadata.reviewWindow}
+        />
+        <TextInput
+          id="publish-window"
+          label="Publish window"
+          onChange={(value) => onMetadataFieldChange("publishWindow", value)}
+          value={draftPlaybook.metadata.publishWindow}
+        />
+        <TextInput
+          id="rehearsal-window"
+          label="Rehearsal window"
+          onChange={(value) => onMetadataFieldChange("rehearsalWindow", value)}
+          value={draftPlaybook.metadata.rehearsalWindow}
+        />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        <TextAreaInput
+          id="playbook-tags"
+          label="Tags"
+          onChange={(value) => onListChange("tags", value)}
+          rows={4}
+          value={draftPlaybook.tags.join(", ")}
+        />
+        <TextAreaInput
+          id="playbook-tools"
+          label="Tools"
+          onChange={(value) => onListChange("tools", value)}
+          rows={4}
+          value={draftPlaybook.tools.join(", ")}
+        />
+        <TextAreaInput
+          id="checkpoint-list"
+          label="Checkpoint list"
+          onChange={onCheckpointsChange}
+          rows={4}
+          value={draftPlaybook.checkpoints.join("\n")}
+        />
+      </div>
+
+      <section className="space-y-4 rounded-[1.5rem] border border-slate-200/70 bg-slate-50 p-5">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">
+              Authored steps
+            </p>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              Each step carries phase, owner, timing, and moderator notes so the
+              rehearsal preview can render the sequence coherently.
+            </p>
+          </div>
+          <button
+            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300"
+            onClick={onAddStep}
+            type="button"
+          >
+            Add rehearsal step
+          </button>
+        </div>
+        <div className="space-y-4">
+          {draftPlaybook.steps.map((step, index) => (
+            <StepCard
+              index={index}
+              key={step.id}
+              onChange={(field, value) =>
+                onStepFieldChange(step.id, field, value)
+              }
+              onRemove={() => onStepRemove(step.id)}
+              step={step}
+            />
+          ))}
+        </div>
+      </section>
+    </section>
+  );
+}

--- a/src/components/field-guide/playbook-review-panel.tsx
+++ b/src/components/field-guide/playbook-review-panel.tsx
@@ -1,0 +1,215 @@
+import type {
+  RehearsalStatus,
+  SavedPlaybook,
+} from "@/components/field-guide/field-guide-data";
+import type { Procedure } from "@/components/field-guide/field-guide-data";
+import RehearsalPreview from "@/components/field-guide/rehearsal-preview";
+
+type PlaybookReviewPanelProps = {
+  description?: string;
+  heading?: string;
+  playbook: SavedPlaybook | null;
+  sourceProcedure: Procedure | null;
+};
+
+const statusClasses = {
+  Draft: "bg-slate-200 text-slate-700",
+  "In Review": "bg-amber-100 text-amber-800",
+  Published: "bg-emerald-100 text-emerald-800",
+} as const;
+
+const rehearsalClasses: Record<RehearsalStatus, string> = {
+  "Needs Revision": "bg-rose-100 text-rose-800",
+  "Ready to Rehearse": "bg-sky-100 text-sky-900",
+  Scheduled: "bg-violet-100 text-violet-900",
+};
+
+export default function PlaybookReviewPanel({
+  description = "Review draft metadata, source context, and the authored rehearsal flow in one panel.",
+  heading = "Playbook review",
+  playbook,
+  sourceProcedure,
+}: PlaybookReviewPanelProps) {
+  if (!playbook) {
+    return (
+      <aside className="rounded-[1.75rem] border border-dashed border-slate-300 bg-white/80 p-8 text-center shadow-lg shadow-slate-200/40">
+        <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">
+          Playbook review
+        </p>
+        <h2 className="mt-3 text-2xl font-semibold text-slate-950">
+          Select or author a playbook to review the draft metadata.
+        </h2>
+        <p className="mt-3 text-sm leading-6 text-slate-600">
+          Saved playbooks stay local to this route, so the review panel updates
+          as soon as you save or publish the current draft.
+        </p>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="space-y-6 rounded-[1.75rem] border border-slate-200/70 bg-white/95 p-6 shadow-lg shadow-slate-200/40">
+      <section>
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-3">
+            <div className="flex flex-wrap gap-2">
+              <span className="rounded-full bg-slate-950 px-3 py-1 text-xs font-semibold text-slate-50">
+                {playbook.team}
+              </span>
+              <span
+                className={`rounded-full px-3 py-1 text-xs font-semibold ${statusClasses[playbook.status]}`}
+              >
+                {playbook.status}
+              </span>
+              <span
+                className={`rounded-full px-3 py-1 text-xs font-semibold ${rehearsalClasses[playbook.rehearsalStatus]}`}
+              >
+                {playbook.rehearsalStatus}
+              </span>
+              <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-700">
+                {playbook.authoringMode}
+              </span>
+            </div>
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">
+                {heading}
+              </p>
+              <h2 className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">
+                {playbook.title}
+              </h2>
+            </div>
+          </div>
+          <div className="rounded-3xl bg-slate-50 px-4 py-3 text-right">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+              Version
+            </p>
+            <p className="mt-2 text-lg font-semibold text-slate-950">
+              {playbook.metadata.version}
+            </p>
+          </div>
+        </div>
+        <p className="mt-4 text-sm leading-7 text-slate-600">{description}</p>
+        <p className="mt-3 text-sm leading-7 text-slate-600">{playbook.summary}</p>
+      </section>
+
+      <section className="grid gap-3 sm:grid-cols-2">
+        <div className="rounded-3xl bg-slate-50 p-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Source procedure
+          </p>
+          <p className="mt-2 text-lg font-semibold text-slate-950">
+            {sourceProcedure?.title ?? "Custom flow"}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-slate-600">
+            {sourceProcedure?.summary ??
+              "The playbook was authored without a single source procedure."}
+          </p>
+        </div>
+        <div className="rounded-3xl bg-slate-50 p-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Rehearsal focus
+          </p>
+          <p className="mt-2 text-lg font-semibold text-slate-950">
+            {playbook.rehearsalFocus}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-slate-600">
+            Audience: {playbook.audience}
+          </p>
+        </div>
+      </section>
+
+      <section className="rounded-[1.5rem] border border-slate-200/70 bg-slate-50 p-5">
+        <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">
+          Draft metadata
+        </p>
+        <div className="mt-4 grid gap-4 text-sm text-slate-600 sm:grid-cols-2">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+              Owner
+            </p>
+            <p className="mt-2 font-medium text-slate-950">
+              {playbook.metadata.owner}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+              Last saved
+            </p>
+            <p className="mt-2 font-medium text-slate-950">
+              {playbook.metadata.lastSaved}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+              Review window
+            </p>
+            <p className="mt-2">{playbook.metadata.reviewWindow}</p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+              Rehearsal window
+            </p>
+            <p className="mt-2">{playbook.metadata.rehearsalWindow}</p>
+          </div>
+          <div className="sm:col-span-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+              Reviewers
+            </p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {playbook.metadata.reviewers.map((reviewer) => (
+                <span
+                  className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-700"
+                  key={reviewer}
+                >
+                  {reviewer}
+                </span>
+              ))}
+            </div>
+          </div>
+          <div className="sm:col-span-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+              Change summary
+            </p>
+            <p className="mt-2 leading-6">{playbook.metadata.changeSummary}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-[1.5rem] border border-slate-200/70 bg-white p-5">
+        <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">
+          Review checkpoints
+        </p>
+        <ol className="mt-4 space-y-3">
+          {playbook.checkpoints.map((checkpoint, index) => (
+            <li
+              className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm leading-6 text-slate-600"
+              key={checkpoint}
+            >
+              <span className="font-semibold text-slate-950">{index + 1}.</span>{" "}
+              {checkpoint}
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <section className="rounded-[1.5rem] border border-slate-200/70 bg-white p-5">
+        <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">
+          Notes and kit
+        </p>
+        <p className="mt-3 text-sm leading-6 text-slate-600">{playbook.notes}</p>
+        <div className="mt-4 flex flex-wrap gap-2">
+          {playbook.tools.map((tool) => (
+            <span
+              className="rounded-full bg-sky-100 px-3 py-1 text-xs font-medium text-sky-900"
+              key={tool}
+            >
+              {tool}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      <RehearsalPreview playbook={playbook} />
+    </aside>
+  );
+}

--- a/src/components/field-guide/rehearsal-preview.tsx
+++ b/src/components/field-guide/rehearsal-preview.tsx
@@ -1,0 +1,104 @@
+import type {
+  PlaybookStepPhase,
+  SavedPlaybook,
+} from "@/components/field-guide/field-guide-data";
+
+type RehearsalPreviewProps = {
+  playbook: SavedPlaybook;
+};
+
+const phaseOrder: PlaybookStepPhase[] = ["Brief", "Execute", "Verify"];
+
+function getPhaseSteps(playbook: SavedPlaybook, phase: PlaybookStepPhase) {
+  return playbook.steps.filter((step) => step.phase === phase);
+}
+
+export default function RehearsalPreview({ playbook }: RehearsalPreviewProps) {
+  return (
+    <section className="rounded-[1.5rem] border border-slate-200/70 bg-slate-50 p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-[0.25em] text-slate-500">
+            Rehearsal preview
+          </p>
+          <p className="mt-2 text-sm leading-6 text-slate-600">
+            Preview the authored flow in stage order before it is saved or
+            published for the wider team.
+          </p>
+        </div>
+        <div className="rounded-2xl bg-white px-4 py-3 text-right shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Total steps
+          </p>
+          <p className="mt-2 text-lg font-semibold text-slate-950">
+            {playbook.steps.length}
+          </p>
+        </div>
+      </div>
+      <div className="mt-5 space-y-4">
+        {phaseOrder.map((phase) => {
+          const steps = getPhaseSteps(playbook, phase);
+
+          if (steps.length === 0) {
+            return null;
+          }
+
+          return (
+            <section
+              className="rounded-3xl border border-slate-200 bg-white p-4"
+              key={phase}
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">
+                    {phase}
+                  </p>
+                  <h3 className="mt-2 text-lg font-semibold text-slate-950">
+                    {steps.length} step{steps.length === 1 ? "" : "s"}
+                  </h3>
+                </div>
+                <span className="rounded-full bg-slate-950 px-3 py-1 text-xs font-semibold text-slate-50">
+                  {steps.map((step) => step.duration).join(" + ")}
+                </span>
+              </div>
+              <ol className="mt-4 space-y-3">
+                {steps.map((step, index) => (
+                  <li
+                    className="rounded-2xl border border-slate-200 bg-slate-50 p-4"
+                    key={step.id}
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <p className="text-sm font-semibold text-slate-950">
+                        {index + 1}. {step.label}
+                      </p>
+                      <span className="rounded-full bg-white px-3 py-1 text-xs font-medium text-slate-600">
+                        {step.owner}
+                      </span>
+                    </div>
+                    <p className="mt-3 text-sm leading-6 text-slate-600">
+                      {step.detail}
+                    </p>
+                    <dl className="mt-4 grid gap-3 text-sm text-slate-600 sm:grid-cols-2">
+                      <div>
+                        <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                          Expected signal
+                        </dt>
+                        <dd className="mt-2">{step.expectedSignal}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                          Moderator tip
+                        </dt>
+                        <dd className="mt-2">{step.rehearsalTip}</dd>
+                      </div>
+                    </dl>
+                  </li>
+                ))}
+              </ol>
+            </section>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./vitest.setup.tsx"],
     css: true,
+    testTimeout: 20000,
   },
 });


### PR DESCRIPTION
## Summary
- extend the Field Guide with saved playbooks, draft metadata, and authoring mode workflows
- add richer library filters plus live review and rehearsal preview panels for custom playbooks
- expand route tests around filtering, authoring, publishing, and preview behavior, and raise the Vitest timeout for heavier route integration tests

## Testing
- npm run lint
- npm run typecheck
- npm test

Closes #70