### PR TITLE
Add queue monitor forecasting and priority explanations

### DIFF
--- a/src/components/queue-monitor/queue-column-board.tsx
+++ b/src/components/queue-monitor/queue-column-board.tsx
@@ -1,52 +1,132 @@
-import type { BacklogItem, AgeFilter, QueueScope, QueueSummary, EscalationLevelId } from "./queue-monitor-data";
+import type {
+  AgeFilter,
+  EscalationLevelId,
+  ForecastWindow,
+  InsightMode,
+  PriorityFilter,
+  QueueScope,
+  QueueTone,
+  ViewMode,
+} from "./queue-monitor-data";
+import type { ItemDisplay, QueueDisplay } from "./queue-monitor-selectors";
+
+import { QueueForecastStrip } from "./queue-forecast-strip";
 
 type QueueColumnBoardProps = {
-  ageFilter: AgeFilter; columns: { items: BacklogItem[]; queue: QueueSummary }[]; queueEscalations: Record<string, number>;
-  queueScope: QueueScope; queueTotals: Record<string, number>; selectedItemId: string | null; selectedQueueId: string | null;
-  escalationState: Record<string, { level: EscalationLevelId }>; onSelectItem: (queueId: string, itemId: string) => void; onSelectQueue: (queueId: string) => void;
+  ageFilter: AgeFilter;
+  columns: { items: ItemDisplay[]; queue: QueueDisplay }[];
+  escalationState: Record<string, { level: EscalationLevelId }>;
+  forecastWindow: ForecastWindow;
+  insightMode: InsightMode;
+  onSelectItem: (queueId: string, itemId: string) => void;
+  onSelectQueue: (queueId: string) => void;
+  priorityFilter: PriorityFilter;
+  queueEscalations: Record<string, number>;
+  queueScope: QueueScope;
+  queueTotals: Record<string, number>;
+  selectedItemId: string | null;
+  selectedQueueId: string | null;
+  viewMode: ViewMode;
 };
 
-const queueToneClasses = {
+const queueToneClasses: Record<QueueTone, string> = {
   stable: "border-emerald-300/20 bg-emerald-300/10 text-emerald-50",
   watch: "border-amber-300/20 bg-amber-300/10 text-amber-50",
   critical: "border-rose-300/20 bg-rose-300/10 text-rose-50",
 };
+
 const severityClasses = {
   low: "bg-slate-200/15 text-slate-100",
   medium: "bg-amber-200/15 text-amber-100",
   high: "bg-rose-200/15 text-rose-100",
 };
-const filterCopy = {
-  all: "all backlog items",
-  aging: "aging or breach items",
-  breach: "breach items",
+
+const priorityBandClasses = {
+  monitor: "border border-slate-300/20 bg-slate-300/10 text-slate-100",
+  expedite: "border border-amber-300/20 bg-amber-300/10 text-amber-100",
+  critical: "border border-rose-300/20 bg-rose-300/10 text-rose-100",
 };
+
+const driverToneClasses = {
+  calm: "border-slate-300/20 bg-slate-300/10 text-slate-100",
+  watch: "border-amber-300/20 bg-amber-300/10 text-amber-100",
+  hot: "border-rose-300/20 bg-rose-300/10 text-rose-100",
+};
+
+const filterCopy = {
+  all: "all backlog anchors",
+  aging: "aging or breach anchors",
+  breach: "breach anchors",
+};
+
+const priorityCopy = {
+  all: "all priorities",
+  expedite: "expedite or critical work",
+  critical: "critical work",
+};
+
 const scopeCopy = {
   all: "all queues",
   watch: "attention queues",
   stable: "stable queues",
 };
 
+function formatEscalation(level: EscalationLevelId) {
+  if (level === "lead") {
+    return "Lead escalated";
+  }
+
+  if (level === "director") {
+    return "Director paged";
+  }
+
+  return "Local watch";
+}
+
+function formatPriorityMovement(delta: number) {
+  if (delta > 0) {
+    return `Priority moves up ${delta} spot${delta === 1 ? "" : "s"}.`;
+  }
+
+  if (delta < 0) {
+    return `Priority drops ${Math.abs(delta)} spot${Math.abs(delta) === 1 ? "" : "s"}.`;
+  }
+
+  return "Priority rank is unchanged.";
+}
+
 export function QueueColumnBoard({
   ageFilter,
   columns,
+  escalationState,
+  forecastWindow,
+  insightMode,
+  onSelectItem,
+  onSelectQueue,
+  priorityFilter,
   queueEscalations,
   queueScope,
   queueTotals,
   selectedItemId,
   selectedQueueId,
-  escalationState,
-  onSelectItem,
-  onSelectQueue,
+  viewMode,
 }: QueueColumnBoardProps) {
   const visibleItemTotal = columns.reduce((sum, column) => sum + column.items.length, 0);
 
   if (visibleItemTotal === 0) {
     return (
       <section className="rounded-[2rem] border border-dashed border-white/15 bg-slate-950/55 p-8 text-center text-slate-200">
-        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">No items in view</p>
-        <h2 className="mt-3 text-2xl font-semibold text-white">The current filter mix leaves {scopeCopy[queueScope]} with no {filterCopy[ageFilter]}.</h2>
-        <p className="mt-3 text-sm leading-6 text-slate-300">Switch the queue scope or age filter to reopen the board and inspect live backlog cards.</p>
+        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">
+          No items in view
+        </p>
+        <h2 className="mt-3 text-2xl font-semibold text-white">
+          The current filter mix leaves {scopeCopy[queueScope]} with no{" "}
+          {filterCopy[ageFilter]} in {priorityCopy[priorityFilter]}.
+        </h2>
+        <p className="mt-3 text-sm leading-6 text-slate-300">
+          Switch the queue scope, age filter, or priority filter to reopen the
+          board and inspect projected queue pressure.
+        </p>
       </section>
     );
   }
@@ -55,57 +135,194 @@ export function QueueColumnBoard({
     <section className="grid gap-4 xl:grid-cols-4">
       {columns.map(({ items, queue }) => {
         const isSelectedQueue = queue.id === selectedQueueId;
-        const throughputDelta = queue.clearedPerHour - queue.intakePerHour;
+        const throughputDelta = queue.displayClearedPerHour - queue.displayIntakePerHour;
 
         return (
-          <article className={`rounded-[1.9rem] border p-4 shadow-[0_20px_70px_rgba(15,23,42,0.32)] ${isSelectedQueue ? "border-orange-200/45 bg-slate-900/95" : "border-white/10 bg-slate-950/72"}`} key={queue.id}>
+          <article
+            className={`rounded-[1.9rem] border p-4 shadow-[0_20px_70px_rgba(15,23,42,0.32)] ${
+              isSelectedQueue
+                ? "border-orange-200/45 bg-slate-900/95"
+                : "border-white/10 bg-slate-950/72"
+            }`}
+            key={queue.id}
+          >
             <button className="w-full text-left" onClick={() => onSelectQueue(queue.id)} type="button">
               <div className="flex flex-wrap gap-2">
-                <span className={`rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-[0.2em] ${queueToneClasses[queue.tone]}`}>{queue.statusLabel}</span>
-                <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-300">{queue.slaWindow}</span>
+                <span
+                  className={`rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-[0.2em] ${queueToneClasses[queue.displayTone]}`}
+                >
+                  {queue.displayStatusLabel}
+                </span>
+                <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-300">
+                  {queue.slaWindow}
+                </span>
+                <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-300">
+                  {viewMode === "live" ? "Live" : forecastWindow.label}
+                </span>
               </div>
               <h2 className="mt-3 text-2xl font-semibold text-white">{queue.label}</h2>
-              <p className="mt-1 text-sm text-slate-300">{queue.region} · {queue.owner}</p>
-              <div className="mt-4 grid grid-cols-2 gap-3 text-sm text-slate-200">
-                <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
-                  <p className="text-xs uppercase tracking-[0.22em] text-slate-400">Visible</p>
-                  <p className="mt-2 text-2xl font-semibold text-white">{items.length}</p>
-                  <p className="text-xs text-slate-400">of {queueTotals[queue.id]} items</p>
+              <p className="mt-1 text-sm text-slate-300">
+                {queue.region} · {queue.owner}
+              </p>
+              <p className="mt-3 text-sm leading-6 text-slate-200">{queue.displaySummary}</p>
+              {insightMode === "operations" ? (
+                <div className="mt-4 grid grid-cols-3 gap-3 text-sm text-slate-200">
+                  <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+                    <p className="text-xs uppercase tracking-[0.22em] text-slate-400">
+                      Queue load
+                    </p>
+                    <p className="mt-2 text-2xl font-semibold text-white">
+                      {queueTotals[queue.id]}
+                    </p>
+                    <p className="text-xs text-slate-400">
+                      {queue.displayBreachCount} breach risk
+                    </p>
+                  </div>
+                  <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+                    <p className="text-xs uppercase tracking-[0.22em] text-slate-400">
+                      Throughput
+                    </p>
+                    <p className="mt-2 text-2xl font-semibold text-white">
+                      {queue.displayClearedPerHour}/{queue.displayIntakePerHour}
+                    </p>
+                    <p
+                      className={`text-xs ${
+                        throughputDelta >= 0 ? "text-emerald-200" : "text-rose-200"
+                      }`}
+                    >
+                      {throughputDelta >= 0 ? `+${throughputDelta}` : throughputDelta} vs
+                      intake
+                    </p>
+                  </div>
+                  <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+                    <p className="text-xs uppercase tracking-[0.22em] text-slate-400">
+                      Carryover
+                    </p>
+                    <p className="mt-2 text-2xl font-semibold text-white">
+                      {queue.displayCarryover}
+                    </p>
+                    <p className="text-xs text-slate-400">
+                      {queue.displayWaitMinutes} min wait
+                    </p>
+                  </div>
                 </div>
-                <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
-                  <p className="text-xs uppercase tracking-[0.22em] text-slate-400">Throughput</p>
-                  <p className="mt-2 text-2xl font-semibold text-white">{queue.clearedPerHour}/{queue.intakePerHour}</p>
-                  <p className={`text-xs ${throughputDelta >= 0 ? "text-emerald-200" : "text-rose-200"}`}>{throughputDelta >= 0 ? `+${throughputDelta}` : throughputDelta} vs intake</p>
+              ) : (
+                <div className="mt-4 space-y-3">
+                  <div className="grid grid-cols-2 gap-3 text-sm text-slate-200">
+                    <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+                      <p className="text-xs uppercase tracking-[0.22em] text-slate-400">
+                        Priority rank
+                      </p>
+                      <p className="mt-2 text-2xl font-semibold text-white">
+                        #{queue.displayPriorityRank}
+                      </p>
+                      <p className="text-xs text-slate-400">
+                        {formatPriorityMovement(queue.displayPriorityDelta)}
+                      </p>
+                    </div>
+                    <div className="rounded-2xl border border-white/10 bg-white/5 p-3">
+                      <p className="text-xs uppercase tracking-[0.22em] text-slate-400">
+                        Rationale
+                      </p>
+                      <p className="mt-2 text-2xl font-semibold text-white">
+                        {queue.displayBreachCount}
+                      </p>
+                      <p className="text-xs text-slate-400">
+                        breach drivers in view
+                      </p>
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    {queue.priorityDrivers.slice(0, 2).map((driver) => (
+                      <div
+                        className={`rounded-[1.2rem] border p-3 text-left ${driverToneClasses[driver.tone]}`}
+                        key={driver.id}
+                      >
+                        <div className="flex items-center justify-between gap-3">
+                          <p className="text-sm font-medium text-white">
+                            {driver.label}
+                          </p>
+                          <span className="text-[11px] uppercase tracking-[0.18em] opacity-80">
+                            {driver.impact}
+                          </span>
+                        </div>
+                        <p className="mt-2 text-sm opacity-85">{driver.detail}</p>
+                      </div>
+                    ))}
+                  </div>
                 </div>
+              )}
+              <div className="mt-4">
+                <QueueForecastStrip
+                  activeWindow={forecastWindow.id}
+                  points={queue.forecast}
+                  variant="compact"
+                />
               </div>
               <div className="mt-3 flex items-center justify-between text-xs uppercase tracking-[0.2em] text-slate-400">
-                <span>{queue.oldestMinutes} min oldest</span>
+                <span>{queue.displayOldestMinutes} min oldest</span>
                 <span>{queueEscalations[queue.id]} local escalations</span>
               </div>
             </button>
             <div className="mt-4 space-y-3">
-              {items.length > 0 ? items.map((item) => {
-                const isSelectedItem = item.id === selectedItemId;
-                const localLevel = escalationState[item.id].level;
+              {items.length > 0 ? (
+                items.map((item) => {
+                  const isSelectedItem = item.id === selectedItemId;
+                  const localLevel = escalationState[item.id].level;
 
-                return (
-                  <button className={`block w-full rounded-[1.4rem] border p-4 text-left transition ${isSelectedItem ? "border-orange-200/45 bg-orange-200/10" : "border-white/10 bg-white/5 hover:bg-white/8"}`} key={item.id} onClick={() => onSelectItem(queue.id, item.id)} type="button">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className={`rounded-full px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.18em] ${severityClasses[item.severity]}`}>{item.severity}</span>
-                      <span className="rounded-full border border-white/10 px-2.5 py-1 text-[11px] uppercase tracking-[0.18em] text-slate-300">{item.ageMinutes} min</span>
-                    </div>
-                    <h3 className="mt-3 text-base font-semibold text-white">{item.title}</h3>
-                    <p className="mt-2 text-sm text-slate-300">{item.customer}</p>
-                    <div className="mt-3 flex items-center justify-between gap-3 text-xs text-slate-400">
-                      <span>{item.caseRef}</span>
-                      <span>{localLevel === "none" ? "Local watch" : localLevel === "lead" ? "Lead escalated" : "Director paged"}</span>
-                    </div>
-                  </button>
-                );
-              }) : (
+                  return (
+                    <button
+                      className={`block w-full rounded-[1.4rem] border p-4 text-left transition ${
+                        isSelectedItem
+                          ? "border-orange-200/45 bg-orange-200/10"
+                          : "border-white/10 bg-white/5 hover:bg-white/8"
+                      }`}
+                      key={item.id}
+                      onClick={() => onSelectItem(queue.id, item.id)}
+                      type="button"
+                    >
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span
+                          className={`rounded-full px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.18em] ${severityClasses[item.severity]}`}
+                        >
+                          {item.severity}
+                        </span>
+                        <span className="rounded-full border border-white/10 px-2.5 py-1 text-[11px] uppercase tracking-[0.18em] text-slate-300">
+                          {viewMode === "live"
+                            ? `${item.displayAgeMinutes} min`
+                            : `${forecastWindow.shortLabel} ${item.displayAgeMinutes} min`}
+                        </span>
+                        <span
+                          className={`rounded-full px-2.5 py-1 text-[11px] uppercase tracking-[0.18em] ${priorityBandClasses[item.displayPriorityBand]}`}
+                        >
+                          {item.displayPriorityBand}
+                        </span>
+                      </div>
+                      <h3 className="mt-3 text-base font-semibold text-white">
+                        {item.title}
+                      </h3>
+                      <p className="mt-2 text-sm text-slate-300">{item.customer}</p>
+                      <p className="mt-2 text-sm leading-6 text-slate-200">
+                        {insightMode === "operations"
+                          ? item.displayRiskLabel
+                          : item.displayPriorityReason}
+                      </p>
+                      <div className="mt-3 flex items-center justify-between gap-3 text-xs text-slate-400">
+                        <span>{item.caseRef}</span>
+                        <span>{formatEscalation(localLevel)}</span>
+                      </div>
+                    </button>
+                  );
+                })
+              ) : (
                 <div className="rounded-[1.5rem] border border-dashed border-white/12 bg-white/[0.03] p-5 text-center">
-                  <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-400">Filtered clear</p>
-                  <p className="mt-3 text-sm leading-6 text-slate-300">No {filterCopy[ageFilter]} are parked in this queue right now.</p>
+                  <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-400">
+                    Filtered clear
+                  </p>
+                  <p className="mt-3 text-sm leading-6 text-slate-300">
+                    No {filterCopy[ageFilter]} in {priorityCopy[priorityFilter]} are
+                    parked in this queue right now.
+                  </p>
                 </div>
               )}
             </div>

--- a/src/components/queue-monitor/queue-detail-panel.tsx
+++ b/src/components/queue-monitor/queue-detail-panel.tsx
@@ -1,13 +1,34 @@
-import type { BacklogItem, EscalationLevel, EscalationLevelId, QueueSummary } from "./queue-monitor-data";
+import type {
+  EscalationLevel,
+  EscalationLevelId,
+  ForecastWindow,
+  InsightMode,
+  ViewMode,
+} from "./queue-monitor-data";
+import type { ItemDisplay, QueueDisplay } from "./queue-monitor-selectors";
+
+import { QueueForecastStrip } from "./queue-forecast-strip";
 
 type LocalEscalationState = {
-  addToDigest: boolean; holdRelease: boolean; level: EscalationLevelId; notifyFloor: boolean; reviewed: boolean;
+  addToDigest: boolean;
+  holdRelease: boolean;
+  level: EscalationLevelId;
+  notifyFloor: boolean;
+  reviewed: boolean;
 };
 
 type QueueDetailPanelProps = {
-  escalationLevels: EscalationLevel[]; itemState: LocalEscalationState | null; queueEscalations: number; queueItemsVisible: number;
-  selectedItem: BacklogItem | null; selectedQueue: QueueSummary | null; onEscalationLevelChange: (level: EscalationLevelId) => void;
+  escalationLevels: EscalationLevel[];
+  forecastWindow: ForecastWindow;
+  insightMode: InsightMode;
+  itemState: LocalEscalationState | null;
+  onEscalationLevelChange: (level: EscalationLevelId) => void;
   onToggle: (key: keyof Omit<LocalEscalationState, "level">) => void;
+  queueEscalations: number;
+  queueItemsVisible: number;
+  selectedItem: ItemDisplay | null;
+  selectedQueue: QueueDisplay | null;
+  viewMode: ViewMode;
 };
 
 const levelToneClasses = {
@@ -16,85 +37,328 @@ const levelToneClasses = {
   hot: "border-rose-300/20 bg-rose-300/10 text-rose-50",
 };
 
-const toggleLabels: { hint: string; key: keyof Omit<LocalEscalationState, "level">; label: string }[] = [
-  { key: "holdRelease", label: "Hold release", hint: "Keep this item parked in the queue preview." },
-  { key: "notifyFloor", label: "Notify floor", hint: "Bring operations into the next sweep." },
-  { key: "addToDigest", label: "Digest flag", hint: "Include the item in the manager digest." },
-  { key: "reviewed", label: "Reviewed", hint: "Mark the local preview as checked." },
+const driverToneClasses = {
+  calm: "border-slate-300/20 bg-slate-300/10 text-slate-100",
+  watch: "border-amber-300/20 bg-amber-300/10 text-amber-100",
+  hot: "border-rose-300/20 bg-rose-300/10 text-rose-100",
+};
+
+const priorityBandClasses = {
+  monitor: "border border-slate-300/20 bg-slate-300/10 text-slate-100",
+  expedite: "border border-amber-300/20 bg-amber-300/10 text-amber-100",
+  critical: "border border-rose-300/20 bg-rose-300/10 text-rose-100",
+};
+
+const toggleLabels: {
+  hint: string;
+  key: keyof Omit<LocalEscalationState, "level">;
+  label: string;
+}[] = [
+  {
+    key: "holdRelease",
+    label: "Hold release",
+    hint: "Keep this item parked in the queue preview.",
+  },
+  {
+    key: "notifyFloor",
+    label: "Notify floor",
+    hint: "Bring operations into the next sweep.",
+  },
+  {
+    key: "addToDigest",
+    label: "Digest flag",
+    hint: "Include the item in the manager digest.",
+  },
+  {
+    key: "reviewed",
+    label: "Reviewed",
+    hint: "Mark the local preview as checked.",
+  },
 ];
+
+function formatPriorityMovement(delta: number) {
+  if (delta > 0) {
+    return `Priority moves up ${delta} spot${delta === 1 ? "" : "s"} by handoff.`;
+  }
+
+  if (delta < 0) {
+    return `Priority drops ${Math.abs(delta)} spot${Math.abs(delta) === 1 ? "" : "s"} by handoff.`;
+  }
+
+  return "Priority rank holds steady across the forecast horizon.";
+}
 
 export function QueueDetailPanel({
   escalationLevels,
+  forecastWindow,
+  insightMode,
   itemState,
+  onEscalationLevelChange,
+  onToggle,
   queueEscalations,
   queueItemsVisible,
   selectedItem,
   selectedQueue,
-  onEscalationLevelChange,
-  onToggle,
+  viewMode,
 }: QueueDetailPanelProps) {
   return (
     <aside className="rounded-[2rem] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.94),rgba(28,25,23,0.94))] p-5 shadow-[0_22px_80px_rgba(0,0,0,0.42)] sm:p-6">
       <div className="rounded-[1.6rem] border border-white/10 bg-white/5 p-4">
-        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Queue preview</p>
-        <h2 className="mt-3 text-2xl font-semibold text-white">{selectedQueue ? selectedQueue.label : "Choose a queue"}</h2>
-        <p className="mt-2 text-sm leading-6 text-slate-300">{selectedQueue ? `${selectedQueue.region} is owned by ${selectedQueue.owner}. ${queueItemsVisible} filtered items are visible with ${queueEscalations} local escalations applied.` : "Pick a queue column to inspect backlog details and adjust local escalation controls."}</p>
+        <div className="flex flex-wrap gap-2">
+          <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-300">
+            {viewMode === "live" ? "Live board" : `${forecastWindow.label} forecast`}
+          </span>
+          <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-300">
+            {insightMode === "operations"
+              ? "Operations detail"
+              : "Priority explanation mode"}
+          </span>
+        </div>
+        <p className="mt-4 text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">
+          Queue preview
+        </p>
+        <h2 className="mt-3 text-2xl font-semibold text-white">
+          {selectedQueue ? selectedQueue.label : "Choose a queue"}
+        </h2>
+        <p className="mt-2 text-sm leading-6 text-slate-300">
+          {selectedQueue
+            ? `${selectedQueue.region} is owned by ${selectedQueue.owner}. ${queueItemsVisible} filtered items are visible with ${queueEscalations} local escalations applied.`
+            : "Pick a queue column to inspect backlog details and adjust local escalation controls."}
+        </p>
         {selectedQueue ? (
-          <div className="mt-4 grid gap-3 sm:grid-cols-3">
-            <div className="rounded-2xl border border-white/10 bg-slate-950/50 p-3"><p className="text-xs uppercase tracking-[0.2em] text-slate-400">Oldest</p><p className="mt-2 text-xl font-semibold text-white">{selectedQueue.oldestMinutes} min</p></div>
-            <div className="rounded-2xl border border-white/10 bg-slate-950/50 p-3"><p className="text-xs uppercase tracking-[0.2em] text-slate-400">Intake</p><p className="mt-2 text-xl font-semibold text-white">{selectedQueue.intakePerHour}/hr</p></div>
-            <div className="rounded-2xl border border-white/10 bg-slate-950/50 p-3"><p className="text-xs uppercase tracking-[0.2em] text-slate-400">Cleared</p><p className="mt-2 text-xl font-semibold text-white">{selectedQueue.clearedPerHour}/hr</p></div>
+          <div className="mt-4 space-y-4">
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div className="rounded-2xl border border-white/10 bg-slate-950/50 p-3">
+                <p className="text-xs uppercase tracking-[0.2em] text-slate-400">
+                  Queue load
+                </p>
+                <p className="mt-2 text-xl font-semibold text-white">
+                  {selectedQueue.displayBacklogCount}
+                </p>
+                <p className="text-xs text-slate-400">
+                  {selectedQueue.displayBreachCount} breach risk
+                </p>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-slate-950/50 p-3">
+                <p className="text-xs uppercase tracking-[0.2em] text-slate-400">
+                  Priority rank
+                </p>
+                <p className="mt-2 text-xl font-semibold text-white">
+                  #{selectedQueue.displayPriorityRank}
+                </p>
+                <p className="text-xs text-slate-400">
+                  {formatPriorityMovement(selectedQueue.displayPriorityDelta)}
+                </p>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-slate-950/50 p-3">
+                <p className="text-xs uppercase tracking-[0.2em] text-slate-400">
+                  Wait pressure
+                </p>
+                <p className="mt-2 text-xl font-semibold text-white">
+                  {selectedQueue.displayWaitMinutes} min
+                </p>
+                <p className="text-xs text-slate-400">
+                  {selectedQueue.displayCarryover} carryover anchors
+                </p>
+              </div>
+            </div>
+            <div className="rounded-[1.35rem] border border-white/10 bg-slate-950/45 p-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+                Short-term trend
+              </p>
+              <p className="mt-2 text-sm leading-6 text-slate-300">
+                {selectedQueue.displaySummary}
+              </p>
+              <div className="mt-4">
+                <QueueForecastStrip
+                  activeWindow={forecastWindow.id}
+                  points={selectedQueue.forecast}
+                />
+              </div>
+            </div>
           </div>
         ) : null}
       </div>
+
+      {selectedQueue ? (
+        <section className="mt-5 rounded-[1.6rem] border border-white/10 bg-white/5 p-4">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">
+                Priority explanation
+              </p>
+              <h3 className="mt-2 text-xl font-semibold text-white">
+                Why this queue is moving
+              </h3>
+            </div>
+            <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.18em] text-slate-300">
+              #{selectedQueue.displayPriorityRank}
+            </span>
+          </div>
+          <p className="mt-3 text-sm leading-6 text-slate-200">
+            {selectedQueue.rationale}
+          </p>
+          {insightMode === "priority" ? (
+            <p className="mt-3 rounded-[1.15rem] border border-orange-300/20 bg-orange-300/10 px-4 py-3 text-sm leading-6 text-orange-50">
+              Priority explanation mode is active. Board cards and this detail
+              panel are keyed to the rationale signals first, with operational
+              metrics still available underneath.
+            </p>
+          ) : null}
+          <div className="mt-4 space-y-3">
+            {selectedQueue.priorityDrivers.map((driver) => (
+              <div
+                className={`rounded-[1.25rem] border p-4 ${driverToneClasses[driver.tone]}`}
+                key={driver.id}
+              >
+                <div className="flex items-center justify-between gap-4">
+                  <p className="font-medium text-white">{driver.label}</p>
+                  <span className="text-xs uppercase tracking-[0.2em] opacity-80">
+                    {driver.impact}
+                  </span>
+                </div>
+                <p className="mt-2 text-sm opacity-90">{driver.detail}</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-4 rounded-[1.3rem] border border-white/10 bg-slate-950/45 p-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+              Pressure signals
+            </p>
+            <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-200">
+              {selectedQueue.pressureSignals.map((signal) => (
+                <li key={signal}>• {signal}</li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      ) : null}
 
       {selectedItem && itemState ? (
         <div className="mt-5 space-y-5">
           <section className="rounded-[1.6rem] border border-white/10 bg-white/5 p-4">
             <div className="flex flex-wrap items-center gap-2">
-              <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-300">{selectedItem.caseRef}</span>
-              <span className="rounded-full border border-orange-300/20 bg-orange-300/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-orange-100">{selectedItem.ageMinutes} min open</span>
+              <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-300">
+                {selectedItem.caseRef}
+              </span>
+              <span className="rounded-full border border-orange-300/20 bg-orange-300/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-orange-100">
+                {selectedItem.displayAgeMinutes} min open
+              </span>
+              <span
+                className={`rounded-full px-3 py-1 text-xs uppercase tracking-[0.2em] ${priorityBandClasses[selectedItem.displayPriorityBand]}`}
+              >
+                {selectedItem.displayPriorityBand}
+              </span>
             </div>
-            <h3 className="mt-3 text-xl font-semibold text-white">{selectedItem.title}</h3>
-            <p className="mt-2 text-sm text-slate-300">{selectedItem.customer} · {selectedItem.segment}</p>
-            <p className="mt-3 text-sm leading-6 text-slate-300">{selectedItem.detail}</p>
+            <h3 className="mt-3 text-xl font-semibold text-white">
+              {selectedItem.title}
+            </h3>
+            <p className="mt-2 text-sm text-slate-300">
+              {selectedItem.customer} · {selectedItem.segment}
+            </p>
+            <p className="mt-3 text-sm leading-6 text-slate-300">
+              {selectedItem.detail}
+            </p>
             <div className="mt-4 rounded-[1.4rem] border border-white/10 bg-slate-950/45 p-4">
-              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">Next action</p>
-              <p className="mt-2 text-sm leading-6 text-slate-200">{selectedItem.nextAction}</p>
-              <p className="mt-3 text-sm text-slate-400">Owner: {selectedItem.owner}</p>
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+                {insightMode === "operations"
+                  ? "Next action"
+                  : "Why this item rises in priority"}
+              </p>
+              <p className="mt-2 text-sm leading-6 text-slate-200">
+                {insightMode === "operations"
+                  ? selectedItem.displayNextAction
+                  : selectedItem.displayPriorityReason}
+              </p>
+              <p className="mt-3 text-sm text-slate-400">
+                {viewMode === "live"
+                  ? `Risk signal: ${selectedItem.displayRiskLabel}`
+                  : `${selectedItem.displayEtaLabel} Risk signal: ${selectedItem.displayRiskLabel}`}
+              </p>
+            </div>
+            <div className="mt-4 rounded-[1.3rem] border border-white/10 bg-slate-950/45 p-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+                Rationale points
+              </p>
+              <ul className="mt-3 space-y-2 text-sm leading-6 text-slate-200">
+                {selectedItem.explanationPoints.map((point) => (
+                  <li key={point}>• {point}</li>
+                ))}
+              </ul>
+              <p className="mt-4 text-sm text-slate-400">Owner: {selectedItem.owner}</p>
             </div>
           </section>
 
           <section className="rounded-[1.6rem] border border-white/10 bg-white/5 p-4">
-            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Escalation level</p>
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">
+              Escalation level
+            </p>
             <div className="mt-4 space-y-3">
               {escalationLevels.map((level) => (
-                <button className={`flex w-full items-start justify-between gap-4 rounded-[1.3rem] border p-4 text-left transition ${itemState.level === level.id ? "border-orange-200/40 bg-orange-200/10" : `${levelToneClasses[level.tone]} hover:bg-white/10`}`} key={level.id} onClick={() => onEscalationLevelChange(level.id)} type="button">
-                  <div><p className="font-medium text-white">{level.label}</p><p className="mt-1 text-sm text-slate-300">{level.note}</p></div>
-                  <span className="text-xs uppercase tracking-[0.22em] text-slate-400">{itemState.level === level.id ? "Selected" : "Available"}</span>
+                <button
+                  className={`flex w-full items-start justify-between gap-4 rounded-[1.3rem] border p-4 text-left transition ${
+                    itemState.level === level.id
+                      ? "border-orange-200/40 bg-orange-200/10"
+                      : `${levelToneClasses[level.tone]} hover:bg-white/10`
+                  }`}
+                  key={level.id}
+                  onClick={() => onEscalationLevelChange(level.id)}
+                  type="button"
+                >
+                  <div>
+                    <p className="font-medium text-white">{level.label}</p>
+                    <p className="mt-1 text-sm text-slate-300">{level.note}</p>
+                  </div>
+                  <span className="text-xs uppercase tracking-[0.22em] text-slate-400">
+                    {itemState.level === level.id ? "Selected" : "Available"}
+                  </span>
                 </button>
               ))}
             </div>
           </section>
 
           <section className="rounded-[1.6rem] border border-white/10 bg-white/5 p-4">
-            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Local controls</p>
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">
+              Local controls
+            </p>
             <div className="mt-4 grid gap-3 sm:grid-cols-2">
               {toggleLabels.map((toggle) => (
-                <button className={`rounded-[1.2rem] border p-4 text-left transition ${itemState[toggle.key] ? "border-emerald-300/30 bg-emerald-300/10 text-emerald-50" : "border-white/10 bg-slate-950/45 text-slate-200 hover:bg-white/10"}`} key={toggle.key} onClick={() => onToggle(toggle.key)} type="button">
+                <button
+                  className={`rounded-[1.2rem] border p-4 text-left transition ${
+                    itemState[toggle.key]
+                      ? "border-emerald-300/30 bg-emerald-300/10 text-emerald-50"
+                      : "border-white/10 bg-slate-950/45 text-slate-200 hover:bg-white/10"
+                  }`}
+                  key={toggle.key}
+                  onClick={() => onToggle(toggle.key)}
+                  type="button"
+                >
                   <p className="font-medium">{toggle.label}</p>
                   <p className="mt-1 text-sm opacity-80">{toggle.hint}</p>
                 </button>
               ))}
             </div>
-            <p className="mt-4 text-sm text-slate-400">These toggles only update this route-local preview state. They do not affect any shared queue or page outside `/queue-monitor`.</p>
+            <p className="mt-4 text-sm text-slate-400">
+              These toggles only update this route-local preview state. They do
+              not affect any shared queue or page outside `/queue-monitor`.
+            </p>
           </section>
         </div>
       ) : (
         <div className="mt-5 rounded-[1.75rem] border border-dashed border-white/12 bg-white/[0.03] p-6 text-center">
-          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-400">Nothing selected</p>
-          <h3 className="mt-3 text-xl font-semibold text-white">{selectedQueue ? "This queue has no items in the current filter view." : "Select a queue column to inspect the backlog."}</h3>
-          <p className="mt-3 text-sm leading-6 text-slate-300">{selectedQueue ? "Change the aging filter or choose another queue to reopen the detail preview." : "The detail panel will show item context and escalation controls once a backlog card is selected."}</p>
+          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-400">
+            Nothing selected
+          </p>
+          <h3 className="mt-3 text-xl font-semibold text-white">
+            {selectedQueue
+              ? "This queue has no items in the current filter view."
+              : "Select a queue column to inspect the backlog."}
+          </h3>
+          <p className="mt-3 text-sm leading-6 text-slate-300">
+            {selectedQueue
+              ? "Change the forecast horizon, age filter, or priority filter to reopen the detail preview."
+              : "The detail panel will show queue rationale, item context, and escalation controls once a backlog card is selected."}
+          </p>
         </div>
       )}
     </aside>

--- a/src/components/queue-monitor/queue-filter-bar.tsx
+++ b/src/components/queue-monitor/queue-filter-bar.tsx
@@ -1,12 +1,59 @@
-import type { AgeFilter, QueueScope } from "./queue-monitor-data";
+import type {
+  AgeFilter,
+  ForecastWindow,
+  ForecastWindowId,
+  InsightMode,
+  PriorityFilter,
+  QueueScope,
+  ViewMode,
+} from "./queue-monitor-data";
 
 type QueueFilterBarProps = {
-  ageCounts: Record<AgeFilter, number>; ageFilter: AgeFilter; queueCounts: Record<QueueScope, number>;
-  queueScope: QueueScope; onAgeFilterChange: (filter: AgeFilter) => void; onQueueScopeChange: (scope: QueueScope) => void;
+  ageCounts: Record<AgeFilter, number>;
+  ageFilter: AgeFilter;
+  forecastWindow: ForecastWindowId;
+  forecastWindows: ForecastWindow[];
+  insightMode: InsightMode;
+  onAgeFilterChange: (filter: AgeFilter) => void;
+  onForecastWindowChange: (windowId: ForecastWindowId) => void;
+  onInsightModeChange: (mode: InsightMode) => void;
+  onPriorityFilterChange: (filter: PriorityFilter) => void;
+  onQueueScopeChange: (scope: QueueScope) => void;
+  onViewModeChange: (mode: ViewMode) => void;
+  priorityCounts: Record<PriorityFilter, number>;
+  priorityFilter: PriorityFilter;
+  queueCounts: Record<QueueScope, number>;
+  queueScope: QueueScope;
+  viewMode: ViewMode;
 };
 
-const queueLabels: Record<QueueScope, string> = { all: "All queues", watch: "Attention only", stable: "Stable only" };
-const ageLabels: Record<AgeFilter, string> = { all: "All ages", aging: "Aging + breach", breach: "Breach only" };
+const viewLabels: Record<ViewMode, string> = {
+  live: "Live board",
+  forecast: "Forecast board",
+};
+
+const insightLabels: Record<InsightMode, string> = {
+  operations: "Operations view",
+  priority: "Priority explanation",
+};
+
+const queueLabels: Record<QueueScope, string> = {
+  all: "All queues",
+  watch: "Attention only",
+  stable: "Stable only",
+};
+
+const ageLabels: Record<AgeFilter, string> = {
+  all: "All ages",
+  aging: "Aging + breach",
+  breach: "Breach only",
+};
+
+const priorityLabels: Record<PriorityFilter, string> = {
+  all: "All priorities",
+  expedite: "Expedite + critical",
+  critical: "Critical only",
+};
 
 function FilterGroup<T extends string>({
   active,
@@ -16,17 +63,26 @@ function FilterGroup<T extends string>({
   onChange,
   values,
 }: {
-  active: T; counts: Record<T, number>; label: string; labels: Record<T, string>; onChange: (value: T) => void; values: T[];
+  active: T;
+  counts: Record<T, number>;
+  label: string;
+  labels: Record<T, string>;
+  onChange: (value: T) => void;
+  values: T[];
 }) {
   return (
     <div>
-      <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">{label}</p>
+      <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">
+        {label}
+      </p>
       <div className="mt-3 flex flex-wrap gap-3">
         {values.map((value) => (
           <button
             aria-pressed={value === active}
             className={`rounded-full px-4 py-2 text-sm font-medium transition ${
-              value === active ? "bg-orange-200 text-slate-950" : "border border-white/12 bg-white/5 text-slate-200 hover:border-orange-200/35 hover:bg-white/10"
+              value === active
+                ? "bg-orange-200 text-slate-950"
+                : "border border-white/12 bg-white/5 text-slate-200 hover:border-orange-200/35 hover:bg-white/10"
             }`}
             key={value}
             onClick={() => onChange(value)}
@@ -43,16 +99,94 @@ function FilterGroup<T extends string>({
 export function QueueFilterBar({
   ageCounts,
   ageFilter,
+  forecastWindow,
+  forecastWindows,
+  insightMode,
+  onAgeFilterChange,
+  onForecastWindowChange,
+  onInsightModeChange,
+  onPriorityFilterChange,
+  onQueueScopeChange,
+  onViewModeChange,
+  priorityCounts,
+  priorityFilter,
   queueCounts,
   queueScope,
-  onAgeFilterChange,
-  onQueueScopeChange,
+  viewMode,
 }: QueueFilterBarProps) {
+  const viewCounts = { live: 1, forecast: 1 } satisfies Record<ViewMode, number>;
+  const insightCounts = {
+    operations: 1,
+    priority: 1,
+  } satisfies Record<InsightMode, number>;
+  const forecastCounts = Object.fromEntries(
+    forecastWindows.map((window) => [window.id, 1]),
+  ) as Record<ForecastWindowId, number>;
+  const forecastLabels = Object.fromEntries(
+    forecastWindows.map((window) => [window.id, window.label]),
+  ) as Record<ForecastWindowId, string>;
+
   return (
     <section className="rounded-[1.75rem] border border-white/10 bg-slate-950/72 p-4 shadow-[0_18px_60px_rgba(15,23,42,0.32)] backdrop-blur">
-      <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
-        <FilterGroup active={queueScope} counts={queueCounts} label="Queue scope" labels={queueLabels} onChange={onQueueScopeChange} values={["all", "watch", "stable"]} />
-        <FilterGroup active={ageFilter} counts={ageCounts} label="Aging filter" labels={ageLabels} onChange={onAgeFilterChange} values={["all", "aging", "breach"]} />
+      <div className="flex flex-col gap-5">
+        <div className="grid gap-5 xl:grid-cols-3">
+          <FilterGroup
+            active={viewMode}
+            counts={viewCounts}
+            label="Board mode"
+            labels={viewLabels}
+            onChange={onViewModeChange}
+            values={["live", "forecast"]}
+          />
+          <FilterGroup
+            active={insightMode}
+            counts={insightCounts}
+            label="Detail emphasis"
+            labels={insightLabels}
+            onChange={onInsightModeChange}
+            values={["operations", "priority"]}
+          />
+          <FilterGroup
+            active={forecastWindow}
+            counts={forecastCounts}
+            label="Forecast horizon"
+            labels={forecastLabels}
+            onChange={onForecastWindowChange}
+            values={["30m", "60m", "90m"]}
+          />
+        </div>
+        <div className="h-px bg-white/10" />
+        <div className="grid gap-5 xl:grid-cols-3">
+          <FilterGroup
+            active={queueScope}
+            counts={queueCounts}
+            label="Queue scope"
+            labels={queueLabels}
+            onChange={onQueueScopeChange}
+            values={["all", "watch", "stable"]}
+          />
+          <FilterGroup
+            active={ageFilter}
+            counts={ageCounts}
+            label="Age filter"
+            labels={ageLabels}
+            onChange={onAgeFilterChange}
+            values={["all", "aging", "breach"]}
+          />
+          <FilterGroup
+            active={priorityFilter}
+            counts={priorityCounts}
+            label="Priority filter"
+            labels={priorityLabels}
+            onChange={onPriorityFilterChange}
+            values={["all", "expedite", "critical"]}
+          />
+        </div>
+        <p className="text-sm leading-6 text-slate-300">
+          Forecast board and the active horizon re-evaluate queue scope, age,
+          and priority filters against projected state, while priority
+          explanation mode shifts the board toward why each queue is moving.
+        </p>
       </div>
     </section>
   );

--- a/src/components/queue-monitor/queue-forecast-strip.tsx
+++ b/src/components/queue-monitor/queue-forecast-strip.tsx
@@ -1,0 +1,67 @@
+import type {
+  ForecastPoint,
+  ForecastWindowId,
+} from "./queue-monitor-data";
+
+type QueueForecastStripProps = {
+  activeWindow: ForecastWindowId;
+  points: ForecastPoint[];
+  variant?: "compact" | "regular";
+};
+
+const toneClasses = {
+  stable: "border-emerald-300/25 bg-emerald-300/10 text-emerald-50",
+  watch: "border-amber-300/25 bg-amber-300/10 text-amber-50",
+  critical: "border-rose-300/25 bg-rose-300/10 text-rose-50",
+};
+
+export function QueueForecastStrip({
+  activeWindow,
+  points,
+  variant = "regular",
+}: QueueForecastStripProps) {
+  const isCompact = variant === "compact";
+
+  return (
+    <div
+      className={`grid gap-2 ${isCompact ? "grid-cols-3" : "grid-cols-1 sm:grid-cols-3"}`}
+    >
+      {points.map((point) => {
+        const isActive = point.windowId === activeWindow;
+
+        return (
+          <div
+            className={`rounded-[1.25rem] border p-3 ${
+              isActive
+                ? "border-orange-200/45 bg-orange-200/10"
+                : toneClasses[point.tone]
+            }`}
+            key={point.windowId}
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] opacity-75">
+                  {point.windowId}
+                </p>
+                <p
+                  className={`mt-2 font-semibold text-white ${isCompact ? "text-lg" : "text-2xl"}`}
+                >
+                  {point.backlogCount}
+                </p>
+              </div>
+              <span className="text-[11px] uppercase tracking-[0.18em] opacity-70">
+                #{point.priorityRank}
+              </span>
+            </div>
+            <p className={`mt-2 ${isCompact ? "text-xs" : "text-sm"} opacity-90`}>
+              {point.statusLabel}
+            </p>
+            <p className={`mt-1 ${isCompact ? "text-[11px]" : "text-xs"} opacity-70`}>
+              {point.breachCount} breach risk · {point.carryover} carryover
+            </p>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/queue-monitor/queue-monitor-data.ts
+++ b/src/components/queue-monitor/queue-monitor-data.ts
@@ -3,51 +3,1189 @@ export type AgeFilter = "all" | "aging" | "breach";
 export type QueueScope = "all" | "watch" | "stable";
 export type AgeBand = "fresh" | "aging" | "breach";
 export type EscalationLevelId = "none" | "lead" | "director";
+export type PriorityBand = "monitor" | "expedite" | "critical";
+export type PriorityFilter = "all" | "expedite" | "critical";
+export type ViewMode = "live" | "forecast";
+export type InsightMode = "operations" | "priority";
+export type ForecastWindowId = "30m" | "60m" | "90m";
+
+export type ForecastWindow = {
+  id: ForecastWindowId;
+  label: string;
+  note: string;
+  shortLabel: string;
+};
+
+export type ForecastPoint = {
+  windowId: ForecastWindowId;
+  backlogCount: number;
+  agingCount: number;
+  breachCount: number;
+  oldestMinutes: number;
+  intakePerHour: number;
+  clearedPerHour: number;
+  tone: QueueTone;
+  statusLabel: string;
+  priorityRank: number;
+  carryover: number;
+  projectedWaitMinutes: number;
+  explanationSummary: string;
+};
+
+export type PriorityDriver = {
+  id: string;
+  label: string;
+  detail: string;
+  impact: string;
+  tone: "calm" | "watch" | "hot";
+};
 
 export type QueueSummary = {
-  id: string; label: string; region: string; owner: string; tone: QueueTone; statusLabel: string;
-  intakePerHour: number; clearedPerHour: number; oldestMinutes: number; slaWindow: string;
+  id: string;
+  label: string;
+  region: string;
+  owner: string;
+  tone: QueueTone;
+  statusLabel: string;
+  intakePerHour: number;
+  clearedPerHour: number;
+  oldestMinutes: number;
+  slaWindow: string;
+  backlogCount: number;
+  agingCount: number;
+  breachCount: number;
+  priorityRank: number;
+  carryover: number;
+  projectedWaitMinutes: number;
+  prioritySummary: string;
+  rationale: string;
+  pressureSignals: string[];
+  priorityDrivers: PriorityDriver[];
+  forecast: ForecastPoint[];
+};
+
+export type BacklogForecastState = {
+  windowId: ForecastWindowId;
+  ageMinutes: number;
+  ageBand: AgeBand;
+  priorityBand: PriorityBand;
+  riskLabel: string;
+  rationale: string;
+  nextAction: string;
+  etaLabel: string;
 };
 
 export type BacklogItem = {
-  id: string; queueId: string; caseRef: string; customer: string; title: string; detail: string;
-  owner: string; ageMinutes: number; ageBand: AgeBand; severity: "low" | "medium" | "high";
-  nextAction: string; segment: string; escalationLevel: EscalationLevelId;
+  id: string;
+  queueId: string;
+  caseRef: string;
+  customer: string;
+  title: string;
+  detail: string;
+  owner: string;
+  ageMinutes: number;
+  ageBand: AgeBand;
+  severity: "low" | "medium" | "high";
+  nextAction: string;
+  segment: string;
+  escalationLevel: EscalationLevelId;
+  priorityBand: PriorityBand;
+  priorityReason: string;
+  explanationPoints: string[];
+  blockingSignal: string;
+  forecast: BacklogForecastState[];
 };
 
-export type ThroughputSummary = { id: string; label: string; value: string; note: string; tone: "up" | "flat" | "down" };
-export type EscalationLevel = { id: EscalationLevelId; label: string; note: string; tone: "calm" | "watch" | "hot" };
+export type ThroughputSummary = {
+  id: string;
+  label: string;
+  value: string;
+  note: string;
+  tone: "up" | "flat" | "down";
+};
+
+export type EscalationLevel = {
+  id: EscalationLevelId;
+  label: string;
+  note: string;
+  tone: "calm" | "watch" | "hot";
+};
 
 export const queueMonitorSnapshot = "Snapshot 09:40 local";
 
-export const throughputSummaries: ThroughputSummary[] = [
-  { id: "inflow", label: "Inflow / hr", value: "142", note: "Eight more than the last half hour.", tone: "up" },
-  { id: "clearance", label: "Clearance / hr", value: "118", note: "Two queues are clearing below intake.", tone: "down" },
-  { id: "stability", label: "Projected carryover", value: "24", note: "If unchanged, two breach items remain by handoff.", tone: "flat" },
+export const forecastWindows: ForecastWindow[] = [
+  {
+    id: "30m",
+    label: "30 min",
+    shortLabel: "30m",
+    note: "Next routing pass",
+  },
+  {
+    id: "60m",
+    label: "60 min",
+    shortLabel: "60m",
+    note: "Shift midpoint forecast",
+  },
+  {
+    id: "90m",
+    label: "90 min",
+    shortLabel: "90m",
+    note: "Handoff risk preview",
+  },
 ];
 
 export const escalationLevels: EscalationLevel[] = [
-  { id: "none", label: "Local watch", note: "Keep the item inside the queue team.", tone: "calm" },
-  { id: "lead", label: "Shift lead", note: "Pull the queue lead into the next pass.", tone: "watch" },
-  { id: "director", label: "Director page", note: "Escalate immediately for deadline risk.", tone: "hot" },
+  {
+    id: "none",
+    label: "Local watch",
+    note: "Keep the item inside the queue team.",
+    tone: "calm",
+  },
+  {
+    id: "lead",
+    label: "Shift lead",
+    note: "Pull the queue lead into the next pass.",
+    tone: "watch",
+  },
+  {
+    id: "director",
+    label: "Director page",
+    note: "Escalate immediately for deadline risk.",
+    tone: "hot",
+  },
 ];
 
 export const queueSummaries: QueueSummary[] = [
-  { id: "claims", label: "Priority Claims", region: "North pod", owner: "Mika Patel", tone: "critical", statusLabel: "Backlog breach", intakePerHour: 38, clearedPerHour: 27, oldestMinutes: 128, slaWindow: "90 min target" },
-  { id: "identity", label: "Identity Review", region: "Trust desk", owner: "Cam Nguyen", tone: "watch", statusLabel: "Aging concentration", intakePerHour: 29, clearedPerHour: 24, oldestMinutes: 82, slaWindow: "75 min target" },
-  { id: "returns", label: "Returns Exceptions", region: "Marketplace lane", owner: "Jules Carter", tone: "watch", statusLabel: "Throughput drift", intakePerHour: 41, clearedPerHour: 35, oldestMinutes: 64, slaWindow: "70 min target" },
-  { id: "loyalty", label: "Loyalty Adjustments", region: "Retention desk", owner: "Ava Brooks", tone: "stable", statusLabel: "Within target", intakePerHour: 22, clearedPerHour: 25, oldestMinutes: 31, slaWindow: "60 min target" },
+  {
+    id: "claims",
+    label: "Priority Claims",
+    region: "North pod",
+    owner: "Mika Patel",
+    tone: "critical",
+    statusLabel: "Backlog breach",
+    intakePerHour: 38,
+    clearedPerHour: 27,
+    oldestMinutes: 128,
+    slaWindow: "90 min target",
+    backlogCount: 17,
+    agingCount: 8,
+    breachCount: 3,
+    priorityRank: 1,
+    carryover: 4,
+    projectedWaitMinutes: 101,
+    prioritySummary:
+      "Claims stays at the top because intake is outrunning clearance and breach work is stacking ahead of the next sweep.",
+    rationale:
+      "Two reopened payer appeals and one blocked trace correction keep director attention locked on the claims lane.",
+    pressureSignals: [
+      "11 more items arrive each hour than the pod clears.",
+      "Three claims are already past the ninety minute target.",
+      "Manual coding rework keeps reopened packets in the same lane.",
+    ],
+    priorityDrivers: [
+      {
+        id: "claims-gap",
+        label: "Intake outruns clearance",
+        impact: "+11 / hr gap",
+        tone: "hot",
+        detail:
+          "The pod is taking in 38 claims an hour and clearing 27, so every sweep adds exposed work instead of burning it down.",
+      },
+      {
+        id: "claims-breach",
+        label: "Existing breach concentration",
+        impact: "3 breach claims",
+        tone: "hot",
+        detail:
+          "Already-breached claims are consuming lead attention and shrinking room for new intake.",
+      },
+      {
+        id: "claims-rework",
+        label: "Reopened packet rework",
+        impact: "2-step correction loop",
+        tone: "watch",
+        detail:
+          "Coding and finance both have to touch the same packet before it can leave the queue.",
+      },
+    ],
+    forecast: [
+      {
+        windowId: "30m",
+        backlogCount: 19,
+        agingCount: 9,
+        breachCount: 4,
+        oldestMinutes: 145,
+        intakePerHour: 40,
+        clearedPerHour: 28,
+        tone: "critical",
+        statusLabel: "Director attention",
+        priorityRank: 1,
+        carryover: 5,
+        projectedWaitMinutes: 106,
+        explanationSummary:
+          "Breach risk climbs if the payer trace stays blocked through the next routing pass.",
+      },
+      {
+        windowId: "60m",
+        backlogCount: 23,
+        agingCount: 11,
+        breachCount: 5,
+        oldestMinutes: 158,
+        intakePerHour: 41,
+        clearedPerHour: 29,
+        tone: "critical",
+        statusLabel: "Stack building",
+        priorityRank: 1,
+        carryover: 6,
+        projectedWaitMinutes: 111,
+        explanationSummary:
+          "Reopened appeals keep director pages active even if one blocked payout clears.",
+      },
+      {
+        windowId: "90m",
+        backlogCount: 27,
+        agingCount: 13,
+        breachCount: 7,
+        oldestMinutes: 173,
+        intakePerHour: 42,
+        clearedPerHour: 29,
+        tone: "critical",
+        statusLabel: "Carryover locked",
+        priorityRank: 1,
+        carryover: 8,
+        projectedWaitMinutes: 118,
+        explanationSummary:
+          "Claims remains the top queue because breach work compounds faster than the pod can absorb it.",
+      },
+    ],
+  },
+  {
+    id: "identity",
+    label: "Identity Review",
+    region: "Trust desk",
+    owner: "Cam Nguyen",
+    tone: "watch",
+    statusLabel: "Aging concentration",
+    intakePerHour: 29,
+    clearedPerHour: 24,
+    oldestMinutes: 82,
+    slaWindow: "75 min target",
+    backlogCount: 12,
+    agingCount: 5,
+    breachCount: 1,
+    priorityRank: 2,
+    carryover: 3,
+    projectedWaitMinutes: 79,
+    prioritySummary:
+      "Identity sits just behind claims because verifier capacity is thin and enterprise KYC packets are bunching together.",
+    rationale:
+      "The queue stays near the top while two-person review coverage is uneven across the next hour.",
+    pressureSignals: [
+      "Verifier coverage drops to one reviewer for the 10:00 block.",
+      "One enterprise packet is already close to its trust desk deadline.",
+      "Manual checksum retries are stretching second-pass review time.",
+    ],
+    priorityDrivers: [
+      {
+        id: "identity-capacity",
+        label: "Second verifier scarcity",
+        impact: "-1 reviewer next pass",
+        tone: "watch",
+        detail:
+          "The trust desk loses one secondary verifier for the 10:00 block, so enterprise packets queue behind each other.",
+      },
+      {
+        id: "identity-enterprise",
+        label: "Enterprise document sensitivity",
+        impact: "2 high-touch packets",
+        tone: "watch",
+        detail:
+          "Large-account document packs need paired review and cannot be cleared in single-pass mode.",
+      },
+      {
+        id: "identity-checksum",
+        label: "Checksum rework",
+        impact: "repeat upload cycle",
+        tone: "calm",
+        detail:
+          "Broken upload packages are adding another manual touch but not yet causing widespread breaches.",
+      },
+    ],
+    forecast: [
+      {
+        windowId: "30m",
+        backlogCount: 13,
+        agingCount: 6,
+        breachCount: 2,
+        oldestMinutes: 95,
+        intakePerHour: 30,
+        clearedPerHour: 24,
+        tone: "watch",
+        statusLabel: "Coverage thinning",
+        priorityRank: 2,
+        carryover: 4,
+        projectedWaitMinutes: 83,
+        explanationSummary:
+          "Enterprise packets start to stack once paired review capacity narrows.",
+      },
+      {
+        windowId: "60m",
+        backlogCount: 15,
+        agingCount: 8,
+        breachCount: 3,
+        oldestMinutes: 108,
+        intakePerHour: 31,
+        clearedPerHour: 24,
+        tone: "watch",
+        statusLabel: "Manual review pileup",
+        priorityRank: 2,
+        carryover: 5,
+        projectedWaitMinutes: 88,
+        explanationSummary:
+          "Identity holds rank two while secondary verification remains the main bottleneck.",
+      },
+      {
+        windowId: "90m",
+        backlogCount: 16,
+        agingCount: 9,
+        breachCount: 4,
+        oldestMinutes: 121,
+        intakePerHour: 31,
+        clearedPerHour: 23,
+        tone: "critical",
+        statusLabel: "Deadline slip risk",
+        priorityRank: 3,
+        carryover: 6,
+        projectedWaitMinutes: 93,
+        explanationSummary:
+          "Identity turns critical by handoff, but returns edges ahead because inbound exceptions spike faster.",
+      },
+    ],
+  },
+  {
+    id: "returns",
+    label: "Returns Exceptions",
+    region: "Marketplace lane",
+    owner: "Jules Carter",
+    tone: "watch",
+    statusLabel: "Throughput drift",
+    intakePerHour: 41,
+    clearedPerHour: 35,
+    oldestMinutes: 64,
+    slaWindow: "70 min target",
+    backlogCount: 14,
+    agingCount: 4,
+    breachCount: 0,
+    priorityRank: 3,
+    carryover: 2,
+    projectedWaitMinutes: 67,
+    prioritySummary:
+      "Returns sits below identity now, but carrier exception volume is building and can move this lane up before handoff.",
+    rationale:
+      "Inbound warehouse and carrier mismatches are still controllable, but the lane has little slack if arrival scans continue to fail.",
+    pressureSignals: [
+      "Returns is taking in six more exceptions an hour than it clears.",
+      "Carrier scan disputes are clustering around the same marketplace lane.",
+      "Fresh items are likely to age into breach by handoff if proof never lands.",
+    ],
+    priorityDrivers: [
+      {
+        id: "returns-gap",
+        label: "Arrival volume ramp",
+        impact: "+6 / hr gap",
+        tone: "watch",
+        detail:
+          "The lane is still clearing most work, but new arrival exceptions are accelerating faster than planned.",
+      },
+      {
+        id: "returns-proof",
+        label: "Proof and scan dependency",
+        impact: "multi-party unblock",
+        tone: "watch",
+        detail:
+          "Warehouse proof and carrier scans both have to land before several exceptions can close.",
+      },
+      {
+        id: "returns-handoff",
+        label: "Handoff exposure",
+        impact: "3 items near target",
+        tone: "calm",
+        detail:
+          "Several exceptions are still fresh now, but they age into real handoff risk if the lane drifts for another hour.",
+      },
+    ],
+    forecast: [
+      {
+        windowId: "30m",
+        backlogCount: 15,
+        agingCount: 5,
+        breachCount: 1,
+        oldestMinutes: 78,
+        intakePerHour: 42,
+        clearedPerHour: 35,
+        tone: "watch",
+        statusLabel: "Aging into target edge",
+        priorityRank: 3,
+        carryover: 3,
+        projectedWaitMinutes: 71,
+        explanationSummary:
+          "Carrier exception arrivals stay manageable, but the oldest item crosses the lane target.",
+      },
+      {
+        windowId: "60m",
+        backlogCount: 16,
+        agingCount: 6,
+        breachCount: 2,
+        oldestMinutes: 91,
+        intakePerHour: 43,
+        clearedPerHour: 35,
+        tone: "watch",
+        statusLabel: "Warehouse proof lag",
+        priorityRank: 3,
+        carryover: 4,
+        projectedWaitMinutes: 75,
+        explanationSummary:
+          "Returns keeps building because carrier scan disputes are not clearing inside the same pass.",
+      },
+      {
+        windowId: "90m",
+        backlogCount: 18,
+        agingCount: 7,
+        breachCount: 3,
+        oldestMinutes: 104,
+        intakePerHour: 44,
+        clearedPerHour: 34,
+        tone: "critical",
+        statusLabel: "Handoff spike",
+        priorityRank: 2,
+        carryover: 5,
+        projectedWaitMinutes: 80,
+        explanationSummary:
+          "Carrier arrivals push this lane ahead of identity by handoff unless proof and scans land together.",
+      },
+    ],
+  },
+  {
+    id: "loyalty",
+    label: "Loyalty Adjustments",
+    region: "Retention desk",
+    owner: "Ava Brooks",
+    tone: "stable",
+    statusLabel: "Within target",
+    intakePerHour: 22,
+    clearedPerHour: 25,
+    oldestMinutes: 31,
+    slaWindow: "60 min target",
+    backlogCount: 8,
+    agingCount: 1,
+    breachCount: 0,
+    priorityRank: 4,
+    carryover: 1,
+    projectedWaitMinutes: 34,
+    prioritySummary:
+      "Loyalty remains stable because the desk is still clearing above intake, even with nightly balance work approaching.",
+    rationale:
+      "The retention desk has room to absorb short-term sync work, so this lane stays last in the priority stack.",
+    pressureSignals: [
+      "Clearance stays ahead of intake for most of the shift.",
+      "Only one tracked item is close to its target window.",
+      "Nightly balance sync adds friction later, but not enough to pull rank yet.",
+    ],
+    priorityDrivers: [
+      {
+        id: "loyalty-buffer",
+        label: "Positive clearance buffer",
+        impact: "+3 / hr",
+        tone: "calm",
+        detail:
+          "The desk is still clearing slightly more work than it takes in, so it can absorb minor drift.",
+      },
+      {
+        id: "loyalty-sync",
+        label: "Nightly sync dependency",
+        impact: "1 queued adjustment",
+        tone: "watch",
+        detail:
+          "A couple of items still depend on the nightly balance sync, but they are not putting the desk over target yet.",
+      },
+      {
+        id: "loyalty-severity",
+        label: "Low severity mix",
+        impact: "consumer volume",
+        tone: "calm",
+        detail:
+          "Most of the desk work is low-severity consumer adjustments rather than hard-stop enterprise issues.",
+      },
+    ],
+    forecast: [
+      {
+        windowId: "30m",
+        backlogCount: 7,
+        agingCount: 1,
+        breachCount: 0,
+        oldestMinutes: 43,
+        intakePerHour: 22,
+        clearedPerHour: 25,
+        tone: "stable",
+        statusLabel: "Buffer intact",
+        priorityRank: 4,
+        carryover: 1,
+        projectedWaitMinutes: 38,
+        explanationSummary:
+          "Loyalty stays comfortably stable while the desk clears above intake.",
+      },
+      {
+        windowId: "60m",
+        backlogCount: 8,
+        agingCount: 2,
+        breachCount: 0,
+        oldestMinutes: 56,
+        intakePerHour: 23,
+        clearedPerHour: 24,
+        tone: "stable",
+        statusLabel: "Sync watch",
+        priorityRank: 4,
+        carryover: 1,
+        projectedWaitMinutes: 42,
+        explanationSummary:
+          "The nightly sync adds some aging work, but not enough to displace the higher-risk lanes.",
+      },
+      {
+        windowId: "90m",
+        backlogCount: 9,
+        agingCount: 3,
+        breachCount: 1,
+        oldestMinutes: 69,
+        intakePerHour: 23,
+        clearedPerHour: 23,
+        tone: "watch",
+        statusLabel: "Sync friction",
+        priorityRank: 4,
+        carryover: 2,
+        projectedWaitMinutes: 47,
+        explanationSummary:
+          "Loyalty slips into watch mode by handoff, but it still trails the other queues on absolute risk.",
+      },
+    ],
+  },
 ];
 
 export const backlogItems: BacklogItem[] = [
-  { id: "claim-140", queueId: "claims", caseRef: "CLM-140", customer: "Northwind Health", title: "Appeal reopened after duplicate denial batch", detail: "Two denial reasons landed on the same claim packet and blocked the automatic close step.", owner: "Remy", ageMinutes: 128, ageBand: "breach", severity: "high", nextAction: "Pull the denial packet before the 10:15 sweep.", segment: "Enterprise", escalationLevel: "director" },
-  { id: "claim-156", queueId: "claims", caseRef: "CLM-156", customer: "Blue Basin Dental", title: "Refund hold waiting on payer trace", detail: "The repayment file is ready, but finance still needs the corrected trace number.", owner: "Nadia", ageMinutes: 93, ageBand: "breach", severity: "medium", nextAction: "Confirm trace ID with finance and release the hold.", segment: "SMB", escalationLevel: "lead" },
-  { id: "claim-162", queueId: "claims", caseRef: "CLM-162", customer: "Crown Labs", title: "Manual coding review queued after rule mismatch", detail: "The edit engine split the modifiers into two review branches, leaving one item parked.", owner: "Owen", ageMinutes: 46, ageBand: "aging", severity: "medium", nextAction: "Resolve the modifier branch and re-run coding.", segment: "Mid-market", escalationLevel: "none" },
-  { id: "id-404", queueId: "identity", caseRef: "ID-404", customer: "Horizon Clinics", title: "Beneficial-owner document failed checksum on resubmission", detail: "The resubmitted PDF is legible, but the checksum on the uploaded package does not match.", owner: "Theo", ageMinutes: 82, ageBand: "aging", severity: "high", nextAction: "Request a clean upload and hold release until it lands.", segment: "Enterprise", escalationLevel: "lead" },
-  { id: "id-417", queueId: "identity", caseRef: "ID-417", customer: "Studio Meridian", title: "Passport image review waiting on secondary verifier", detail: "The first reviewer cleared the image; the second verification slot has not picked it up yet.", owner: "Iris", ageMinutes: 58, ageBand: "aging", severity: "medium", nextAction: "Pull the item into the next trust desk pairing.", segment: "SMB", escalationLevel: "none" },
-  { id: "ret-212", queueId: "returns", caseRef: "RET-212", customer: "Evergreen Outfitters", title: "Warehouse exception lacks arrival scan for carton 3", detail: "The return is partially received, but one carton still shows as in transit in the partner feed.", owner: "Liam", ageMinutes: 64, ageBand: "aging", severity: "medium", nextAction: "Confirm the missing scan with the carrier rep.", segment: "Retail", escalationLevel: "lead" },
-  { id: "ret-229", queueId: "returns", caseRef: "RET-229", customer: "Paper Kite", title: "Carrier credit request paused on surcharge dispute", detail: "The refund total is agreed, but the surcharge line item is still contested in the handoff notes.", owner: "June", ageMinutes: 39, ageBand: "fresh", severity: "low", nextAction: "Clear the surcharge note and relaunch the credit memo.", segment: "SMB", escalationLevel: "none" },
-  { id: "ret-244", queueId: "returns", caseRef: "RET-244", customer: "Northstar Outdoors", title: "Restock rejection sent back for image proof", detail: "The warehouse note references damage, but the proof image never attached to the return record.", owner: "Piper", ageMinutes: 22, ageBand: "fresh", severity: "low", nextAction: "Attach warehouse proof and continue the rejection.", segment: "Retail", escalationLevel: "none" },
-  { id: "loy-087", queueId: "loyalty", caseRef: "LOY-087", customer: "Maple & Co.", title: "Points reversal waiting on duplicate-order check", detail: "The order pair is already linked, but the system has not cleared the reversal hold yet.", owner: "Sage", ageMinutes: 31, ageBand: "fresh", severity: "low", nextAction: "Verify duplicate ownership and post the reversal.", segment: "Consumer", escalationLevel: "none" },
-  { id: "loy-091", queueId: "loyalty", caseRef: "LOY-091", customer: "Pine Harbor", title: "Tier adjustment pending nightly balance sync", detail: "The requested tier move is ready to post after the next ledger snapshot completes.", owner: "Arlo", ageMinutes: 18, ageBand: "fresh", severity: "low", nextAction: "Carry this item into the overnight sync window.", segment: "Consumer", escalationLevel: "none" },
+  {
+    id: "claim-140",
+    queueId: "claims",
+    caseRef: "CLM-140",
+    customer: "Northwind Health",
+    title: "Appeal reopened after duplicate denial batch",
+    detail:
+      "Two denial reasons landed on the same claim packet and blocked the automatic close step.",
+    owner: "Remy",
+    ageMinutes: 128,
+    ageBand: "breach",
+    severity: "high",
+    nextAction: "Pull the denial packet before the 10:15 sweep.",
+    segment: "Enterprise",
+    escalationLevel: "director",
+    priorityBand: "critical",
+    priorityReason:
+      "Already in breach with duplicate-denial rework still open across coding and finance.",
+    explanationPoints: [
+      "Two denial reasons force a manual packet rebuild.",
+      "The enterprise account misses revenue timing if this stays parked.",
+      "Director paging is already active because the target window is blown.",
+    ],
+    blockingSignal:
+      "Finance and coding both need the corrected denial packet before release can restart.",
+    forecast: [
+      {
+        windowId: "30m",
+        ageMinutes: 153,
+        ageBand: "breach",
+        priorityBand: "critical",
+        riskLabel: "Another sweep misses if the duplicate-denial packet is still unresolved.",
+        rationale:
+          "Claims remains the top breach driver because the reopened packet still needs two teams to clear it.",
+        nextAction:
+          "Keep the director page open and route coding support into the next pass.",
+        etaLabel: "Projected to stay open through the next 30 minutes.",
+      },
+      {
+        windowId: "60m",
+        ageMinutes: 176,
+        ageBand: "breach",
+        priorityBand: "critical",
+        riskLabel: "Carryover becomes certain if the trace repair does not land in the midpoint pass.",
+        rationale:
+          "The reopened packet keeps claims pinned at the top because it blocks both breach clearance and new intake.",
+        nextAction:
+          "Hold payout release and push the corrected packet into the director review bundle.",
+        etaLabel: "Likely to remain open into the shift midpoint.",
+      },
+      {
+        windowId: "90m",
+        ageMinutes: 203,
+        ageBand: "breach",
+        priorityBand: "critical",
+        riskLabel: "Handoff starts with this packet still open unless finance and coding close the loop together.",
+        rationale:
+          "This appeal continues to anchor the claims queue because no single team can clear it alone.",
+        nextAction:
+          "Escalate the packet as handoff-critical and keep the director page active.",
+        etaLabel: "Projected to survive into handoff without multi-team intervention.",
+      },
+    ],
+  },
+  {
+    id: "claim-156",
+    queueId: "claims",
+    caseRef: "CLM-156",
+    customer: "Blue Basin Dental",
+    title: "Refund hold waiting on payer trace",
+    detail:
+      "The repayment file is ready, but finance still needs the corrected trace number.",
+    owner: "Nadia",
+    ageMinutes: 93,
+    ageBand: "breach",
+    severity: "medium",
+    nextAction: "Confirm trace ID with finance and release the hold.",
+    segment: "SMB",
+    escalationLevel: "lead",
+    priorityBand: "expedite",
+    priorityReason:
+      "The item is already over target and one missing payer trace keeps it from clearing.",
+    explanationPoints: [
+      "The repayment file is complete except for the corrected trace number.",
+      "Every missed pass keeps the claims pod under its clearance target.",
+      "Lead escalation is enough for now, but the item is drifting toward director review.",
+    ],
+    blockingSignal:
+      "Finance cannot post the repayment without the corrected payer trace on file.",
+    forecast: [
+      {
+        windowId: "30m",
+        ageMinutes: 118,
+        ageBand: "breach",
+        priorityBand: "expedite",
+        riskLabel: "The repayment misses another pass if the trace ID still has not been corrected.",
+        rationale:
+          "This claim stays near the front because it is simple work blocked by one missing finance dependency.",
+        nextAction: "Pull finance into the next pass and verify the trace against the payer log.",
+        etaLabel: "Projected to remain unresolved through the next routing pass.",
+      },
+      {
+        windowId: "60m",
+        ageMinutes: 141,
+        ageBand: "breach",
+        priorityBand: "critical",
+        riskLabel: "The refund becomes a handoff blocker once it sits open for another hour.",
+        rationale:
+          "The trace blocker becomes director-visible because the claim is now pure carryover risk.",
+        nextAction: "Promote the claim into the director digest if the payer trace is still missing.",
+        etaLabel: "Likely to escalate by the midpoint forecast window.",
+      },
+      {
+        windowId: "90m",
+        ageMinutes: 166,
+        ageBand: "breach",
+        priorityBand: "critical",
+        riskLabel: "Without the trace fix, this refund rolls directly into handoff as unresolved carryover.",
+        rationale:
+          "A simple finance dependency becomes a critical carryover item by handoff.",
+        nextAction:
+          "Keep the claim in the handoff packet and page finance if the trace is still absent.",
+        etaLabel: "Projected to remain open into handoff without intervention.",
+      },
+    ],
+  },
+  {
+    id: "claim-162",
+    queueId: "claims",
+    caseRef: "CLM-162",
+    customer: "Crown Labs",
+    title: "Manual coding review queued after rule mismatch",
+    detail:
+      "The edit engine split the modifiers into two review branches, leaving one item parked.",
+    owner: "Owen",
+    ageMinutes: 46,
+    ageBand: "aging",
+    severity: "medium",
+    nextAction: "Resolve the modifier branch and re-run coding.",
+    segment: "Mid-market",
+    escalationLevel: "none",
+    priorityBand: "monitor",
+    priorityReason:
+      "Not yet in breach, but the branch mismatch is likely to age into claims carryover if it stays untouched.",
+    explanationPoints: [
+      "The claim is blocked by a split modifier path inside the edit engine.",
+      "A fast coding touch closes it now, but delay pushes it into the breach stack.",
+      "The item is still local-watch material while it remains under target.",
+    ],
+    blockingSignal:
+      "Coding needs to collapse the modifier branches before the claim can resume automation.",
+    forecast: [
+      {
+        windowId: "30m",
+        ageMinutes: 71,
+        ageBand: "aging",
+        priorityBand: "expedite",
+        riskLabel: "This claim reaches the target edge if the modifier branch is still split in the next pass.",
+        rationale:
+          "The branch mismatch starts consuming higher priority because it is about to tip into breach territory.",
+        nextAction: "Pull a coding reviewer into the next sweep and clear the rule split.",
+        etaLabel: "Projected to become an expedite item inside 30 minutes.",
+      },
+      {
+        windowId: "60m",
+        ageMinutes: 96,
+        ageBand: "breach",
+        priorityBand: "expedite",
+        riskLabel: "The claim crosses the ninety minute target unless the modifier branch is corrected.",
+        rationale:
+          "A once-manageable coding defect becomes visible carryover pressure by the midpoint forecast.",
+        nextAction: "Promote the claim into the lead queue for the next coding pass.",
+        etaLabel: "Projected to breach by the 60 minute forecast.",
+      },
+      {
+        windowId: "90m",
+        ageMinutes: 121,
+        ageBand: "breach",
+        priorityBand: "critical",
+        riskLabel: "The parked coding mismatch becomes a handoff-critical claim if it is still untouched.",
+        rationale:
+          "The claim turns critical because it adds to the same breach stack already pulling claims to rank one.",
+        nextAction: "Escalate the coding mismatch into the director digest before handoff.",
+        etaLabel: "Projected to become critical by handoff.",
+      },
+    ],
+  },
+  {
+    id: "id-404",
+    queueId: "identity",
+    caseRef: "ID-404",
+    customer: "Horizon Clinics",
+    title: "Beneficial-owner document failed checksum on resubmission",
+    detail:
+      "The resubmitted PDF is legible, but the checksum on the uploaded package does not match.",
+    owner: "Theo",
+    ageMinutes: 82,
+    ageBand: "aging",
+    severity: "high",
+    nextAction: "Request a clean upload and hold release until it lands.",
+    segment: "Enterprise",
+    escalationLevel: "lead",
+    priorityBand: "expedite",
+    priorityReason:
+      "Paired review is needed and the broken upload package is already close to the trust desk deadline.",
+    explanationPoints: [
+      "The package needs a clean re-upload before paired review can finish.",
+      "Enterprise document handling raises the consequence of delay.",
+      "The queue is capacity-constrained because one verifier drops out in the next block.",
+    ],
+    blockingSignal:
+      "The upload package cannot pass paired review until the checksum mismatch is removed.",
+    forecast: [
+      {
+        windowId: "30m",
+        ageMinutes: 103,
+        ageBand: "breach",
+        priorityBand: "critical",
+        riskLabel: "This packet breaches the trust target if a clean upload does not arrive before the next pass.",
+        rationale:
+          "The enterprise document becomes the sharpest identity risk once it crosses the paired review deadline.",
+        nextAction: "Hold release and route the client to a clean upload lane immediately.",
+        etaLabel: "Projected to breach inside the next 30 minutes.",
+      },
+      {
+        windowId: "60m",
+        ageMinutes: 126,
+        ageBand: "breach",
+        priorityBand: "critical",
+        riskLabel: "The packet becomes a primary trust desk carryover item without a clean resubmission.",
+        rationale:
+          "Verifier scarcity and enterprise sensitivity keep this item near the top of the identity stack.",
+        nextAction:
+          "Escalate the upload failure into the lead digest and reserve paired review capacity.",
+        etaLabel: "Likely to remain open into the shift midpoint.",
+      },
+      {
+        windowId: "90m",
+        ageMinutes: 149,
+        ageBand: "breach",
+        priorityBand: "critical",
+        riskLabel: "Handoff begins with this packet unresolved unless the clean upload lands before the last paired-review slot.",
+        rationale:
+          "This packet continues to anchor identity risk because the queue cannot clear it in single-review mode.",
+        nextAction:
+          "Mark the packet as handoff-critical and keep paired review reserved for the clean upload.",
+        etaLabel: "Projected to remain unresolved by handoff.",
+      },
+    ],
+  },
+  {
+    id: "id-417",
+    queueId: "identity",
+    caseRef: "ID-417",
+    customer: "Studio Meridian",
+    title: "Passport image review waiting on secondary verifier",
+    detail:
+      "The first reviewer cleared the image; the second verification slot has not picked it up yet.",
+    owner: "Iris",
+    ageMinutes: 58,
+    ageBand: "aging",
+    severity: "medium",
+    nextAction: "Pull the item into the next trust desk pairing.",
+    segment: "SMB",
+    escalationLevel: "none",
+    priorityBand: "monitor",
+    priorityReason:
+      "Second verifier coverage stays thin for the next hour, so this image check is likely to age into breach.",
+    explanationPoints: [
+      "Only the second verification touch is missing.",
+      "Trust desk capacity drops before the pending pair slot refreshes.",
+      "The item is still recoverable without director attention if it gets the next slot.",
+    ],
+    blockingSignal:
+      "The trust desk cannot finish the review until a secondary verifier claims the package.",
+    forecast: [
+      {
+        windowId: "30m",
+        ageMinutes: 82,
+        ageBand: "aging",
+        priorityBand: "expedite",
+        riskLabel: "This review reaches the trust desk edge if the secondary verifier slot stays empty.",
+        rationale:
+          "The item becomes an expedite candidate because the queue has fewer paired-review slots than pending work.",
+        nextAction: "Reserve the next paired-review slot for this image package.",
+        etaLabel: "Projected to move into expedite focus inside 30 minutes.",
+      },
+      {
+        windowId: "60m",
+        ageMinutes: 104,
+        ageBand: "breach",
+        priorityBand: "expedite",
+        riskLabel: "The passport review breaches if the second verifier still has not picked it up by midpoint.",
+        rationale:
+          "The review becomes visible queue pressure once it tips over target and competes with enterprise packets.",
+        nextAction: "Promote the image package into the lead queue and claim the next verifier slot.",
+        etaLabel: "Projected to breach by the midpoint forecast.",
+      },
+      {
+        windowId: "90m",
+        ageMinutes: 127,
+        ageBand: "breach",
+        priorityBand: "critical",
+        riskLabel: "Handoff inherits this review unless the secondary verifier slot is claimed before the last pass.",
+        rationale:
+          "The package becomes critical because paired-review scarcity keeps it in front of fresh intake.",
+        nextAction:
+          "Add the package to the handoff digest and pull a backup verifier if available.",
+        etaLabel: "Projected to become critical by handoff.",
+      },
+    ],
+  },
+  {
+    id: "ret-212",
+    queueId: "returns",
+    caseRef: "RET-212",
+    customer: "Evergreen Outfitters",
+    title: "Warehouse exception lacks arrival scan for carton 3",
+    detail:
+      "The return is partially received, but one carton still shows as in transit in the partner feed.",
+    owner: "Liam",
+    ageMinutes: 64,
+    ageBand: "aging",
+    severity: "medium",
+    nextAction: "Confirm the missing scan with the carrier rep.",
+    segment: "Retail",
+    escalationLevel: "lead",
+    priorityBand: "expedite",
+    priorityReason:
+      "The lane is still under target overall, but this carton will breach quickly if the carrier scan never lands.",
+    explanationPoints: [
+      "Warehouse and carrier systems disagree on the third carton status.",
+      "The exception closes fast once the missing scan posts.",
+      "The returns lane is trending up, so older exceptions get more expensive each pass.",
+    ],
+    blockingSignal:
+      "Carrier confirmation is required before the warehouse can finish the exception closeout.",
+    forecast: [
+      {
+        windowId: "30m",
+        ageMinutes: 86,
+        ageBand: "breach",
+        priorityBand: "expedite",
+        riskLabel: "The exception breaches the lane target if the missing arrival scan is still absent next pass.",
+        rationale:
+          "A single scan dependency becomes visible returns pressure once the oldest carton crosses target.",
+        nextAction: "Call the carrier rep in the next pass and flag the shipment for scan recovery.",
+        etaLabel: "Projected to breach inside the next 30 minutes.",
+      },
+      {
+        windowId: "60m",
+        ageMinutes: 109,
+        ageBand: "breach",
+        priorityBand: "critical",
+        riskLabel: "The carton exception becomes a handoff risk once it sits unresolved through midpoint.",
+        rationale:
+          "Carrier and warehouse dependencies keep the lane from burning down its oldest work.",
+        nextAction: "Page the lane lead and hold the warehouse exception open for direct carrier follow-up.",
+        etaLabel: "Likely to escalate by the 60 minute forecast.",
+      },
+      {
+        windowId: "90m",
+        ageMinutes: 132,
+        ageBand: "breach",
+        priorityBand: "critical",
+        riskLabel: "Returns handoff inherits this scan dispute if the carrier feed still disagrees on carton 3.",
+        rationale:
+          "The unresolved scan becomes one of the items that pushes returns above identity by handoff.",
+        nextAction: "Carry the scan dispute into the handoff deck and request direct carrier escalation.",
+        etaLabel: "Projected to remain open into handoff.",
+      },
+    ],
+  },
+  {
+    id: "ret-229",
+    queueId: "returns",
+    caseRef: "RET-229",
+    customer: "Paper Kite",
+    title: "Carrier credit request paused on surcharge dispute",
+    detail:
+      "The refund total is agreed, but the surcharge line item is still contested in the handoff notes.",
+    owner: "June",
+    ageMinutes: 39,
+    ageBand: "fresh",
+    severity: "low",
+    nextAction: "Clear the surcharge note and relaunch the credit memo.",
+    segment: "SMB",
+    escalationLevel: "none",
+    priorityBand: "monitor",
+    priorityReason:
+      "Fresh today, but likely to move up if the surcharge dispute still blocks the memo in the next two passes.",
+    explanationPoints: [
+      "The disputed surcharge is the only unresolved field on the memo.",
+      "This is low-severity work now, but it ages quickly in a busy returns lane.",
+      "The item stays local if the next pass resolves the note cleanly.",
+    ],
+    blockingSignal:
+      "Finance needs the surcharge note cleared before the carrier credit memo can resume.",
+    forecast: [
+      {
+        windowId: "30m",
+        ageMinutes: 61,
+        ageBand: "aging",
+        priorityBand: "monitor",
+        riskLabel: "The memo starts aging if the surcharge dispute is still unresolved next pass.",
+        rationale:
+          "The item remains manageable, but it no longer benefits from fresh-work slack once the lane keeps building.",
+        nextAction: "Resolve the surcharge note before the next memo batch is assembled.",
+        etaLabel: "Projected to enter aging state inside 30 minutes.",
+      },
+      {
+        windowId: "60m",
+        ageMinutes: 84,
+        ageBand: "aging",
+        priorityBand: "expedite",
+        riskLabel: "The disputed memo joins the expedite set if it misses the midpoint batch.",
+        rationale:
+          "Returns volume makes even low-severity disputes matter once they crowd the next carrier batch.",
+        nextAction: "Pull the memo into the lead queue and clear the surcharge note manually.",
+        etaLabel: "Projected to move into expedite focus by midpoint.",
+      },
+      {
+        windowId: "90m",
+        ageMinutes: 108,
+        ageBand: "breach",
+        priorityBand: "expedite",
+        riskLabel: "The memo breaches before handoff if the surcharge dispute still blocks the credit release.",
+        rationale:
+          "A low-severity dispute becomes meaningful because the returns lane is already carrying older scan exceptions.",
+        nextAction: "Add the memo to the handoff packet if the surcharge note is still unresolved.",
+        etaLabel: "Projected to breach by handoff.",
+      },
+    ],
+  },
+  {
+    id: "ret-244",
+    queueId: "returns",
+    caseRef: "RET-244",
+    customer: "Northstar Outdoors",
+    title: "Restock rejection sent back for image proof",
+    detail:
+      "The warehouse note references damage, but the proof image never attached to the return record.",
+    owner: "Piper",
+    ageMinutes: 22,
+    ageBand: "fresh",
+    severity: "low",
+    nextAction: "Attach warehouse proof and continue the rejection.",
+    segment: "Retail",
+    escalationLevel: "none",
+    priorityBand: "monitor",
+    priorityReason:
+      "Low urgency now, though missing proof becomes more expensive if the lane stays above planned intake.",
+    explanationPoints: [
+      "Only the warehouse proof image is missing from the record.",
+      "The case can close fast if the proof posts before the next batch.",
+      "Fresh work in returns loses priority fast once arrival exceptions keep stacking.",
+    ],
+    blockingSignal:
+      "The warehouse must attach the damage image before the rejection can be finalized.",
+    forecast: [
+      {
+        windowId: "30m",
+        ageMinutes: 46,
+        ageBand: "fresh",
+        priorityBand: "monitor",
+        riskLabel: "Still low-risk if proof lands in the next warehouse upload batch.",
+        rationale:
+          "The item stays local because missing proof is the only unresolved step and the age is still manageable.",
+        nextAction: "Confirm the image upload in the next warehouse sync.",
+        etaLabel: "Projected to remain fresh through the next 30 minutes.",
+      },
+      {
+        windowId: "60m",
+        ageMinutes: 69,
+        ageBand: "aging",
+        priorityBand: "monitor",
+        riskLabel: "The restock rejection starts aging if the proof image still has not attached by midpoint.",
+        rationale:
+          "The lane has to spend attention on older scan disputes first, so missing proof becomes a secondary drag.",
+        nextAction: "Queue the proof request behind carrier scan recovery.",
+        etaLabel: "Projected to enter aging state by midpoint.",
+      },
+      {
+        windowId: "90m",
+        ageMinutes: 93,
+        ageBand: "aging",
+        priorityBand: "expedite",
+        riskLabel: "The missing proof image becomes handoff work if warehouse sync still has not landed.",
+        rationale:
+          "The item joins the expedite set once fresh-work slack disappears from the returns lane.",
+        nextAction: "Add the proof gap to the handoff list if the upload still has not posted.",
+        etaLabel: "Projected to become expedite by handoff.",
+      },
+    ],
+  },
+  {
+    id: "loy-087",
+    queueId: "loyalty",
+    caseRef: "LOY-087",
+    customer: "Maple & Co.",
+    title: "Points reversal waiting on duplicate-order check",
+    detail:
+      "The order pair is already linked, but the system has not cleared the reversal hold yet.",
+    owner: "Sage",
+    ageMinutes: 31,
+    ageBand: "fresh",
+    severity: "low",
+    nextAction: "Verify duplicate ownership and post the reversal.",
+    segment: "Consumer",
+    escalationLevel: "none",
+    priorityBand: "monitor",
+    priorityReason:
+      "Stable desk conditions keep this low, though the nightly sync can make it age if it misses the current window.",
+    explanationPoints: [
+      "Duplicate ownership is already linked on the order pair.",
+      "The only remaining blocker is the reversal hold release.",
+      "Loyalty has enough buffer that this item stays local until the sync window tightens.",
+    ],
+    blockingSignal:
+      "The points reversal cannot post until the duplicate-order hold clears in the ledger.",
+    forecast: [
+      {
+        windowId: "30m",
+        ageMinutes: 47,
+        ageBand: "fresh",
+        priorityBand: "monitor",
+        riskLabel: "Still low-risk while the retention desk keeps clearing above intake.",
+        rationale:
+          "The item remains low priority because loyalty still has enough buffer to absorb the sync dependency.",
+        nextAction: "Watch for the duplicate-order hold to clear in the next ledger refresh.",
+        etaLabel: "Projected to remain fresh through the next 30 minutes.",
+      },
+      {
+        windowId: "60m",
+        ageMinutes: 63,
+        ageBand: "aging",
+        priorityBand: "monitor",
+        riskLabel: "The reversal starts aging once the nightly sync window begins to crowd the desk.",
+        rationale:
+          "The only thing lifting this item is the approaching ledger sync, not acute queue pressure.",
+        nextAction: "Queue the reversal for the first post-sync release batch.",
+        etaLabel: "Projected to enter aging state by midpoint.",
+      },
+      {
+        windowId: "90m",
+        ageMinutes: 78,
+        ageBand: "aging",
+        priorityBand: "expedite",
+        riskLabel: "The reversal becomes handoff watch work if the ledger hold survives into the sync window.",
+        rationale:
+          "The item moves up modestly because loyalty loses some of its clearance buffer late in the shift.",
+        nextAction: "Carry the reversal into the sync watchlist if the hold is still active.",
+        etaLabel: "Projected to become expedite near handoff.",
+      },
+    ],
+  },
+  {
+    id: "loy-091",
+    queueId: "loyalty",
+    caseRef: "LOY-091",
+    customer: "Pine Harbor",
+    title: "Tier adjustment pending nightly balance sync",
+    detail:
+      "The requested tier move is ready to post after the next ledger snapshot completes.",
+    owner: "Arlo",
+    ageMinutes: 18,
+    ageBand: "fresh",
+    severity: "low",
+    nextAction: "Carry this item into the overnight sync window.",
+    segment: "Consumer",
+    escalationLevel: "none",
+    priorityBand: "monitor",
+    priorityReason:
+      "Lowest current priority because the desk is still stable and the item is intentionally parked for the nightly sync.",
+    explanationPoints: [
+      "The tier move is otherwise ready to post.",
+      "The next ledger snapshot is the intended release point.",
+      "This only rises if the sync queue starts to crowd late in the shift.",
+    ],
+    blockingSignal:
+      "The ledger snapshot has to complete before the tier adjustment can post cleanly.",
+    forecast: [
+      {
+        windowId: "30m",
+        ageMinutes: 34,
+        ageBand: "fresh",
+        priorityBand: "monitor",
+        riskLabel: "Still intentionally parked while the nightly sync window approaches.",
+        rationale:
+          "This is planned waiting, not operational pressure, so it stays at the bottom of the stack.",
+        nextAction: "Leave the adjustment parked until the ledger snapshot starts.",
+        etaLabel: "Projected to remain fresh through the next 30 minutes.",
+      },
+      {
+        windowId: "60m",
+        ageMinutes: 51,
+        ageBand: "fresh",
+        priorityBand: "monitor",
+        riskLabel: "Remains low-risk as long as the loyalty desk keeps its clearance buffer.",
+        rationale:
+          "The sync dependency is expected and still not displacing more urgent work.",
+        nextAction: "Prepare the adjustment for the first post-sync release wave.",
+        etaLabel: "Projected to stay low priority through midpoint.",
+      },
+      {
+        windowId: "90m",
+        ageMinutes: 68,
+        ageBand: "aging",
+        priorityBand: "expedite",
+        riskLabel: "The tier change joins the sync watchlist by handoff if the ledger window slips.",
+        rationale:
+          "The item rises only because loyalty loses its surplus clearance late in the shift.",
+        nextAction: "Move the adjustment into the sync watchlist before handoff.",
+        etaLabel: "Projected to enter aging watch by handoff.",
+      },
+    ],
+  },
 ];

--- a/src/components/queue-monitor/queue-monitor-header.tsx
+++ b/src/components/queue-monitor/queue-monitor-header.tsx
@@ -1,8 +1,21 @@
-import type { ThroughputSummary } from "./queue-monitor-data";
+import type {
+  ForecastWindow,
+  InsightMode,
+  ThroughputSummary,
+  ViewMode,
+} from "./queue-monitor-data";
 
 type QueueMonitorHeaderProps = {
-  agingCount: number; backlogTotal: number; breachCount: number; escalatedCount: number;
-  queuesAtRisk: number; snapshot: string; throughputSummaries: ThroughputSummary[];
+  agingCount: number;
+  backlogTotal: number;
+  breachCount: number;
+  escalatedCount: number;
+  forecastWindow: ForecastWindow;
+  insightMode: InsightMode;
+  queuesAtRisk: number;
+  snapshot: string;
+  throughputSummaries: ThroughputSummary[];
+  viewMode: ViewMode;
 };
 
 const throughputToneClasses = {
@@ -16,43 +29,80 @@ export function QueueMonitorHeader({
   backlogTotal,
   breachCount,
   escalatedCount,
+  forecastWindow,
+  insightMode,
   queuesAtRisk,
   snapshot,
   throughputSummaries,
+  viewMode,
 }: QueueMonitorHeaderProps) {
   return (
     <header className="rounded-[2rem] border border-white/10 bg-[linear-gradient(140deg,rgba(17,24,39,0.96),rgba(67,20,7,0.82))] p-6 shadow-[0_28px_100px_rgba(0,0,0,0.42)] sm:p-8">
       <div className="flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
         <div className="max-w-3xl">
-          <p className="text-xs font-semibold uppercase tracking-[0.34em] text-orange-200">Queue monitor</p>
-          <h1 className="mt-4 text-4xl font-semibold tracking-tight text-white sm:text-5xl">Backlog pressure, queue throughput, and escalation decisions in one isolated route.</h1>
-          <p className="mt-4 text-sm leading-6 text-slate-200 sm:text-base">The totals, columns, and escalation controls below are driven entirely by feature-local mock data and client-side state.</p>
+          <div className="flex flex-wrap gap-2 text-xs font-semibold uppercase tracking-[0.28em] text-orange-200">
+            <span>Queue monitor</span>
+            <span className="rounded-full border border-white/10 px-3 py-1 text-[11px] tracking-[0.22em] text-orange-100">
+              {viewMode === "live" ? "Live board" : `${forecastWindow.label} forecast`}
+            </span>
+            <span className="rounded-full border border-white/10 px-3 py-1 text-[11px] tracking-[0.22em] text-slate-200">
+              {insightMode === "operations"
+                ? "Operations mode"
+                : "Priority explanation mode"}
+            </span>
+          </div>
+          <h1 className="mt-4 text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+            Forecast queue pressure, explain priority shifts, and steer local
+            escalation choices from one isolated route.
+          </h1>
+          <p className="mt-4 text-sm leading-6 text-slate-200 sm:text-base">
+            The board below keeps queue load, projected pressure, and rationale
+            messaging aligned to the same local data model so forecast mode does
+            not drift away from the live filters or detail panel.
+          </p>
         </div>
-        <div className="grid gap-3 sm:grid-cols-3 xl:w-[27rem]">
+        <div className="grid gap-3 sm:grid-cols-3 xl:w-[29rem]">
           <div className="rounded-3xl border border-white/10 bg-white/8 p-4 text-white">
-            <p className="text-sm text-slate-300">Backlog total</p>
+            <p className="text-sm text-slate-300">
+              {viewMode === "live" ? "Active backlog" : "Projected backlog"}
+            </p>
             <p className="mt-2 text-3xl font-semibold">{backlogTotal}</p>
-            <p className="mt-1 text-sm text-slate-300">{queuesAtRisk} queues need attention</p>
+            <p className="mt-1 text-sm text-slate-300">
+              {queuesAtRisk} queues need attention
+            </p>
           </div>
           <div className="rounded-3xl border border-amber-300/20 bg-amber-300/10 p-4 text-amber-50">
-            <p className="text-sm text-amber-100/80">Aging items</p>
+            <p className="text-sm text-amber-100/80">
+              {viewMode === "live" ? "Aging items" : "Projected aging"}
+            </p>
             <p className="mt-2 text-3xl font-semibold">{agingCount}</p>
-            <p className="mt-1 text-sm text-amber-100/80">{breachCount} over target window</p>
+            <p className="mt-1 text-sm text-amber-100/80">
+              {breachCount} over target window
+            </p>
           </div>
           <div className="rounded-3xl border border-orange-300/20 bg-orange-300/12 p-4 text-orange-50">
-            <p className="text-sm text-orange-100/80">Escalations</p>
+            <p className="text-sm text-orange-100/80">Local escalations</p>
             <p className="mt-2 text-3xl font-semibold">{escalatedCount}</p>
-            <p className="mt-1 text-sm text-orange-100/80">{snapshot}</p>
+            <p className="mt-1 text-sm text-orange-100/80">
+              {viewMode === "live" ? snapshot : `${forecastWindow.note} from ${snapshot}`}
+            </p>
           </div>
         </div>
       </div>
       <div className="mt-6 grid gap-3 lg:grid-cols-3">
         {throughputSummaries.map((summary) => (
-          <div className={`rounded-[1.6rem] border p-4 ${throughputToneClasses[summary.tone]}`} key={summary.id}>
-            <p className="text-xs font-semibold uppercase tracking-[0.26em] opacity-75">{summary.label}</p>
+          <div
+            className={`rounded-[1.6rem] border p-4 ${throughputToneClasses[summary.tone]}`}
+            key={summary.id}
+          >
+            <p className="text-xs font-semibold uppercase tracking-[0.26em] opacity-75">
+              {summary.label}
+            </p>
             <div className="mt-3 flex items-end justify-between gap-4">
               <p className="text-3xl font-semibold">{summary.value}</p>
-              <p className="max-w-40 text-right text-sm opacity-80">{summary.note}</p>
+              <p className="max-w-40 text-right text-sm opacity-80">
+                {summary.note}
+              </p>
             </div>
           </div>
         ))}

--- a/src/components/queue-monitor/queue-monitor-selectors.ts
+++ b/src/components/queue-monitor/queue-monitor-selectors.ts
@@ -1,0 +1,389 @@
+import {
+  backlogItems,
+  forecastWindows,
+  queueSummaries,
+  type AgeBand,
+  type AgeFilter,
+  type BacklogForecastState,
+  type BacklogItem,
+  type EscalationLevelId,
+  type ForecastPoint,
+  type ForecastWindow,
+  type ForecastWindowId,
+  type PriorityBand,
+  type PriorityFilter,
+  type QueueScope,
+  type QueueSummary,
+  type QueueTone,
+  type ThroughputSummary,
+  type ViewMode,
+} from "./queue-monitor-data";
+
+export type EscalationStateSnapshot = Record<string, { level: EscalationLevelId }>;
+
+export type QueueDisplay = QueueSummary & {
+  activePoint: ForecastPoint | null;
+  displayAgingCount: number;
+  displayBacklogCount: number;
+  displayBreachCount: number;
+  displayCarryover: number;
+  displayClearedPerHour: number;
+  displayIntakePerHour: number;
+  displayOldestMinutes: number;
+  displayPriorityDelta: number;
+  displayPriorityRank: number;
+  displayStatusLabel: string;
+  displaySummary: string;
+  displayTone: QueueTone;
+  displayWaitMinutes: number;
+};
+
+export type ItemDisplay = BacklogItem & {
+  activeForecast: BacklogForecastState | null;
+  displayAgeBand: AgeBand;
+  displayAgeMinutes: number;
+  displayEtaLabel: string;
+  displayNextAction: string;
+  displayPriorityBand: PriorityBand;
+  displayPriorityReason: string;
+  displayRiskLabel: string;
+};
+
+export type QueueColumn = {
+  items: ItemDisplay[];
+  queue: QueueDisplay;
+};
+
+export type QueueMonitorView = {
+  ageCounts: Record<AgeFilter, number>;
+  agingCount: number;
+  backlogTotal: number;
+  breachCount: number;
+  columns: QueueColumn[];
+  escalatedCount: number;
+  forecastWindowMeta: ForecastWindow;
+  nextItemId: string | null;
+  nextQueueId: string | null;
+  priorityCounts: Record<PriorityFilter, number>;
+  queueCounts: Record<QueueScope, number>;
+  queueEscalations: Record<string, number>;
+  queueTotals: Record<string, number>;
+  queuesAtRisk: number;
+  scopedItems: ItemDisplay[];
+  selectedItem: ItemDisplay | null;
+  selectedQueue: QueueDisplay | null;
+  throughputSummaries: ThroughputSummary[];
+};
+
+type BuildQueueMonitorViewOptions = {
+  ageFilter: AgeFilter;
+  escalationState: EscalationStateSnapshot;
+  forecastWindow: ForecastWindowId;
+  priorityFilter: PriorityFilter;
+  queueScope: QueueScope;
+  selectedItemId: string | null;
+  selectedQueueId: string | null;
+  viewMode: ViewMode;
+};
+
+function getForecastWindow(windowId: ForecastWindowId) {
+  return forecastWindows.find((window) => window.id === windowId) ?? forecastWindows[0];
+}
+
+function getQueueForecastPoint(queue: QueueSummary, windowId: ForecastWindowId) {
+  return queue.forecast.find((point) => point.windowId === windowId) ?? queue.forecast[0];
+}
+
+function getItemForecastState(item: BacklogItem, windowId: ForecastWindowId) {
+  return item.forecast.find((state) => state.windowId === windowId) ?? item.forecast[0];
+}
+
+export function matchesQueueScope(tone: QueueTone, scope: QueueScope) {
+  if (scope === "watch") {
+    return tone !== "stable";
+  }
+
+  if (scope === "stable") {
+    return tone === "stable";
+  }
+
+  return true;
+}
+
+export function matchesAgeFilter(ageBand: AgeBand, filter: AgeFilter) {
+  if (filter === "aging") {
+    return ageBand !== "fresh";
+  }
+
+  if (filter === "breach") {
+    return ageBand === "breach";
+  }
+
+  return true;
+}
+
+export function matchesPriorityFilter(priorityBand: PriorityBand, filter: PriorityFilter) {
+  if (filter === "expedite") {
+    return priorityBand !== "monitor";
+  }
+
+  if (filter === "critical") {
+    return priorityBand === "critical";
+  }
+
+  return true;
+}
+
+function buildQueueDisplay(
+  queue: QueueSummary,
+  viewMode: ViewMode,
+  forecastWindow: ForecastWindowId,
+) {
+  if (viewMode === "forecast") {
+    const point = getQueueForecastPoint(queue, forecastWindow);
+
+    return {
+      ...queue,
+      activePoint: point,
+      displayAgingCount: point.agingCount,
+      displayBacklogCount: point.backlogCount,
+      displayBreachCount: point.breachCount,
+      displayCarryover: point.carryover,
+      displayClearedPerHour: point.clearedPerHour,
+      displayIntakePerHour: point.intakePerHour,
+      displayOldestMinutes: point.oldestMinutes,
+      displayPriorityDelta: queue.priorityRank - point.priorityRank,
+      displayPriorityRank: point.priorityRank,
+      displayStatusLabel: point.statusLabel,
+      displaySummary: point.explanationSummary,
+      displayTone: point.tone,
+      displayWaitMinutes: point.projectedWaitMinutes,
+    } satisfies QueueDisplay;
+  }
+
+  return {
+    ...queue,
+    activePoint: null,
+    displayAgingCount: queue.agingCount,
+    displayBacklogCount: queue.backlogCount,
+    displayBreachCount: queue.breachCount,
+    displayCarryover: queue.carryover,
+    displayClearedPerHour: queue.clearedPerHour,
+    displayIntakePerHour: queue.intakePerHour,
+    displayOldestMinutes: queue.oldestMinutes,
+    displayPriorityDelta: 0,
+    displayPriorityRank: queue.priorityRank,
+    displayStatusLabel: queue.statusLabel,
+    displaySummary: queue.prioritySummary,
+    displayTone: queue.tone,
+    displayWaitMinutes: queue.projectedWaitMinutes,
+  } satisfies QueueDisplay;
+}
+
+function buildItemDisplay(
+  item: BacklogItem,
+  viewMode: ViewMode,
+  forecastWindow: ForecastWindowId,
+) {
+  if (viewMode === "forecast") {
+    const state = getItemForecastState(item, forecastWindow);
+
+    return {
+      ...item,
+      activeForecast: state,
+      displayAgeBand: state.ageBand,
+      displayAgeMinutes: state.ageMinutes,
+      displayEtaLabel: state.etaLabel,
+      displayNextAction: state.nextAction,
+      displayPriorityBand: state.priorityBand,
+      displayPriorityReason: state.rationale,
+      displayRiskLabel: state.riskLabel,
+    } satisfies ItemDisplay;
+  }
+
+  return {
+    ...item,
+    activeForecast: null,
+    displayAgeBand: item.ageBand,
+    displayAgeMinutes: item.ageMinutes,
+    displayEtaLabel: "Current queue state",
+    displayNextAction: item.nextAction,
+    displayPriorityBand: item.priorityBand,
+    displayPriorityReason: item.priorityReason,
+    displayRiskLabel: item.blockingSignal,
+  } satisfies ItemDisplay;
+}
+
+function buildThroughputSummaries(
+  queues: QueueDisplay[],
+  viewMode: ViewMode,
+  forecastWindowMeta: ForecastWindow,
+) {
+  const totalIntake = queues.reduce((sum, queue) => sum + queue.displayIntakePerHour, 0);
+  const totalClearance = queues.reduce(
+    (sum, queue) => sum + queue.displayClearedPerHour,
+    0,
+  );
+  const totalCarryover = queues.reduce((sum, queue) => sum + queue.displayCarryover, 0);
+  const queuesUnderwater = queues.filter(
+    (queue) => queue.displayClearedPerHour < queue.displayIntakePerHour,
+  ).length;
+  const queuesCritical = queues.filter((queue) => queue.displayTone === "critical").length;
+
+  return [
+    {
+      id: "inflow",
+      label: "Inflow / hr",
+      value: `${totalIntake}`,
+      note:
+        viewMode === "forecast"
+          ? `${forecastWindowMeta.note} keeps arrivals elevated in claims and returns.`
+          : `${queuesUnderwater} queues are taking in more work than they clear.`,
+      tone: totalIntake > totalClearance ? "up" : "flat",
+    },
+    {
+      id: "clearance",
+      label: "Clearance / hr",
+      value: `${totalClearance}`,
+      note:
+        viewMode === "forecast"
+          ? `Assumes no extra staffing before the ${forecastWindowMeta.label} mark.`
+          : "Current staffing is holding only one queue above intake.",
+      tone: totalClearance >= totalIntake ? "up" : "down",
+    },
+    {
+      id: "stability",
+      label: "Projected carryover",
+      value: `${totalCarryover}`,
+      note:
+        viewMode === "forecast"
+          ? `${queuesCritical} queues are forecast to stay in critical territory by ${forecastWindowMeta.label}.`
+          : "If unchanged, these tracked anchors remain exposed into the next pass.",
+      tone:
+        totalCarryover > 4 ? "down" : queues.some((queue) => queue.displayTone !== "stable") ? "flat" : "up",
+    },
+  ] satisfies ThroughputSummary[];
+}
+
+export function buildQueueMonitorView({
+  ageFilter,
+  escalationState,
+  forecastWindow,
+  priorityFilter,
+  queueScope,
+  selectedItemId,
+  selectedQueueId,
+  viewMode,
+}: BuildQueueMonitorViewOptions): QueueMonitorView {
+  const forecastWindowMeta = getForecastWindow(forecastWindow);
+  const queueDisplays = queueSummaries.map((queue) =>
+    buildQueueDisplay(queue, viewMode, forecastWindow),
+  );
+  const itemDisplays = backlogItems.map((item) =>
+    buildItemDisplay(item, viewMode, forecastWindow),
+  );
+  const visibleQueues = queueDisplays.filter((queue) =>
+    matchesQueueScope(queue.displayTone, queueScope),
+  );
+  const scopedItems = itemDisplays.filter((item) =>
+    visibleQueues.some((queue) => queue.id === item.queueId),
+  );
+  const filteredItems = scopedItems.filter(
+    (item) =>
+      matchesAgeFilter(item.displayAgeBand, ageFilter) &&
+      matchesPriorityFilter(item.displayPriorityBand, priorityFilter),
+  );
+  const columns = visibleQueues.map((queue) => ({
+    items: filteredItems.filter((item) => item.queueId === queue.id),
+    queue,
+  }));
+  const nextQueueId = visibleQueues.some((queue) => queue.id === selectedQueueId)
+    ? selectedQueueId
+    : visibleQueues[0]?.id ?? null;
+  const nextQueueItems =
+    columns.find((column) => column.queue.id === nextQueueId)?.items ?? [];
+  const nextItemId = nextQueueItems.some((item) => item.id === selectedItemId)
+    ? selectedItemId
+    : nextQueueItems[0]?.id ?? null;
+  const selectedQueue =
+    visibleQueues.find((queue) => queue.id === nextQueueId) ?? null;
+  const selectedItem =
+    nextQueueItems.find((item) => item.id === nextItemId) ?? null;
+
+  const queueCounts = {
+    all: queueDisplays.length,
+    watch: queueDisplays.filter((queue) => matchesQueueScope(queue.displayTone, "watch"))
+      .length,
+    stable: queueDisplays.filter((queue) => matchesQueueScope(queue.displayTone, "stable"))
+      .length,
+  } satisfies Record<QueueScope, number>;
+
+  const ageCounts = {
+    all: scopedItems.length,
+    aging: scopedItems.filter((item) => matchesAgeFilter(item.displayAgeBand, "aging"))
+      .length,
+    breach: scopedItems.filter((item) => matchesAgeFilter(item.displayAgeBand, "breach"))
+      .length,
+  } satisfies Record<AgeFilter, number>;
+
+  const priorityCounts = {
+    all: scopedItems.length,
+    expedite: scopedItems.filter((item) =>
+      matchesPriorityFilter(item.displayPriorityBand, "expedite"),
+    ).length,
+    critical: scopedItems.filter((item) =>
+      matchesPriorityFilter(item.displayPriorityBand, "critical"),
+    ).length,
+  } satisfies Record<PriorityFilter, number>;
+
+  const queueTotals = Object.fromEntries(
+    queueDisplays.map((queue) => [queue.id, queue.displayBacklogCount]),
+  ) as Record<string, number>;
+
+  const queueEscalations = Object.fromEntries(
+    queueDisplays.map((queue) => [
+      queue.id,
+      itemDisplays.filter(
+        (item) =>
+          item.queueId === queue.id && escalationState[item.id]?.level !== "none",
+      ).length,
+    ]),
+  ) as Record<string, number>;
+
+  return {
+    ageCounts,
+    agingCount: queueDisplays.reduce(
+      (sum, queue) => sum + queue.displayAgingCount,
+      0,
+    ),
+    backlogTotal: queueDisplays.reduce(
+      (sum, queue) => sum + queue.displayBacklogCount,
+      0,
+    ),
+    breachCount: queueDisplays.reduce(
+      (sum, queue) => sum + queue.displayBreachCount,
+      0,
+    ),
+    columns,
+    escalatedCount: itemDisplays.filter(
+      (item) => escalationState[item.id]?.level !== "none",
+    ).length,
+    forecastWindowMeta,
+    nextItemId,
+    nextQueueId,
+    priorityCounts,
+    queueCounts,
+    queueEscalations,
+    queueTotals,
+    queuesAtRisk: queueDisplays.filter((queue) => queue.displayTone !== "stable")
+      .length,
+    scopedItems,
+    selectedItem,
+    selectedQueue,
+    throughputSummaries: buildThroughputSummaries(
+      queueDisplays,
+      viewMode,
+      forecastWindowMeta,
+    ),
+  };
+}

--- a/src/components/queue-monitor/queue-monitor-shell.test.tsx
+++ b/src/components/queue-monitor/queue-monitor-shell.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { QueueMonitorShell } from "./queue-monitor-shell";
+
+function clickButtonByText(text: string | RegExp, index = 0) {
+  const target = screen.getAllByText(text)[index];
+  const button = target?.closest("button");
+
+  if (!button) {
+    throw new Error(`No button found for ${String(text)}`);
+  }
+
+  fireEvent.click(button);
+}
+
+describe("QueueMonitorShell", () => {
+  it(
+    "uses projected item state when forecast mode and filters are active",
+    () => {
+    render(<QueueMonitorShell />);
+
+      clickButtonByText(/^Breach only$/i);
+
+      expect(
+        screen.queryByText("Manual coding review queued after rule mismatch"),
+      ).not.toBeInTheDocument();
+
+      clickButtonByText(/^Forecast board$/i);
+      clickButtonByText(/^90 min$/i);
+
+      expect(
+        screen.getByText("Manual coding review queued after rule mismatch"),
+      ).toBeInTheDocument();
+    },
+    15000,
+  );
+
+  it(
+    "shows queue and item rationale in priority explanation mode",
+    () => {
+    render(<QueueMonitorShell />);
+
+      clickButtonByText(/^Priority explanation$/i);
+
+      expect(
+        screen.getByText(/Priority explanation mode is active/i),
+      ).toBeInTheDocument();
+      expect(screen.getAllByText("Intake outruns clearance").length).toBeGreaterThan(0);
+
+      clickButtonByText(/Passport image review waiting on secondary verifier/i);
+
+      expect(
+        screen.getAllByText(
+          /Second verifier coverage stays thin for the next hour/i,
+        ).length,
+      ).toBeGreaterThan(0);
+      expect(
+        screen.getByText(
+          /The trust desk cannot finish the review until a secondary verifier claims the package/i,
+        ),
+      ).toBeInTheDocument();
+    },
+    15000,
+  );
+
+  it(
+    "keeps queue detail aligned to the active forecast horizon",
+    () => {
+    render(<QueueMonitorShell />);
+
+      clickButtonByText(/^Forecast board$/i);
+      clickButtonByText(/^90 min$/i);
+      clickButtonByText(/^Returns Exceptions$/i);
+
+      expect(
+        screen.getAllByText(
+          "Carrier arrivals push this lane ahead of identity by handoff unless proof and scans land together.",
+        ).length,
+      ).toBeGreaterThan(0);
+      expect(
+        screen.getByText("Priority moves up 1 spot by handoff."),
+      ).toBeInTheDocument();
+    },
+    15000,
+  );
+});

--- a/src/components/queue-monitor/queue-monitor-shell.tsx
+++ b/src/components/queue-monitor/queue-monitor-shell.tsx
@@ -9,80 +9,76 @@ import { QueueMonitorHeader } from "./queue-monitor-header";
 import {
   backlogItems,
   escalationLevels,
+  forecastWindows,
   queueMonitorSnapshot,
   queueSummaries,
-  throughputSummaries,
   type AgeFilter,
   type EscalationLevelId,
+  type ForecastWindowId,
+  type InsightMode,
+  type PriorityFilter,
   type QueueScope,
+  type ViewMode,
 } from "./queue-monitor-data";
+import { buildQueueMonitorView } from "./queue-monitor-selectors";
 
 type LocalEscalationState = {
-  addToDigest: boolean; holdRelease: boolean; level: EscalationLevelId; notifyFloor: boolean; reviewed: boolean;
+  addToDigest: boolean;
+  holdRelease: boolean;
+  level: EscalationLevelId;
+  notifyFloor: boolean;
+  reviewed: boolean;
 };
 
-function matchesQueueScope(tone: (typeof queueSummaries)[number]["tone"], scope: QueueScope) {
-  if (scope === "watch") return tone !== "stable";
-  if (scope === "stable") return tone === "stable";
-  return true;
-}
-
-function matchesAgeFilter(ageBand: (typeof backlogItems)[number]["ageBand"], filter: AgeFilter) {
-  if (filter === "aging") return ageBand !== "fresh";
-  if (filter === "breach") return ageBand === "breach";
-  return true;
-}
-
 const initialEscalationState = Object.fromEntries(
-  backlogItems.map((item) => [item.id, {
-    level: item.escalationLevel,
-    holdRelease: item.ageBand === "breach",
-    notifyFloor: item.severity === "high",
-    addToDigest: item.escalationLevel === "director",
-    reviewed: false,
-  }]),
+  backlogItems.map((item) => [
+    item.id,
+    {
+      addToDigest: item.escalationLevel === "director",
+      holdRelease: item.ageBand === "breach",
+      level: item.escalationLevel,
+      notifyFloor: item.severity === "high",
+      reviewed: false,
+    },
+  ]),
 ) as Record<string, LocalEscalationState>;
 
 export function QueueMonitorShell() {
+  const [viewMode, setViewMode] = useState<ViewMode>("live");
+  const [insightMode, setInsightMode] = useState<InsightMode>("operations");
+  const [forecastWindow, setForecastWindow] = useState<ForecastWindowId>("60m");
   const [queueScope, setQueueScope] = useState<QueueScope>("all");
   const [ageFilter, setAgeFilter] = useState<AgeFilter>("all");
-  const [selectedQueueId, setSelectedQueueId] = useState<string | null>(queueSummaries[0]?.id ?? null);
-  const [selectedItemId, setSelectedItemId] = useState<string | null>(backlogItems[0]?.id ?? null);
-  const [escalationState, setEscalationState] = useState<Record<string, LocalEscalationState>>(initialEscalationState);
+  const [priorityFilter, setPriorityFilter] = useState<PriorityFilter>("all");
+  const [selectedQueueId, setSelectedQueueId] = useState<string | null>(
+    queueSummaries[0]?.id ?? null,
+  );
+  const [selectedItemId, setSelectedItemId] = useState<string | null>(
+    backlogItems[0]?.id ?? null,
+  );
+  const [escalationState, setEscalationState] = useState<
+    Record<string, LocalEscalationState>
+  >(initialEscalationState);
 
-  const visibleQueues = queueSummaries.filter((queue) => matchesQueueScope(queue.tone, queueScope));
-  const columns = visibleQueues.map((queue) => ({
-    queue,
-    items: backlogItems.filter((item) => item.queueId === queue.id && matchesAgeFilter(item.ageBand, ageFilter)),
-  }));
-  const nextQueueId = visibleQueues.some((queue) => queue.id === selectedQueueId) ? selectedQueueId : visibleQueues[0]?.id ?? null;
-  const nextQueueItems = columns.find((column) => column.queue.id === nextQueueId)?.items ?? [];
-  const nextItemId = nextQueueItems.some((item) => item.id === selectedItemId) ? selectedItemId : nextQueueItems[0]?.id ?? null;
+  const view = buildQueueMonitorView({
+    ageFilter,
+    escalationState,
+    forecastWindow,
+    priorityFilter,
+    queueScope,
+    selectedItemId,
+    selectedQueueId,
+    viewMode,
+  });
 
-  const selectedQueue = queueSummaries.find((queue) => queue.id === nextQueueId) ?? null;
-  const selectedItem = nextQueueItems.find((item) => item.id === nextItemId) ?? null;
-  const selectedItemState = selectedItem ? escalationState[selectedItem.id] : null;
-  const scopedItems = backlogItems.filter((item) => visibleQueues.some((queue) => queue.id === item.queueId));
-  const backlogTotal = backlogItems.length;
-  const agingCount = backlogItems.filter((item) => item.ageBand !== "fresh").length;
-  const breachCount = backlogItems.filter((item) => item.ageBand === "breach").length;
-  const escalatedCount = backlogItems.filter((item) => escalationState[item.id].level !== "none").length;
-  const queuesAtRisk = queueSummaries.filter((queue) => queue.tone !== "stable").length;
-  const queueCounts = {
-    all: queueSummaries.length,
-    watch: queueSummaries.filter((queue) => matchesQueueScope(queue.tone, "watch")).length,
-    stable: queueSummaries.filter((queue) => matchesQueueScope(queue.tone, "stable")).length,
-  };
-  const ageCounts = {
-    all: scopedItems.length,
-    aging: scopedItems.filter((item) => matchesAgeFilter(item.ageBand, "aging")).length,
-    breach: scopedItems.filter((item) => matchesAgeFilter(item.ageBand, "breach")).length,
-  };
-  const queueTotals = Object.fromEntries(queueSummaries.map((queue) => [queue.id, backlogItems.filter((item) => item.queueId === queue.id).length])) as Record<string, number>;
-  const queueEscalations = Object.fromEntries(queueSummaries.map((queue) => [queue.id, backlogItems.filter((item) => item.queueId === queue.id && escalationState[item.id].level !== "none").length])) as Record<string, number>;
+  const selectedItemState = view.selectedItem
+    ? escalationState[view.selectedItem.id]
+    : null;
 
   const handleSelectQueue = (queueId: string) => {
-    const queueItems = columns.find((column) => column.queue.id === queueId)?.items ?? [];
+    const queueItems =
+      view.columns.find((column) => column.queue.id === queueId)?.items ?? [];
+
     startTransition(() => {
       setSelectedQueueId(queueId);
       setSelectedItemId(queueItems[0]?.id ?? null);
@@ -97,29 +93,115 @@ export function QueueMonitorShell() {
   };
 
   const handleEscalationLevelChange = (level: EscalationLevelId) => {
-    if (!selectedItem) return;
+    if (!view.selectedItem) {
+      return;
+    }
+
     startTransition(() => {
-      setEscalationState((current) => ({ ...current, [selectedItem.id]: { ...current[selectedItem.id], level } }));
+      setEscalationState((current) => ({
+        ...current,
+        [view.selectedItem!.id]: {
+          ...current[view.selectedItem!.id],
+          level,
+        },
+      }));
     });
   };
 
   const handleToggle = (key: keyof Omit<LocalEscalationState, "level">) => {
-    if (!selectedItem) return;
+    if (!view.selectedItem) {
+      return;
+    }
+
     startTransition(() => {
-      setEscalationState((current) => ({ ...current, [selectedItem.id]: { ...current[selectedItem.id], [key]: !current[selectedItem.id][key] } }));
+      setEscalationState((current) => ({
+        ...current,
+        [view.selectedItem!.id]: {
+          ...current[view.selectedItem!.id],
+          [key]: !current[view.selectedItem!.id][key],
+        },
+      }));
     });
   };
 
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(251,146,60,0.18),transparent_30%),radial-gradient(circle_at_top_right,rgba(248,113,113,0.14),transparent_26%),linear-gradient(180deg,#111827_0%,#0f172a_52%,#020617_100%)] px-4 py-6 text-slate-100 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-7xl space-y-6">
-        <QueueMonitorHeader agingCount={agingCount} backlogTotal={backlogTotal} breachCount={breachCount} escalatedCount={escalatedCount} queuesAtRisk={queuesAtRisk} snapshot={queueMonitorSnapshot} throughputSummaries={throughputSummaries} />
+        <QueueMonitorHeader
+          agingCount={view.agingCount}
+          backlogTotal={view.backlogTotal}
+          breachCount={view.breachCount}
+          escalatedCount={view.escalatedCount}
+          forecastWindow={view.forecastWindowMeta}
+          insightMode={insightMode}
+          queuesAtRisk={view.queuesAtRisk}
+          snapshot={queueMonitorSnapshot}
+          throughputSummaries={view.throughputSummaries}
+          viewMode={viewMode}
+        />
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1.65fr)_minmax(21rem,0.95fr)]">
           <section className="space-y-5">
-            <QueueFilterBar ageCounts={ageCounts} ageFilter={ageFilter} onAgeFilterChange={(filter) => startTransition(() => setAgeFilter(filter))} onQueueScopeChange={(scope) => startTransition(() => setQueueScope(scope))} queueCounts={queueCounts} queueScope={queueScope} />
-            <QueueColumnBoard ageFilter={ageFilter} columns={columns} escalationState={escalationState} onSelectItem={handleSelectItem} onSelectQueue={handleSelectQueue} queueEscalations={queueEscalations} queueScope={queueScope} queueTotals={queueTotals} selectedItemId={nextItemId} selectedQueueId={nextQueueId} />
+            <QueueFilterBar
+              ageCounts={view.ageCounts}
+              ageFilter={ageFilter}
+              forecastWindow={forecastWindow}
+              forecastWindows={forecastWindows}
+              insightMode={insightMode}
+              onAgeFilterChange={(filter) =>
+                startTransition(() => setAgeFilter(filter))
+              }
+              onForecastWindowChange={(windowId) =>
+                startTransition(() => setForecastWindow(windowId))
+              }
+              onInsightModeChange={(mode) =>
+                startTransition(() => setInsightMode(mode))
+              }
+              onPriorityFilterChange={(filter) =>
+                startTransition(() => setPriorityFilter(filter))
+              }
+              onQueueScopeChange={(scope) =>
+                startTransition(() => setQueueScope(scope))
+              }
+              onViewModeChange={(mode) => startTransition(() => setViewMode(mode))}
+              priorityCounts={view.priorityCounts}
+              priorityFilter={priorityFilter}
+              queueCounts={view.queueCounts}
+              queueScope={queueScope}
+              viewMode={viewMode}
+            />
+            <QueueColumnBoard
+              ageFilter={ageFilter}
+              columns={view.columns}
+              escalationState={escalationState}
+              forecastWindow={view.forecastWindowMeta}
+              insightMode={insightMode}
+              onSelectItem={handleSelectItem}
+              onSelectQueue={handleSelectQueue}
+              priorityFilter={priorityFilter}
+              queueEscalations={view.queueEscalations}
+              queueScope={queueScope}
+              queueTotals={view.queueTotals}
+              selectedItemId={view.nextItemId}
+              selectedQueueId={view.nextQueueId}
+              viewMode={viewMode}
+            />
           </section>
-          <QueueDetailPanel escalationLevels={escalationLevels} itemState={selectedItemState} onEscalationLevelChange={handleEscalationLevelChange} onToggle={handleToggle} queueEscalations={selectedQueue ? queueEscalations[selectedQueue.id] : 0} queueItemsVisible={nextQueueItems.length} selectedItem={selectedItem} selectedQueue={selectedQueue} />
+          <QueueDetailPanel
+            escalationLevels={escalationLevels}
+            forecastWindow={view.forecastWindowMeta}
+            insightMode={insightMode}
+            itemState={selectedItemState}
+            onEscalationLevelChange={handleEscalationLevelChange}
+            onToggle={handleToggle}
+            queueEscalations={view.selectedQueue ? view.queueEscalations[view.selectedQueue.id] : 0}
+            queueItemsVisible={
+              view.columns.find((column) => column.queue.id === view.nextQueueId)?.items
+                .length ?? 0
+            }
+            selectedItem={view.selectedItem}
+            selectedQueue={view.selectedQueue}
+            viewMode={viewMode}
+          />
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- add forecast windows, projected queue state, and rationale metadata for Queue Monitor
- wire the board, filters, and detail panel to shared live/forecast selectors plus a priority explanation mode
- add queue monitor rendering tests for projected filtering, rationale visibility, and forecast-detail alignment

## Testing
- npm run lint
- npm run typecheck
- npm test
- npm run build

Closes #71