### PR TITLE
[Test] Build Signal Lab multi-stream comparison workspace

### DIFF
--- a/src/app/signal-lab/page.tsx
+++ b/src/app/signal-lab/page.tsx
@@ -5,7 +5,7 @@ import { SignalLabWorkspace } from "@/components/signal-lab/signal-lab-workspace
 export const metadata: Metadata = {
   title: "Signal Lab",
   description:
-    "Synthetic monitoring workspace with stream cards, anomaly markers, and inspector panels.",
+    "Comparison-first signal workspace with pinned anomaly streams, confidence trends, and a dedicated inspector.",
 };
 
 export default function SignalLabPage() {

--- a/src/components/signal-lab/anomaly-list.tsx
+++ b/src/components/signal-lab/anomaly-list.tsx
@@ -1,6 +1,10 @@
-import type { SignalAnomaly } from "./mock-data";
+import {
+  getSignalStreamById,
+  type Severity,
+  type SignalAnomaly,
+} from "./mock-data";
 
-const severityClasses = {
+const severityClasses: Record<Severity, string> = {
   low: "border-sky-400/30 bg-sky-400/10 text-sky-200",
   medium: "border-amber-400/30 bg-amber-400/10 text-amber-200",
   high: "border-rose-400/30 bg-rose-400/10 text-rose-200",
@@ -9,20 +13,25 @@ const severityClasses = {
 type AnomalyListProps = {
   anomalies: SignalAnomaly[];
   acknowledgedIds: string[];
+  comparedIds: string[];
   showDismissed: boolean;
   onToggleAcknowledged: (anomalyId: string) => void;
   onToggleDismissed: (anomalyId: string) => void;
   onToggleDismissedView: () => void;
-  onSelectStream: (streamId: string) => void;
+  onInspectStream: (streamId: string) => void;
+  onPinStream: (streamId: string) => void;
 };
+
 export function AnomalyList({
   anomalies,
   acknowledgedIds,
+  comparedIds,
   showDismissed,
   onToggleAcknowledged,
   onToggleDismissed,
   onToggleDismissedView,
-  onSelectStream,
+  onInspectStream,
+  onPinStream,
 }: AnomalyListProps) {
   return (
     <section
@@ -31,8 +40,12 @@ export function AnomalyList({
     >
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <p className="text-xs uppercase tracking-[0.35em] text-slate-400">Anomaly Feed</p>
-          <h2 className="mt-2 text-xl font-semibold text-white">Synthetic incidents</h2>
+          <p className="text-xs uppercase tracking-[0.35em] text-slate-400">
+            Anomaly Feed
+          </p>
+          <h2 className="mt-2 text-xl font-semibold text-white">
+            Confidence-moving incidents
+          </h2>
         </div>
         <button
           className="rounded-full border border-white/10 px-4 py-2 text-sm text-slate-200 transition hover:border-white/20 hover:bg-white/5"
@@ -45,41 +58,93 @@ export function AnomalyList({
       <div className="mt-5 space-y-3">
         {anomalies.length === 0 ? (
           <div className="rounded-[1.5rem] border border-dashed border-white/10 px-5 py-8 text-sm text-slate-400">
-            No anomalies match the current view. Restore dismissed items or clear stream focus to widen the sweep.
+            No anomalies match the current view. Restore dismissed items or pin
+            more streams to widen the comparison surface.
           </div>
         ) : null}
         {anomalies.map((anomaly) => {
+          const stream = getSignalStreamById(anomaly.streamId);
           const isTracked = acknowledgedIds.includes(anomaly.id);
+          const isPinned = comparedIds.includes(anomaly.streamId);
           const dismissLabel = `Dismiss ${anomaly.title}`;
           const trackLabel = `${isTracked ? "Release" : "Track"} ${anomaly.title}`;
+
           return (
             <article
               key={anomaly.id}
               className="rounded-[1.5rem] border border-white/10 bg-white/[0.03] p-4"
             >
               <div className="flex flex-wrap items-start justify-between gap-3">
-                <div className="max-w-2xl">
+                <div className="max-w-3xl">
                   <div className="flex flex-wrap items-center gap-2">
-                    <span className={`rounded-full border px-3 py-1 text-xs uppercase tracking-[0.25em] ${severityClasses[anomaly.severity]}`}>
+                    <span
+                      className={`rounded-full border px-3 py-1 text-xs uppercase tracking-[0.25em] ${severityClasses[anomaly.severity]}`}
+                    >
                       {anomaly.severity}
                     </span>
-                    <span className="text-xs uppercase tracking-[0.2em] text-slate-500">{anomaly.detectedAt}</span>
+                    <span className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                      {anomaly.detectedAt}
+                    </span>
+                    {stream ? (
+                      <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-300">
+                        {stream.name}
+                      </span>
+                    ) : null}
                   </div>
-                  <h3 className="mt-3 text-lg font-medium text-white">{anomaly.title}</h3>
-                  <p className="mt-2 text-sm leading-6 text-slate-300">{anomaly.summary}</p>
+                  <h3 className="mt-3 text-lg font-medium text-white">
+                    {anomaly.title}
+                  </h3>
+                  <p className="mt-2 text-sm leading-6 text-slate-300">
+                    {anomaly.summary}
+                  </p>
                 </div>
                 <div className="text-right">
-                  <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Delta</p>
-                  <p className="mt-2 text-lg font-medium text-white">{anomaly.delta}</p>
+                  <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                    Delta
+                  </p>
+                  <p className="mt-2 text-lg font-medium text-white">
+                    {anomaly.delta}
+                  </p>
                 </div>
               </div>
+
+              <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
+                  <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                    Confidence shift
+                  </p>
+                  <p className="mt-2 text-sm text-white">
+                    {anomaly.confidenceShift}
+                  </p>
+                </div>
+                <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
+                  <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                    Driver
+                  </p>
+                  <p className="mt-2 text-sm text-white">{anomaly.driver}</p>
+                </div>
+              </div>
+
               <div className="mt-4 flex flex-wrap gap-2">
                 <button
                   className="rounded-full border border-cyan-400/20 bg-cyan-400/10 px-4 py-2 text-sm text-cyan-100 transition hover:border-cyan-300/40"
-                  onClick={() => onSelectStream(anomaly.streamId)}
+                  onClick={() => onInspectStream(anomaly.streamId)}
                   type="button"
                 >
-                  Jump to stream
+                  Inspect stream
+                </button>
+                <button
+                  aria-label={`${isPinned ? "Remove" : "Pin"} stream ${stream?.name ?? anomaly.streamId}`}
+                  aria-pressed={isPinned}
+                  className={`rounded-full border px-4 py-2 text-sm transition ${
+                    isPinned
+                      ? "border-cyan-400/30 bg-cyan-400/10 text-cyan-100"
+                      : "border-white/10 text-slate-100 hover:border-cyan-300/40 hover:bg-cyan-400/10"
+                  }`}
+                  onClick={() => onPinStream(anomaly.streamId)}
+                  type="button"
+                >
+                  {isPinned ? "Pinned stream" : "Pin stream"}
                 </button>
                 <button
                   aria-label={trackLabel}
@@ -98,7 +163,12 @@ export function AnomalyList({
                   Dismiss
                 </button>
               </div>
-              <p className="mt-3 text-sm text-slate-400">{anomaly.recommendation}</p>
+
+              <div className="mt-4 space-y-2 text-sm text-slate-400">
+                <p>{anomaly.explanation}</p>
+                <p>{anomaly.compareNote}</p>
+                <p>{anomaly.recommendation}</p>
+              </div>
             </article>
           );
         })}

--- a/src/components/signal-lab/comparison-workbench.tsx
+++ b/src/components/signal-lab/comparison-workbench.tsx
@@ -1,0 +1,331 @@
+import {
+  comparisonWindows,
+  getHistoryForWindow,
+  type ComparisonWindow,
+  type SignalStream,
+  type StreamStatus,
+} from "./mock-data";
+import {
+  getConfidenceShiftLabel,
+  getWindowLabel,
+  type ComparisonDetail,
+  type ComparisonSummary,
+} from "./signal-lab-model";
+
+const statusClasses: Record<StreamStatus, string> = {
+  stable: "border-emerald-400/30 bg-emerald-400/10 text-emerald-200",
+  drifting: "border-amber-400/30 bg-amber-400/10 text-amber-200",
+  critical: "border-rose-400/30 bg-rose-400/10 text-rose-200",
+};
+
+type ComparisonWorkbenchProps = {
+  comparedStreams: SignalStream[];
+  comparisonSummary: ComparisonSummary | null;
+  comparisonDetail: ComparisonDetail | null;
+  comparisonView: "summary" | "detail";
+  comparisonWindow: ComparisonWindow;
+  openAnomalyCount: number;
+  onChangeView: (view: "summary" | "detail") => void;
+  onChangeWindow: (window: ComparisonWindow) => void;
+  onClearComparison: () => void;
+};
+
+function TrendStrip({
+  stream,
+  comparisonWindow,
+}: {
+  stream: SignalStream;
+  comparisonWindow: ComparisonWindow;
+}) {
+  const history = getHistoryForWindow(stream, comparisonWindow);
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="font-medium text-white">{stream.name}</p>
+          <p className="mt-1 text-sm text-slate-400">{stream.channel}</p>
+        </div>
+        <div className="text-right">
+          <p className="text-sm text-white">{stream.confidence}% confidence</p>
+          <p className="mt-1 text-xs uppercase tracking-[0.2em] text-slate-400">
+            {getConfidenceShiftLabel(stream, comparisonWindow)}
+          </p>
+        </div>
+      </div>
+      <div className="mt-4 flex h-24 items-end gap-2">
+        {history.map((point) => (
+          <div className="flex-1" key={`${stream.id}-${point.time}`}>
+            <div
+              className={`w-full rounded-t-xl ${stream.status === "critical" ? "bg-rose-400/80" : stream.status === "drifting" ? "bg-amber-400/80" : "bg-cyan-400/80"}`}
+              style={{ height: `${Math.max(24, point.confidence)}%` }}
+            />
+            <p className="mt-2 text-center text-[0.65rem] uppercase tracking-[0.15em] text-slate-500">
+              {point.time}
+            </p>
+          </div>
+        ))}
+      </div>
+      <p className="mt-3 text-sm text-slate-400">
+        {history.at(-1)?.note ?? stream.outlook}
+      </p>
+    </div>
+  );
+}
+
+export function ComparisonWorkbench({
+  comparedStreams,
+  comparisonSummary,
+  comparisonDetail,
+  comparisonView,
+  comparisonWindow,
+  openAnomalyCount,
+  onChangeView,
+  onChangeWindow,
+  onClearComparison,
+}: ComparisonWorkbenchProps) {
+  return (
+    <section
+      aria-label="Comparison workspace"
+      className="rounded-[1.75rem] border border-white/10 bg-slate-950/75 p-5 backdrop-blur"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-[0.35em] text-slate-400">
+            Comparison Workspace
+          </p>
+          <h2 className="mt-2 text-xl font-semibold text-white">
+            Pinned multi-stream analysis
+          </h2>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">
+            Switch between summary and detail views to compare signal behavior
+            over time and explain confidence changes across the pinned set.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {(["summary", "detail"] as const).map((view) => (
+            <button
+              key={view}
+              aria-pressed={comparisonView === view}
+              className={`rounded-full border px-4 py-2 text-sm transition ${
+                comparisonView === view
+                  ? "border-cyan-400/30 bg-cyan-400/10 text-cyan-100"
+                  : "border-white/10 text-slate-100 hover:border-white/20 hover:bg-white/5"
+              }`}
+              onClick={() => onChangeView(view)}
+              type="button"
+            >
+              {view === "summary" ? "Summary view" : "Detail view"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        {comparisonWindows.map((window) => (
+          <button
+            key={window.id}
+            aria-pressed={comparisonWindow === window.id}
+            className={`rounded-full border px-4 py-2 text-sm transition ${
+              comparisonWindow === window.id
+                ? "border-white/20 bg-white/10 text-white"
+                : "border-white/10 text-slate-200 hover:border-white/20 hover:bg-white/5"
+            }`}
+            onClick={() => onChangeWindow(window.id)}
+            type="button"
+          >
+            {window.label}
+          </button>
+        ))}
+        {comparedStreams.length > 0 ? (
+          <button
+            className="rounded-full border border-white/10 px-4 py-2 text-sm text-slate-200 transition hover:border-white/20 hover:bg-white/5"
+            onClick={onClearComparison}
+            type="button"
+          >
+            Clear pinned streams
+          </button>
+        ) : null}
+      </div>
+
+      {comparedStreams.length < 2 || !comparisonSummary || !comparisonDetail ? (
+        <div className="mt-5 rounded-[1.5rem] border border-dashed border-white/10 px-5 py-8 text-sm text-slate-400">
+          Pin at least two streams to unlock the comparison workspace. With one
+          stream pinned, the inspector still explains anomalies, but the summary
+          and detail views remain intentionally empty.
+        </div>
+      ) : null}
+
+      {comparedStreams.length >= 2 && comparisonSummary && comparisonDetail ? (
+        <>
+          <div className="mt-5 flex flex-wrap gap-2">
+            {comparedStreams.map((stream) => (
+              <span
+                key={stream.id}
+                className={`rounded-full border px-3 py-1 text-xs uppercase tracking-[0.2em] ${statusClasses[stream.status]}`}
+              >
+                {stream.name}
+              </span>
+            ))}
+            <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-300">
+              {getWindowLabel(comparisonWindow)}
+            </span>
+          </div>
+
+          {comparisonView === "summary" ? (
+            <div className="mt-6 grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.85fr)]">
+              <div>
+                <h3 className="text-2xl font-semibold text-white">
+                  {comparisonSummary.headline}
+                </h3>
+                <p className="mt-3 text-sm leading-6 text-slate-300">
+                  {comparisonSummary.narrative}
+                </p>
+
+                <div className="mt-5 grid gap-3 sm:grid-cols-3">
+                  {comparisonSummary.metrics.map((metric) => (
+                    <div
+                      key={metric.label}
+                      className="rounded-2xl border border-white/10 bg-white/[0.03] p-4"
+                    >
+                      <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                        {metric.label}
+                      </p>
+                      <p className="mt-2 text-xl font-medium text-white">
+                        {metric.value}
+                      </p>
+                      <p className="mt-2 text-sm text-slate-400">
+                        {metric.detail}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+
+                <div className="mt-5 space-y-4">
+                  {comparedStreams.map((stream) => (
+                    <TrendStrip
+                      comparisonWindow={comparisonWindow}
+                      key={stream.id}
+                      stream={stream}
+                    />
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <div className="rounded-[1.5rem] border border-white/10 bg-white/[0.03] p-5">
+                  <p className="text-xs uppercase tracking-[0.3em] text-slate-500">
+                    Summary highlights
+                  </p>
+                  <ul className="mt-4 space-y-3 text-sm leading-6 text-slate-300">
+                    {comparisonSummary.highlights.map((highlight) => (
+                      <li key={highlight}>{highlight}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div className="rounded-[1.5rem] border border-white/10 bg-white/[0.03] p-5">
+                  <p className="text-xs uppercase tracking-[0.3em] text-slate-500">
+                    Recommendation
+                  </p>
+                  <p className="mt-3 text-sm leading-6 text-slate-300">
+                    {comparisonSummary.recommendation}
+                  </p>
+                  <p className="mt-4 text-sm text-slate-400">
+                    {openAnomalyCount} open anomalies are attached to the
+                    currently pinned comparison set.
+                  </p>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="mt-6 space-y-4">
+              <div className="rounded-[1.5rem] border border-white/10 bg-white/[0.03] p-5">
+                <div className="grid gap-3 border-b border-white/10 pb-3 text-xs uppercase tracking-[0.2em] text-slate-500 sm:grid-cols-[minmax(0,1.8fr)_repeat(4,minmax(0,1fr))]">
+                  <span>Stream</span>
+                  <span>Confidence</span>
+                  <span>Lens shift</span>
+                  <span>Anomaly load</span>
+                  <span>Driver</span>
+                </div>
+                <div className="mt-4 space-y-4">
+                  {comparisonDetail.rows.map((row) => {
+                    const stream = comparedStreams.find(
+                      (candidate) => candidate.id === row.id,
+                    );
+
+                    if (!stream) {
+                      return null;
+                    }
+
+                    return (
+                      <article
+                        key={row.id}
+                        className="rounded-2xl border border-white/10 bg-black/20 p-4"
+                      >
+                        <div className="grid gap-4 sm:grid-cols-[minmax(0,1.8fr)_repeat(4,minmax(0,1fr))]">
+                          <div>
+                            <div className="flex flex-wrap items-center gap-2">
+                              <p className="font-medium text-white">
+                                {row.name}
+                              </p>
+                              <span
+                                className={`rounded-full border px-3 py-1 text-[0.65rem] uppercase tracking-[0.2em] ${statusClasses[row.status]}`}
+                              >
+                                {row.status}
+                              </span>
+                            </div>
+                            <p className="mt-2 text-sm text-slate-400">
+                              {row.watchword}
+                            </p>
+                            <p className="mt-2 text-sm text-slate-400">
+                              {row.note}
+                            </p>
+                          </div>
+                          <div>
+                            <p className="text-sm text-white">
+                              {row.confidence}
+                            </p>
+                          </div>
+                          <div>
+                            <p className="text-sm text-white">{row.shift}</p>
+                          </div>
+                          <div>
+                            <p className="text-sm text-white">
+                              {row.anomalyLoad}
+                            </p>
+                          </div>
+                          <div>
+                            <p className="text-sm text-white">{row.driver}</p>
+                          </div>
+                        </div>
+                        <div className="mt-4">
+                          <TrendStrip
+                            comparisonWindow={comparisonWindow}
+                            stream={stream}
+                          />
+                        </div>
+                      </article>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div className="grid gap-4 lg:grid-cols-3">
+                {comparisonDetail.insights.map((insight) => (
+                  <div
+                    key={insight}
+                    className="rounded-[1.5rem] border border-white/10 bg-white/[0.03] p-5"
+                  >
+                    <p className="text-sm leading-6 text-slate-300">
+                      {insight}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/signal-lab/inspector-panel.tsx
+++ b/src/components/signal-lab/inspector-panel.tsx
@@ -1,4 +1,13 @@
-import type { SignalStream } from "./mock-data";
+import type {
+  ComparisonWindow,
+  SignalAnomaly,
+  SignalStream,
+} from "./mock-data";
+import {
+  getConfidenceShiftLabel,
+  getWindowLabel,
+  type InspectorPeerNote,
+} from "./signal-lab-model";
 
 const toneClasses = {
   steady: "text-emerald-200",
@@ -8,31 +17,53 @@ const toneClasses = {
 
 type InspectorPanelProps = {
   stream: SignalStream | null;
-  anomalyCount: number;
-  isFocused: boolean;
+  anomalies: SignalAnomaly[];
+  peerNotes: InspectorPeerNote[];
+  comparisonWindow: ComparisonWindow;
+  isCompared: boolean;
   isMuted: boolean;
   isPaused: boolean;
   onClearSelection: () => void;
-  onToggleFocus: () => void;
+  onToggleCompare: () => void;
   onToggleMute: () => void;
   onTogglePause: () => void;
 };
 
 export function InspectorPanel({
   stream,
-  anomalyCount,
-  isFocused,
+  anomalies,
+  peerNotes,
+  comparisonWindow,
+  isCompared,
   isMuted,
   isPaused,
   onClearSelection,
-  onToggleFocus,
+  onToggleCompare,
   onToggleMute,
   onTogglePause,
 }: InspectorPanelProps) {
   const controls = [
-    { active: isPaused, activeClasses: "border-amber-400/30 bg-amber-400/10 text-amber-100", idleLabel: "Pause stream", activeLabel: "Resume stream", onClick: onTogglePause },
-    { active: isMuted, activeClasses: "border-slate-400/30 bg-slate-400/10 text-slate-100", idleLabel: "Mute stream", activeLabel: "Unmute stream", onClick: onToggleMute },
-    { active: isFocused, activeClasses: "border-cyan-400/30 bg-cyan-400/10 text-cyan-100", idleLabel: "Focus stream", activeLabel: "Release focus", onClick: onToggleFocus },
+    {
+      active: isPaused,
+      activeClasses: "border-amber-400/30 bg-amber-400/10 text-amber-100",
+      idleLabel: "Pause stream",
+      activeLabel: "Resume stream",
+      onClick: onTogglePause,
+    },
+    {
+      active: isMuted,
+      activeClasses: "border-slate-400/30 bg-slate-400/10 text-slate-100",
+      idleLabel: "Mute stream",
+      activeLabel: "Unmute stream",
+      onClick: onToggleMute,
+    },
+    {
+      active: isCompared,
+      activeClasses: "border-cyan-400/30 bg-cyan-400/10 text-cyan-100",
+      idleLabel: "Pin stream",
+      activeLabel: "Unpin stream",
+      onClick: onToggleCompare,
+    },
   ];
 
   if (!stream) {
@@ -44,9 +75,12 @@ export function InspectorPanel({
         <p className="text-xs uppercase tracking-[0.35em] text-slate-500">
           Inspector Panel
         </p>
-        <h2 className="mt-4 text-2xl font-semibold text-white">No stream selected</h2>
+        <h2 className="mt-4 text-2xl font-semibold text-white">
+          No stream selected
+        </h2>
         <p className="mt-3 text-sm leading-6 text-slate-400">
-          Select a stream card to inspect the synthetic readings, recent markers, and local controls. Selecting the same card again clears the workspace back to this idle state.
+          Inspect a stream card or jump in from the anomaly feed to explain
+          confidence changes, compare peers, and review local controls.
         </p>
       </aside>
     );
@@ -59,8 +93,12 @@ export function InspectorPanel({
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <p className="text-xs uppercase tracking-[0.35em] text-slate-400">Inspector Panel</p>
-          <h2 className="mt-3 text-2xl font-semibold text-white">{stream.name}</h2>
+          <p className="text-xs uppercase tracking-[0.35em] text-slate-400">
+            Inspector Panel
+          </p>
+          <h2 className="mt-3 text-2xl font-semibold text-white">
+            {stream.name}
+          </h2>
           <p className="mt-2 text-sm text-slate-400">
             {stream.channel} / {stream.region}
           </p>
@@ -73,19 +111,35 @@ export function InspectorPanel({
           Clear selection
         </button>
       </div>
+
       <div className="mt-5 grid gap-3 sm:grid-cols-2">
-        {[["Cadence", stream.cadence], ["Open anomalies", String(anomalyCount)]].map(([label, value]) => (
-          <div key={label} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
-            <p className="text-xs uppercase tracking-[0.2em] text-slate-500">{label}</p>
+        {[
+          ["Confidence", `${stream.confidence}%`],
+          ["Visible shift", `${getConfidenceShiftLabel(stream, comparisonWindow)} in the ${getWindowLabel(comparisonWindow)}`],
+          ["Open anomalies", String(anomalies.length)],
+          ["Compared peers", String(peerNotes.length)],
+        ].map(([label, value]) => (
+          <div
+            key={label}
+            className="rounded-2xl border border-white/10 bg-white/[0.03] p-4"
+          >
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+              {label}
+            </p>
             <p className="mt-2 text-lg font-medium text-white">{value}</p>
           </div>
         ))}
       </div>
+
       <div className="mt-5 grid gap-3 sm:grid-cols-3">
         {controls.map((control) => (
           <button
             key={control.idleLabel}
-            className={`rounded-2xl border px-4 py-3 text-left text-sm transition ${control.active ? control.activeClasses : "border-white/10 bg-white/[0.03] text-slate-100 hover:border-white/20"}`}
+            className={`rounded-2xl border px-4 py-3 text-left text-sm transition ${
+              control.active
+                ? control.activeClasses
+                : "border-white/10 bg-white/[0.03] text-slate-100 hover:border-white/20"
+            }`}
             onClick={control.onClick}
             type="button"
           >
@@ -93,28 +147,143 @@ export function InspectorPanel({
           </button>
         ))}
       </div>
-      <div className="mt-6">
-        <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Inspector reads</p>
-        <div className="mt-3 grid gap-3 sm:grid-cols-3">
-          {stream.readings.map((reading) => (
-            <div key={reading.label} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
-              <p className="text-sm text-slate-400">{reading.label}</p>
-              <p className="mt-2 text-xl font-medium text-white">{reading.value}</p>
-              <p className={`mt-2 text-sm ${toneClasses[reading.tone]}`}>{reading.trend}</p>
+
+      <div className="mt-6 rounded-[1.5rem] border border-white/10 bg-white/[0.03] p-5">
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-500">
+          Confidence narrative
+        </p>
+        <p className="mt-3 text-sm leading-6 text-slate-300">
+          {stream.confidenceStory}
+        </p>
+        <div className="mt-4 grid gap-3 sm:grid-cols-3">
+          {[
+            ["Baseline", stream.baseline],
+            ["Drift driver", stream.driftDriver],
+            ["Outlook", stream.outlook],
+          ].map(([label, value]) => (
+            <div
+              key={label}
+              className="rounded-2xl border border-white/10 bg-black/20 p-4"
+            >
+              <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                {label}
+              </p>
+              <p className="mt-2 text-sm text-white">{value}</p>
             </div>
           ))}
         </div>
       </div>
+
       <div className="mt-6">
-        <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Marker trail</p>
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs uppercase tracking-[0.3em] text-slate-500">
+            Anomaly explanations
+          </p>
+          <p className="text-sm text-slate-400">
+            {anomalies.length} linked to this stream
+          </p>
+        </div>
+        <div className="mt-3 space-y-3">
+          {anomalies.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-white/10 px-4 py-6 text-sm text-slate-400">
+              No anomalies are linked to the inspected stream.
+            </div>
+          ) : null}
+          {anomalies.map((anomaly) => (
+            <article
+              key={anomaly.id}
+              className="rounded-2xl border border-white/10 bg-white/[0.03] p-4"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <p className="font-medium text-white">{anomaly.title}</p>
+                <p className="text-sm text-slate-500">{anomaly.detectedAt}</p>
+              </div>
+              <p className="mt-2 text-sm text-slate-300">
+                {anomaly.confidenceShift}
+              </p>
+              <p className="mt-2 text-sm text-slate-400">
+                {anomaly.explanation}
+              </p>
+              <p className="mt-2 text-sm text-slate-400">
+                {anomaly.compareNote}
+              </p>
+            </article>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs uppercase tracking-[0.3em] text-slate-500">
+            Compared peers
+          </p>
+          <p className="text-sm text-slate-400">
+            {peerNotes.length} active comparisons
+          </p>
+        </div>
+        <div className="mt-3 space-y-3">
+          {peerNotes.length === 0 ? (
+            <div className="rounded-2xl border border-dashed border-white/10 px-4 py-6 text-sm text-slate-400">
+              Pin at least one additional stream to generate peer comparison
+              notes in the inspector.
+            </div>
+          ) : null}
+          {peerNotes.map((note) => (
+            <article
+              key={note.peerId}
+              className="rounded-2xl border border-white/10 bg-white/[0.03] p-4"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <p className="font-medium text-white">{note.peerName}</p>
+                <p className="text-sm text-slate-400">{note.confidenceGap}</p>
+              </div>
+              <p className="mt-2 text-sm text-slate-300">{note.shiftGap}</p>
+              <p className="mt-2 text-sm text-slate-400">{note.summary}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-500">
+          Inspector reads
+        </p>
+        <div className="mt-3 grid gap-3 sm:grid-cols-3">
+          {stream.readings.map((reading) => (
+            <div
+              key={reading.label}
+              className="rounded-2xl border border-white/10 bg-white/[0.03] p-4"
+            >
+              <p className="text-sm text-slate-400">{reading.label}</p>
+              <p className="mt-2 text-xl font-medium text-white">
+                {reading.value}
+              </p>
+              <p className={`mt-2 text-sm ${toneClasses[reading.tone]}`}>
+                {reading.trend}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <p className="text-xs uppercase tracking-[0.3em] text-slate-500">
+          Marker trail
+        </p>
         <div className="mt-3 space-y-3">
           {stream.markers.map((marker) => (
-            <div key={`${marker.label}-${marker.time}`} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+            <div
+              key={`${marker.label}-${marker.time}`}
+              className="rounded-2xl border border-white/10 bg-white/[0.03] p-4"
+            >
               <div className="flex items-center justify-between gap-3">
                 <p className="font-medium text-white">{marker.label}</p>
                 <p className="text-sm text-slate-500">{marker.time}</p>
               </div>
               <p className="mt-2 text-sm text-slate-400">{marker.detail}</p>
+              <p className="mt-2 text-sm text-slate-400">
+                {marker.confidenceNote}
+              </p>
             </div>
           ))}
         </div>

--- a/src/components/signal-lab/mock-data.ts
+++ b/src/components/signal-lab/mock-data.ts
@@ -2,8 +2,54 @@ export type StreamStatus = "stable" | "drifting" | "critical";
 export type Severity = "low" | "medium" | "high";
 export type ReadingTone = "steady" | "watch" | "alert";
 
-export type StreamReading = { label: string; value: string; trend: string; tone: ReadingTone };
-export type StreamMarker = { label: string; time: string; detail: string };
+export const comparisonWindows = [
+  {
+    id: "45m",
+    label: "45m lens",
+    detail: "Recent recovery pulses and short-run confidence swings.",
+  },
+  {
+    id: "2h",
+    label: "2h lens",
+    detail: "Full anomaly run covering the current operating block.",
+  },
+  {
+    id: "shift",
+    label: "Shift lens",
+    detail: "Handoff posture across the longer operator window.",
+  },
+] as const;
+
+export type ComparisonWindow = (typeof comparisonWindows)[number]["id"];
+
+export type StreamReading = {
+  label: string;
+  value: string;
+  trend: string;
+  tone: ReadingTone;
+};
+
+export type StreamMarker = {
+  label: string;
+  time: string;
+  detail: string;
+  confidenceNote: string;
+};
+
+export type StreamTrendPoint = {
+  time: string;
+  confidence: number;
+  phaseLock: number;
+  echoSpill: number;
+  anomalyLoad: number;
+  note: string;
+};
+
+export type StreamCallout = {
+  label: string;
+  detail: string;
+};
+
 export type SignalStream = {
   id: string;
   name: string;
@@ -15,8 +61,16 @@ export type SignalStream = {
   noiseFloor: string;
   syncWindow: string;
   region: string;
+  confidence: number;
+  baseline: string;
+  watchword: string;
+  confidenceStory: string;
+  driftDriver: string;
+  outlook: string;
   readings: StreamReading[];
   markers: StreamMarker[];
+  history: StreamTrendPoint[];
+  callouts: StreamCallout[];
 };
 
 export type SignalAnomaly = {
@@ -28,56 +82,531 @@ export type SignalAnomaly = {
   detectedAt: string;
   delta: string;
   recommendation: string;
+  confidenceShift: string;
+  driver: string;
+  explanation: string;
+  compareNote: string;
 };
 
 export const heartbeatSeed = "2026-04-19T09:30:00.000Z";
-const reading = (label: string, value: string, trend: string, tone: ReadingTone): StreamReading => ({ label, value, trend, tone });
-const marker = (label: string, time: string, detail: string): StreamMarker => ({ label, time, detail });
+
+const reading = (
+  label: string,
+  value: string,
+  trend: string,
+  tone: ReadingTone,
+): StreamReading => ({
+  label,
+  value,
+  trend,
+  tone,
+});
+
+const marker = (
+  label: string,
+  time: string,
+  detail: string,
+  confidenceNote: string,
+): StreamMarker => ({
+  label,
+  time,
+  detail,
+  confidenceNote,
+});
+
+const point = (
+  time: string,
+  confidence: number,
+  phaseLock: number,
+  echoSpill: number,
+  anomalyLoad: number,
+  note: string,
+): StreamTrendPoint => ({
+  time,
+  confidence,
+  phaseLock,
+  echoSpill,
+  anomalyLoad,
+  note,
+});
+
+const callout = (label: string, detail: string): StreamCallout => ({
+  label,
+  detail,
+});
+
 export const signalStreams: SignalStream[] = [
   {
-    id: "ion-trace-07", name: "Ion Trace 07", channel: "Substrate relay", status: "stable", owner: "Console North",
-    throughput: "184 kHz", cadence: "4.2 ms jitter", noiseFloor: "-72 dB", syncWindow: "94.8%", region: "Delta Shelf",
-    readings: [reading("Phase lock", "0.91", "+0.02", "steady"), reading("Return gain", "8.4 dB", "-0.1", "steady"), reading("Echo spill", "3.7%", "+0.4", "watch")],
-    markers: [marker("Bootstrap", "09:24:12", "Loop seal closed"), marker("Sweep", "09:27:40", "Noise gate normalized"), marker("Pulse", "09:29:58", "Signal plateau retained")],
+    id: "ion-trace-07",
+    name: "Ion Trace 07",
+    channel: "Substrate relay",
+    status: "stable",
+    owner: "Console North",
+    throughput: "184 kHz",
+    cadence: "4.2 ms jitter",
+    noiseFloor: "-72 dB",
+    syncWindow: "94.8%",
+    region: "Delta Shelf",
+    confidence: 91,
+    baseline: "Bootstrap-calibrated relay reference",
+    watchword: "Fast local recovery",
+    confidenceStory:
+      "Confidence dipped briefly during the latest bootstrap gate slip, then recovered above the morning line within two heartbeat cycles.",
+    driftDriver: "bootstrap gate slip",
+    outlook:
+      "Good baseline candidate for side-by-side comparisons against noisier channels.",
+    readings: [
+      reading("Phase lock", "0.91", "+0.02", "steady"),
+      reading("Return gain", "8.4 dB", "-0.1", "steady"),
+      reading("Echo spill", "3.7%", "+0.4", "watch"),
+    ],
+    markers: [
+      marker(
+        "Bootstrap",
+        "09:24:12",
+        "Loop seal closed before the last relay sweep.",
+        "Confidence recovered after the gate cleared.",
+      ),
+      marker(
+        "Sweep",
+        "09:27:40",
+        "Noise gate normalized with no saturation spike.",
+        "The stream returned to its normal confidence band.",
+      ),
+      marker(
+        "Pulse",
+        "09:29:58",
+        "Synthetic plateau retained on the final pulse cluster.",
+        "No further confidence drift appeared after the pulse.",
+      ),
+    ],
+    history: [
+      point("08:10", 86, 0.87, 4.2, 1, "Bootstrap slip begins."),
+      point("08:35", 87, 0.88, 4.0, 1, "Gate stabilizer catches up."),
+      point("09:00", 88, 0.89, 3.9, 1, "Confidence returns to baseline."),
+      point("09:15", 90, 0.91, 3.8, 0, "Plateau restored."),
+      point("09:30", 89, 0.9, 3.9, 1, "Minor spill returns."),
+      point("09:45", 91, 0.91, 3.7, 0, "Relay closes strong."),
+    ],
+    callouts: [
+      callout(
+        "Baseline role",
+        "Keeps the cleanest substrate relay profile in the current set.",
+      ),
+      callout(
+        "Confidence anchor",
+        "Recovered faster than any other stream after a negative event.",
+      ),
+      callout(
+        "Compare use",
+        "Best pinned beside drifting channels to isolate whether noise is systemic.",
+      ),
+    ],
   },
   {
-    id: "phase-array-12", name: "Phase Array 12", channel: "Synthetic mirror", status: "drifting", owner: "Vector Room",
-    throughput: "236 kHz", cadence: "9.6 ms jitter", noiseFloor: "-61 dB", syncWindow: "87.2%", region: "North Basin",
-    readings: [reading("Phase lock", "0.74", "-0.11", "watch"), reading("Return gain", "6.1 dB", "-0.8", "watch"), reading("Echo spill", "9.8%", "+2.1", "alert")],
-    markers: [marker("Offset", "09:18:09", "Mirror lane diverged"), marker("Drift", "09:26:41", "Threshold crossed"), marker("Clamp", "09:29:22", "Recovery bias applied")],
+    id: "phase-array-12",
+    name: "Phase Array 12",
+    channel: "Synthetic mirror",
+    status: "drifting",
+    owner: "Vector Room",
+    throughput: "236 kHz",
+    cadence: "9.6 ms jitter",
+    noiseFloor: "-61 dB",
+    syncWindow: "87.2%",
+    region: "North Basin",
+    confidence: 74,
+    baseline: "Mirror lane reference with manual clamp support",
+    watchword: "Mirror divergence",
+    confidenceStory:
+      "Confidence has been sliding for the full operating block because the mirror lane keeps drifting wider than the recovery clamp can absorb.",
+    driftDriver: "mirror lane divergence",
+    outlook:
+      "Needs comparison against a stable reference before the clamp setting is tuned again.",
+    readings: [
+      reading("Phase lock", "0.74", "-0.11", "watch"),
+      reading("Return gain", "6.1 dB", "-0.8", "watch"),
+      reading("Echo spill", "9.8%", "+2.1", "alert"),
+    ],
+    markers: [
+      marker(
+        "Offset",
+        "09:18:09",
+        "Mirror lane diverged off the expected return angle.",
+        "Confidence began falling immediately after the offset marker.",
+      ),
+      marker(
+        "Drift",
+        "09:26:41",
+        "Threshold crossed and operator clamp bias applied.",
+        "The clamp slowed the drop but did not reverse it.",
+      ),
+      marker(
+        "Clamp",
+        "09:29:22",
+        "Recovery bias held the stream inside manual control range.",
+        "Confidence stabilized temporarily while the clamp remained active.",
+      ),
+    ],
+    history: [
+      point("08:10", 86, 0.86, 7.6, 1, "Mirror lane still inside envelope."),
+      point("08:35", 83, 0.82, 8.1, 1, "Return angle begins widening."),
+      point("09:00", 80, 0.79, 8.6, 2, "Clamp is engaged."),
+      point("09:15", 78, 0.77, 9.1, 2, "Manual bias slows the loss."),
+      point("09:30", 76, 0.75, 9.6, 2, "Spill continues to grow."),
+      point("09:45", 74, 0.74, 9.8, 2, "Mirror stays outside the preferred lane."),
+    ],
+    callouts: [
+      callout(
+        "Pressure point",
+        "Confidence loss tracks almost one-for-one with widening spill.",
+      ),
+      callout(
+        "Operator note",
+        "Recovery clamp buys time but does not remove the underlying divergence.",
+      ),
+      callout(
+        "Compare use",
+        "Pair with Ion Trace 07 or Harbor Sim 21 to see whether instability is local.",
+      ),
+    ],
   },
   {
-    id: "lattice-echo-03", name: "Lattice Echo 03", channel: "Null cage", status: "critical", owner: "Archive West",
-    throughput: "117 kHz", cadence: "14.8 ms jitter", noiseFloor: "-54 dB", syncWindow: "72.4%", region: "Quiet Fringe",
-    readings: [reading("Phase lock", "0.41", "-0.23", "alert"), reading("Return gain", "3.3 dB", "-1.9", "alert"), reading("Echo spill", "18.4%", "+4.7", "alert")],
-    markers: [marker("Fault", "09:15:38", "Carrier split detected"), marker("Spike", "09:21:03", "Synthetic bloom flared"), marker("Hold", "09:28:11", "Operator froze relay")],
+    id: "lattice-echo-03",
+    name: "Lattice Echo 03",
+    channel: "Null cage",
+    status: "critical",
+    owner: "Archive West",
+    throughput: "117 kHz",
+    cadence: "14.8 ms jitter",
+    noiseFloor: "-54 dB",
+    syncWindow: "72.4%",
+    region: "Quiet Fringe",
+    confidence: 58,
+    baseline: "Null cage relay under frozen hold conditions",
+    watchword: "Escalating bloom",
+    confidenceStory:
+      "Confidence is collapsing because every third pulse packet flares the return path and forces the null cage into increasingly narrow recovery windows.",
+    driftDriver: "echo bloom flare",
+    outlook:
+      "Treat as the watch floor in any comparison workspace until relay saturation risk is removed.",
+    readings: [
+      reading("Phase lock", "0.41", "-0.23", "alert"),
+      reading("Return gain", "3.3 dB", "-1.9", "alert"),
+      reading("Echo spill", "18.4%", "+4.7", "alert"),
+    ],
+    markers: [
+      marker(
+        "Fault",
+        "09:15:38",
+        "Carrier split detected inside the null cage.",
+        "Confidence dropped sharply after the split.",
+      ),
+      marker(
+        "Spike",
+        "09:21:03",
+        "Synthetic bloom flared on the third pulse cycle.",
+        "Each bloom flare removed another band of confidence.",
+      ),
+      marker(
+        "Hold",
+        "09:28:11",
+        "Operator froze the relay before the cage saturated.",
+        "The hold stopped a steeper decline but did not recover the stream.",
+      ),
+    ],
+    history: [
+      point("08:10", 78, 0.64, 11.2, 1, "Return path already warm."),
+      point("08:35", 72, 0.58, 12.6, 1, "Bloom cycles start repeating."),
+      point("09:00", 69, 0.53, 14.1, 2, "Third-pulse flare confirmed."),
+      point("09:15", 64, 0.48, 15.9, 2, "Carrier split widens."),
+      point("09:30", 60, 0.44, 17.5, 2, "Null cage forced into hold."),
+      point("09:45", 58, 0.41, 18.4, 2, "Confidence stays in the critical band."),
+    ],
+    callouts: [
+      callout(
+        "Critical floor",
+        "Lowest-confidence stream in the workspace and the largest anomaly burden.",
+      ),
+      callout(
+        "Immediate question",
+        "Need to separate cage instability from upstream bloom amplification.",
+      ),
+      callout(
+        "Compare use",
+        "Pin beside stable streams to quantify how much bloom is local versus shared.",
+      ),
+    ],
   },
   {
-    id: "harbor-sim-21", name: "Harbor Sim 21", channel: "Coastal sampler", status: "stable", owner: "Dock Array",
-    throughput: "201 kHz", cadence: "5.7 ms jitter", noiseFloor: "-69 dB", syncWindow: "92.1%", region: "South Break",
-    readings: [reading("Phase lock", "0.88", "+0.01", "steady"), reading("Return gain", "7.6 dB", "+0.2", "steady"), reading("Echo spill", "4.4%", "-0.3", "steady")],
-    markers: [marker("Anchor", "09:17:20", "Baseline restored"), marker("Trim", "09:25:33", "Channel weight balanced"), marker("Pulse", "09:29:44", "Heartbeat confirmed")],
+    id: "harbor-sim-21",
+    name: "Harbor Sim 21",
+    channel: "Coastal sampler",
+    status: "stable",
+    owner: "Dock Array",
+    throughput: "201 kHz",
+    cadence: "5.7 ms jitter",
+    noiseFloor: "-69 dB",
+    syncWindow: "92.1%",
+    region: "South Break",
+    confidence: 88,
+    baseline: "Balanced coastal sampler reference",
+    watchword: "Flat confidence curve",
+    confidenceStory:
+      "Confidence stayed nearly flat after a resolved cadence shear, which makes this stream a strong comparator for recent drift investigations.",
+    driftDriver: "resolved cadence shear",
+    outlook:
+      "Useful control stream when operators need to check whether a spike is environmental.",
+    readings: [
+      reading("Phase lock", "0.88", "+0.01", "steady"),
+      reading("Return gain", "7.6 dB", "+0.2", "steady"),
+      reading("Echo spill", "4.4%", "-0.3", "steady"),
+    ],
+    markers: [
+      marker(
+        "Anchor",
+        "09:17:20",
+        "Baseline restored after sampler trim correction.",
+        "Confidence returned to the morning baseline and held.",
+      ),
+      marker(
+        "Trim",
+        "09:25:33",
+        "Channel weight balanced across the coastal band.",
+        "No secondary loss appeared after trim.",
+      ),
+      marker(
+        "Pulse",
+        "09:29:44",
+        "Heartbeat confirmed at target cadence.",
+        "Confidence remained flat through the last pulse cycle.",
+      ),
+    ],
+    history: [
+      point("08:10", 84, 0.85, 4.8, 1, "Minor cadence shear appears."),
+      point("08:35", 85, 0.86, 4.7, 1, "Sampler trim begins."),
+      point("09:00", 86, 0.87, 4.6, 1, "Shear is already easing."),
+      point("09:15", 87, 0.88, 4.5, 0, "Baseline returns."),
+      point("09:30", 88, 0.88, 4.4, 0, "Channel remains balanced."),
+      point("09:45", 88, 0.88, 4.4, 0, "Confidence holds flat."),
+    ],
+    callouts: [
+      callout(
+        "Control stream",
+        "Most even confidence shape after the sampler trim was applied.",
+      ),
+      callout(
+        "Residual risk",
+        "Cadence shear is resolved, but the recovery should still be reviewed.",
+      ),
+      callout(
+        "Compare use",
+        "Pairs well with drifting streams to confirm whether spill is localized.",
+      ),
+    ],
+  },
+  {
+    id: "prism-tide-05",
+    name: "Prism Tide 05",
+    channel: "Refracted sampler",
+    status: "drifting",
+    owner: "Helix Pier",
+    throughput: "168 kHz",
+    cadence: "7.4 ms jitter",
+    noiseFloor: "-66 dB",
+    syncWindow: "89.9%",
+    region: "Glass Inlet",
+    confidence: 82,
+    baseline: "Refracted sampling lane with tidal reflection",
+    watchword: "Oscillating harmonic residue",
+    confidenceStory:
+      "Confidence is still net positive on the longer lens, but the latest harmonic residue reintroduced oscillation that needs to be compared against the cleaner baselines.",
+    driftDriver: "harmonic residue rebounds",
+    outlook:
+      "Worth pinning when operators need a stream that is neither clean nor critical.",
+    readings: [
+      reading("Phase lock", "0.83", "+0.03", "steady"),
+      reading("Return gain", "6.9 dB", "-0.2", "watch"),
+      reading("Echo spill", "7.1%", "+1.4", "watch"),
+    ],
+    markers: [
+      marker(
+        "Refract",
+        "09:12:06",
+        "Tidal reflection clipped the outer sampling lane.",
+        "Confidence rose first, then softened as residue returned.",
+      ),
+      marker(
+        "Ripple",
+        "09:23:17",
+        "Harmonic residue widened across the refracted path.",
+        "The stream lost some of its earlier gains after the ripple.",
+      ),
+      marker(
+        "Balance",
+        "09:31:48",
+        "Operator rebalanced the sampler without muting the lane.",
+        "Confidence stayed above the morning line despite the wobble.",
+      ),
+    ],
+    history: [
+      point("08:10", 79, 0.79, 6.2, 1, "Sampler wakes into a clean band."),
+      point("08:35", 81, 0.81, 6.5, 1, "Tidal reflection lifts the lane."),
+      point("09:00", 82, 0.82, 6.8, 1, "Confidence peaks early."),
+      point("09:15", 83, 0.84, 6.9, 1, "Refracted path stays strong."),
+      point("09:30", 81, 0.82, 7.0, 1, "Residue returns."),
+      point("09:45", 82, 0.83, 7.1, 1, "Operator rebalance steadies the loss."),
+    ],
+    callouts: [
+      callout(
+        "Middle signal",
+        "Sits between the cleanest baselines and the critical floor.",
+      ),
+      callout(
+        "Useful comparison",
+        "Helps determine whether newer residue events are likely to self-correct.",
+      ),
+      callout(
+        "Watch item",
+        "Latest oscillation makes it a good peer for Phase Array 12 detail checks.",
+      ),
+    ],
   },
 ];
+
 export const signalAnomalies: SignalAnomaly[] = [
   {
-    id: "phase-drift-envelope", streamId: "phase-array-12", title: "Phase drift beyond synthetic envelope", severity: "high",
-    summary: "Mirror channel yaw is widening faster than the auto-clamp can recover.", detectedAt: "09:28:45", delta: "+14.2%",
-    recommendation: "Focus the stream and watch the next recovery pass.",
+    id: "phase-drift-envelope",
+    streamId: "phase-array-12",
+    title: "Phase drift beyond synthetic envelope",
+    severity: "high",
+    summary:
+      "Mirror channel yaw is widening faster than the auto-clamp can recover.",
+    detectedAt: "09:28:45",
+    delta: "+14.2%",
+    recommendation:
+      "Pin this stream beside a stable baseline before changing the clamp again.",
+    confidenceShift: "-12 pts in the 2h lens",
+    driver: "Mirror lane divergence",
+    explanation:
+      "The clamp arrests the acceleration but does not pull the mirror back into the expected lane, so confidence keeps bleeding after every pulse.",
+    compareNote:
+      "Compared with Ion Trace 07, the spill rate is more than double while the reference lane remains steady.",
   },
   {
-    id: "echo-bloom-flare", streamId: "lattice-echo-03", title: "Echo bloom flare on null cage return", severity: "high",
-    summary: "The return path shows a repeated flare every third pulse packet.", detectedAt: "09:26:58", delta: "+22.9%",
-    recommendation: "Pause the stream before the relay saturates.",
+    id: "mirror-recovery-lag",
+    streamId: "phase-array-12",
+    title: "Recovery clamp lag after offset correction",
+    severity: "medium",
+    summary:
+      "Manual bias is active, but the recovery curve still lags the last two checkpoints.",
+    detectedAt: "09:31:12",
+    delta: "+5.4%",
+    recommendation:
+      "Inspect the next two recovery markers before releasing manual control.",
+    confidenceShift: "-4 pts after clamp engagement",
+    driver: "Delayed clamp response",
+    explanation:
+      "The operator clamp is keeping the stream operable, but its recovery tail is too slow to reverse the recent loss within the current operating block.",
+    compareNote:
+      "Harbor Sim 21 recovered a similar cadence issue without a persistent tail, which makes this lag stand out.",
   },
   {
-    id: "noise-gate-slip", streamId: "ion-trace-07", title: "Noise gate slip near bootstrap marker", severity: "medium",
-    summary: "A brief gate slip appeared after the last bootstrap cycle.", detectedAt: "09:24:13", delta: "+6.1%",
-    recommendation: "Track the anomaly to compare with the next heartbeat.",
+    id: "echo-bloom-flare",
+    streamId: "lattice-echo-03",
+    title: "Echo bloom flare on null cage return",
+    severity: "high",
+    summary:
+      "The return path shows a repeated flare every third pulse packet.",
+    detectedAt: "09:26:58",
+    delta: "+22.9%",
+    recommendation:
+      "Keep the relay under hold and compare it with a clean baseline before resuming.",
+    confidenceShift: "-20 pts in the 2h lens",
+    driver: "Repeated third-pulse bloom flare",
+    explanation:
+      "Each flare widens the return bloom and strips confidence from the null cage because the hold arrives after the highest-energy packet has already landed.",
+    compareNote:
+      "No other pinned stream shows a decay slope this steep, even when spill is already elevated.",
   },
   {
-    id: "cadence-shear", streamId: "harbor-sim-21", title: "Cadence shear resolved but still reportable", severity: "low",
-    summary: "A resolved cadence shear remains within the historical watch range.", detectedAt: "09:19:05", delta: "+2.3%",
-    recommendation: "Dismiss after operator review if the channel stays steady.",
+    id: "noise-gate-slip",
+    streamId: "ion-trace-07",
+    title: "Noise gate slip near bootstrap marker",
+    severity: "medium",
+    summary:
+      "A brief gate slip appeared after the last bootstrap cycle.",
+    detectedAt: "09:24:13",
+    delta: "+6.1%",
+    recommendation:
+      "Keep it pinned as the reference if the next heartbeat stays clean.",
+    confidenceShift: "-3 pts, then recovered",
+    driver: "Bootstrap gate slip",
+    explanation:
+      "The gate slip caused a short-lived spill increase, but the relay regained its confidence band before the next full sweep.",
+    compareNote:
+      "The recovery window is much shorter than the one currently affecting Phase Array 12.",
+  },
+  {
+    id: "cadence-shear",
+    streamId: "harbor-sim-21",
+    title: "Cadence shear resolved but still reportable",
+    severity: "low",
+    summary:
+      "A resolved cadence shear remains within the historical watch range.",
+    detectedAt: "09:19:05",
+    delta: "+2.3%",
+    recommendation:
+      "Keep as a calm comparator until the next shoreline sampling cycle completes.",
+    confidenceShift: "+4 pts since the early shear",
+    driver: "Minor sampler trim lag",
+    explanation:
+      "The issue is effectively closed, but it is still valuable because it shows what a healthy recovery shape looks like in the same workspace.",
+    compareNote:
+      "Useful as the low-drama reference when comparing noisy or critical streams.",
+  },
+  {
+    id: "harmonic-ghost",
+    streamId: "prism-tide-05",
+    title: "Harmonic residue ghosting on refracted lane",
+    severity: "medium",
+    summary:
+      "A refracted residue band returned after the sampler had almost cleared.",
+    detectedAt: "09:30:28",
+    delta: "+8.7%",
+    recommendation:
+      "Pair with a stable lane to decide whether the residue is self-correcting or growing.",
+    confidenceShift: "+3 pts, then softened to +1",
+    driver: "Refracted harmonic residue",
+    explanation:
+      "The stream still sits above its early confidence line, but the residue wobble is eating into those gains and could become a persistent drift pattern.",
+    compareNote:
+      "It is a strong midpoint reference when the workspace needs something between calm and critical.",
   },
 ];
+
+export function getSignalStreamById(streamId: string | null | undefined) {
+  if (!streamId) {
+    return null;
+  }
+
+  return signalStreams.find((stream) => stream.id === streamId) ?? null;
+}
+
+export function getSignalStreamAnomalies(streamId: string) {
+  return signalAnomalies.filter((anomaly) => anomaly.streamId === streamId);
+}
+
+export function getHistoryForWindow(
+  stream: SignalStream,
+  window: ComparisonWindow,
+) {
+  switch (window) {
+    case "45m":
+      return stream.history.slice(-4);
+    case "shift":
+      return stream.history;
+    case "2h":
+    default:
+      return stream.history.slice(-6);
+  }
+}

--- a/src/components/signal-lab/signal-lab-header.tsx
+++ b/src/components/signal-lab/signal-lab-header.tsx
@@ -5,7 +5,10 @@ type SignalLabHeaderProps = {
   openAnomalies: number;
   mutedStreams: number;
   pausedStreams: number;
-  focusedStream: string | null;
+  activeStream: string | null;
+  comparedStreams: number;
+  comparisonView: "summary" | "detail";
+  comparisonWindowLabel: string;
 };
 
 export function SignalLabHeader({
@@ -15,37 +18,58 @@ export function SignalLabHeader({
   openAnomalies,
   mutedStreams,
   pausedStreams,
-  focusedStream,
+  activeStream,
+  comparedStreams,
+  comparisonView,
+  comparisonWindowLabel,
 }: SignalLabHeaderProps) {
   const panels = [
-    { label: "Lab State", value: labState, detail: `Heartbeat ${heartbeat}` },
-    { label: "Active Sweep", value: `${activeStreams} streams / ${openAnomalies} anomalies`, detail: `Paused ${pausedStreams} / Muted ${mutedStreams}` },
-    { label: "Focus Lock", value: focusedStream ?? "No stream focused", detail: "Select a card again to clear the inspector.", span: true },
+    {
+      label: "Lab state",
+      value: labState,
+      detail: `Heartbeat ${heartbeat}`,
+    },
+    {
+      label: "Comparison",
+      value: `${comparedStreams} pinned / ${openAnomalies} open anomalies`,
+      detail: `${comparisonView === "summary" ? "Summary" : "Detail"} view on the ${comparisonWindowLabel}`,
+    },
+    {
+      label: "Inspector lock",
+      value: activeStream ?? "No stream selected",
+      detail: `Active ${activeStreams} / Paused ${pausedStreams} / Muted ${mutedStreams}`,
+    },
   ];
 
   return (
     <header className="rounded-[2rem] border border-cyan-400/20 bg-slate-950/80 p-6 shadow-[0_24px_90px_rgba(8,145,178,0.18)] backdrop-blur">
       <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
-        <div className="max-w-2xl">
+        <div className="max-w-3xl">
           <p className="text-xs uppercase tracking-[0.45em] text-cyan-300">
             Signal Lab
           </p>
           <h1 className="mt-3 text-3xl font-semibold tracking-tight text-white sm:text-4xl">
-            Synthetic streams with local controls and live inspector state.
+            Multi-stream comparison workspace for anomaly drift and confidence
+            shifts.
           </h1>
           <p className="mt-3 text-sm leading-6 text-slate-300 sm:text-base">
-            The workspace stays client-side: stream focus, anomaly triage, and
-            operator toggles all update locally without server calls.
+            Pin multiple streams, switch between summary and detail lenses, and
+            inspect confidence movement without leaving the client-side
+            workspace.
           </p>
         </div>
         <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
           {panels.map((panel) => (
             <div
               key={panel.label}
-              className={`rounded-2xl border border-white/10 bg-white/5 px-4 py-3 ${panel.span ? "sm:col-span-2 xl:col-span-1" : ""}`}
+              className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3"
             >
-              <p className="text-xs uppercase tracking-[0.3em] text-slate-400">{panel.label}</p>
-              <p className="mt-2 text-lg font-medium text-white">{panel.value}</p>
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-400">
+                {panel.label}
+              </p>
+              <p className="mt-2 text-lg font-medium text-white">
+                {panel.value}
+              </p>
               <p className="mt-1 text-sm text-slate-400">{panel.detail}</p>
             </div>
           ))}

--- a/src/components/signal-lab/signal-lab-model.test.ts
+++ b/src/components/signal-lab/signal-lab-model.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildComparisonDetail,
+  buildComparisonSummary,
+  buildInspectorPeerNotes,
+} from "./signal-lab-model";
+
+describe("signal lab comparison model", () => {
+  it("summarizes pinned comparison posture across multiple streams", () => {
+    const summary = buildComparisonSummary(
+      ["ion-trace-07", "phase-array-12", "lattice-echo-03"],
+      "2h",
+    );
+
+    expect(summary?.headline).toContain("Ion Trace 07");
+    expect(summary?.headline).toContain("Lattice Echo 03");
+    expect(summary?.metrics[0]?.value).toBe("3");
+  });
+
+  it("builds detail rows and peer notes for the inspector", () => {
+    const detail = buildComparisonDetail(
+      ["ion-trace-07", "phase-array-12", "lattice-echo-03"],
+      "45m",
+    );
+    const peerNotes = buildInspectorPeerNotes(
+      "phase-array-12",
+      ["ion-trace-07", "phase-array-12", "lattice-echo-03"],
+      "45m",
+    );
+
+    expect(detail?.rows[0]?.name).toBe("Ion Trace 07");
+    expect(detail?.rows.at(-1)?.name).toBe("Lattice Echo 03");
+    expect(peerNotes).toHaveLength(2);
+    expect(peerNotes[0]?.summary).toMatch(/still outranks|stays ahead/i);
+  });
+});

--- a/src/components/signal-lab/signal-lab-model.ts
+++ b/src/components/signal-lab/signal-lab-model.ts
@@ -1,0 +1,243 @@
+import {
+  getHistoryForWindow,
+  getSignalStreamAnomalies,
+  getSignalStreamById,
+  type ComparisonWindow,
+  type SignalStream,
+} from "./mock-data";
+
+export type ComparisonMetric = {
+  label: string;
+  value: string;
+  detail: string;
+};
+
+export type ComparisonSummary = {
+  headline: string;
+  narrative: string;
+  metrics: ComparisonMetric[];
+  highlights: string[];
+  recommendation: string;
+};
+
+export type ComparisonDetailRow = {
+  id: string;
+  name: string;
+  status: SignalStream["status"];
+  confidence: string;
+  shift: string;
+  anomalyLoad: string;
+  driver: string;
+  watchword: string;
+  note: string;
+};
+
+export type ComparisonDetail = {
+  rows: ComparisonDetailRow[];
+  insights: string[];
+};
+
+export type InspectorPeerNote = {
+  peerId: string;
+  peerName: string;
+  confidenceGap: string;
+  shiftGap: string;
+  summary: string;
+};
+
+const windowLabels: Record<ComparisonWindow, string> = {
+  "45m": "45m lens",
+  "2h": "2h lens",
+  shift: "shift lens",
+};
+
+function getUniqueStreams(streamIds: string[]) {
+  return Array.from(new Set(streamIds)).flatMap((streamId) => {
+    const stream = getSignalStreamById(streamId);
+
+    return stream ? [stream] : [];
+  });
+}
+
+function getConfidenceShift(stream: SignalStream, window: ComparisonWindow) {
+  const history = getHistoryForWindow(stream, window);
+  const first = history[0];
+  const last = history.at(-1);
+
+  if (!first || !last) {
+    return 0;
+  }
+
+  return last.confidence - first.confidence;
+}
+
+function formatSignedValue(value: number, unit = "pts") {
+  if (value === 0) {
+    return `0 ${unit}`;
+  }
+
+  return `${value > 0 ? "+" : ""}${value} ${unit}`;
+}
+
+function formatAnomalyLoad(count: number) {
+  return `${count} ${count === 1 ? "anomaly" : "anomalies"}`;
+}
+
+export function getWindowLabel(window: ComparisonWindow) {
+  return windowLabels[window];
+}
+
+export function getConfidenceShiftLabel(
+  stream: SignalStream,
+  window: ComparisonWindow,
+) {
+  return formatSignedValue(getConfidenceShift(stream, window));
+}
+
+export function buildComparisonSummary(
+  streamIds: string[],
+  window: ComparisonWindow,
+): ComparisonSummary | null {
+  const streams = getUniqueStreams(streamIds);
+
+  if (streams.length < 2) {
+    return null;
+  }
+
+  const leader = streams.reduce((best, stream) =>
+    stream.confidence > best.confidence ? stream : best,
+  );
+  const laggard = streams.reduce((worst, stream) =>
+    stream.confidence < worst.confidence ? stream : worst,
+  );
+  const widestShiftStream = streams.reduce((current, stream) =>
+    Math.abs(getConfidenceShift(stream, window)) >
+    Math.abs(getConfidenceShift(current, window))
+      ? stream
+      : current,
+  );
+  const averageConfidence = Math.round(
+    streams.reduce((total, stream) => total + stream.confidence, 0) /
+      streams.length,
+  );
+  const totalAnomalies = streams.reduce(
+    (total, stream) => total + getSignalStreamAnomalies(stream.id).length,
+    0,
+  );
+  const improvingCount = streams.filter(
+    (stream) => getConfidenceShift(stream, window) > 0,
+  ).length;
+  const slippingCount = streams.filter(
+    (stream) => getConfidenceShift(stream, window) < 0,
+  ).length;
+  const spread = leader.confidence - laggard.confidence;
+
+  return {
+    headline: `${leader.name} anchors the comparison while ${laggard.name} sets the watch floor.`,
+    narrative: `Across the ${getWindowLabel(window)}, pinned streams average ${averageConfidence}% confidence with a ${spread}-point spread from the strongest baseline to the weakest return path.`,
+    metrics: [
+      {
+        label: "Pinned streams",
+        value: String(streams.length),
+        detail: streams.map((stream) => stream.name).join(" / "),
+      },
+      {
+        label: "Confidence spread",
+        value: `${spread} pts`,
+        detail: `${leader.name} leads at ${leader.confidence}% while ${laggard.name} trails at ${laggard.confidence}%.`,
+      },
+      {
+        label: "Open anomaly load",
+        value: String(totalAnomalies),
+        detail: `${widestShiftStream.name} shows the sharpest lens swing at ${getConfidenceShiftLabel(widestShiftStream, window)}.`,
+      },
+    ],
+    highlights: [
+      `${leader.name} is the cleanest reference because ${leader.outlook.toLowerCase()}`,
+      slippingCount > 0
+        ? `${slippingCount} pinned stream${slippingCount === 1 ? "" : "s"} are still losing confidence in the active lens.`
+        : "No pinned stream is losing confidence in the active lens.",
+      improvingCount > 0
+        ? `${improvingCount} pinned stream${improvingCount === 1 ? "" : "s"} are recovering or trending up, which gives the workspace a usable comparison baseline.`
+        : "None of the pinned streams are improving, so treat the workspace as active watch only.",
+      `${laggard.name} needs the closest inspection because ${laggard.confidenceStory.toLowerCase()}`,
+    ],
+    recommendation: `Use ${leader.name} as the baseline and inspect ${laggard.name} for ${laggard.watchword.toLowerCase()}.`,
+  };
+}
+
+export function buildComparisonDetail(
+  streamIds: string[],
+  window: ComparisonWindow,
+): ComparisonDetail | null {
+  const streams = getUniqueStreams(streamIds);
+
+  if (streams.length < 2) {
+    return null;
+  }
+
+  const rows = streams
+    .map((stream) => {
+      const anomalyCount = getSignalStreamAnomalies(stream.id).length;
+
+      return {
+        id: stream.id,
+        name: stream.name,
+        status: stream.status,
+        confidence: `${stream.confidence}%`,
+        shift: getConfidenceShiftLabel(stream, window),
+        anomalyLoad: formatAnomalyLoad(anomalyCount),
+        driver: stream.driftDriver,
+        watchword: stream.watchword,
+        note: stream.outlook,
+      };
+    })
+    .sort((left, right) => Number.parseInt(right.confidence, 10) - Number.parseInt(left.confidence, 10));
+
+  const strongest = rows[0];
+  const weakest = rows.at(-1);
+  const totalAnomalies = rows.reduce((total, row) => {
+    const count = Number.parseInt(row.anomalyLoad, 10);
+    return total + count;
+  }, 0);
+
+  return {
+    rows,
+    insights: [
+      `${strongest.name} holds the strongest confidence posture in the ${getWindowLabel(window)} at ${strongest.confidence}.`,
+      `${weakest?.name ?? strongest.name} is the current outlier and should stay visible beside the strongest baseline until its drift driver narrows.`,
+      `${totalAnomalies} open anomaly threads are represented across the pinned set, which keeps the detail view useful even when one stream looks calm.`,
+    ],
+  };
+}
+
+export function buildInspectorPeerNotes(
+  streamId: string | null,
+  compareIds: string[],
+  window: ComparisonWindow,
+): InspectorPeerNote[] {
+  const subject = getSignalStreamById(streamId);
+
+  if (!subject) {
+    return [];
+  }
+
+  return getUniqueStreams(compareIds)
+    .filter((stream) => stream.id !== subject.id)
+    .map((peer) => {
+      const confidenceGap = subject.confidence - peer.confidence;
+      const shiftGap =
+        getConfidenceShift(subject, window) - getConfidenceShift(peer, window);
+
+      return {
+        peerId: peer.id,
+        peerName: peer.name,
+        confidenceGap: formatSignedValue(confidenceGap),
+        shiftGap: `${formatSignedValue(shiftGap)} lens delta`,
+        summary:
+          confidenceGap >= 0
+            ? `${subject.name} still outranks ${peer.name}, but ${peer.driftDriver.toLowerCase()} keeps the gap active.`
+            : `${peer.name} stays ahead of ${subject.name}, so the current drift still favors the comparison baseline over the inspected stream.`,
+      };
+    });
+}

--- a/src/components/signal-lab/signal-lab-workspace.test.tsx
+++ b/src/components/signal-lab/signal-lab-workspace.test.tsx
@@ -4,27 +4,102 @@ import { describe, expect, it } from "vitest";
 import { SignalLabWorkspace } from "./signal-lab-workspace";
 
 describe("SignalLabWorkspace", () => {
-  it("updates the inspector when a new stream is selected", () => {
+  it("pins multiple streams and switches the comparison workspace into detail view", () => {
     render(<SignalLabWorkspace />);
 
-    fireEvent.click(screen.getByRole("button", { name: /Phase Array 12/i }));
+    const comparisonWorkspace = screen.getByLabelText(/Comparison workspace/i);
 
-    const inspector = screen.getByLabelText(/Inspector panel/i);
-    expect(within(inspector).getByText(/Phase Array 12/i)).toBeInTheDocument();
-    expect(within(inspector).getByText(/North Basin/i)).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Pin Lattice Echo 03 for comparison/i,
+      }),
+    );
+
+    expect(
+      within(comparisonWorkspace).getByText(
+        /Ion Trace 07 \/ Phase Array 12 \/ Lattice Echo 03/i,
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      within(comparisonWorkspace).getByRole("button", {
+        name: /Detail view/i,
+      }),
+    );
+
+    expect(within(comparisonWorkspace).getByText(/^Lens shift$/i)).toBeInTheDocument();
+    expect(
+      within(comparisonWorkspace).getByText(
+        /open anomaly threads are represented/i,
+      ),
+    ).toBeInTheDocument();
   });
 
-  it("handles anomaly dismissal and restore locally", () => {
+  it("explains anomalies and confidence shifts inside the inspector", () => {
     render(<SignalLabWorkspace />);
+
     fireEvent.click(
-      screen.getByRole("button", { name: /Dismiss Phase drift beyond synthetic envelope/i }),
+      screen.getByRole("button", { name: /Inspect Phase Array 12/i }),
     );
-    expect(screen.queryByText(/Phase drift beyond synthetic envelope/i)).not.toBeInTheDocument();
+
+    const inspector = screen.getByLabelText(/Inspector panel/i);
+
+    expect(
+      within(inspector).getByRole("heading", { name: /Phase Array 12/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(inspector).getByText(/Confidence narrative/i),
+    ).toBeInTheDocument();
+    expect(
+      within(inspector).getAllByText(/-12 pts in the 2h lens/i),
+    ).toHaveLength(2);
+    expect(
+      within(inspector).getByText(/Mirror lane divergence/i),
+    ).toBeInTheDocument();
+    expect(
+      within(inspector).getByText(/stays ahead of Phase Array 12/i),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps anomaly actions local for pinning, dismissal, and restore", () => {
+    render(<SignalLabWorkspace />);
+
+    const comparisonWorkspace = screen.getByLabelText(/Comparison workspace/i);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Pin stream Prism Tide 05/i,
+      }),
+    );
+
+    expect(
+      within(comparisonWorkspace).getByText(
+        /Ion Trace 07 \/ Phase Array 12 \/ Prism Tide 05/i,
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Dismiss Phase drift beyond synthetic envelope/i,
+      }),
+    );
+
+    expect(
+      screen.queryByText(/Phase drift beyond synthetic envelope/i),
+    ).not.toBeInTheDocument();
+
     fireEvent.click(screen.getByRole("button", { name: /Show dismissed/i }));
-    expect(screen.getByText(/Phase drift beyond synthetic envelope/i)).toBeInTheDocument();
+
+    expect(
+      screen.getByText(/Phase drift beyond synthetic envelope/i),
+    ).toBeInTheDocument();
+
     fireEvent.click(
-      screen.getByRole("button", { name: /Track Phase drift beyond synthetic envelope/i }),
+      screen.getByRole("button", {
+        name: /Track Harmonic residue ghosting on refracted lane/i,
+      }),
     );
+
     expect(screen.getByText("Tracked")).toBeInTheDocument();
   });
 });

--- a/src/components/signal-lab/signal-lab-workspace.tsx
+++ b/src/components/signal-lab/signal-lab-workspace.tsx
@@ -3,12 +3,22 @@
 import { startTransition, useEffect, useEffectEvent, useState } from "react";
 
 import {
+  getSignalStreamAnomalies,
+  getSignalStreamById,
   heartbeatSeed,
   signalAnomalies,
   signalStreams,
+  type ComparisonWindow,
 } from "./mock-data";
 import { AnomalyList } from "./anomaly-list";
+import { ComparisonWorkbench } from "./comparison-workbench";
 import { InspectorPanel } from "./inspector-panel";
+import {
+  buildComparisonDetail,
+  buildComparisonSummary,
+  buildInspectorPeerNotes,
+  getWindowLabel,
+} from "./signal-lab-model";
 import { SignalLabHeader } from "./signal-lab-header";
 import { StreamGrid } from "./stream-grid";
 
@@ -18,77 +28,148 @@ const heartbeatFormatter = new Intl.DateTimeFormat("en-US", {
   second: "2-digit",
 });
 const heartbeatStepMs = 5000;
+const maxComparedStreams = 4;
 
 function toggleId(items: string[], id: string) {
-  return items.includes(id) ? items.filter((item) => item !== id) : [...items, id];
+  return items.includes(id)
+    ? items.filter((item) => item !== id)
+    : [...items, id];
 }
+
+function toggleCompareId(items: string[], id: string) {
+  if (items.includes(id)) {
+    return items.filter((item) => item !== id);
+  }
+
+  if (items.length < maxComparedStreams) {
+    return [...items, id];
+  }
+
+  return [...items.slice(1), id];
+}
+
 export function SignalLabWorkspace() {
-  const [selectedStreamId, setSelectedStreamId] = useState<string | null>(signalStreams[0]?.id ?? null);
+  const [selectedStreamId, setSelectedStreamId] = useState<string | null>(
+    signalStreams[0]?.id ?? null,
+  );
+  const [comparedIds, setComparedIds] = useState<string[]>(
+    signalStreams.slice(0, 2).map((stream) => stream.id),
+  );
+  const [comparisonView, setComparisonView] = useState<"summary" | "detail">(
+    "summary",
+  );
+  const [comparisonWindow, setComparisonWindow] =
+    useState<ComparisonWindow>("2h");
   const [dismissedIds, setDismissedIds] = useState<string[]>([]);
   const [acknowledgedIds, setAcknowledgedIds] = useState<string[]>([]);
   const [mutedIds, setMutedIds] = useState<string[]>([]);
   const [pausedIds, setPausedIds] = useState<string[]>([]);
-  const [focusedStreamId, setFocusedStreamId] = useState<string | null>(null);
   const [showDismissed, setShowDismissed] = useState(false);
   const [heartbeatTick, setHeartbeatTick] = useState(0);
+
   const tickHeartbeat = useEffectEvent(() => {
     setHeartbeatTick((value) => value + 1);
   });
+
   useEffect(() => {
     const timerId = window.setInterval(() => tickHeartbeat(), heartbeatStepMs);
+
     return () => window.clearInterval(timerId);
   }, []);
-  const selectedStream = signalStreams.find((stream) => stream.id === selectedStreamId) ?? null;
-  const focusedStream = signalStreams.find((stream) => stream.id === focusedStreamId) ?? null;
-  const visibleStreams = focusedStreamId ? signalStreams.filter((stream) => stream.id === focusedStreamId) : signalStreams;
-  const openAnomalies = signalAnomalies.filter((anomaly) => !dismissedIds.includes(anomaly.id));
-  const visibleAnomalies = signalAnomalies.filter((anomaly) => {
-    if (focusedStreamId && anomaly.streamId !== focusedStreamId) return false;
-    return showDismissed || !dismissedIds.includes(anomaly.id);
+
+  const selectedStream = getSignalStreamById(selectedStreamId);
+  const comparedStreams = comparedIds.flatMap((streamId) => {
+    const stream = getSignalStreamById(streamId);
+
+    return stream ? [stream] : [];
   });
-  const selectedStreamAnomalies = selectedStream ? openAnomalies.filter((anomaly) => anomaly.streamId === selectedStream.id) : [];
-  const heartbeat = heartbeatFormatter.format(new Date(new Date(heartbeatSeed).getTime() + heartbeatTick * heartbeatStepMs));
+  const openAnomalies = signalAnomalies.filter(
+    (anomaly) => !dismissedIds.includes(anomaly.id),
+  );
+  const visibleAnomalies = signalAnomalies.filter(
+    (anomaly) => showDismissed || !dismissedIds.includes(anomaly.id),
+  );
+  const selectedStreamAnomalies = selectedStream
+    ? getSignalStreamAnomalies(selectedStream.id)
+    : [];
+  const comparedOpenAnomalies = openAnomalies.filter((anomaly) =>
+    comparedIds.includes(anomaly.streamId),
+  );
+  const comparisonSummary = buildComparisonSummary(
+    comparedIds,
+    comparisonWindow,
+  );
+  const comparisonDetail = buildComparisonDetail(comparedIds, comparisonWindow);
+  const inspectorPeerNotes = buildInspectorPeerNotes(
+    selectedStreamId,
+    comparedIds,
+    comparisonWindow,
+  );
+  const heartbeat = heartbeatFormatter.format(
+    new Date(new Date(heartbeatSeed).getTime() + heartbeatTick * heartbeatStepMs),
+  );
   const activeStreams = signalStreams.length - pausedIds.length;
-  const labState = focusedStreamId
-    ? "Focused capture"
-    : openAnomalies.some((anomaly) => anomaly.severity === "high")
-      ? "Critical watch"
-      : pausedIds.length > 0
-        ? "Partial hold"
-        : "Nominal sweep";
-  const handleSelectStream = (streamId: string) => {
+  const labState =
+    comparedIds.length >= 3
+      ? "Comparison sweep"
+      : comparedIds.length >= 2
+        ? "Pairwise compare"
+        : openAnomalies.some((anomaly) => anomaly.severity === "high")
+          ? "Critical watch"
+          : pausedIds.length > 0
+            ? "Partial hold"
+            : "Nominal sweep";
+
+  const handleInspectStream = (streamId: string) => {
     startTransition(() => {
-      const nextStreamId = selectedStreamId === streamId ? null : streamId;
-      setSelectedStreamId(nextStreamId);
-      if (nextStreamId === null && focusedStreamId === streamId) {
-        setFocusedStreamId(null);
-      }
+      setSelectedStreamId((current) => (current === streamId ? null : streamId));
     });
   };
+
+  const handleToggleCompare = (streamId: string) => {
+    startTransition(() => {
+      setComparedIds((items) => toggleCompareId(items, streamId));
+      setSelectedStreamId(streamId);
+    });
+  };
+
   const handleClearSelection = () => {
     startTransition(() => {
       setSelectedStreamId(null);
-      setFocusedStreamId(null);
     });
   };
+
+  const handleClearComparison = () => {
+    startTransition(() => {
+      setComparedIds([]);
+    });
+  };
+
   const handleTogglePause = () => {
-    if (!selectedStreamId) return;
+    if (!selectedStreamId) {
+      return;
+    }
+
     setPausedIds((items) => toggleId(items, selectedStreamId));
   };
+
   const handleToggleMute = () => {
-    if (!selectedStreamId) return;
+    if (!selectedStreamId) {
+      return;
+    }
+
     setMutedIds((items) => toggleId(items, selectedStreamId));
   };
-  const handleToggleFocus = () => {
-    if (!selectedStreamId) return;
-    setFocusedStreamId((current) => (current === selectedStreamId ? null : selectedStreamId));
-  };
+
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(34,211,238,0.18),_transparent_35%),linear-gradient(135deg,_#020617_0%,_#111827_45%,_#020617_100%)] px-4 py-6 text-slate-100 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-7xl">
         <SignalLabHeader
+          activeStream={selectedStream?.name ?? null}
           activeStreams={activeStreams}
-          focusedStream={focusedStream?.name ?? null}
+          comparedStreams={comparedStreams.length}
+          comparisonView={comparisonView}
+          comparisonWindowLabel={getWindowLabel(comparisonWindow)}
           heartbeat={heartbeat}
           labState={labState}
           mutedStreams={mutedIds.length}
@@ -96,36 +177,72 @@ export function SignalLabWorkspace() {
           pausedStreams={pausedIds.length}
         />
 
-        <div className="mt-6 grid gap-6 xl:grid-cols-[minmax(0,1.55fr)_minmax(320px,0.95fr)]">
+        <div className="mt-6 grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(340px,1fr)]">
           <div className="space-y-6">
             <StreamGrid
-              focusedStreamId={focusedStreamId}
+              comparedIds={comparedIds}
               mutedIds={mutedIds}
-              onSelectStream={handleSelectStream}
+              onInspectStream={handleInspectStream}
+              onToggleCompare={handleToggleCompare}
               pausedIds={pausedIds}
               selectedStreamId={selectedStreamId}
-              streams={visibleStreams}
+              streams={signalStreams}
             />
+
+            <ComparisonWorkbench
+              comparedStreams={comparedStreams}
+              comparisonDetail={comparisonDetail}
+              comparisonSummary={comparisonSummary}
+              comparisonView={comparisonView}
+              comparisonWindow={comparisonWindow}
+              onChangeView={(view) =>
+                startTransition(() => setComparisonView(view))
+              }
+              onChangeWindow={(window) =>
+                startTransition(() => setComparisonWindow(window))
+              }
+              onClearComparison={handleClearComparison}
+              openAnomalyCount={comparedOpenAnomalies.length}
+            />
+
             <AnomalyList
               acknowledgedIds={acknowledgedIds}
               anomalies={visibleAnomalies}
-              onSelectStream={(streamId) => startTransition(() => setSelectedStreamId(streamId))}
-              onToggleAcknowledged={(anomalyId) => setAcknowledgedIds((items) => toggleId(items, anomalyId))}
-              onToggleDismissed={(anomalyId) => setDismissedIds((items) => toggleId(items, anomalyId))}
-              onToggleDismissedView={() => setShowDismissed((value) => !value)}
+              comparedIds={comparedIds}
+              onInspectStream={(streamId) =>
+                startTransition(() => setSelectedStreamId(streamId))
+              }
+              onPinStream={handleToggleCompare}
+              onToggleAcknowledged={(anomalyId) =>
+                setAcknowledgedIds((items) => toggleId(items, anomalyId))
+              }
+              onToggleDismissed={(anomalyId) =>
+                setDismissedIds((items) => toggleId(items, anomalyId))
+              }
+              onToggleDismissedView={() =>
+                startTransition(() => setShowDismissed((value) => !value))
+              }
               showDismissed={showDismissed}
             />
           </div>
 
           <InspectorPanel
-            anomalyCount={selectedStreamAnomalies.length}
-            isFocused={selectedStream ? focusedStreamId === selectedStream.id : false}
+            anomalies={selectedStreamAnomalies}
+            comparisonWindow={comparisonWindow}
+            isCompared={selectedStream ? comparedIds.includes(selectedStream.id) : false}
             isMuted={selectedStream ? mutedIds.includes(selectedStream.id) : false}
             isPaused={selectedStream ? pausedIds.includes(selectedStream.id) : false}
             onClearSelection={handleClearSelection}
-            onToggleFocus={handleToggleFocus}
+            onToggleCompare={() => {
+              if (!selectedStreamId) {
+                return;
+              }
+
+              handleToggleCompare(selectedStreamId);
+            }}
             onToggleMute={handleToggleMute}
             onTogglePause={handleTogglePause}
+            peerNotes={inspectorPeerNotes}
             stream={selectedStream}
           />
         </div>

--- a/src/components/signal-lab/stream-grid.tsx
+++ b/src/components/signal-lab/stream-grid.tsx
@@ -1,4 +1,5 @@
 import type { SignalStream, StreamStatus } from "./mock-data";
+import { getConfidenceShiftLabel } from "./signal-lab-model";
 
 const statusClasses: Record<StreamStatus, string> = {
   stable: "border-emerald-400/30 bg-emerald-400/10 text-emerald-200",
@@ -9,19 +10,21 @@ const statusClasses: Record<StreamStatus, string> = {
 type StreamGridProps = {
   streams: SignalStream[];
   selectedStreamId: string | null;
-  focusedStreamId: string | null;
+  comparedIds: string[];
   mutedIds: string[];
   pausedIds: string[];
-  onSelectStream: (streamId: string) => void;
+  onInspectStream: (streamId: string) => void;
+  onToggleCompare: (streamId: string) => void;
 };
 
 export function StreamGrid({
   streams,
   selectedStreamId,
-  focusedStreamId,
+  comparedIds,
   mutedIds,
   pausedIds,
-  onSelectStream,
+  onInspectStream,
+  onToggleCompare,
 }: StreamGridProps) {
   return (
     <section
@@ -34,45 +37,52 @@ export function StreamGrid({
             Stream Cards
           </p>
           <h2 className="mt-2 text-xl font-semibold text-white">
-            Channel sweep
+            Comparison candidates
           </h2>
         </div>
-        <p className="text-sm text-slate-400">{streams.length} visible</p>
+        <p className="text-sm text-slate-400">
+          {comparedIds.length} pinned / {streams.length} visible
+        </p>
       </div>
 
       <div className="mt-5 grid gap-4 md:grid-cols-2">
         {streams.map((stream) => {
           const isSelected = selectedStreamId === stream.id;
-          const isFocused = focusedStreamId === stream.id;
+          const isCompared = comparedIds.includes(stream.id);
           const isMuted = mutedIds.includes(stream.id);
           const isPaused = pausedIds.includes(stream.id);
           const stats = [
             ["Throughput", stream.throughput],
-            ["Sync Window", stream.syncWindow],
-            ["Noise Floor", stream.noiseFloor],
+            ["Sync window", stream.syncWindow],
+            ["Confidence", `${stream.confidence}%`],
             ["Owner", stream.owner],
           ];
 
           return (
-            <button
+            <article
               key={stream.id}
-              className={`rounded-[1.5rem] border p-5 text-left transition hover:-translate-y-0.5 ${
-                isSelected
-                  ? "border-cyan-300/50 bg-cyan-400/10 shadow-[0_18px_50px_rgba(34,211,238,0.14)]"
-                  : "border-white/10 bg-white/[0.03] hover:border-white/20"
+              className={`rounded-[1.5rem] border p-5 transition ${
+                isCompared
+                  ? "border-cyan-300/40 bg-cyan-400/10 shadow-[0_18px_50px_rgba(34,211,238,0.14)]"
+                  : "border-white/10 bg-white/[0.03]"
               }`}
-              onClick={() => onSelectStream(stream.id)}
-              type="button"
             >
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div>
-                  <p className="text-lg font-semibold text-white">{stream.name}</p>
-                  <p className="mt-1 text-sm text-slate-400">{stream.channel}</p>
+                  <p className="text-lg font-semibold text-white">
+                    {stream.name}
+                  </p>
+                  <p className="mt-1 text-sm text-slate-400">
+                    {stream.channel}
+                  </p>
                 </div>
-                <span className={`rounded-full border px-3 py-1 text-xs uppercase tracking-[0.25em] ${statusClasses[stream.status]}`}>
+                <span
+                  className={`rounded-full border px-3 py-1 text-xs uppercase tracking-[0.25em] ${statusClasses[stream.status]}`}
+                >
                   {stream.status}
                 </span>
               </div>
+
               <div className="mt-4 grid grid-cols-2 gap-3 text-sm text-slate-300">
                 {stats.map(([label, value]) => (
                   <div key={label}>
@@ -81,12 +91,76 @@ export function StreamGrid({
                   </div>
                 ))}
               </div>
-              <div className="mt-4 flex flex-wrap gap-2 text-xs uppercase tracking-[0.2em]">
-                {isFocused ? <span className="rounded-full border border-cyan-400/30 bg-cyan-400/10 px-3 py-1 text-cyan-200">Focused</span> : null}
-                {isPaused ? <span className="rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-1 text-amber-200">Paused</span> : null}
-                {isMuted ? <span className="rounded-full border border-slate-400/30 bg-slate-400/10 px-3 py-1 text-slate-200">Muted</span> : null}
+
+              <div className="mt-4 rounded-2xl border border-white/10 bg-black/20 p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                    Confidence
+                  </p>
+                  <p className="text-xs uppercase tracking-[0.2em] text-slate-400">
+                    {getConfidenceShiftLabel(stream, "2h")} / 2h
+                  </p>
+                </div>
+                <p className="mt-2 text-sm leading-6 text-slate-300">
+                  {stream.confidenceStory}
+                </p>
               </div>
-            </button>
+
+              <div className="mt-4 flex flex-wrap gap-2 text-xs uppercase tracking-[0.2em]">
+                {isSelected ? (
+                  <span className="rounded-full border border-white/20 bg-white/10 px-3 py-1 text-white">
+                    Inspecting
+                  </span>
+                ) : null}
+                {isCompared ? (
+                  <span className="rounded-full border border-cyan-400/30 bg-cyan-400/10 px-3 py-1 text-cyan-200">
+                    Pinned
+                  </span>
+                ) : null}
+                {isPaused ? (
+                  <span className="rounded-full border border-amber-400/30 bg-amber-400/10 px-3 py-1 text-amber-200">
+                    Paused
+                  </span>
+                ) : null}
+                {isMuted ? (
+                  <span className="rounded-full border border-slate-400/30 bg-slate-400/10 px-3 py-1 text-slate-200">
+                    Muted
+                  </span>
+                ) : null}
+                <span className="rounded-full border border-white/10 px-3 py-1 text-slate-300">
+                  {stream.watchword}
+                </span>
+              </div>
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                <button
+                  aria-label={`Inspect ${stream.name}`}
+                  aria-pressed={isSelected}
+                  className={`rounded-full border px-4 py-2 text-sm transition ${
+                    isSelected
+                      ? "border-white/20 bg-white/10 text-white"
+                      : "border-white/10 text-slate-100 hover:border-white/20 hover:bg-white/5"
+                  }`}
+                  onClick={() => onInspectStream(stream.id)}
+                  type="button"
+                >
+                  {isSelected ? "Inspecting" : "Inspect stream"}
+                </button>
+                <button
+                  aria-label={`${isCompared ? "Remove" : "Pin"} ${stream.name} for comparison`}
+                  aria-pressed={isCompared}
+                  className={`rounded-full border px-4 py-2 text-sm transition ${
+                    isCompared
+                      ? "border-cyan-400/30 bg-cyan-400/10 text-cyan-100"
+                      : "border-white/10 text-slate-100 hover:border-cyan-300/40 hover:bg-cyan-400/10"
+                  }`}
+                  onClick={() => onToggleCompare(stream.id)}
+                  type="button"
+                >
+                  {isCompared ? "Pinned" : "Pin to compare"}
+                </button>
+              </div>
+            </article>
           );
         })}
       </div>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,5 +11,7 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./vitest.setup.tsx"],
     css: true,
+    maxWorkers: 1,
+    testTimeout: 30000,
   },
 });


### PR DESCRIPTION
## Summary
- add a comparison-first Signal Lab workspace with pinned multi-stream analysis, summary/detail views, and historical confidence lenses
- expand Signal Lab fixtures and derived comparison models so the inspector can explain anomaly drivers and confidence shifts
- add coverage for comparison state, inspector behavior, and the comparison model while making Vitest deterministic for the heavier route suites

## Testing
- npm run lint
- npm run typecheck
- npm test

Closes #65