### PR TITLE
Add Asset Catalog reservation planner and bundle recommendations

### DIFF
--- a/src/app/asset-catalog/mock-data.ts
+++ b/src/app/asset-catalog/mock-data.ts
@@ -1,5 +1,13 @@
 export type AssetAvailability = "available" | "reserved" | "hold" | "maintenance";
 export type AssetCategoryId = "camera" | "audio" | "lighting" | "support";
+export type ReservationIntentId = "interview" | "field" | "livestream" | "walkthrough";
+export type PlanningWindowId =
+  | "today-pm"
+  | "tomorrow-am"
+  | "tomorrow-pm"
+  | "friday-dawn";
+export type ForecastStatus = "clear" | "tight" | "conflict";
+export type CrewProfileId = "solo" | "pair" | "crew";
 
 export type AssetCategory = {
   id: AssetCategoryId;
@@ -11,6 +19,30 @@ export type AvailabilityOption = {
   id: AssetAvailability;
   label: string;
   note: string;
+};
+
+export type ReservationIntent = {
+  id: ReservationIntentId;
+  label: string;
+  summary: string;
+  requiredCategories: AssetCategoryId[];
+  preferredTags: string[];
+  checklist: string[];
+};
+
+export type PlanningWindow = {
+  id: PlanningWindowId;
+  label: string;
+  pickupLabel: string;
+  returnLabel: string;
+  pressureLabel: string;
+  note: string;
+};
+
+export type CrewProfile = {
+  id: CrewProfileId;
+  label: string;
+  summary: string;
 };
 
 export type AssetCatalogItem = {
@@ -25,6 +57,9 @@ export type AssetCatalogItem = {
   tags: string[];
   kit: string[];
   condition: string;
+  recommendedFor: ReservationIntentId[];
+  prepLead: string;
+  crewFit: string;
 };
 
 export type ReservationPreview = {
@@ -37,22 +72,180 @@ export type ReservationPreview = {
   handoffZone: string;
   checklist: string[];
   note: string;
+  linkedWindowId: PlanningWindowId;
+  conflicts: string[];
 };
 
-export const assetCatalogSyncLabel = "Inventory refresh 09:12 IST";
+export type AssetForecast = {
+  assetId: string;
+  windowId: PlanningWindowId;
+  status: ForecastStatus;
+  coverageLabel: string;
+  note: string;
+  alternativeAssetIds: string[];
+};
+
+export type BundleBlueprint = {
+  id: string;
+  intentId: ReservationIntentId;
+  label: string;
+  summary: string;
+  heroAssetId: string;
+  assetIds: string[];
+  optionalAssetIds: string[];
+  note: string;
+};
+
+export const assetCatalogSyncLabel = "Planner refresh 09:12 IST";
 
 export const assetCategories: AssetCategory[] = [
-  { id: "camera", label: "Camera", summary: "Bodies, handheld kits, and lens-ready capture gear." },
-  { id: "audio", label: "Audio", summary: "Wireless capture, field recorders, and lav sets." },
-  { id: "lighting", label: "Lighting", summary: "Portable panels, key lights, and modifier kits." },
-  { id: "support", label: "Support", summary: "Tripods, stabilizers, and grip accessories." },
+  {
+    id: "camera",
+    label: "Camera",
+    summary: "Bodies, handheld kits, and lens-ready capture gear.",
+  },
+  {
+    id: "audio",
+    label: "Audio",
+    summary: "Wireless capture, field recorders, and lav sets.",
+  },
+  {
+    id: "lighting",
+    label: "Lighting",
+    summary: "Portable panels, key lights, and modifier kits.",
+  },
+  {
+    id: "support",
+    label: "Support",
+    summary: "Tripods, stabilizers, and grip accessories.",
+  },
 ];
 
 export const availabilityOptions: AvailabilityOption[] = [
-  { id: "available", label: "Ready now", note: "Bench checked and clear for pickup." },
-  { id: "reserved", label: "Reserved", note: "Already staged for an upcoming handoff." },
-  { id: "hold", label: "On hold", note: "Temporarily blocked pending confirmation." },
-  { id: "maintenance", label: "Maintenance", note: "In service or calibration review." },
+  {
+    id: "available",
+    label: "Ready now",
+    note: "Bench checked and clear for pickup.",
+  },
+  {
+    id: "reserved",
+    label: "Reserved",
+    note: "Already staged for an upcoming handoff.",
+  },
+  {
+    id: "hold",
+    label: "On hold",
+    note: "Temporarily blocked pending confirmation.",
+  },
+  {
+    id: "maintenance",
+    label: "Maintenance",
+    note: "In service or calibration review.",
+  },
+];
+
+export const reservationIntents: ReservationIntent[] = [
+  {
+    id: "interview",
+    label: "Interview",
+    summary: "Sit-down coverage with clean dialog, flattering light, and a stable hero angle.",
+    requiredCategories: ["camera", "audio", "lighting", "support"],
+    preferredTags: ["interview", "studio", "fast-turn"],
+    checklist: [
+      "Confirm who signs for the hero camera handoff.",
+      "Stage primary and backup audio before pickup.",
+      "Reserve one soft key light and one stable support option.",
+    ],
+  },
+  {
+    id: "field",
+    label: "Field Run",
+    summary: "Fast-moving location work where mobility and battery discipline matter most.",
+    requiredCategories: ["camera", "audio", "support"],
+    preferredTags: ["travel", "wireless-monitor", "4k"],
+    checklist: [
+      "Check mobile power, media, and rain cover notes.",
+      "Confirm the stabilization plan for walking shots.",
+      "Pack the most portable audio option that still clears talent count.",
+    ],
+  },
+  {
+    id: "livestream",
+    label: "Livestream",
+    summary: "Multi-signal capture that prioritizes reliable audio, clean power, and quick troubleshooting.",
+    requiredCategories: ["camera", "audio", "lighting"],
+    preferredTags: ["livestream", "studio", "battery-heavy"],
+    checklist: [
+      "Confirm stream ingest format and monitor routing.",
+      "Reserve a redundant audio path for the host feed.",
+      "Add at least one controllable key light for exposure swings.",
+    ],
+  },
+  {
+    id: "walkthrough",
+    label: "Walkthrough",
+    summary: "Mobile movement with stabilized framing, light dialogue, and a compact crew footprint.",
+    requiredCategories: ["camera", "audio", "support"],
+    preferredTags: ["travel", "interview", "wireless-monitor"],
+    checklist: [
+      "Balance the gimbal before battery swaps.",
+      "Confirm wireless audio range for moving talent.",
+      "Plan one fallback support option if the path gets crowded.",
+    ],
+  },
+];
+
+export const planningWindows: PlanningWindow[] = [
+  {
+    id: "today-pm",
+    label: "Today PM",
+    pickupLabel: "Today, 15:00-17:30",
+    returnLabel: "Tomorrow, 11:00",
+    pressureLabel: "Same-day rush",
+    note: "Expect tighter handoff staffing and limited repack time.",
+  },
+  {
+    id: "tomorrow-am",
+    label: "Tomorrow AM",
+    pickupLabel: "Tomorrow, 08:30-10:30",
+    returnLabel: "Tomorrow, 19:00",
+    pressureLabel: "Prime slot",
+    note: "This is the busiest pickup window for interview and launch shoots.",
+  },
+  {
+    id: "tomorrow-pm",
+    label: "Tomorrow PM",
+    pickupLabel: "Tomorrow, 13:00-16:30",
+    returnLabel: "Friday, 10:00",
+    pressureLabel: "Mixed load-out",
+    note: "Most returns are in flight, so substitutes get easier after 14:00.",
+  },
+  {
+    id: "friday-dawn",
+    label: "Friday Dawn",
+    pickupLabel: "Friday, 06:30-08:00",
+    returnLabel: "Monday, 09:00",
+    pressureLabel: "Crew advance",
+    note: "Good window for field crews that can stage the night before.",
+  },
+];
+
+export const crewProfiles: CrewProfile[] = [
+  {
+    id: "solo",
+    label: "Solo op",
+    summary: "Keep the kit minimal and easy to reset between shots.",
+  },
+  {
+    id: "pair",
+    label: "2-person crew",
+    summary: "Balanced coverage with room for one backup accessory.",
+  },
+  {
+    id: "crew",
+    label: "Small crew",
+    summary: "Add support gear and leave time for handoff coordination.",
+  },
 ];
 
 export const assetTags = [
@@ -64,6 +257,8 @@ export const assetTags = [
   "studio",
   "interview",
   "fast-turn",
+  "cinema",
+  "motion",
 ];
 
 export const assetCatalogItems: AssetCatalogItem[] = [
@@ -79,6 +274,9 @@ export const assetCatalogItems: AssetCatalogItem[] = [
     tags: ["4k", "wireless-monitor", "travel"],
     kit: ["FX3 body", "24-70mm lens", "2x CFexpress cards"],
     condition: "Bench checked 25 minutes ago",
+    recommendedFor: ["field", "walkthrough", "livestream"],
+    prepLead: "20 minutes",
+    crewFit: "Solo or paired operator",
   },
   {
     id: "cam-c70",
@@ -89,9 +287,28 @@ export const assetCatalogItems: AssetCatalogItem[] = [
     zone: "Reservation shelf 2",
     summary: "Interview-ready cinema body with ND filters and a compact audio breakout.",
     nextWindow: "Pickup window opens at 11:30",
-    tags: ["interview", "studio", "fast-turn"],
+    tags: ["interview", "studio", "fast-turn", "cinema"],
     kit: ["C70 body", "RF 24-105mm lens", "Top-handle XLR module"],
     condition: "Staged with printed checkout sheet",
+    recommendedFor: ["interview", "livestream"],
+    prepLead: "30 minutes",
+    crewFit: "2-person crew or producer assist",
+  },
+  {
+    id: "cam-a7s3",
+    name: "Sony A7S III Creator Set",
+    categoryId: "camera",
+    availability: "available",
+    sku: "CAM-041",
+    zone: "Mirrorless locker 3",
+    summary: "Compact low-light body packaged for creators who need fast lens swaps and light travel.",
+    nextWindow: "Open after quick lens wipe",
+    tags: ["travel", "livestream", "interview"],
+    kit: ["A7S III body", "24mm prime", "HDMI cage"],
+    condition: "HDMI port retested during morning prep",
+    recommendedFor: ["field", "livestream", "walkthrough"],
+    prepLead: "15 minutes",
+    crewFit: "Solo operator",
   },
   {
     id: "aud-mixpre",
@@ -105,6 +322,9 @@ export const assetCatalogItems: AssetCatalogItem[] = [
     tags: ["interview", "livestream", "fast-turn"],
     kit: ["MixPre-6 II", "2x shotgun mics", "Headphone split"],
     condition: "Battery pack topped off overnight",
+    recommendedFor: ["interview", "livestream"],
+    prepLead: "25 minutes",
+    crewFit: "Pair or small crew",
   },
   {
     id: "aud-lav",
@@ -118,6 +338,25 @@ export const assetCatalogItems: AssetCatalogItem[] = [
     tags: ["travel", "interview", "battery-heavy"],
     kit: ["2x transmitters", "2x lav mics", "Receiver dock"],
     condition: "RF scan passed on channel bank B",
+    recommendedFor: ["interview", "field", "walkthrough"],
+    prepLead: "10 minutes",
+    crewFit: "Solo through small crew",
+  },
+  {
+    id: "aud-boom",
+    name: "Boom + Shotgun Dialogue Kit",
+    categoryId: "audio",
+    availability: "available",
+    sku: "AUD-032",
+    zone: "Boom rack",
+    summary: "Dialogue-first kit with shock mount, wind protection, and a fast-deploy boom pole.",
+    nextWindow: "Open for assisted checkout",
+    tags: ["interview", "studio", "cinema"],
+    kit: ["Shotgun mic", "Carbon boom pole", "Indoor and outdoor wind kit"],
+    condition: "Shock mount collar replaced on Monday",
+    recommendedFor: ["interview", "field"],
+    prepLead: "15 minutes",
+    crewFit: "Pair or dedicated audio assist",
   },
   {
     id: "lit-aputure",
@@ -131,6 +370,9 @@ export const assetCatalogItems: AssetCatalogItem[] = [
     tags: ["studio", "fast-turn", "battery-heavy"],
     kit: ["300D head", "Light Dome II", "C-stand adapter"],
     condition: "Packed with sandbag tags",
+    recommendedFor: ["interview", "livestream"],
+    prepLead: "35 minutes",
+    crewFit: "Pair or small crew",
   },
   {
     id: "lit-tubes",
@@ -144,6 +386,25 @@ export const assetCatalogItems: AssetCatalogItem[] = [
     tags: ["livestream", "travel", "studio"],
     kit: ["2x RGB tubes", "Floor mounts", "Charging brick"],
     condition: "Latch replacement in progress",
+    recommendedFor: ["livestream", "field"],
+    prepLead: "Unavailable",
+    crewFit: "Any crew once repaired",
+  },
+  {
+    id: "lit-nanlite",
+    name: "Nanlite Forza Travel Light",
+    categoryId: "lighting",
+    availability: "available",
+    sku: "LGT-033",
+    zone: "Portable light shelf",
+    summary: "Compact daylight light with foldable softbox for remote interviews and pop-up sets.",
+    nextWindow: "Ready after accessory check",
+    tags: ["travel", "interview", "fast-turn"],
+    kit: ["Forza head", "Collapsible softbox", "Battery plate"],
+    condition: "Softbox rods tagged and matched",
+    recommendedFor: ["interview", "field", "walkthrough"],
+    prepLead: "15 minutes",
+    crewFit: "Solo or pair",
   },
   {
     id: "sup-sachtler",
@@ -157,6 +418,9 @@ export const assetCatalogItems: AssetCatalogItem[] = [
     tags: ["travel", "studio", "4k"],
     kit: ["Flowtech legs", "Fluid head", "Mid spreader"],
     condition: "Counterbalance verified this morning",
+    recommendedFor: ["interview", "field", "livestream"],
+    prepLead: "10 minutes",
+    crewFit: "Any crew size",
   },
   {
     id: "sup-rs4",
@@ -167,9 +431,28 @@ export const assetCatalogItems: AssetCatalogItem[] = [
     zone: "Ready rack B",
     summary: "Stabilizer bundle held while lens compatibility is confirmed with the camera team.",
     nextWindow: "Hold expires at 10:45",
-    tags: ["travel", "wireless-monitor", "4k"],
+    tags: ["travel", "wireless-monitor", "4k", "motion"],
     kit: ["RS 4 combo", "Focus motor", "Briefcase handle"],
     condition: "Balance plate marked for FX3 payload",
+    recommendedFor: ["field", "walkthrough"],
+    prepLead: "20 minutes",
+    crewFit: "Solo or pair",
+  },
+  {
+    id: "sup-slider",
+    name: "Slider + Monopod Motion Pack",
+    categoryId: "support",
+    availability: "available",
+    sku: "SUP-022",
+    zone: "Motion drawer",
+    summary: "Portable motion support for b-roll pickups and compact set coverage.",
+    nextWindow: "Ready after quick plate check",
+    tags: ["motion", "studio", "livestream"],
+    kit: ["Carbon slider", "Monopod", "Flat-mount plate"],
+    condition: "Plate screws retorqued before staging",
+    recommendedFor: ["livestream", "field"],
+    prepLead: "15 minutes",
+    crewFit: "Pair preferred",
   },
 ];
 
@@ -179,11 +462,20 @@ export const reservationPreviews: ReservationPreview[] = [
     assetId: "cam-c70",
     requester: "Mina Torres",
     project: "Customer Story Sprint",
-    pickupWindow: "11:30-12:00",
+    pickupWindow: "Tomorrow, 09:00-09:30",
     returnWindow: "Tomorrow by 17:30",
     handoffZone: "Front desk handoff",
-    checklist: ["Lens cap and ND pack", "Fresh media cards", "Signed interview kit receipt"],
+    checklist: [
+      "Lens cap and ND pack",
+      "Fresh media cards",
+      "Signed interview kit receipt",
+    ],
     note: "Keep the top handle attached for the lav receiver bracket.",
+    linkedWindowId: "tomorrow-am",
+    conflicts: [
+      "The hero camera overlaps the most requested interview slot.",
+      "A swap to the FX3 keeps the pickup window alive if the customer story runs late.",
+    ],
   },
   {
     id: "res-mixpre",
@@ -193,19 +485,35 @@ export const reservationPreviews: ReservationPreview[] = [
     pickupWindow: "Needs approval before 12:15",
     returnWindow: "Same day by 19:00",
     handoffZone: "Audio locker release",
-    checklist: ["Confirm guest count", "Attach backup SD card", "Add spare NP-F battery"],
+    checklist: [
+      "Confirm guest count",
+      "Attach backup SD card",
+      "Add spare NP-F battery",
+    ],
     note: "Reservation is blocked until the guest lineup is final.",
+    linkedWindowId: "today-pm",
+    conflicts: [
+      "Approval has not landed yet, so the recorder cannot auto-stage.",
+    ],
   },
   {
     id: "res-300d",
     assetId: "lit-aputure",
     requester: "Rhea Malik",
     project: "Warehouse Hero Shoot",
-    pickupWindow: "13:15 dock load-out",
+    pickupWindow: "Tomorrow, 13:15 dock load-out",
     returnWindow: "Two days after wrap",
     handoffZone: "Lighting cart dispatch",
-    checklist: ["Softbox rods taped", "Ballast tie-down added", "Truck manifest signed"],
+    checklist: [
+      "Softbox rods taped",
+      "Ballast tie-down added",
+      "Truck manifest signed",
+    ],
     note: "Pair with the C-stand already assigned to lane 4.",
+    linkedWindowId: "tomorrow-pm",
+    conflicts: [
+      "The ballast is already committed to a truck load-out in the same window.",
+    ],
   },
   {
     id: "res-rs4",
@@ -215,7 +523,126 @@ export const reservationPreviews: ReservationPreview[] = [
     pickupWindow: "Hold until 10:45",
     returnWindow: "Tomorrow by 10:00",
     handoffZone: "Grip wall release",
-    checklist: ["Confirm lens weight", "Rebalance after battery swap", "Include focus motor cable"],
+    checklist: [
+      "Confirm lens weight",
+      "Rebalance after battery swap",
+      "Include focus motor cable",
+    ],
     note: "If the lens swap is denied, release the hold back to ready inventory.",
+    linkedWindowId: "today-pm",
+    conflicts: [
+      "Compatibility sign-off is still pending from the camera team.",
+    ],
+  },
+  {
+    id: "res-a7s3",
+    assetId: "cam-a7s3",
+    requester: "Ari Chen",
+    project: "Pop-up Livestream Desk",
+    pickupWindow: "Friday, 06:45 pickup",
+    returnWindow: "Friday by 22:00",
+    handoffZone: "Streaming prep bench",
+    checklist: [
+      "Pack full-size HDMI backup",
+      "Label ingest LUT slot",
+      "Add cage cold shoe for monitor",
+    ],
+    note: "This booking can slide earlier if Thursday returns land on time.",
+    linkedWindowId: "friday-dawn",
+    conflicts: [],
+  },
+];
+
+export const assetForecasts: AssetForecast[] = [
+  { assetId: "cam-fx3", windowId: "today-pm", status: "clear", coverageLabel: "Open bench", note: "Battery set is already conditioned for a same-day release.", alternativeAssetIds: ["cam-a7s3"] },
+  { assetId: "cam-fx3", windowId: "tomorrow-am", status: "tight", coverageLabel: "High demand", note: "Three field teams are targeting this body for the morning window.", alternativeAssetIds: ["cam-a7s3", "cam-c70"] },
+  { assetId: "cam-fx3", windowId: "tomorrow-pm", status: "clear", coverageLabel: "Flexible", note: "The afternoon load loosens once the dock pickup clears.", alternativeAssetIds: ["cam-a7s3"] },
+  { assetId: "cam-fx3", windowId: "friday-dawn", status: "clear", coverageLabel: "Crew advance", note: "Best slot if the gimbal team can stage the night before.", alternativeAssetIds: ["cam-a7s3"] },
+  { assetId: "cam-c70", windowId: "today-pm", status: "tight", coverageLabel: "Booked prep", note: "The interview package is staged for another producer later today.", alternativeAssetIds: ["cam-fx3", "cam-a7s3"] },
+  { assetId: "cam-c70", windowId: "tomorrow-am", status: "conflict", coverageLabel: "Collision risk", note: "Existing reservation overlaps the prime interview slot.", alternativeAssetIds: ["cam-fx3", "cam-a7s3"] },
+  { assetId: "cam-c70", windowId: "tomorrow-pm", status: "tight", coverageLabel: "Possible release", note: "The hero package may reopen if the customer story wraps before lunch.", alternativeAssetIds: ["cam-fx3"] },
+  { assetId: "cam-c70", windowId: "friday-dawn", status: "clear", coverageLabel: "Open after reset", note: "Friday dawn is the cleanest window for the cinema body this week.", alternativeAssetIds: ["cam-a7s3"] },
+  { assetId: "cam-a7s3", windowId: "today-pm", status: "clear", coverageLabel: "Standby ready", note: "The mirrorless kit is caged and waiting for assignment.", alternativeAssetIds: ["cam-fx3"] },
+  { assetId: "cam-a7s3", windowId: "tomorrow-am", status: "clear", coverageLabel: "Good fallback", note: "Use this body when the C70 or FX3 windows get crowded.", alternativeAssetIds: ["cam-fx3"] },
+  { assetId: "cam-a7s3", windowId: "tomorrow-pm", status: "clear", coverageLabel: "Open block", note: "Little pressure in the afternoon because the stream desk uses a different lens set.", alternativeAssetIds: ["cam-fx3"] },
+  { assetId: "cam-a7s3", windowId: "friday-dawn", status: "tight", coverageLabel: "Pre-staged stream", note: "Friday dawn is tentatively marked for a pop-up livestream desk.", alternativeAssetIds: ["cam-fx3"] },
+  { assetId: "aud-mixpre", windowId: "today-pm", status: "conflict", coverageLabel: "Approval hold", note: "The current hold blocks automated release until the guest list is final.", alternativeAssetIds: ["aud-lav", "aud-boom"] },
+  { assetId: "aud-mixpre", windowId: "tomorrow-am", status: "tight", coverageLabel: "Recorder demand", note: "Podcast and fireside requests both want the same recorder window.", alternativeAssetIds: ["aud-lav"] },
+  { assetId: "aud-mixpre", windowId: "tomorrow-pm", status: "clear", coverageLabel: "Late release", note: "Afternoon staging works if the earlier hold expires on time.", alternativeAssetIds: ["aud-lav", "aud-boom"] },
+  { assetId: "aud-mixpre", windowId: "friday-dawn", status: "clear", coverageLabel: "Open audio bench", note: "Most Friday crews only need wireless packs before sunrise.", alternativeAssetIds: ["aud-lav"] },
+  { assetId: "aud-lav", windowId: "today-pm", status: "clear", coverageLabel: "Fast release", note: "Wireless set is already charged and frequency scanned.", alternativeAssetIds: ["aud-boom"] },
+  { assetId: "aud-lav", windowId: "tomorrow-am", status: "tight", coverageLabel: "High attach rate", note: "Nearly every interview plan wants this lav set for the morning slot.", alternativeAssetIds: ["aud-boom", "aud-mixpre"] },
+  { assetId: "aud-lav", windowId: "tomorrow-pm", status: "clear", coverageLabel: "Balanced", note: "The afternoon release queue usually has spare wireless coverage.", alternativeAssetIds: ["aud-boom"] },
+  { assetId: "aud-lav", windowId: "friday-dawn", status: "clear", coverageLabel: "Good travel fit", note: "Friday dawn crews prefer this smaller wireless package.", alternativeAssetIds: ["aud-boom"] },
+  { assetId: "aud-boom", windowId: "today-pm", status: "clear", coverageLabel: "Low queue", note: "Dialogue kit can be staged quickly if an audio assist is confirmed.", alternativeAssetIds: ["aud-lav"] },
+  { assetId: "aud-boom", windowId: "tomorrow-am", status: "clear", coverageLabel: "Open support", note: "Useful relief valve when lav inventory tightens.", alternativeAssetIds: ["aud-lav"] },
+  { assetId: "aud-boom", windowId: "tomorrow-pm", status: "clear", coverageLabel: "Steady", note: "No active conflicts in the afternoon window.", alternativeAssetIds: ["aud-lav"] },
+  { assetId: "aud-boom", windowId: "friday-dawn", status: "tight", coverageLabel: "Early assist", note: "Needs an extra audio hand if it leaves before the support desk opens fully.", alternativeAssetIds: ["aud-lav"] },
+  { assetId: "lit-aputure", windowId: "today-pm", status: "tight", coverageLabel: "Truck prep", note: "The ballast is staged for a dock departure later today.", alternativeAssetIds: ["lit-nanlite"] },
+  { assetId: "lit-aputure", windowId: "tomorrow-am", status: "tight", coverageLabel: "Booked reset", note: "Morning prep is committed unless the warehouse shoot slips.", alternativeAssetIds: ["lit-nanlite"] },
+  { assetId: "lit-aputure", windowId: "tomorrow-pm", status: "conflict", coverageLabel: "Load-out conflict", note: "The current reservation owns the afternoon load-out slot.", alternativeAssetIds: ["lit-nanlite"] },
+  { assetId: "lit-aputure", windowId: "friday-dawn", status: "clear", coverageLabel: "Open after return", note: "By Friday dawn the key light should be fully reset and relabeled.", alternativeAssetIds: ["lit-nanlite"] },
+  { assetId: "lit-tubes", windowId: "today-pm", status: "conflict", coverageLabel: "Repair bench", note: "Tube batteries are still in service and cannot be released.", alternativeAssetIds: ["lit-nanlite", "lit-aputure"] },
+  { assetId: "lit-tubes", windowId: "tomorrow-am", status: "conflict", coverageLabel: "Repair bench", note: "The latch replacement is still blocking this pickup window.", alternativeAssetIds: ["lit-nanlite"] },
+  { assetId: "lit-tubes", windowId: "tomorrow-pm", status: "tight", coverageLabel: "Possible return", note: "The service bench may clear the pair in time for an afternoon pickup.", alternativeAssetIds: ["lit-nanlite"] },
+  { assetId: "lit-tubes", windowId: "friday-dawn", status: "clear", coverageLabel: "Likely restored", note: "The pair is expected back in the catalog before Friday dawn.", alternativeAssetIds: ["lit-nanlite"] },
+  { assetId: "lit-nanlite", windowId: "today-pm", status: "clear", coverageLabel: "Portable standby", note: "Travel light can fill either interview or walk-and-talk plans today.", alternativeAssetIds: ["lit-aputure"] },
+  { assetId: "lit-nanlite", windowId: "tomorrow-am", status: "clear", coverageLabel: "Best substitute", note: "This is the cleanest lighting option for the crowded morning window.", alternativeAssetIds: ["lit-aputure"] },
+  { assetId: "lit-nanlite", windowId: "tomorrow-pm", status: "clear", coverageLabel: "Reliable", note: "No truck dependencies and no ballast bottleneck in the afternoon.", alternativeAssetIds: ["lit-aputure"] },
+  { assetId: "lit-nanlite", windowId: "friday-dawn", status: "clear", coverageLabel: "Travel ready", note: "Battery plate is already staged for the dawn crew call.", alternativeAssetIds: ["lit-aputure"] },
+  { assetId: "sup-sachtler", windowId: "today-pm", status: "clear", coverageLabel: "Open support", note: "Tripod can leave immediately with no balancing work.", alternativeAssetIds: ["sup-slider"] },
+  { assetId: "sup-sachtler", windowId: "tomorrow-am", status: "tight", coverageLabel: "Interview demand", note: "Two interview requests are likely to grab the same tripod class in the morning.", alternativeAssetIds: ["sup-slider", "sup-rs4"] },
+  { assetId: "sup-sachtler", windowId: "tomorrow-pm", status: "clear", coverageLabel: "Low friction", note: "Tripod inventory loosens after lunch once the studio returns land.", alternativeAssetIds: ["sup-slider"] },
+  { assetId: "sup-sachtler", windowId: "friday-dawn", status: "clear", coverageLabel: "Advance-ready", note: "A strong option for crews staging overnight.", alternativeAssetIds: ["sup-slider"] },
+  { assetId: "sup-rs4", windowId: "today-pm", status: "conflict", coverageLabel: "Compatibility hold", note: "The gimbal cannot release until the lens package is approved.", alternativeAssetIds: ["sup-sachtler", "sup-slider"] },
+  { assetId: "sup-rs4", windowId: "tomorrow-am", status: "tight", coverageLabel: "Likely release", note: "This hold should clear by morning if the camera team approves the payload.", alternativeAssetIds: ["sup-sachtler"] },
+  { assetId: "sup-rs4", windowId: "tomorrow-pm", status: "clear", coverageLabel: "Motion friendly", note: "The afternoon slot is the safest time to book the gimbal.", alternativeAssetIds: ["sup-sachtler"] },
+  { assetId: "sup-rs4", windowId: "friday-dawn", status: "clear", coverageLabel: "Open runway", note: "Friday dawn is a clean motion window once the hold expires.", alternativeAssetIds: ["sup-sachtler"] },
+  { assetId: "sup-slider", windowId: "today-pm", status: "clear", coverageLabel: "Accessory open", note: "Motion pack is easy to stage with almost no prep queue.", alternativeAssetIds: ["sup-sachtler"] },
+  { assetId: "sup-slider", windowId: "tomorrow-am", status: "clear", coverageLabel: "Backup support", note: "Useful when the tripod line starts backing up.", alternativeAssetIds: ["sup-sachtler"] },
+  { assetId: "sup-slider", windowId: "tomorrow-pm", status: "tight", coverageLabel: "B-roll rush", note: "Afternoon creative teams often grab the motion pack for hero inserts.", alternativeAssetIds: ["sup-sachtler"] },
+  { assetId: "sup-slider", windowId: "friday-dawn", status: "clear", coverageLabel: "Low queue", note: "Few dawn crews request slider coverage before they load out.", alternativeAssetIds: ["sup-sachtler"] },
+];
+
+export const bundleBlueprints: BundleBlueprint[] = [
+  {
+    id: "interview-sprint",
+    intentId: "interview",
+    label: "Interview Sprint",
+    summary: "Stable hero camera, clean wireless audio, one key light, and a tripod for fast sit-down coverage.",
+    heroAssetId: "cam-c70",
+    assetIds: ["cam-c70", "aud-lav", "lit-nanlite", "sup-sachtler"],
+    optionalAssetIds: ["aud-mixpre", "aud-boom"],
+    note: "Swap the hero camera to the FX3 if the prime morning slot stays blocked.",
+  },
+  {
+    id: "field-runner",
+    intentId: "field",
+    label: "Field Runner",
+    summary: "Lean field package centered on mobility, battery discipline, and one moving support option.",
+    heroAssetId: "cam-fx3",
+    assetIds: ["cam-fx3", "aud-lav", "sup-rs4", "lit-nanlite"],
+    optionalAssetIds: ["sup-slider", "aud-boom"],
+    note: "Best for teams who can accept a gimbal compatibility review before pickup.",
+  },
+  {
+    id: "livestream-desk",
+    intentId: "livestream",
+    label: "Livestream Desk",
+    summary: "Compact stream package with reliable camera output, recorder coverage, and controllable key light.",
+    heroAssetId: "cam-a7s3",
+    assetIds: ["cam-a7s3", "aud-mixpre", "lit-aputure", "sup-sachtler"],
+    optionalAssetIds: ["sup-slider", "aud-lav"],
+    note: "If the 300D remains booked, move the bundle to the Forza and keep the rest of the desk intact.",
+  },
+  {
+    id: "campus-walkthrough",
+    intentId: "walkthrough",
+    label: "Campus Walkthrough",
+    summary: "Walking coverage with a compact camera body, wireless talent audio, and stabilized support.",
+    heroAssetId: "cam-fx3",
+    assetIds: ["cam-fx3", "aud-lav", "sup-rs4"],
+    optionalAssetIds: ["lit-nanlite", "cam-a7s3"],
+    note: "Add the travel light only if the route has indoor stops that need a fast key.",
   },
 ];

--- a/src/app/asset-catalog/page.tsx
+++ b/src/app/asset-catalog/page.tsx
@@ -4,7 +4,8 @@ import { AssetCatalogShell } from "@/components/asset-catalog/asset-catalog-shel
 
 export const metadata: Metadata = {
   title: "Asset Catalog | API Test",
-  description: "Searchable mock asset catalog with availability filters and local reservation previews.",
+  description:
+    "Reservation planning workspace with asset forecasting, bundle recommendations, and route-local preview flows.",
 };
 
 export default function AssetCatalogPage() {

--- a/src/app/asset-catalog/planner.test.ts
+++ b/src/app/asset-catalog/planner.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildBundleRecommendations,
+  buildReservationConflicts,
+  buildReservationPlannerSnapshot,
+} from "./planner";
+
+describe("asset catalog planner helpers", () => {
+  it("prioritizes the interview bundle around the selected hero asset", () => {
+    const recommendations = buildBundleRecommendations({
+      primaryAssetId: "cam-c70",
+      assetIds: ["cam-c70"],
+      intentId: "interview",
+      windowId: "friday-dawn",
+      crewProfileId: "pair",
+      flexibleMatching: true,
+    });
+
+    expect(recommendations[0]?.id).toBe("interview-sprint");
+    expect(recommendations[0]?.statusLabel).toBe("Ready to apply");
+  });
+
+  it("surfaces blocking conflicts for maintenance and forecast collisions", () => {
+    const conflicts = buildReservationConflicts({
+      primaryAssetId: "lit-tubes",
+      assetIds: ["lit-tubes"],
+      intentId: "livestream",
+      windowId: "today-pm",
+      crewProfileId: "pair",
+      flexibleMatching: false,
+    });
+
+    expect(
+      conflicts.some(
+        (conflict) =>
+          conflict.severity === "blocking" &&
+          conflict.title.includes("maintenance"),
+      ),
+    ).toBe(true);
+    expect(
+      conflicts.some(
+        (conflict) =>
+          conflict.severity === "blocking" &&
+          conflict.title.includes("forecasted demand"),
+      ),
+    ).toBe(true);
+  });
+
+  it("merges intent, preview, and crew notes into the snapshot checklist", () => {
+    const snapshot = buildReservationPlannerSnapshot({
+      primaryAssetId: "cam-c70",
+      assetIds: ["cam-c70", "aud-lav"],
+      intentId: "interview",
+      windowId: "tomorrow-am",
+      crewProfileId: "crew",
+      flexibleMatching: true,
+    });
+
+    expect(snapshot.primaryPreview?.project).toBe("Customer Story Sprint");
+    expect(snapshot.checklist).toContain("Signed interview kit receipt");
+    expect(snapshot.checklist).toContain(
+      "Assign one crew member to gear handoff and return notes.",
+    );
+    expect(snapshot.missingCategories.map((category) => category.id)).toEqual(
+      expect.arrayContaining(["lighting", "support"]),
+    );
+  });
+});

--- a/src/app/asset-catalog/planner.ts
+++ b/src/app/asset-catalog/planner.ts
@@ -1,0 +1,432 @@
+import {
+  assetCatalogItems,
+  assetCategories,
+  assetForecasts,
+  bundleBlueprints,
+  crewProfiles,
+  planningWindows,
+  reservationIntents,
+  reservationPreviews,
+  type AssetCatalogItem,
+  type AssetCategory,
+  type AssetForecast,
+  type BundleBlueprint,
+  type CrewProfile,
+  type CrewProfileId,
+  type PlanningWindow,
+  type PlanningWindowId,
+  type ReservationIntent,
+  type ReservationIntentId,
+  type ReservationPreview,
+} from "./mock-data";
+
+export type ConflictSeverity = "note" | "warning" | "blocking";
+
+export type PlannerConflict = {
+  id: string;
+  severity: ConflictSeverity;
+  title: string;
+  detail: string;
+  resolution: string;
+  assetId?: string;
+};
+
+export type BundleRecommendation = {
+  id: string;
+  label: string;
+  summary: string;
+  heroAssetId: string;
+  assetIds: string[];
+  optionalAssetIds: string[];
+  matchScore: number;
+  coverageLabel: string;
+  statusLabel: "Ready to apply" | "Needs one swap" | "Needs review";
+  reason: string;
+  caution: string;
+  conflictCount: number;
+};
+
+export type ReservationPlanInput = {
+  primaryAssetId: string | null;
+  assetIds: string[];
+  intentId: ReservationIntentId;
+  windowId: PlanningWindowId;
+  crewProfileId: CrewProfileId;
+  flexibleMatching: boolean;
+};
+
+export type ReservationPlannerSnapshot = {
+  primaryAsset: AssetCatalogItem | null;
+  primaryPreview: ReservationPreview | null;
+  planAssets: AssetCatalogItem[];
+  intent: ReservationIntent;
+  window: PlanningWindow;
+  crewProfile: CrewProfile;
+  forecasts: AssetForecast[];
+  coveredCategories: AssetCategory[];
+  missingCategories: AssetCategory[];
+  conflicts: PlannerConflict[];
+  recommendations: BundleRecommendation[];
+  checklist: string[];
+};
+
+const assetMap = new Map(assetCatalogItems.map((asset) => [asset.id, asset]));
+const categoryMap = new Map(assetCategories.map((category) => [category.id, category]));
+const previewMap = new Map(reservationPreviews.map((preview) => [preview.assetId, preview]));
+const forecastMap = new Map(
+  assetForecasts.map((forecast) => [`${forecast.assetId}:${forecast.windowId}`, forecast]),
+);
+const intentMap = new Map(reservationIntents.map((intent) => [intent.id, intent]));
+const windowMap = new Map(planningWindows.map((window) => [window.id, window]));
+const crewMap = new Map(crewProfiles.map((crewProfile) => [crewProfile.id, crewProfile]));
+
+function uniqueStrings(values: string[]) {
+  return Array.from(new Set(values));
+}
+
+function joinLabels(labels: string[]) {
+  if (labels.length === 0) {
+    return "";
+  }
+
+  if (labels.length === 1) {
+    return labels[0] ?? "";
+  }
+
+  if (labels.length === 2) {
+    return `${labels[0]} and ${labels[1]}`;
+  }
+
+  return `${labels.slice(0, -1).join(", ")}, and ${labels.at(-1)}`;
+}
+
+function normalizePlanAssetIds(primaryAssetId: string | null, assetIds: string[]) {
+  const orderedIds = primaryAssetId ? [primaryAssetId, ...assetIds] : assetIds;
+
+  return uniqueStrings(orderedIds).filter((assetId) => assetMap.has(assetId));
+}
+
+function getBundleConflictCount(
+  bundle: BundleBlueprint,
+  windowId: PlanningWindowId,
+  flexibleMatching: boolean,
+) {
+  return bundle.assetIds.reduce((count, assetId) => {
+    const asset = getAssetById(assetId);
+    const forecast = getAssetForecast(assetId, windowId);
+
+    if (!asset) {
+      return count;
+    }
+
+    if (asset.availability === "maintenance") {
+      return count + 1;
+    }
+
+    if (forecast?.status === "conflict") {
+      return count + 1;
+    }
+
+    if (!flexibleMatching && asset.availability !== "available") {
+      return count + 1;
+    }
+
+    return count;
+  }, 0);
+}
+
+export function getAssetById(assetId: string) {
+  return assetMap.get(assetId) ?? null;
+}
+
+export function getReservationPreviewByAssetId(assetId: string) {
+  return previewMap.get(assetId) ?? null;
+}
+
+export function getAssetForecast(assetId: string, windowId: PlanningWindowId) {
+  return forecastMap.get(`${assetId}:${windowId}`) ?? null;
+}
+
+export function buildReservationConflicts(
+  input: ReservationPlanInput,
+): PlannerConflict[] {
+  const planAssetIds = normalizePlanAssetIds(input.primaryAssetId, input.assetIds);
+  const planAssets = planAssetIds
+    .map((assetId) => getAssetById(assetId))
+    .filter((asset): asset is AssetCatalogItem => asset !== null);
+  const intent = intentMap.get(input.intentId) ?? reservationIntents[0];
+  const conflicts: PlannerConflict[] = [];
+
+  if (planAssets.length === 0) {
+    return conflicts;
+  }
+
+  for (const asset of planAssets) {
+    const preview = getReservationPreviewByAssetId(asset.id);
+    const forecast = getAssetForecast(asset.id, input.windowId);
+    const alternatives =
+      forecast?.alternativeAssetIds
+        .map((assetId) => getAssetById(assetId)?.name)
+        .filter((name): name is string => Boolean(name)) ?? [];
+
+    if (asset.availability === "maintenance") {
+      conflicts.push({
+        id: `maintenance:${asset.id}`,
+        assetId: asset.id,
+        severity: "blocking",
+        title: `${asset.name} is in maintenance`,
+        detail: `${asset.condition}. The planner should not rely on this asset for the active pickup window.`,
+        resolution: alternatives.length > 0
+          ? `Swap to ${joinLabels(alternatives)} or move the pickup window.`
+          : "Swap to another asset or move the pickup window.",
+      });
+    } else if (asset.availability === "reserved") {
+      conflicts.push({
+        id: `reserved:${asset.id}`,
+        assetId: asset.id,
+        severity: input.flexibleMatching ? "warning" : "blocking",
+        title: `${asset.name} is already reserved`,
+        detail: preview
+          ? `Assigned to ${preview.project} during ${preview.pickupWindow}.`
+          : `${asset.name} is committed to another handoff plan.`,
+        resolution: alternatives.length > 0
+          ? `Use ${joinLabels(alternatives)} or shift the plan to a looser window.`
+          : "Choose another pickup window or swap the hero asset.",
+      });
+    } else if (asset.availability === "hold") {
+      conflicts.push({
+        id: `hold:${asset.id}`,
+        assetId: asset.id,
+        severity: "warning",
+        title: `${asset.name} is on hold`,
+        detail: preview?.note ?? `${asset.name} is still waiting on confirmation before release.`,
+        resolution: alternatives.length > 0
+          ? `Keep a backup ready: ${joinLabels(alternatives)}.`
+          : "Confirm the hold owner or keep a backup ready.",
+      });
+    }
+
+    if (forecast?.status === "tight") {
+      conflicts.push({
+        id: `tight:${asset.id}:${input.windowId}`,
+        assetId: asset.id,
+        severity: "warning",
+        title: `${asset.name} has a tight pickup window`,
+        detail: forecast.note,
+        resolution: alternatives.length > 0
+          ? `Pre-stage ${joinLabels(alternatives)} as alternates.`
+          : "Use a later pickup slot if the schedule can flex.",
+      });
+    }
+
+    if (forecast?.status === "conflict") {
+      conflicts.push({
+        id: `forecast:${asset.id}:${input.windowId}`,
+        assetId: asset.id,
+        severity: "blocking",
+        title: `${asset.name} conflicts with the forecasted demand`,
+        detail: forecast.note,
+        resolution: alternatives.length > 0
+          ? `Swap to ${joinLabels(alternatives)} or choose another planning window.`
+          : "Choose another planning window.",
+      });
+    }
+  }
+
+  const coveredCategories = new Set(planAssets.map((asset) => asset.categoryId));
+  const missingCategories = intent.requiredCategories
+    .filter((categoryId) => !coveredCategories.has(categoryId))
+    .map((categoryId) => categoryMap.get(categoryId)?.label)
+    .filter((label): label is string => Boolean(label));
+
+  if (missingCategories.length > 0) {
+    conflicts.push({
+      id: `coverage:${input.intentId}`,
+      severity: "warning",
+      title: "Plan is missing supporting coverage",
+      detail: `${intent.label} reservations usually need ${joinLabels(missingCategories)}.`,
+      resolution: `Add ${joinLabels(missingCategories)} before locking the reservation preview.`,
+    });
+  }
+
+  if (input.crewProfileId === "crew" && !coveredCategories.has("support")) {
+    conflicts.push({
+      id: "crew-support-gap",
+      severity: "warning",
+      title: "Small crew plan needs a support anchor",
+      detail: "Crew-sized pickups turn over more smoothly when one support item is reserved up front.",
+      resolution: "Add a tripod, gimbal, or slider before handing off the plan.",
+    });
+  }
+
+  return conflicts;
+}
+
+export function buildBundleRecommendations(
+  input: ReservationPlanInput,
+): BundleRecommendation[] {
+  const intent = intentMap.get(input.intentId) ?? reservationIntents[0];
+  const selectedIds = new Set(normalizePlanAssetIds(input.primaryAssetId, input.assetIds));
+
+  return bundleBlueprints
+    .map((bundle) => {
+      const bundleAssets = bundle.assetIds
+        .map((assetId) => getAssetById(assetId))
+        .filter((asset): asset is AssetCatalogItem => asset !== null);
+      const overlapCount = bundle.assetIds.filter((assetId) => selectedIds.has(assetId)).length;
+      const coverageCount = intent.requiredCategories.filter((categoryId) =>
+        bundleAssets.some((asset) => asset.categoryId === categoryId),
+      ).length;
+      const conflictCount = getBundleConflictCount(
+        bundle,
+        input.windowId,
+        input.flexibleMatching,
+      );
+
+      let score = 18;
+
+      if (bundle.intentId === input.intentId) {
+        score += 28;
+      }
+
+      if (input.primaryAssetId && bundle.assetIds.includes(input.primaryAssetId)) {
+        score += 24;
+      }
+
+      score += overlapCount * 10;
+      score += coverageCount * 5;
+
+      for (const asset of bundleAssets) {
+        if (asset.recommendedFor.includes(input.intentId)) {
+          score += 4;
+        }
+
+        if (intent.preferredTags.some((tag) => asset.tags.includes(tag))) {
+          score += 2;
+        }
+
+        if (asset.availability === "available") {
+          score += 4;
+        } else if (asset.availability === "hold") {
+          score -= input.flexibleMatching ? 4 : 10;
+        } else if (asset.availability === "reserved") {
+          score -= input.flexibleMatching ? 8 : 14;
+        } else if (asset.availability === "maintenance") {
+          score -= 18;
+        }
+
+        const forecast = getAssetForecast(asset.id, input.windowId);
+
+        if (forecast?.status === "clear") {
+          score += 3;
+        } else if (forecast?.status === "tight") {
+          score -= 5;
+        } else if (forecast?.status === "conflict") {
+          score -= 16;
+        }
+      }
+
+      if (
+        input.crewProfileId === "crew" &&
+        bundleAssets.some((asset) => asset.categoryId === "support")
+      ) {
+        score += 6;
+      }
+
+      const optionalNames = bundle.optionalAssetIds
+        .map((assetId) => getAssetById(assetId)?.name)
+        .filter((name): name is string => Boolean(name));
+      const statusLabel: BundleRecommendation["statusLabel"] =
+        conflictCount === 0
+          ? "Ready to apply"
+          : conflictCount === 1
+            ? "Needs one swap"
+            : "Needs review";
+      const coverageLabel = `${coverageCount}/${intent.requiredCategories.length} core categories covered`;
+      const reason = input.primaryAssetId && bundle.assetIds.includes(input.primaryAssetId)
+        ? `Built around ${getAssetById(input.primaryAssetId)?.name ?? "the selected hero asset"}.`
+        : `Best aligned to the ${intent.label.toLowerCase()} plan settings.`;
+      const caution = conflictCount > 0
+        ? `${conflictCount} asset${conflictCount === 1 ? "" : "s"} need alternate timing or substitutions.`
+        : optionalNames.length > 0
+          ? `Optional add-ons: ${joinLabels(optionalNames)}.`
+          : bundle.note;
+
+      return {
+        id: bundle.id,
+        label: bundle.label,
+        summary: bundle.summary,
+        heroAssetId: bundle.heroAssetId,
+        assetIds: bundle.assetIds,
+        optionalAssetIds: bundle.optionalAssetIds,
+        matchScore: score,
+        coverageLabel,
+        statusLabel,
+        reason,
+        caution,
+        conflictCount,
+      };
+    })
+    .sort((left, right) => right.matchScore - left.matchScore)
+    .slice(0, 3);
+}
+
+export function buildReservationPlannerSnapshot(
+  input: ReservationPlanInput,
+): ReservationPlannerSnapshot {
+  const planAssetIds = uniqueStrings(input.assetIds).filter((assetId) =>
+    assetMap.has(assetId),
+  );
+  const analysisAssetIds = normalizePlanAssetIds(input.primaryAssetId, input.assetIds);
+  const planAssets = planAssetIds
+    .map((assetId) => getAssetById(assetId))
+    .filter((asset): asset is AssetCatalogItem => asset !== null);
+  const analysisAssets = analysisAssetIds
+    .map((assetId) => getAssetById(assetId))
+    .filter((asset): asset is AssetCatalogItem => asset !== null);
+  const primaryAsset =
+    (input.primaryAssetId ? getAssetById(input.primaryAssetId) : null) ??
+    planAssets[0] ??
+    null;
+  const primaryPreview = primaryAsset
+    ? getReservationPreviewByAssetId(primaryAsset.id)
+    : null;
+  const intent = intentMap.get(input.intentId) ?? reservationIntents[0];
+  const window = windowMap.get(input.windowId) ?? planningWindows[0];
+  const crewProfile = crewMap.get(input.crewProfileId) ?? crewProfiles[0];
+  const forecasts = analysisAssets
+    .map((asset) => getAssetForecast(asset.id, input.windowId))
+    .filter((forecast): forecast is AssetForecast => forecast !== null);
+  const coveredCategories = assetCategories.filter((category) =>
+    analysisAssets.some((asset) => asset.categoryId === category.id),
+  );
+  const missingCategories = assetCategories.filter(
+    (category) =>
+      intent.requiredCategories.includes(category.id) &&
+      !coveredCategories.some((coveredCategory) => coveredCategory.id === category.id),
+  );
+  const conflicts = buildReservationConflicts(input);
+  const recommendations = buildBundleRecommendations(input);
+  const checklist = uniqueStrings([
+    ...intent.checklist,
+    ...(primaryPreview?.checklist ?? []),
+    ...(crewProfile.id === "crew"
+      ? ["Assign one crew member to gear handoff and return notes."]
+      : []),
+  ]);
+
+  return {
+    primaryAsset,
+    primaryPreview,
+    planAssets,
+    intent,
+    window,
+    crewProfile,
+    forecasts,
+    coveredCategories,
+    missingCategories,
+    conflicts,
+    recommendations,
+    checklist,
+  };
+}

--- a/src/components/asset-catalog/asset-card.tsx
+++ b/src/components/asset-catalog/asset-card.tsx
@@ -1,11 +1,19 @@
-import type { AssetCatalogItem, ReservationPreview } from "@/app/asset-catalog/mock-data";
+import type {
+  AssetCatalogItem,
+  AssetForecast,
+  ReservationPreview,
+} from "@/app/asset-catalog/mock-data";
 
 type AssetCardProps = {
   asset: AssetCatalogItem;
+  bundleHint: string | null;
   categoryLabel: string;
+  forecast: AssetForecast | null;
+  focused: boolean;
+  planned: boolean;
   preview: ReservationPreview | null;
-  selected: boolean;
-  onSelect: () => void;
+  onFocus: () => void;
+  onTogglePlan: () => void;
 };
 
 const availabilityStyles = {
@@ -15,38 +23,114 @@ const availabilityStyles = {
   maintenance: "border-slate-300 bg-slate-100 text-slate-800",
 } as const;
 
-export function AssetCard({ asset, categoryLabel, preview, selected, onSelect }: AssetCardProps) {
+const forecastStyles = {
+  clear: "border-emerald-200 bg-emerald-50 text-emerald-900",
+  tight: "border-amber-200 bg-amber-50 text-amber-900",
+  conflict: "border-rose-200 bg-rose-50 text-rose-900",
+} as const;
+
+export function AssetCard({
+  asset,
+  bundleHint,
+  categoryLabel,
+  forecast,
+  focused,
+  planned,
+  preview,
+  onFocus,
+  onTogglePlan,
+}: AssetCardProps) {
   return (
     <article
       className={`rounded-[1.75rem] border p-5 transition ${
-        selected
+        focused
           ? "border-cyan-700 bg-cyan-950 text-white shadow-[0_20px_70px_-42px_rgba(8,145,178,0.85)]"
-          : "border-slate-200/80 bg-white/95 text-slate-900 shadow-[0_20px_70px_-46px_rgba(15,23,42,0.38)] hover:-translate-y-0.5 hover:border-cyan-200"
+          : planned
+            ? "border-cyan-200 bg-cyan-50/80 text-slate-900 shadow-[0_20px_70px_-46px_rgba(15,23,42,0.28)]"
+            : "border-slate-200/80 bg-white/95 text-slate-900 shadow-[0_20px_70px_-46px_rgba(15,23,42,0.38)] hover:-translate-y-0.5 hover:border-cyan-200"
       }`}
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="space-y-2">
           <div className="flex flex-wrap items-center gap-2">
-            <span className={`rounded-full border px-2.5 py-1 text-xs font-medium ${selected ? "border-white/20 bg-white/10 text-white" : availabilityStyles[asset.availability]}`}>
+            <span
+              className={`rounded-full border px-2.5 py-1 text-xs font-medium ${
+                focused
+                  ? "border-white/20 bg-white/10 text-white"
+                  : availabilityStyles[asset.availability]
+              }`}
+            >
               {asset.availability}
             </span>
-            <span className={`text-xs font-medium uppercase tracking-[0.2em] ${selected ? "text-cyan-100" : "text-slate-500"}`}>{categoryLabel}</span>
+            {forecast ? (
+              <span
+                className={`rounded-full border px-2.5 py-1 text-xs font-medium ${
+                  focused
+                    ? "border-white/20 bg-white/10 text-white"
+                    : forecastStyles[forecast.status]
+                }`}
+              >
+                {forecast.coverageLabel}
+              </span>
+            ) : null}
+            <span
+              className={`text-xs font-medium uppercase tracking-[0.2em] ${
+                focused ? "text-cyan-100" : "text-slate-500"
+              }`}
+            >
+              {categoryLabel}
+            </span>
           </div>
           <div>
             <h2 className="text-xl font-semibold tracking-tight">{asset.name}</h2>
-            <p className={`mt-1 text-sm leading-6 ${selected ? "text-cyan-50" : "text-slate-600"}`}>{asset.summary}</p>
+            <p
+              className={`mt-1 text-sm leading-6 ${
+                focused ? "text-cyan-50" : planned ? "text-slate-700" : "text-slate-600"
+              }`}
+            >
+              {asset.summary}
+            </p>
           </div>
         </div>
-        <div className={`rounded-2xl border px-3 py-2 text-right text-xs ${selected ? "border-white/15 bg-white/10 text-cyan-50" : "border-slate-200 bg-slate-50 text-slate-600"}`}>
+        <div
+          className={`rounded-2xl border px-3 py-2 text-right text-xs ${
+            focused
+              ? "border-white/15 bg-white/10 text-cyan-50"
+              : "border-slate-200 bg-white text-slate-600"
+          }`}
+        >
           <p>{asset.sku}</p>
           <p className="mt-1">{asset.zone}</p>
+          <p className="mt-2">{asset.prepLead} prep</p>
         </div>
       </div>
 
-      <div className="mt-5 grid gap-4 sm:grid-cols-2">
+      {bundleHint ? (
+        <div
+          className={`mt-4 rounded-2xl px-3 py-3 text-sm ${
+            focused
+              ? "bg-white/10 text-cyan-50"
+              : "border border-cyan-200 bg-cyan-50 text-cyan-900"
+          }`}
+        >
+          Top bundle fit: <span className="font-semibold">{bundleHint}</span>
+        </div>
+      ) : null}
+
+      <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
         <div>
-          <p className={`text-xs uppercase tracking-[0.2em] ${selected ? "text-cyan-100" : "text-slate-500"}`}>Kit Includes</p>
-          <ul className={`mt-2 space-y-2 text-sm ${selected ? "text-cyan-50" : "text-slate-700"}`}>
+          <p
+            className={`text-xs uppercase tracking-[0.2em] ${
+              focused ? "text-cyan-100" : "text-slate-500"
+            }`}
+          >
+            Kit Includes
+          </p>
+          <ul
+            className={`mt-2 space-y-2 text-sm ${
+              focused ? "text-cyan-50" : "text-slate-700"
+            }`}
+          >
             {asset.kit.map((item) => (
               <li key={item}>- {item}</li>
             ))}
@@ -54,12 +138,52 @@ export function AssetCard({ asset, categoryLabel, preview, selected, onSelect }:
         </div>
         <div className="space-y-3">
           <div>
-            <p className={`text-xs uppercase tracking-[0.2em] ${selected ? "text-cyan-100" : "text-slate-500"}`}>Next Window</p>
-            <p className={`mt-2 text-sm ${selected ? "text-cyan-50" : "text-slate-700"}`}>{asset.nextWindow}</p>
+            <p
+              className={`text-xs uppercase tracking-[0.2em] ${
+                focused ? "text-cyan-100" : "text-slate-500"
+              }`}
+            >
+              Planning Notes
+            </p>
+            <p
+              className={`mt-2 text-sm ${
+                focused ? "text-cyan-50" : "text-slate-700"
+              }`}
+            >
+              {forecast?.note ?? asset.nextWindow}
+            </p>
           </div>
           <div>
-            <p className={`text-xs uppercase tracking-[0.2em] ${selected ? "text-cyan-100" : "text-slate-500"}`}>Condition</p>
-            <p className={`mt-2 text-sm ${selected ? "text-cyan-50" : "text-slate-700"}`}>{asset.condition}</p>
+            <p
+              className={`text-xs uppercase tracking-[0.2em] ${
+                focused ? "text-cyan-100" : "text-slate-500"
+              }`}
+            >
+              Crew Fit
+            </p>
+            <p
+              className={`mt-2 text-sm ${
+                focused ? "text-cyan-50" : "text-slate-700"
+              }`}
+            >
+              {asset.crewFit}
+            </p>
+          </div>
+          <div>
+            <p
+              className={`text-xs uppercase tracking-[0.2em] ${
+                focused ? "text-cyan-100" : "text-slate-500"
+              }`}
+            >
+              Condition
+            </p>
+            <p
+              className={`mt-2 text-sm ${
+                focused ? "text-cyan-50" : "text-slate-700"
+              }`}
+            >
+              {asset.condition}
+            </p>
           </div>
         </div>
       </div>
@@ -68,7 +192,13 @@ export function AssetCard({ asset, categoryLabel, preview, selected, onSelect }:
         {asset.tags.map((tag) => (
           <span
             key={tag}
-            className={`rounded-full px-2.5 py-1 text-xs font-medium ${selected ? "bg-white/10 text-cyan-50" : "bg-slate-100 text-slate-600"}`}
+            className={`rounded-full px-2.5 py-1 text-xs font-medium ${
+              focused
+                ? "bg-white/10 text-cyan-50"
+                : planned
+                  ? "bg-white text-slate-700"
+                  : "bg-slate-100 text-slate-600"
+            }`}
           >
             {tag}
           </span>
@@ -76,22 +206,47 @@ export function AssetCard({ asset, categoryLabel, preview, selected, onSelect }:
       </div>
 
       <div className="mt-5 flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
-        <p className={`text-sm ${selected ? "text-cyan-50" : "text-slate-600"}`}>
-          {preview ? `Reservation preview: ${preview.project}` : "No reservation preview attached yet."}
-        </p>
-        <button
-          aria-label={`${selected ? "Clear" : "Preview"} reservation: ${asset.name}`}
-          aria-pressed={selected}
-          className={`rounded-full px-4 py-2 text-sm font-medium transition ${
-            selected
-              ? "bg-white text-cyan-950 hover:bg-cyan-50"
-              : "bg-cyan-950 text-white hover:bg-cyan-900"
+        <p
+          className={`text-sm ${
+            focused ? "text-cyan-50" : planned ? "text-slate-700" : "text-slate-600"
           }`}
-          onClick={onSelect}
-          type="button"
         >
-          {selected ? "Clear preview" : "Preview reservation"}
-        </button>
+          {preview
+            ? `Reservation preview: ${preview.project}`
+            : planned
+              ? "Added to the reservation draft."
+              : "Not yet attached to the active reservation draft."}
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <button
+            aria-label={`${focused ? "Hide" : "Inspect"} asset: ${asset.name}`}
+            aria-pressed={focused}
+            className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+              focused
+                ? "bg-white text-cyan-950 hover:bg-cyan-50"
+                : "border border-slate-300 bg-white text-slate-700 hover:border-slate-400 hover:bg-slate-100"
+            }`}
+            onClick={onFocus}
+            type="button"
+          >
+            {focused ? "Hide details" : "Inspect"}
+          </button>
+          <button
+            aria-label={`${planned ? "Remove from" : "Add to"} reservation: ${
+              asset.name
+            }`}
+            aria-pressed={planned}
+            className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+              focused
+                ? "border border-white/15 bg-white/10 text-white hover:bg-white/20"
+                : "bg-cyan-950 text-white hover:bg-cyan-900"
+            }`}
+            onClick={onTogglePlan}
+            type="button"
+          >
+            {planned ? "Remove from draft" : "Add to reservation"}
+          </button>
+        </div>
       </div>
     </article>
   );

--- a/src/components/asset-catalog/asset-catalog-header.tsx
+++ b/src/components/asset-catalog/asset-catalog-header.tsx
@@ -1,58 +1,103 @@
 type AssetCatalogHeaderProps = {
+  bundleReadyCount: number;
+  draftAssets: number;
+  forecastAlerts: number;
+  readyAssets: number;
   syncLabel: string;
   totalAssets: number;
-  readyAssets: number;
-  reservedAssets: number;
-  attentionAssets: number;
+  windowLabel: string;
 };
 
 export function AssetCatalogHeader({
+  bundleReadyCount,
+  draftAssets,
+  forecastAlerts,
+  readyAssets,
   syncLabel,
   totalAssets,
-  readyAssets,
-  reservedAssets,
-  attentionAssets,
+  windowLabel,
 }: AssetCatalogHeaderProps) {
   return (
     <section className="overflow-hidden rounded-[2rem] border border-slate-200/70 bg-white/90 shadow-[0_24px_80px_-40px_rgba(15,23,42,0.45)] backdrop-blur">
       <div className="bg-[linear-gradient(135deg,rgba(14,116,144,0.14),rgba(251,191,36,0.14),rgba(255,255,255,0.9))] px-5 py-6 sm:px-7 sm:py-7">
         <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
           <div className="max-w-3xl space-y-3">
-            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-cyan-700">Asset Catalog</p>
+            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-cyan-700">
+              Asset Catalog Planner
+            </p>
             <div className="space-y-2">
               <h1 className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
-                Searchable checkout board for cameras, audio, lighting, and support gear.
+                Plan reservations with forecast pressure, bundle suggestions, and
+                a draft handoff preview.
               </h1>
               <p className="max-w-2xl text-sm leading-6 text-slate-600 sm:text-base">
-                Everything on this route is feature-local: mock inventory, availability logic, selection state, and reservation previews stay inside the asset catalog.
+                Build a route-local reservation draft instead of only browsing
+                inventory. Every bundle, forecast warning, and preview change stays
+                isolated inside the asset catalog experience.
               </p>
             </div>
           </div>
-          <div className="rounded-full border border-cyan-200 bg-cyan-50/80 px-4 py-2 text-sm font-medium text-cyan-900">
-            {syncLabel}
+          <div className="space-y-3">
+            <div className="rounded-full border border-cyan-200 bg-cyan-50/80 px-4 py-2 text-sm font-medium text-cyan-900">
+              {syncLabel}
+            </div>
+            <div className="rounded-full border border-amber-200 bg-amber-50/80 px-4 py-2 text-sm font-medium text-amber-900">
+              Planning against {windowLabel}
+            </div>
           </div>
         </div>
       </div>
-      <div className="grid gap-3 border-t border-slate-200/70 px-5 py-5 sm:grid-cols-2 sm:px-7 lg:grid-cols-4">
+      <div className="grid gap-3 border-t border-slate-200/70 px-5 py-5 sm:grid-cols-2 sm:px-7 xl:grid-cols-5">
         <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
-          <p className="text-xs uppercase tracking-[0.24em] text-slate-500">Catalog</p>
+          <p className="text-xs uppercase tracking-[0.24em] text-slate-500">
+            Catalog
+          </p>
           <p className="mt-2 text-2xl font-semibold text-slate-900">{totalAssets}</p>
-          <p className="mt-1 text-sm text-slate-600">Mock assets in this isolated route.</p>
+          <p className="mt-1 text-sm text-slate-600">
+            Mock assets available to the planner.
+          </p>
+        </div>
+        <div className="rounded-2xl border border-cyan-200 bg-cyan-50 px-4 py-4">
+          <p className="text-xs uppercase tracking-[0.24em] text-cyan-700">
+            Draft Plan
+          </p>
+          <p className="mt-2 text-2xl font-semibold text-cyan-950">{draftAssets}</p>
+          <p className="mt-1 text-sm text-cyan-900">
+            Assets currently staged in the reservation.
+          </p>
         </div>
         <div className="rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-4">
-          <p className="text-xs uppercase tracking-[0.24em] text-emerald-700">Ready Now</p>
-          <p className="mt-2 text-2xl font-semibold text-emerald-950">{readyAssets}</p>
-          <p className="mt-1 text-sm text-emerald-800">Clear for immediate checkout.</p>
+          <p className="text-xs uppercase tracking-[0.24em] text-emerald-700">
+            Ready Now
+          </p>
+          <p className="mt-2 text-2xl font-semibold text-emerald-950">
+            {readyAssets}
+          </p>
+          <p className="mt-1 text-sm text-emerald-800">
+            Clear for immediate pickup or bundle use.
+          </p>
+        </div>
+        <div className="rounded-2xl border border-violet-200 bg-violet-50 px-4 py-4">
+          <p className="text-xs uppercase tracking-[0.24em] text-violet-700">
+            Ready Bundles
+          </p>
+          <p className="mt-2 text-2xl font-semibold text-violet-950">
+            {bundleReadyCount}
+          </p>
+          <p className="mt-1 text-sm text-violet-900">
+            Recommendation paths with no blocking conflicts.
+          </p>
         </div>
         <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-4">
-          <p className="text-xs uppercase tracking-[0.24em] text-amber-700">Reserved</p>
-          <p className="mt-2 text-2xl font-semibold text-amber-950">{reservedAssets}</p>
-          <p className="mt-1 text-sm text-amber-800">Already tied to a handoff window.</p>
-        </div>
-        <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-4">
-          <p className="text-xs uppercase tracking-[0.24em] text-rose-700">Needs Attention</p>
-          <p className="mt-2 text-2xl font-semibold text-rose-950">{attentionAssets}</p>
-          <p className="mt-1 text-sm text-rose-800">Items on hold or in maintenance.</p>
+          <p className="text-xs uppercase tracking-[0.24em] text-amber-700">
+            Forecast Alerts
+          </p>
+          <p className="mt-2 text-2xl font-semibold text-amber-950">
+            {forecastAlerts}
+          </p>
+          <p className="mt-1 text-sm text-amber-900">
+            Assets under pressure in the active pickup window.
+          </p>
         </div>
       </div>
     </section>

--- a/src/components/asset-catalog/asset-catalog-shell.test.tsx
+++ b/src/components/asset-catalog/asset-catalog-shell.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AssetCatalogShell } from "./asset-catalog-shell";
+
+describe("AssetCatalogShell", () => {
+  it("applies a recommended bundle and populates the reservation draft", () => {
+    render(<AssetCatalogShell />);
+
+    fireEvent.click(screen.getByLabelText("Apply bundle: Interview Sprint"));
+
+    expect(screen.getByText("4 selected")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Remove from reservation: Canon C70 Interview Pack"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Existing reservation on this asset")).toBeInTheDocument();
+  }, 20000);
+
+  it("shows forecast pressure for the focused asset", () => {
+    render(<AssetCatalogShell />);
+
+    fireEvent.click(screen.getByLabelText("Inspect asset: Canon C70 Interview Pack"));
+    fireEvent.click(screen.getByText("Forecast Board"));
+
+    expect(
+      screen.getByText(
+        "Compare availability pressure before locking the pickup window.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Collision risk").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(
+        /Existing reservation overlaps the prime interview slot\./i,
+      ).length,
+    ).toBeGreaterThan(0);
+  }, 20000);
+
+  it("surfaces missing coverage when the draft is incomplete", () => {
+    render(<AssetCatalogShell />);
+
+    fireEvent.click(screen.getByLabelText("Add to reservation: Sony FX3 Field Kit"));
+
+    expect(screen.getByText("Plan is missing supporting coverage")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Add audio, lighting, and support/i),
+    ).toBeInTheDocument();
+  }, 20000);
+
+  it("keeps the focused asset in preview when filters hide it", () => {
+    render(<AssetCatalogShell />);
+
+    fireEvent.click(screen.getByLabelText("Inspect asset: Sony FX3 Field Kit"));
+    fireEvent.click(screen.getByText("Reserved - 2"));
+
+    expect(
+      screen.getByText("Sony FX3 Field Kit is outside the current filters."),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset filters" }));
+
+    expect(
+      screen.queryByText("Sony FX3 Field Kit is outside the current filters."),
+    ).not.toBeInTheDocument();
+  }, 20000);
+});

--- a/src/components/asset-catalog/asset-catalog-shell.tsx
+++ b/src/components/asset-catalog/asset-catalog-shell.tsx
@@ -7,68 +7,182 @@ import {
   assetCatalogSyncLabel,
   assetCategories,
   availabilityOptions,
+  crewProfiles,
+  planningWindows,
+  reservationIntents,
   reservationPreviews,
   type AssetAvailability,
   type AssetCategoryId,
+  type CrewProfileId,
+  type PlanningWindowId,
+  type ReservationIntentId,
 } from "@/app/asset-catalog/mock-data";
+import {
+  buildReservationPlannerSnapshot,
+  getAssetById,
+  getAssetForecast,
+} from "@/app/asset-catalog/planner";
 import { AssetCard } from "./asset-card";
 import { AssetCatalogHeader } from "./asset-catalog-header";
+import { BundleRecommendations } from "./bundle-recommendations";
 import { CatalogControls } from "./catalog-controls";
 import { CategoryTabs } from "./category-tabs";
+import { ForecastBoard } from "./forecast-board";
+import { PlannerTabs } from "./planner-tabs";
 import { ReservationPreview } from "./reservation-preview";
+
+type PlannerViewId = "browse" | "planner" | "forecast";
 
 function matchesQuery(assetId: string, query: string) {
   return assetId.includes(query);
 }
 
+function uniqueAssetIds(assetIds: string[]) {
+  return Array.from(new Set(assetIds));
+}
+
 export function AssetCatalogShell() {
   const [query, setQuery] = useState("");
-  const [activeCategory, setActiveCategory] = useState<AssetCategoryId | "all">("all");
-  const [activeAvailability, setActiveAvailability] = useState<AssetAvailability | "all">("all");
-  const [selectedAssetId, setSelectedAssetId] = useState<string | null>(null);
+  const [activeCategory, setActiveCategory] = useState<AssetCategoryId | "all">(
+    "all",
+  );
+  const [activeAvailability, setActiveAvailability] = useState<
+    AssetAvailability | "all"
+  >("all");
+  const [plannerView, setPlannerView] = useState<PlannerViewId>("planner");
+  const [focusedAssetId, setFocusedAssetId] = useState<string | null>(null);
+  const [plannedAssetIds, setPlannedAssetIds] = useState<string[]>([]);
+  const [intentId, setIntentId] = useState<ReservationIntentId>("interview");
+  const [windowId, setWindowId] = useState<PlanningWindowId>("tomorrow-am");
+  const [crewProfileId, setCrewProfileId] = useState<CrewProfileId>("pair");
+  const [flexibleMatching, setFlexibleMatching] = useState(true);
   const deferredQuery = useDeferredValue(query).trim().toLowerCase();
 
   const visibleAssets = assetCatalogItems.filter((asset) => {
-    const searchable = [asset.name, asset.sku, asset.zone, asset.summary, asset.condition, ...asset.tags, ...asset.kit]
+    const searchable = [
+      asset.name,
+      asset.sku,
+      asset.zone,
+      asset.summary,
+      asset.condition,
+      asset.crewFit,
+      ...asset.tags,
+      ...asset.kit,
+    ]
       .join(" ")
       .toLowerCase();
 
     return (
-      (!deferredQuery || searchable.includes(deferredQuery) || matchesQuery(asset.id, deferredQuery)) &&
+      (!deferredQuery ||
+        searchable.includes(deferredQuery) ||
+        matchesQuery(asset.id, deferredQuery)) &&
       (activeCategory === "all" || asset.categoryId === activeCategory) &&
       (activeAvailability === "all" || asset.availability === activeAvailability)
     );
   });
 
-  const selectedAsset = assetCatalogItems.find((asset) => asset.id === selectedAssetId) ?? null;
-  const selectionHidden = selectedAsset ? !visibleAssets.some((asset) => asset.id === selectedAsset.id) : false;
-  const selectedPreview = selectedAsset ? reservationPreviews.find((preview) => preview.assetId === selectedAsset.id) ?? null : null;
-  const hasFilters = query.trim().length > 0 || activeCategory !== "all" || activeAvailability !== "all";
-  const readyAssets = assetCatalogItems.filter((asset) => asset.availability === "available").length;
-  const reservedAssets = assetCatalogItems.filter((asset) => asset.availability === "reserved").length;
-  const attentionAssets = assetCatalogItems.filter((asset) => asset.availability === "hold" || asset.availability === "maintenance").length;
+  const plannerSnapshot = buildReservationPlannerSnapshot({
+    primaryAssetId: focusedAssetId,
+    assetIds: plannedAssetIds,
+    intentId,
+    windowId,
+    crewProfileId,
+    flexibleMatching,
+  });
+  const focusedAsset = plannerSnapshot.primaryAsset;
+  const focusedPreview = focusedAsset
+    ? reservationPreviews.find((preview) => preview.assetId === focusedAsset.id) ?? null
+    : null;
+  const focusedForecast = focusedAsset
+    ? getAssetForecast(focusedAsset.id, windowId)
+    : null;
+  const selectionHidden = focusedAsset
+    ? !visibleAssets.some((asset) => asset.id === focusedAsset.id)
+    : false;
+  const hasFilters =
+    query.trim().length > 0 ||
+    activeCategory !== "all" ||
+    activeAvailability !== "all";
+  const hasPlanningChanges =
+    plannerView !== "planner" ||
+    focusedAssetId !== null ||
+    plannedAssetIds.length > 0 ||
+    intentId !== "interview" ||
+    windowId !== "tomorrow-am" ||
+    crewProfileId !== "pair" ||
+    !flexibleMatching;
+  const readyAssets = assetCatalogItems.filter(
+    (asset) => asset.availability === "available",
+  ).length;
+  const forecastAlerts = assetCatalogItems.filter((asset) => {
+    const forecast = getAssetForecast(asset.id, windowId);
 
+    return forecast?.status === "tight" || forecast?.status === "conflict";
+  }).length;
+  const bundleReadyCount = plannerSnapshot.recommendations.filter(
+    (recommendation) => recommendation.conflictCount === 0,
+  ).length;
   const categoryTabs = [
     {
       id: "all",
       label: "All assets",
-      summary: "Entire checkout floor with every mock item in view.",
+      summary: "Entire planner catalog across every checkout lane.",
       count: assetCatalogItems.length,
     },
     ...assetCategories.map((category) => ({
       ...category,
-      count: assetCatalogItems.filter((asset) => asset.categoryId === category.id).length,
+      count: assetCatalogItems.filter(
+        (asset) => asset.categoryId === category.id,
+      ).length,
     })),
   ];
-
   const availabilityCounts = availabilityOptions.map((availability) => ({
     ...availability,
-    count: assetCatalogItems.filter((asset) => asset.availability === availability.id).length,
+    count: assetCatalogItems.filter(
+      (asset) => asset.availability === availability.id,
+    ).length,
   }));
-
-  const selectedCategoryLabel = selectedAsset
-    ? assetCategories.find((category) => category.id === selectedAsset.categoryId)?.label ?? null
+  const selectedCategoryLabel = focusedAsset
+    ? assetCategories.find((category) => category.id === focusedAsset.categoryId)?.label ??
+      null
     : null;
+  const activeWindow =
+    planningWindows.find((window) => window.id === windowId) ?? planningWindows[0];
+  const activeIntent =
+    reservationIntents.find((intent) => intent.id === intentId) ??
+    reservationIntents[0];
+  const activeCrewProfile =
+    crewProfiles.find((crewProfile) => crewProfile.id === crewProfileId) ??
+    crewProfiles[0];
+  const plannerViews = [
+    {
+      id: "planner",
+      label: "Plan Reservation",
+      summary: "Build a draft, inspect conflicts, and apply bundles in one flow.",
+      badge: `${plannerSnapshot.planAssets.length} in draft`,
+    },
+    {
+      id: "browse",
+      label: "Browse Inventory",
+      summary: "Review inventory cards without leaving the draft context.",
+      badge: `${visibleAssets.length} visible`,
+    },
+    {
+      id: "forecast",
+      label: "Forecast Board",
+      summary: "Pressure-test the active pickup window before confirming the plan.",
+      badge: `${forecastAlerts} alerts`,
+    },
+  ];
+  const topRecommendation = plannerSnapshot.recommendations[0];
+  const topBundleAssetIds = new Set(topRecommendation?.assetIds ?? []);
+  const forecastAssets =
+    plannerSnapshot.planAssets.length > 0
+      ? plannerSnapshot.planAssets
+      : visibleAssets.slice(0, 4);
+
+  const resolveAssetName = (assetId: string) =>
+    getAssetById(assetId)?.name ?? assetId;
 
   const handleResetFilters = () => {
     startTransition(() => {
@@ -78,45 +192,156 @@ export function AssetCatalogShell() {
     });
   };
 
+  const handleResetPlanner = () => {
+    startTransition(() => {
+      setPlannerView("planner");
+      setFocusedAssetId(null);
+      setPlannedAssetIds([]);
+      setIntentId("interview");
+      setWindowId("tomorrow-am");
+      setCrewProfileId("pair");
+      setFlexibleMatching(true);
+    });
+  };
+
+  const handleFocusAsset = (assetId: string) => {
+    startTransition(() => {
+      setFocusedAssetId((current) => (current === assetId ? null : assetId));
+    });
+  };
+
+  const handleTogglePlanAsset = (assetId: string) => {
+    startTransition(() => {
+      setPlannedAssetIds((current) => {
+        if (current.includes(assetId)) {
+          return current.filter((existingAssetId) => existingAssetId !== assetId);
+        }
+
+        return uniqueAssetIds([...current, assetId]);
+      });
+      setFocusedAssetId((current) => current ?? assetId);
+      setPlannerView("planner");
+    });
+  };
+
+  const handleApplyBundle = (assetIds: string[], heroAssetId: string) => {
+    startTransition(() => {
+      setPlannedAssetIds(uniqueAssetIds(assetIds));
+      setFocusedAssetId(heroAssetId);
+      setPlannerView("planner");
+    });
+  };
+
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(8,145,178,0.18),transparent_28%),radial-gradient(circle_at_top_right,rgba(251,191,36,0.18),transparent_24%),linear-gradient(180deg,#f8fafc_0%,#fff7ed_48%,#ecfeff_100%)] px-4 py-6 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-7xl space-y-6">
         <AssetCatalogHeader
-          attentionAssets={attentionAssets}
+          bundleReadyCount={bundleReadyCount}
+          draftAssets={plannerSnapshot.planAssets.length}
+          forecastAlerts={forecastAlerts}
           readyAssets={readyAssets}
-          reservedAssets={reservedAssets}
           syncLabel={assetCatalogSyncLabel}
           totalAssets={assetCatalogItems.length}
+          windowLabel={activeWindow.label}
+        />
+
+        <PlannerTabs
+          activeView={plannerView}
+          onChange={(viewId) =>
+            startTransition(() => setPlannerView(viewId as PlannerViewId))
+          }
+          views={plannerViews}
         />
 
         <CategoryTabs
           activeCategory={activeCategory}
           categories={categoryTabs}
-          onChange={(categoryId) => startTransition(() => setActiveCategory(categoryId as AssetCategoryId | "all"))}
+          onChange={(categoryId) =>
+            startTransition(() =>
+              setActiveCategory(categoryId as AssetCategoryId | "all"),
+            )
+          }
         />
 
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(21rem,0.92fr)]">
           <section className="space-y-5">
             <CatalogControls
               activeAvailability={activeAvailability}
+              activeCrewProfileId={crewProfileId}
+              activeIntentId={intentId}
+              activeWindowId={windowId}
               availabilityCounts={availabilityCounts}
+              crewProfiles={crewProfiles}
+              flexibleMatching={flexibleMatching}
               hasFilters={hasFilters}
-              onAvailabilityChange={(availability) => startTransition(() => setActiveAvailability(availability))}
+              hasPlanningChanges={hasPlanningChanges}
+              intents={reservationIntents}
+              onAvailabilityChange={(availability) =>
+                startTransition(() => setActiveAvailability(availability))
+              }
+              onCrewProfileChange={(nextCrewProfileId) =>
+                startTransition(() => setCrewProfileId(nextCrewProfileId))
+              }
+              onFlexibleMatchingChange={(value) =>
+                startTransition(() => setFlexibleMatching(value))
+              }
+              onIntentChange={(nextIntentId) =>
+                startTransition(() => setIntentId(nextIntentId))
+              }
               onQueryChange={(value) => startTransition(() => setQuery(value))}
-              onReset={handleResetFilters}
+              onResetFilters={handleResetFilters}
+              onResetPlanner={handleResetPlanner}
+              onWindowChange={(nextWindowId) =>
+                startTransition(() => setWindowId(nextWindowId))
+              }
+              planCount={plannerSnapshot.planAssets.length}
               query={query}
               resultCount={visibleAssets.length}
               totalCount={assetCatalogItems.length}
+              windows={planningWindows}
             />
+
+            {plannerView === "planner" ? (
+              <BundleRecommendations
+                plannedAssetIds={plannedAssetIds}
+                recommendations={plannerSnapshot.recommendations}
+                resolveAssetName={resolveAssetName}
+                onApplyBundle={handleApplyBundle}
+                onInspectAsset={handleFocusAsset}
+              />
+            ) : null}
+
+            {plannerView === "forecast" ? (
+              <ForecastBoard
+                activeWindowId={windowId}
+                assets={forecastAssets}
+                focusedAssetId={focusedAssetId}
+                onInspectAsset={handleFocusAsset}
+              />
+            ) : null}
 
             <section className="space-y-4">
               <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                 <div>
-                  <h2 className="text-lg font-semibold text-slate-900">Asset listing</h2>
-                  <p className="text-sm text-slate-600">Search results update on the client and never affect any other route.</p>
+                  <h2 className="text-lg font-semibold text-slate-900">
+                    {plannerView === "browse"
+                      ? "Asset listing"
+                      : plannerView === "forecast"
+                        ? "Planner inventory"
+                        : "Reservation candidates"}
+                  </h2>
+                  <p className="text-sm text-slate-600">
+                    {plannerView === "browse"
+                      ? "Browse the isolated mock catalog and inspect any handoff without leaving the route."
+                      : plannerView === "forecast"
+                        ? "Use the catalog beneath the forecast board to pull substitutes into the draft."
+                        : "Add assets directly to the draft and use the recommendations to close coverage gaps."}
+                  </p>
                 </div>
                 <div className="rounded-full border border-slate-200 bg-white/80 px-3 py-2 text-sm text-slate-600">
-                  {visibleAssets.length === 1 ? "1 matching asset" : `${visibleAssets.length} matching assets`}
+                  {visibleAssets.length === 1
+                    ? "1 matching asset"
+                    : `${visibleAssets.length} matching assets`}
                 </div>
               </div>
 
@@ -126,21 +351,39 @@ export function AssetCatalogShell() {
                     <AssetCard
                       key={asset.id}
                       asset={asset}
-                      categoryLabel={assetCategories.find((category) => category.id === asset.categoryId)?.label ?? asset.categoryId}
-                      onSelect={() =>
-                        startTransition(() => setSelectedAssetId((current) => current === asset.id ? null : asset.id))
+                      bundleHint={
+                        topBundleAssetIds.has(asset.id) && topRecommendation
+                          ? topRecommendation.label
+                          : null
                       }
-                      preview={reservationPreviews.find((preview) => preview.assetId === asset.id) ?? null}
-                      selected={selectedAssetId === asset.id}
+                      categoryLabel={
+                        assetCategories.find((category) => category.id === asset.categoryId)
+                          ?.label ?? asset.categoryId
+                      }
+                      forecast={getAssetForecast(asset.id, windowId)}
+                      focused={focusedAssetId === asset.id}
+                      planned={plannedAssetIds.includes(asset.id)}
+                      preview={
+                        reservationPreviews.find(
+                          (preview) => preview.assetId === asset.id,
+                        ) ?? null
+                      }
+                      onFocus={() => handleFocusAsset(asset.id)}
+                      onTogglePlan={() => handleTogglePlanAsset(asset.id)}
                     />
                   ))}
                 </div>
               ) : (
                 <div className="rounded-[1.9rem] border border-dashed border-slate-300 bg-white/85 p-8 text-center shadow-[0_20px_70px_-46px_rgba(15,23,42,0.38)]">
-                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">No Matches</p>
-                  <h3 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900">No assets match the current search and availability filters.</h3>
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                    No Matches
+                  </p>
+                  <h3 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900">
+                    No assets match the current search and availability filters.
+                  </h3>
                   <p className="mt-3 text-sm leading-6 text-slate-600">
-                    Try a different tag, switch categories, or clear the filters to bring the full mock catalog back into view.
+                    Try a different tag, switch categories, or clear the filters to
+                    bring the full planner catalog back into view.
                   </p>
                   {hasFilters ? (
                     <button
@@ -158,12 +401,24 @@ export function AssetCatalogShell() {
 
           <div className="xl:sticky xl:top-6 xl:self-start">
             <ReservationPreview
-              asset={selectedAsset}
+              asset={focusedAsset}
               categoryLabel={selectedCategoryLabel}
-              onClearSelection={() => startTransition(() => setSelectedAssetId(null))}
-              onResetFilters={handleResetFilters}
-              preview={selectedPreview}
+              checklist={plannerSnapshot.checklist}
+              conflicts={plannerSnapshot.conflicts}
+              coveredCategories={plannerSnapshot.coveredCategories}
+              crewProfile={activeCrewProfile}
+              forecast={focusedForecast}
+              intent={activeIntent}
+              missingCategories={plannerSnapshot.missingCategories}
+              planAssets={plannerSnapshot.planAssets}
+              preview={focusedPreview}
+              recommendations={plannerSnapshot.recommendations}
+              resolveAssetName={resolveAssetName}
               selectionHidden={selectionHidden}
+              window={activeWindow}
+              onClearPlan={() => startTransition(() => setPlannedAssetIds([]))}
+              onClearSelection={() => startTransition(() => setFocusedAssetId(null))}
+              onResetFilters={handleResetFilters}
             />
           </div>
         </div>

--- a/src/components/asset-catalog/bundle-recommendations.tsx
+++ b/src/components/asset-catalog/bundle-recommendations.tsx
@@ -1,0 +1,116 @@
+import type { BundleRecommendation } from "@/app/asset-catalog/planner";
+
+type BundleRecommendationsProps = {
+  plannedAssetIds: string[];
+  recommendations: BundleRecommendation[];
+  resolveAssetName: (assetId: string) => string;
+  onApplyBundle: (assetIds: string[], heroAssetId: string) => void;
+  onInspectAsset: (assetId: string) => void;
+};
+
+const statusStyles = {
+  "Ready to apply": "border-emerald-200 bg-emerald-50 text-emerald-900",
+  "Needs one swap": "border-amber-200 bg-amber-50 text-amber-900",
+  "Needs review": "border-rose-200 bg-rose-50 text-rose-900",
+} as const;
+
+export function BundleRecommendations({
+  plannedAssetIds,
+  recommendations,
+  resolveAssetName,
+  onApplyBundle,
+  onInspectAsset,
+}: BundleRecommendationsProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-slate-200/80 bg-white/92 p-5 shadow-[0_20px_70px_-46px_rgba(15,23,42,0.4)]">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+            Bundle Recommendations
+          </p>
+          <h2 className="mt-2 text-xl font-semibold tracking-tight text-slate-900">
+            Apply a starter kit, then fine-tune the reservation draft.
+          </h2>
+        </div>
+        <p className="text-sm text-slate-600">
+          {plannedAssetIds.length === 0
+            ? "No assets in the draft yet."
+            : `${plannedAssetIds.length} asset${
+                plannedAssetIds.length === 1 ? "" : "s"
+              } already staged in the draft.`}
+        </p>
+      </div>
+
+      <div className="mt-5 grid gap-4 xl:grid-cols-3">
+        {recommendations.map((recommendation) => {
+          const bundleAssetNames = recommendation.assetIds.map(resolveAssetName);
+
+          return (
+            <article
+              key={recommendation.id}
+              className="rounded-[1.55rem] border border-slate-200 bg-slate-50/90 p-4"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h3 className="text-lg font-semibold text-slate-900">
+                    {recommendation.label}
+                  </h3>
+                  <p className="mt-2 text-sm leading-6 text-slate-600">
+                    {recommendation.summary}
+                  </p>
+                </div>
+                <span
+                  className={`rounded-full border px-2.5 py-1 text-xs font-medium ${
+                    statusStyles[recommendation.statusLabel]
+                  }`}
+                >
+                  {recommendation.statusLabel}
+                </span>
+              </div>
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                {bundleAssetNames.map((assetName) => (
+                  <span
+                    key={`${recommendation.id}:${assetName}`}
+                    className="rounded-full bg-white px-2.5 py-1 text-xs font-medium text-slate-600"
+                  >
+                    {assetName}
+                  </span>
+                ))}
+              </div>
+
+              <div className="mt-4 rounded-2xl border border-slate-200 bg-white px-3 py-3 text-sm text-slate-700">
+                <p className="font-medium text-slate-900">{recommendation.coverageLabel}</p>
+                <p className="mt-2">{recommendation.reason}</p>
+                <p className="mt-2 text-slate-600">{recommendation.caution}</p>
+              </div>
+
+              <div className="mt-4 flex flex-wrap gap-3">
+                <button
+                  aria-label={`Apply bundle: ${recommendation.label}`}
+                  className="rounded-full bg-cyan-950 px-4 py-2 text-sm font-medium text-white transition hover:bg-cyan-900"
+                  onClick={() =>
+                    onApplyBundle(recommendation.assetIds, recommendation.heroAssetId)
+                  }
+                  type="button"
+                >
+                  Apply bundle
+                </button>
+                <button
+                  aria-label={`Inspect hero asset: ${resolveAssetName(
+                    recommendation.heroAssetId,
+                  )}`}
+                  className="rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-100"
+                  onClick={() => onInspectAsset(recommendation.heroAssetId)}
+                  type="button"
+                >
+                  Inspect hero asset
+                </button>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/asset-catalog/catalog-controls.tsx
+++ b/src/components/asset-catalog/catalog-controls.tsx
@@ -1,33 +1,69 @@
-import type { AssetAvailability, AvailabilityOption } from "@/app/asset-catalog/mock-data";
+import type {
+  AssetAvailability,
+  AvailabilityOption,
+  CrewProfile,
+  PlanningWindow,
+  ReservationIntent,
+} from "@/app/asset-catalog/mock-data";
 
 type CatalogControlsProps = {
   activeAvailability: AssetAvailability | "all";
+  activeCrewProfileId: CrewProfile["id"];
+  activeIntentId: ReservationIntent["id"];
+  activeWindowId: PlanningWindow["id"];
   availabilityCounts: Array<AvailabilityOption & { count: number }>;
+  crewProfiles: CrewProfile[];
+  flexibleMatching: boolean;
   hasFilters: boolean;
+  hasPlanningChanges: boolean;
+  intents: ReservationIntent[];
   onAvailabilityChange: (availability: AssetAvailability | "all") => void;
+  onCrewProfileChange: (crewProfileId: CrewProfile["id"]) => void;
+  onFlexibleMatchingChange: (value: boolean) => void;
+  onIntentChange: (intentId: ReservationIntent["id"]) => void;
   onQueryChange: (query: string) => void;
-  onReset: () => void;
+  onResetFilters: () => void;
+  onResetPlanner: () => void;
+  onWindowChange: (windowId: PlanningWindow["id"]) => void;
+  planCount: number;
   query: string;
   resultCount: number;
   totalCount: number;
+  windows: PlanningWindow[];
 };
 
 export function CatalogControls({
   activeAvailability,
+  activeCrewProfileId,
+  activeIntentId,
+  activeWindowId,
   availabilityCounts,
+  crewProfiles,
+  flexibleMatching,
   hasFilters,
+  hasPlanningChanges,
+  intents,
   onAvailabilityChange,
+  onCrewProfileChange,
+  onFlexibleMatchingChange,
+  onIntentChange,
   onQueryChange,
-  onReset,
+  onResetFilters,
+  onResetPlanner,
+  onWindowChange,
+  planCount,
   query,
   resultCount,
   totalCount,
+  windows,
 }: CatalogControlsProps) {
   return (
-    <section className="rounded-[1.75rem] border border-slate-200/80 bg-white/90 p-5 shadow-[0_20px_70px_-46px_rgba(15,23,42,0.4)]">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+    <section className="rounded-[1.75rem] border border-slate-200/80 bg-white/92 p-5 shadow-[0_20px_70px_-46px_rgba(15,23,42,0.4)]">
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
         <label className="flex-1 space-y-2">
-          <span className="text-sm font-medium text-slate-700">Search inventory</span>
+          <span className="text-sm font-medium text-slate-700">
+            Search inventory
+          </span>
           <input
             aria-label="Search assets"
             className="w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-cyan-500 focus:bg-white"
@@ -37,55 +73,170 @@ export function CatalogControls({
             value={query}
           />
         </label>
-        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
-          Showing <span className="font-semibold text-slate-900">{resultCount}</span> of{" "}
-          <span className="font-semibold text-slate-900">{totalCount}</span> assets
+        <div className="grid gap-3 sm:grid-cols-2 xl:min-w-[20rem]">
+          <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+            Showing <span className="font-semibold text-slate-900">{resultCount}</span>{" "}
+            of <span className="font-semibold text-slate-900">{totalCount}</span> assets
+          </div>
+          <div className="rounded-2xl border border-cyan-200 bg-cyan-50 px-4 py-3 text-sm text-cyan-900">
+            Draft reservation:{" "}
+            <span className="font-semibold">
+              {planCount} asset{planCount === 1 ? "" : "s"}
+            </span>
+          </div>
         </div>
       </div>
 
-      <div className="mt-5 flex flex-wrap gap-2">
-        <button
-          aria-pressed={activeAvailability === "all"}
-          className={`rounded-full border px-3.5 py-2 text-sm font-medium transition ${
-            activeAvailability === "all"
-              ? "border-cyan-700 bg-cyan-950 text-white"
-              : "border-slate-200 bg-white text-slate-700 hover:border-cyan-200 hover:bg-cyan-50"
-          }`}
-          onClick={() => onAvailabilityChange("all")}
-          type="button"
-        >
-          Any status
-        </button>
-        {availabilityCounts.map((availability) => (
+      <div className="mt-5">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+          Availability filter
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2">
           <button
-            key={availability.id}
-            aria-pressed={activeAvailability === availability.id}
+            aria-pressed={activeAvailability === "all"}
             className={`rounded-full border px-3.5 py-2 text-sm font-medium transition ${
-              activeAvailability === availability.id
+              activeAvailability === "all"
                 ? "border-cyan-700 bg-cyan-950 text-white"
                 : "border-slate-200 bg-white text-slate-700 hover:border-cyan-200 hover:bg-cyan-50"
             }`}
-            onClick={() => onAvailabilityChange(availability.id)}
+            onClick={() => onAvailabilityChange("all")}
             type="button"
           >
-            {availability.label} - {availability.count}
+            Any status
           </button>
-        ))}
+          {availabilityCounts.map((availability) => (
+            <button
+              key={availability.id}
+              aria-pressed={activeAvailability === availability.id}
+              className={`rounded-full border px-3.5 py-2 text-sm font-medium transition ${
+                activeAvailability === availability.id
+                  ? "border-cyan-700 bg-cyan-950 text-white"
+                  : "border-slate-200 bg-white text-slate-700 hover:border-cyan-200 hover:bg-cyan-50"
+              }`}
+              onClick={() => onAvailabilityChange(availability.id)}
+              type="button"
+            >
+              {availability.label} - {availability.count}
+            </button>
+          ))}
+        </div>
       </div>
 
-      <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <p className="text-sm text-slate-600">
-          Availability filters stay local to this route and only affect the mock asset catalog below.
-        </p>
-        {hasFilters ? (
-          <button
-            className="rounded-full border border-slate-300 px-3.5 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-100"
-            onClick={onReset}
-            type="button"
-          >
-            Reset search and filters
-          </button>
-        ) : null}
+      <div className="mt-5 grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)]">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+            Reservation intent
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {intents.map((intent) => (
+              <button
+                key={intent.id}
+                aria-pressed={activeIntentId === intent.id}
+                className={`rounded-full border px-3.5 py-2 text-sm font-medium transition ${
+                  activeIntentId === intent.id
+                    ? "border-cyan-700 bg-cyan-950 text-white"
+                    : "border-slate-200 bg-white text-slate-700 hover:border-cyan-200 hover:bg-cyan-50"
+                }`}
+                onClick={() => onIntentChange(intent.id)}
+                type="button"
+              >
+                {intent.label}
+              </button>
+            ))}
+          </div>
+          <p className="mt-3 text-sm leading-6 text-slate-600">
+            Use the reservation intent to bias bundle recommendations and conflict
+            checks toward the type of pickup you are planning.
+          </p>
+        </div>
+
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+            Pickup window
+          </p>
+          <div className="mt-3 grid gap-2 sm:grid-cols-2">
+            {windows.map((window) => (
+              <button
+                key={window.id}
+                aria-pressed={activeWindowId === window.id}
+                className={`rounded-2xl border px-3.5 py-3 text-left text-sm font-medium transition ${
+                  activeWindowId === window.id
+                    ? "border-cyan-700 bg-cyan-950 text-white"
+                    : "border-slate-200 bg-slate-50 text-slate-700 hover:border-cyan-200 hover:bg-cyan-50"
+                }`}
+                onClick={() => onWindowChange(window.id)}
+                type="button"
+              >
+                <span className="block">{window.label}</span>
+                <span
+                  className={`mt-1 block text-xs ${
+                    activeWindowId === window.id ? "text-cyan-100" : "text-slate-500"
+                  }`}
+                >
+                  {window.pressureLabel}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-5 xl:grid-cols-[minmax(0,1fr)_auto] xl:items-end">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+            Crew footprint
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {crewProfiles.map((crewProfile) => (
+              <button
+                key={crewProfile.id}
+                aria-pressed={activeCrewProfileId === crewProfile.id}
+                className={`rounded-full border px-3.5 py-2 text-sm font-medium transition ${
+                  activeCrewProfileId === crewProfile.id
+                    ? "border-cyan-700 bg-cyan-950 text-white"
+                    : "border-slate-200 bg-white text-slate-700 hover:border-cyan-200 hover:bg-cyan-50"
+                }`}
+                onClick={() => onCrewProfileChange(crewProfile.id)}
+                type="button"
+              >
+                {crewProfile.label}
+              </button>
+            ))}
+          </div>
+          <label className="mt-4 flex items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+            <input
+              checked={flexibleMatching}
+              className="h-4 w-4 rounded border-slate-300 text-cyan-950 focus:ring-cyan-700"
+              onChange={(event) => onFlexibleMatchingChange(event.target.checked)}
+              type="checkbox"
+            />
+            <span>
+              Allow flexible substitutes when the planner hits holds or existing
+              reservations.
+            </span>
+          </label>
+        </div>
+
+        <div className="flex flex-wrap gap-3">
+          {hasFilters ? (
+            <button
+              className="rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:bg-slate-100"
+              onClick={onResetFilters}
+              type="button"
+            >
+              Reset search and filters
+            </button>
+          ) : null}
+          {hasPlanningChanges ? (
+            <button
+              className="rounded-full border border-cyan-200 bg-cyan-50 px-4 py-2 text-sm font-medium text-cyan-950 transition hover:border-cyan-300 hover:bg-cyan-100"
+              onClick={onResetPlanner}
+              type="button"
+            >
+              Reset planner
+            </button>
+          ) : null}
+        </div>
       </div>
     </section>
   );

--- a/src/components/asset-catalog/forecast-board.tsx
+++ b/src/components/asset-catalog/forecast-board.tsx
@@ -1,0 +1,173 @@
+import {
+  planningWindows,
+  type AssetCatalogItem,
+  type PlanningWindowId,
+} from "@/app/asset-catalog/mock-data";
+import { getAssetForecast } from "@/app/asset-catalog/planner";
+
+type ForecastBoardProps = {
+  activeWindowId: PlanningWindowId;
+  assets: AssetCatalogItem[];
+  focusedAssetId: string | null;
+  onInspectAsset: (assetId: string) => void;
+};
+
+const forecastStyles = {
+  clear: "border-emerald-200 bg-emerald-50 text-emerald-900",
+  tight: "border-amber-200 bg-amber-50 text-amber-900",
+  conflict: "border-rose-200 bg-rose-50 text-rose-900",
+} as const;
+
+export function ForecastBoard({
+  activeWindowId,
+  assets,
+  focusedAssetId,
+  onInspectAsset,
+}: ForecastBoardProps) {
+  if (assets.length === 0) {
+    return (
+      <section className="rounded-[1.75rem] border border-dashed border-slate-300 bg-white/85 p-6 text-center shadow-[0_20px_70px_-46px_rgba(15,23,42,0.38)]">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+          Forecast Board
+        </p>
+        <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900">
+          Add an asset to the draft to compare upcoming pickup pressure.
+        </h2>
+        <p className="mt-3 text-sm leading-6 text-slate-600">
+          The forecast board becomes more useful once at least one asset is under
+          consideration for the reservation.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-[1.75rem] border border-slate-200/80 bg-white/92 p-5 shadow-[0_20px_70px_-46px_rgba(15,23,42,0.4)]">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+            Forecast Board
+          </p>
+          <h2 className="mt-2 text-xl font-semibold tracking-tight text-slate-900">
+            Compare availability pressure before locking the pickup window.
+          </h2>
+        </div>
+        <p className="text-sm text-slate-600">
+          Active planning window:{" "}
+          <span className="font-semibold text-slate-900">
+            {planningWindows.find((window) => window.id === activeWindowId)?.label}
+          </span>
+        </p>
+      </div>
+
+      <div className="mt-5 space-y-4">
+        {assets.map((asset) => {
+          const activeForecast = getAssetForecast(asset.id, activeWindowId);
+          const isFocused = focusedAssetId === asset.id;
+
+          return (
+            <article
+              key={asset.id}
+              className={`rounded-[1.55rem] border p-4 transition ${
+                isFocused
+                  ? "border-cyan-700 bg-cyan-950 text-white shadow-[0_16px_45px_-28px_rgba(8,145,178,0.85)]"
+                  : "border-slate-200 bg-slate-50"
+              }`}
+            >
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                <div className="max-w-2xl">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <h3 className="text-lg font-semibold">{asset.name}</h3>
+                    <span
+                      className={`rounded-full px-2.5 py-1 text-xs font-medium ${
+                        isFocused ? "bg-white/10 text-cyan-50" : "bg-white text-slate-600"
+                      }`}
+                    >
+                      {asset.zone}
+                    </span>
+                  </div>
+                  <p
+                    className={`mt-2 text-sm leading-6 ${
+                      isFocused ? "text-cyan-50" : "text-slate-600"
+                    }`}
+                  >
+                    {asset.summary}
+                  </p>
+                </div>
+                <button
+                  aria-label={`Inspect forecast asset: ${asset.name}`}
+                  className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                    isFocused
+                      ? "bg-white text-cyan-950 hover:bg-cyan-50"
+                      : "border border-slate-300 bg-white text-slate-700 hover:border-slate-400 hover:bg-slate-100"
+                  }`}
+                  onClick={() => onInspectAsset(asset.id)}
+                  type="button"
+                >
+                  {isFocused ? "Focused in planner" : "Focus in planner"}
+                </button>
+              </div>
+
+              <div className="mt-4 grid gap-3 lg:grid-cols-4">
+                {planningWindows.map((window) => {
+                  const forecast = getAssetForecast(asset.id, window.id);
+
+                  if (!forecast) {
+                    return null;
+                  }
+
+                  return (
+                    <div
+                      key={`${asset.id}:${window.id}`}
+                      className={`rounded-2xl border px-3 py-3 ${
+                        isFocused ? "border-white/15 bg-white/10" : "border-slate-200 bg-white"
+                      }`}
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <p
+                          className={`text-xs uppercase tracking-[0.2em] ${
+                            isFocused ? "text-cyan-100" : "text-slate-500"
+                          }`}
+                        >
+                          {window.label}
+                        </p>
+                        <span
+                          className={`rounded-full border px-2.5 py-1 text-xs font-medium ${
+                            isFocused
+                              ? "border-white/15 bg-white/10 text-white"
+                              : forecastStyles[forecast.status]
+                          }`}
+                        >
+                          {forecast.coverageLabel}
+                        </span>
+                      </div>
+                      <p
+                        className={`mt-3 text-sm leading-6 ${
+                          isFocused ? "text-cyan-50" : "text-slate-600"
+                        }`}
+                      >
+                        {forecast.note}
+                      </p>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {activeForecast ? (
+                <p
+                  className={`mt-4 rounded-2xl px-3 py-3 text-sm leading-6 ${
+                    isFocused
+                      ? "bg-white/10 text-cyan-50"
+                      : "bg-slate-900 text-slate-100"
+                  }`}
+                >
+                  Active window note: {activeForecast.note}
+                </p>
+              ) : null}
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/asset-catalog/planner-tabs.tsx
+++ b/src/components/asset-catalog/planner-tabs.tsx
@@ -1,0 +1,60 @@
+type PlannerView = {
+  id: string;
+  label: string;
+  summary: string;
+  badge: string;
+};
+
+type PlannerTabsProps = {
+  activeView: string;
+  views: PlannerView[];
+  onChange: (viewId: string) => void;
+};
+
+export function PlannerTabs({
+  activeView,
+  views,
+  onChange,
+}: PlannerTabsProps) {
+  return (
+    <section className="rounded-[1.75rem] border border-slate-200/80 bg-white/90 p-3 shadow-[0_20px_70px_-46px_rgba(15,23,42,0.4)]">
+      <div className="grid gap-3 lg:grid-cols-3">
+        {views.map((view) => {
+          const isActive = view.id === activeView;
+
+          return (
+            <button
+              key={view.id}
+              aria-pressed={isActive}
+              className={`rounded-[1.45rem] border px-4 py-4 text-left transition ${
+                isActive
+                  ? "border-cyan-700 bg-cyan-950 text-white shadow-[0_16px_45px_-28px_rgba(8,145,178,0.9)]"
+                  : "border-slate-200 bg-slate-50 text-slate-900 hover:border-cyan-200 hover:bg-cyan-50"
+              }`}
+              onClick={() => onChange(view.id)}
+              type="button"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-sm font-semibold">{view.label}</span>
+                <span
+                  className={`rounded-full px-2.5 py-1 text-xs font-medium ${
+                    isActive ? "bg-white/15 text-white" : "bg-white text-slate-600"
+                  }`}
+                >
+                  {view.badge}
+                </span>
+              </div>
+              <p
+                className={`mt-2 text-sm leading-6 ${
+                  isActive ? "text-cyan-50" : "text-slate-600"
+                }`}
+              >
+                {view.summary}
+              </p>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/asset-catalog/reservation-preview.tsx
+++ b/src/components/asset-catalog/reservation-preview.tsx
@@ -1,48 +1,120 @@
-import type { AssetCatalogItem, ReservationPreview as ReservationPreviewData } from "@/app/asset-catalog/mock-data";
+import type {
+  AssetCatalogItem,
+  AssetCategory,
+  AssetForecast,
+  CrewProfile,
+  PlanningWindow,
+  ReservationIntent,
+  ReservationPreview as ReservationPreviewData,
+} from "@/app/asset-catalog/mock-data";
+import type {
+  BundleRecommendation,
+  PlannerConflict,
+} from "@/app/asset-catalog/planner";
 
 type ReservationPreviewProps = {
   asset: AssetCatalogItem | null;
   categoryLabel: string | null;
+  checklist: string[];
+  conflicts: PlannerConflict[];
+  coveredCategories: AssetCategory[];
+  crewProfile: CrewProfile;
+  forecast: AssetForecast | null;
+  intent: ReservationIntent;
+  missingCategories: AssetCategory[];
+  planAssets: AssetCatalogItem[];
   preview: ReservationPreviewData | null;
+  recommendations: BundleRecommendation[];
   selectionHidden: boolean;
+  window: PlanningWindow;
+  resolveAssetName: (assetId: string) => string;
+  onClearPlan: () => void;
   onClearSelection: () => void;
   onResetFilters: () => void;
 };
 
-const availabilityCopy = {
-  available: "Ready to be staged immediately.",
-  reserved: "Already assigned to an upcoming checkout.",
-  hold: "Blocked until the current hold condition is cleared.",
-  maintenance: "Unavailable while service work is in progress.",
+const forecastCopy = {
+  clear: "No blocking forecast signal in the active pickup window.",
+  tight: "Demand is elevated, so keep alternates ready before confirming.",
+  conflict: "The current window is likely to collide with another staged reservation.",
+} as const;
+
+const conflictStyles = {
+  note: "border-slate-200 bg-slate-50 text-slate-800",
+  warning: "border-amber-200 bg-amber-50 text-amber-900",
+  blocking: "border-rose-200 bg-rose-50 text-rose-900",
 } as const;
 
 export function ReservationPreview({
   asset,
   categoryLabel,
+  checklist,
+  conflicts,
+  coveredCategories,
+  crewProfile,
+  forecast,
+  intent,
+  missingCategories,
+  planAssets,
   preview,
+  recommendations,
   selectionHidden,
+  window,
+  resolveAssetName,
+  onClearPlan,
   onClearSelection,
   onResetFilters,
 }: ReservationPreviewProps) {
-  if (!asset) {
+  if (!asset && planAssets.length === 0) {
+    const topRecommendation = recommendations[0];
+
     return (
       <aside className="rounded-[1.9rem] border border-dashed border-slate-300 bg-white/80 p-6 shadow-[0_20px_70px_-46px_rgba(15,23,42,0.38)]">
-        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">Reservation Preview</p>
-        <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900">Select an asset to inspect its handoff plan.</h2>
-        <p className="mt-3 text-sm leading-6 text-slate-600">
-          The side panel stays empty until you choose a card from the catalog. Selection and preview copy stay local to this route.
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+          Reservation Preview
         </p>
+        <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900">
+          Start a draft by adding assets or applying a recommended bundle.
+        </h2>
+        <p className="mt-3 text-sm leading-6 text-slate-600">
+          The planner will turn selected assets into a reservation preview with
+          forecast warnings, missing coverage, and handoff notes.
+        </p>
+        {topRecommendation ? (
+          <div className="mt-5 rounded-[1.5rem] border border-cyan-200 bg-cyan-50 px-4 py-4">
+            <p className="text-xs uppercase tracking-[0.2em] text-cyan-700">
+              Suggested Starter
+            </p>
+            <h3 className="mt-2 text-lg font-semibold text-cyan-950">
+              {topRecommendation.label}
+            </h3>
+            <p className="mt-2 text-sm leading-6 text-cyan-900">
+              {topRecommendation.summary}
+            </p>
+            <p className="mt-3 text-sm text-cyan-900">
+              Hero asset:{" "}
+              <span className="font-semibold">
+                {resolveAssetName(topRecommendation.heroAssetId)}
+              </span>
+            </p>
+          </div>
+        ) : null}
       </aside>
     );
   }
 
-  if (selectionHidden) {
+  if (selectionHidden && asset) {
     return (
       <aside className="rounded-[1.9rem] border border-amber-200 bg-amber-50/90 p-6 shadow-[0_20px_70px_-46px_rgba(15,23,42,0.38)]">
-        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-amber-700">Reservation Preview</p>
-        <h2 className="mt-3 text-2xl font-semibold tracking-tight text-amber-950">{asset.name} is outside the current filters.</h2>
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-amber-700">
+          Reservation Preview
+        </p>
+        <h2 className="mt-3 text-2xl font-semibold tracking-tight text-amber-950">
+          {asset.name} is outside the current filters.
+        </h2>
         <p className="mt-3 text-sm leading-6 text-amber-900">
-          The asset is still selected, but the active search or availability filter removed it from the visible catalog.
+          The asset remains focused in the reservation draft, but the active search
+          or availability filter removed it from the visible catalog.
         </p>
         <div className="mt-5 flex flex-wrap gap-3">
           <button
@@ -57,72 +129,244 @@ export function ReservationPreview({
             onClick={onClearSelection}
             type="button"
           >
-            Clear selection
+            Clear focus
           </button>
         </div>
       </aside>
     );
   }
 
+  const coverageLabel =
+    coveredCategories.length > 0
+      ? coveredCategories.map((category) => category.label).join(", ")
+      : "No categories covered yet";
+  const missingLabel =
+    missingCategories.length > 0
+      ? missingCategories.map((category) => category.label).join(", ")
+      : "None";
+  const topRecommendation = recommendations[0];
+
   return (
     <aside className="rounded-[1.9rem] border border-slate-200/80 bg-white/92 p-6 shadow-[0_20px_70px_-46px_rgba(15,23,42,0.38)]">
       <div className="flex items-start justify-between gap-3">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">Reservation Preview</p>
-          <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900">{asset.name}</h2>
-          <p className="mt-2 text-sm text-slate-600">{categoryLabel ?? asset.categoryId} - {asset.zone}</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+            Reservation Preview
+          </p>
+          <h2 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900">
+            {asset ? asset.name : "Draft reservation"}
+          </h2>
+          <p className="mt-2 text-sm text-slate-600">
+            {asset ? `${categoryLabel ?? asset.categoryId} - ${asset.zone}` : "No hero asset selected"}{" "}
+            · {window.pickupLabel}
+          </p>
         </div>
-        <button
-          className="rounded-full border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100"
-          onClick={onClearSelection}
-          type="button"
-        >
-          Deselect
-        </button>
+        <div className="flex flex-wrap gap-2">
+          {asset ? (
+            <button
+              className="rounded-full border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100"
+              onClick={onClearSelection}
+              type="button"
+            >
+              Clear focus
+            </button>
+          ) : null}
+          {planAssets.length > 0 ? (
+            <button
+              className="rounded-full border border-cyan-200 bg-cyan-50 px-3 py-2 text-sm font-medium text-cyan-950 transition hover:border-cyan-300 hover:bg-cyan-100"
+              onClick={onClearPlan}
+              type="button"
+            >
+              Clear draft
+            </button>
+          ) : null}
+        </div>
       </div>
 
-      <div className="mt-5 rounded-[1.5rem] bg-slate-950 px-4 py-4 text-slate-50">
-        <p className="text-xs uppercase tracking-[0.22em] text-cyan-200">Availability</p>
-        <p className="mt-2 text-xl font-semibold capitalize">{asset.availability}</p>
-        <p className="mt-2 text-sm leading-6 text-slate-300">{availabilityCopy[asset.availability]}</p>
+      <div className="mt-5 grid gap-3 sm:grid-cols-2">
+        <div className="rounded-[1.5rem] bg-slate-950 px-4 py-4 text-slate-50">
+          <p className="text-xs uppercase tracking-[0.22em] text-cyan-200">
+            Planning Window
+          </p>
+          <p className="mt-2 text-xl font-semibold">{window.label}</p>
+          <p className="mt-2 text-sm leading-6 text-slate-300">{window.note}</p>
+        </div>
+        <div className="rounded-[1.5rem] border border-slate-200 bg-slate-50 px-4 py-4">
+          <p className="text-xs uppercase tracking-[0.22em] text-slate-500">
+            Draft Settings
+          </p>
+          <p className="mt-2 text-lg font-semibold text-slate-900">
+            {intent.label} · {crewProfile.label}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-slate-600">
+            {intent.summary}
+          </p>
+        </div>
       </div>
 
-      {preview ? (
-        <div className="mt-5 space-y-5">
-          <div className="grid gap-3 sm:grid-cols-2">
-            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
-              <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Requester</p>
-              <p className="mt-2 text-lg font-semibold text-slate-900">{preview.requester}</p>
-              <p className="mt-1 text-sm text-slate-600">{preview.project}</p>
-            </div>
-            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
-              <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Handoff</p>
-              <p className="mt-2 text-sm font-medium text-slate-900">{preview.pickupWindow}</p>
-              <p className="mt-1 text-sm text-slate-600">{preview.handoffZone}</p>
-            </div>
+      {forecast && asset ? (
+        <div className="mt-5 rounded-[1.5rem] border border-slate-200 bg-white px-4 py-4">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-sm font-semibold text-slate-900">Hero asset forecast</p>
+            <span className="rounded-full bg-cyan-50 px-2.5 py-1 text-xs font-medium text-cyan-800">
+              {forecast.coverageLabel}
+            </span>
           </div>
+          <p className="mt-3 text-sm leading-6 text-slate-700">{forecast.note}</p>
+          <p className="mt-2 text-sm text-slate-600">{forecastCopy[forecast.status]}</p>
+        </div>
+      ) : null}
 
-          <div className="rounded-2xl border border-slate-200 bg-white px-4 py-4">
-            <div className="flex items-center justify-between gap-3">
-              <p className="text-sm font-semibold text-slate-900">Return window</p>
-              <span className="rounded-full bg-cyan-50 px-2.5 py-1 text-xs font-medium text-cyan-800">{preview.returnWindow}</span>
-            </div>
-            <ul className="mt-4 space-y-3 text-sm text-slate-700">
-              {preview.checklist.map((item) => (
-                <li key={item}>- {item}</li>
-              ))}
-            </ul>
-            <p className="mt-4 rounded-2xl bg-slate-50 px-3 py-3 text-sm leading-6 text-slate-600">{preview.note}</p>
+      <div className="mt-5 rounded-[1.5rem] border border-slate-200 bg-white px-4 py-4">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-sm font-semibold text-slate-900">Draft assets</p>
+          <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700">
+            {planAssets.length} selected
+          </span>
+        </div>
+        {planAssets.length > 0 ? (
+          <div className="mt-4 flex flex-wrap gap-2">
+            {planAssets.map((planAsset) => (
+              <span
+                key={planAsset.id}
+                className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700"
+              >
+                {planAsset.name}
+              </span>
+            ))}
           </div>
+        ) : (
+          <p className="mt-3 text-sm leading-6 text-slate-600">
+            No assets are locked into the draft yet. Focusing an asset gives the
+            planner a starting point for recommendations.
+          </p>
+        )}
+      </div>
+
+      <div className="mt-5 grid gap-3 sm:grid-cols-2">
+        <div className="rounded-[1.5rem] border border-slate-200 bg-slate-50 px-4 py-4">
+          <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+            Covered Lanes
+          </p>
+          <p className="mt-2 text-sm leading-6 text-slate-900">{coverageLabel}</p>
+        </div>
+        <div className="rounded-[1.5rem] border border-slate-200 bg-slate-50 px-4 py-4">
+          <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+            Missing Before Checkout
+          </p>
+          <p className="mt-2 text-sm leading-6 text-slate-900">{missingLabel}</p>
+        </div>
+      </div>
+
+      {conflicts.length > 0 ? (
+        <div className="mt-5 space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-sm font-semibold text-slate-900">Conflicts and notes</p>
+            <span className="rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700">
+              {conflicts.length} signal{conflicts.length === 1 ? "" : "s"}
+            </span>
+          </div>
+          {conflicts.map((conflict) => (
+            <div
+              key={conflict.id}
+              className={`rounded-[1.35rem] border px-4 py-4 ${conflictStyles[conflict.severity]}`}
+            >
+              <p className="text-sm font-semibold">{conflict.title}</p>
+              <p className="mt-2 text-sm leading-6">{conflict.detail}</p>
+              <p className="mt-2 text-sm">{conflict.resolution}</p>
+            </div>
+          ))}
         </div>
       ) : (
-        <div className="mt-5 rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-5">
-          <p className="text-sm font-semibold text-slate-900">No reservation is attached to this asset yet.</p>
-          <p className="mt-2 text-sm leading-6 text-slate-600">
-            {asset.nextWindow} This panel stays local and can represent either an empty scheduling slate or a simple ready-to-book handoff.
+        <div className="mt-5 rounded-[1.5rem] border border-emerald-200 bg-emerald-50 px-4 py-4 text-emerald-900">
+          <p className="text-sm font-semibold">No blocking conflicts in the current draft.</p>
+          <p className="mt-2 text-sm leading-6">
+            The selected assets align with the active reservation window and intent.
           </p>
         </div>
       )}
+
+      {preview ? (
+        <div className="mt-5 rounded-[1.5rem] border border-slate-200 bg-white px-4 py-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <p className="text-sm font-semibold text-slate-900">
+                Existing reservation on this asset
+              </p>
+              <p className="mt-2 text-lg font-semibold text-slate-900">
+                {preview.project}
+              </p>
+              <p className="mt-1 text-sm text-slate-600">{preview.requester}</p>
+            </div>
+            <div className="rounded-full bg-cyan-50 px-3 py-2 text-xs font-medium text-cyan-900">
+              {preview.pickupWindow}
+            </div>
+          </div>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-3 py-3">
+              <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                Return window
+              </p>
+              <p className="mt-2 text-sm font-medium text-slate-900">
+                {preview.returnWindow}
+              </p>
+              <p className="mt-1 text-sm text-slate-600">{preview.handoffZone}</p>
+            </div>
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 px-3 py-3">
+              <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                Attached signals
+              </p>
+              <ul className="mt-2 space-y-2 text-sm text-slate-700">
+                {preview.conflicts.length > 0 ? (
+                  preview.conflicts.map((conflict) => (
+                    <li key={conflict}>- {conflict}</li>
+                  ))
+                ) : (
+                  <li>- No active conflicts on the current reservation.</li>
+                )}
+              </ul>
+            </div>
+          </div>
+          <p className="mt-4 rounded-2xl bg-slate-50 px-3 py-3 text-sm leading-6 text-slate-600">
+            {preview.note}
+          </p>
+        </div>
+      ) : null}
+
+      <div className="mt-5 rounded-[1.5rem] border border-slate-200 bg-slate-50 px-4 py-4">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-sm font-semibold text-slate-900">Reservation checklist</p>
+          <span className="rounded-full bg-white px-2.5 py-1 text-xs font-medium text-slate-600">
+            {checklist.length} items
+          </span>
+        </div>
+        <ul className="mt-4 space-y-2 text-sm text-slate-700">
+          {checklist.map((item) => (
+            <li key={item}>- {item}</li>
+          ))}
+        </ul>
+      </div>
+
+      {topRecommendation ? (
+        <div className="mt-5 rounded-[1.5rem] border border-cyan-200 bg-cyan-50 px-4 py-4">
+          <p className="text-xs uppercase tracking-[0.2em] text-cyan-700">
+            Best Next Recommendation
+          </p>
+          <h3 className="mt-2 text-lg font-semibold text-cyan-950">
+            {topRecommendation.label}
+          </h3>
+          <p className="mt-2 text-sm leading-6 text-cyan-900">
+            {topRecommendation.reason}
+          </p>
+          <p className="mt-2 text-sm text-cyan-900">{topRecommendation.caution}</p>
+          <p className="mt-3 text-sm text-cyan-900">
+            Includes:{" "}
+            <span className="font-medium">
+              {topRecommendation.assetIds.map(resolveAssetName).join(", ")}
+            </span>
+          </p>
+        </div>
+      ) : null}
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- expand the Asset Catalog into a reservation planning workspace with intent, pickup-window, crew, and substitute controls
- add forecast-driven bundle recommendations, actionable draft selection, and a richer reservation preview panel
- add planner helper coverage plus shell interaction tests for planning, forecasting, and hidden-selection recovery

## Testing
- npm run typecheck
- npm run lint -- src/app/asset-catalog src/components/asset-catalog
- npx vitest run src/app/asset-catalog/planner.test.ts src/components/asset-catalog/asset-catalog-shell.test.tsx

## Notes
- `npm test` still times out in several unrelated existing suites when run end-to-end locally; the new Asset Catalog tests pass in isolation.

Closes #66