### PR TITLE
feat: add parcel hub route balancing simulator

### DIFF
--- a/src/app/parcel-hub/page.tsx
+++ b/src/app/parcel-hub/page.tsx
@@ -3,7 +3,8 @@ import { ParcelHubShell } from "@/components/parcel-hub/parcel-hub-shell";
 
 export const metadata: Metadata = {
   title: "Parcel Hub | API Test",
-  description: "Mock parcel operations route with lane summaries and local exception handling.",
+  description:
+    "Mock parcel operations route with route-balancing simulation, SLA risk views, and exception previews.",
 };
 
 export default function ParcelHubPage() {

--- a/src/components/mission-briefing/MissionBriefingShell.test.tsx
+++ b/src/components/mission-briefing/MissionBriefingShell.test.tsx
@@ -6,45 +6,57 @@ import { missionScenarios } from "@/app/mission-briefing/mission-data";
 import { MissionBriefingShell } from "./MissionBriefingShell";
 
 describe("MissionBriefingShell", () => {
-  it("updates the selected scenario and keeps notes in local state", () => {
-    render(<MissionBriefingShell scenarios={missionScenarios} />);
+  it(
+    "updates the selected scenario and keeps notes in local state",
+    () => {
+      render(<MissionBriefingShell scenarios={missionScenarios} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /harbor echo/i }));
-    expect(
-      screen.getByText(/Cargo timing is healthy, but pier access stays fragile/i),
-    ).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: /harbor echo/i }));
+      expect(
+        screen.getByText(
+          /Cargo timing is healthy, but pier access stays fragile/i,
+        ),
+      ).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText(/decision notes/i), {
-      target: { value: "Delay insertion until the patrol overlap clears." },
-    });
+      fireEvent.change(screen.getByLabelText(/decision notes/i), {
+        target: { value: "Delay insertion until the patrol overlap clears." },
+      });
 
-    fireEvent.click(screen.getByRole("button", { name: /polar relay/i }));
-    fireEvent.click(screen.getByRole("button", { name: /harbor echo/i }));
+      fireEvent.click(screen.getByRole("button", { name: /polar relay/i }));
+      fireEvent.click(screen.getByRole("button", { name: /harbor echo/i }));
 
-    expect(screen.getByLabelText(/decision notes/i)).toHaveValue(
-      "Delay insertion until the patrol overlap clears.",
-    );
-  });
+      expect(screen.getByLabelText(/decision notes/i)).toHaveValue(
+        "Delay insertion until the patrol overlap clears.",
+      );
+    },
+    15000,
+  );
 
-  it("shows empty-state copy for filtered and deselected views", () => {
-    render(<MissionBriefingShell scenarios={missionScenarios} />);
+  it(
+    "shows empty-state copy for filtered and deselected views",
+    () => {
+      render(<MissionBriefingShell scenarios={missionScenarios} />);
 
-    fireEvent.change(screen.getByLabelText(/search scenarios/i), {
-      target: { value: "zz-no-match" },
-    });
+      fireEvent.change(screen.getByLabelText(/search scenarios/i), {
+        target: { value: "zz-no-match" },
+      });
 
-    expect(
-      screen.getByText(/No scenarios match this filter\./i),
-    ).toBeInTheDocument();
+      expect(
+        screen.getByText(/No scenarios match this filter\./i),
+      ).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText(/search scenarios/i), {
-      target: { value: "" },
-    });
+      fireEvent.change(screen.getByLabelText(/search scenarios/i), {
+        target: { value: "" },
+      });
 
-    fireEvent.click(screen.getByRole("button", { name: /clear focus/i }));
+      fireEvent.click(screen.getByRole("button", { name: /clear focus/i }));
 
-    expect(
-      screen.getByText(/Select a scenario card to populate the briefing workspace\./i),
-    ).toBeInTheDocument();
-  });
+      expect(
+        screen.getByText(
+          /Select a scenario card to populate the briefing workspace\./i,
+        ),
+      ).toBeInTheDocument();
+    },
+    15000,
+  );
 });

--- a/src/components/parcel-hub/exception-drawer.tsx
+++ b/src/components/parcel-hub/exception-drawer.tsx
@@ -1,10 +1,18 @@
-import type { LaneException, ShipmentLane } from "./parcel-hub-data";
+import type {
+  ProjectedLane,
+  ProjectedLaneException,
+} from "./parcel-hub-simulator";
 
 export type DrawerScope = "open" | "resolved" | "all";
 
 type ExceptionDrawerProps = {
-  exceptions: LaneException[]; onClearSelection: () => void; onScopeChange: (scope: DrawerScope) => void;
-  onToggleResolved: (exceptionId: string) => void; resolvedIds: Record<string, boolean>; scope: DrawerScope; selectedLane: ShipmentLane | null;
+  activeScenarioLabel: string | null;
+  exceptions: ProjectedLaneException[];
+  onClearSelection: () => void;
+  onScopeChange: (scope: DrawerScope) => void;
+  onToggleResolved: (exceptionId: string) => void;
+  scope: DrawerScope;
+  selectedLane: ProjectedLane | null;
 };
 
 const severityClasses = {
@@ -13,19 +21,25 @@ const severityClasses = {
   low: "border-sky-300/20 bg-sky-300/10 text-sky-100",
 };
 
+const previewStateClasses = {
+  active: "border-white/10 bg-white/5 text-slate-200",
+  softened: "border-amber-300/20 bg-amber-300/10 text-amber-100",
+  resolved: "border-emerald-300/20 bg-emerald-300/10 text-emerald-100",
+  introduced: "border-fuchsia-300/20 bg-fuchsia-300/10 text-fuchsia-100",
+};
+
 export function ExceptionDrawer({
+  activeScenarioLabel,
   exceptions,
   onClearSelection,
   onScopeChange,
   onToggleResolved,
-  resolvedIds,
   scope,
   selectedLane,
 }: ExceptionDrawerProps) {
   const scopedExceptions = exceptions.filter((exception) => {
-    const isResolved = Boolean(resolvedIds[exception.id]);
-    if (scope === "open") return !isResolved;
-    if (scope === "resolved") return isResolved;
+    if (scope === "open") return !exception.isResolved;
+    if (scope === "resolved") return exception.isResolved;
     return true;
   });
 
@@ -43,6 +57,21 @@ export function ExceptionDrawer({
               ? `${selectedLane.origin} to ${selectedLane.destination} with ${selectedLane.departureWindow} dispatch window.`
               : "Select a lane card to inspect active exceptions or verify that a clear lane has nothing parked."}
           </p>
+          {selectedLane ? (
+            <div className="mt-3 flex flex-wrap gap-2 text-xs uppercase tracking-[0.22em] text-slate-400">
+              <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-slate-200">
+                {selectedLane.projectedStatusLabel}
+              </span>
+              <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-slate-200">
+                {selectedLane.projectedOpenExceptions} open after preview
+              </span>
+              {activeScenarioLabel ? (
+                <span className="rounded-full border border-amber-300/20 bg-amber-300/10 px-3 py-1 text-amber-100">
+                  {activeScenarioLabel}
+                </span>
+              ) : null}
+            </div>
+          ) : null}
         </div>
         {selectedLane ? (
           <button className="rounded-full border border-white/12 bg-white/5 px-3 py-2 text-sm text-slate-200 transition hover:bg-white/10" onClick={onClearSelection} type="button">Close</button>
@@ -74,28 +103,44 @@ export function ExceptionDrawer({
       ) : scopedExceptions.length > 0 ? (
         <div className="mt-5 space-y-3">
           {scopedExceptions.map((exception) => {
-            const isResolved = Boolean(resolvedIds[exception.id]);
-
             return (
               <article className="rounded-[1.5rem] border border-white/10 bg-white/5 p-4" key={exception.id}>
                 <div className="flex flex-wrap items-center gap-2">
                   <span className={`rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-[0.2em] ${severityClasses[exception.severity]}`}>{exception.severity}</span>
                   <span className="rounded-full border border-white/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-300">{exception.type}</span>
+                  <span className={`rounded-full border px-3 py-1 text-xs uppercase tracking-[0.2em] ${previewStateClasses[exception.previewState]}`}>{exception.previewLabel}</span>
                   <span className="text-xs uppercase tracking-[0.2em] text-slate-500">{exception.updatedAt}</span>
                 </div>
                 <h3 className="mt-3 text-lg font-semibold text-white">{exception.title}</h3>
                 <p className="mt-2 text-sm leading-6 text-slate-300">{exception.detail}</p>
+                <div className="mt-3 rounded-[1.25rem] border border-white/10 bg-slate-950/55 p-3">
+                  <p className="text-xs uppercase tracking-[0.18em] text-slate-500">
+                    Preview note
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-slate-300">
+                    {exception.previewNote}
+                  </p>
+                </div>
                 <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
-                  <p className="text-sm text-slate-300">{exception.owner}</p>
-                  <button
-                    className={`rounded-full px-4 py-2 text-sm font-medium transition ${
-                      isResolved ? "border border-emerald-300/25 bg-emerald-300/10 text-emerald-100 hover:bg-emerald-300/15" : "bg-amber-300 text-slate-950 hover:bg-amber-200"
-                    }`}
-                    onClick={() => onToggleResolved(exception.id)}
-                    type="button"
-                  >
-                    {isResolved ? "Reopen marker" : "Mark resolved"}
-                  </button>
+                  <div className="space-y-1 text-sm text-slate-300">
+                    <p>{exception.owner}</p>
+                    <p>{exception.affectedParcels} parcels affected</p>
+                  </div>
+                  {exception.canToggleResolved ? (
+                    <button
+                      className={`rounded-full px-4 py-2 text-sm font-medium transition ${
+                        exception.isResolved ? "border border-emerald-300/25 bg-emerald-300/10 text-emerald-100 hover:bg-emerald-300/15" : "bg-amber-300 text-slate-950 hover:bg-amber-200"
+                      }`}
+                      onClick={() => onToggleResolved(exception.id)}
+                      type="button"
+                    >
+                      {exception.isResolved ? "Reopen marker" : "Mark resolved"}
+                    </button>
+                  ) : (
+                    <span className="rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm text-slate-300">
+                      Preview only
+                    </span>
+                  )}
                 </div>
               </article>
             );

--- a/src/components/parcel-hub/lane-board.tsx
+++ b/src/components/parcel-hub/lane-board.tsx
@@ -1,6 +1,11 @@
-import type { ShipmentLane } from "./parcel-hub-data";
+import type { ProjectedLane } from "./parcel-hub-simulator";
 
-type LaneBoardProps = { lanes: ShipmentLane[]; resolvedIds: Record<string, boolean>; selectedLaneId: string | null; onInspectLane: (laneId: string) => void };
+type LaneBoardProps = {
+  activeScenarioLabel: string | null;
+  lanes: ProjectedLane[];
+  selectedLaneId: string | null;
+  onInspectLane: (laneId: string) => void;
+};
 
 const laneToneClasses = {
   steady: "border-emerald-300/25 bg-emerald-300/10 text-emerald-100",
@@ -17,11 +22,12 @@ const groupStatusClasses: Record<string, string> = {
   Reweigh: "bg-orange-200/15 text-orange-100",
   "Split sort": "bg-fuchsia-200/15 text-fuchsia-100",
   "Weather hold": "bg-cyan-200/15 text-cyan-100",
+  "Flex receive": "bg-emerald-200/15 text-emerald-100",
 };
 
 export function LaneBoard({
+  activeScenarioLabel,
   lanes,
-  resolvedIds,
   selectedLaneId,
   onInspectLane,
 }: LaneBoardProps) {
@@ -30,17 +36,37 @@ export function LaneBoard({
       <section className="rounded-[2rem] border border-dashed border-white/15 bg-slate-950/55 p-8 text-center text-slate-200">
         <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">No lanes</p>
         <h2 className="mt-3 text-2xl font-semibold text-white">The current lane filter has nothing staged.</h2>
-        <p className="mt-3 text-sm leading-6 text-slate-300">Switch back to all lanes to reopen the board and inspect route-level exceptions.</p>
+        <p className="mt-3 text-sm leading-6 text-slate-300">
+          Switch back to all lanes to reopen the board and inspect route-level
+          exceptions.
+        </p>
       </section>
     );
   }
 
+  const formatSigned = (value: number) => {
+    if (value === 0) {
+      return "0";
+    }
+
+    return `${value > 0 ? "+" : ""}${value}`;
+  };
+
   return (
     <section className="space-y-4">
       {lanes.map((lane) => {
-        const unresolvedCount = lane.exceptionIds.filter((id) => !resolvedIds[id]).length;
-        const resolvedCount = lane.exceptionIds.filter((id) => resolvedIds[id]).length;
         const isSelected = lane.id === selectedLaneId;
+        const introducedRisks = lane.projectedExceptions.filter(
+          (exception) => exception.previewState === "introduced",
+        ).length;
+        const resolvedInPreview = lane.projectedExceptions.filter(
+          (exception) => exception.previewState === "resolved",
+        ).length;
+        const softenedInPreview = lane.projectedExceptions.filter(
+          (exception) => exception.previewState === "softened",
+        ).length;
+        const isScenarioTouched =
+          lane.inboundMoves.length > 0 || lane.outboundMoves.length > 0;
 
         return (
           <article
@@ -54,36 +80,186 @@ export function LaneBoard({
             <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
               <div className="space-y-3">
                 <div className="flex flex-wrap gap-3">
-                  <span className={`rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-[0.22em] ${laneToneClasses[lane.tone]}`}>{lane.statusLabel}</span>
-                  <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.22em] text-slate-300">{lane.departureWindow}</span>
+                  <span
+                    className={`rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-[0.22em] ${laneToneClasses[lane.projectedTone]}`}
+                  >
+                    {lane.projectedStatusLabel}
+                  </span>
+                  <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.22em] text-slate-300">
+                    {lane.departureWindow}
+                  </span>
+                  {isScenarioTouched ? (
+                    <span className="rounded-full border border-amber-300/20 bg-amber-300/10 px-3 py-1 text-xs uppercase tracking-[0.22em] text-amber-100">
+                      {activeScenarioLabel ?? "Scenario preview"}
+                    </span>
+                  ) : null}
                 </div>
-                <div><h2 className="text-2xl font-semibold text-white">{lane.laneCode}</h2><p className="mt-1 text-sm text-slate-300">{lane.origin} to {lane.destination}</p></div>
+                <div>
+                  <h2 className="text-2xl font-semibold text-white">
+                    {lane.laneCode}
+                  </h2>
+                  <p className="mt-1 text-sm text-slate-300">
+                    {lane.origin} to {lane.destination}
+                  </p>
+                </div>
                 <div className="flex flex-wrap gap-4 text-sm text-slate-300">
-                  <span>{lane.checkpoint}</span>
+                  <span>{lane.projectedCheckpoint}</span>
                   <span>{lane.trailerFill}</span>
-                  <span>{lane.delayedParcels} parcels delayed</span>
+                  <span>{lane.projectedDelayedParcels} parcels delayed</span>
                 </div>
+                <p className="max-w-2xl text-sm leading-6 text-slate-300">
+                  {lane.projectedBalanceNote}
+                </p>
               </div>
               <div className="flex flex-col gap-3 sm:min-w-52">
                 <div className="rounded-3xl border border-white/10 bg-white/5 p-4">
-                  <p className="text-xs uppercase tracking-[0.24em] text-slate-400">Exception queue</p>
-                  <p className="mt-2 text-2xl font-semibold text-white">{unresolvedCount}</p>
-                  <p className="mt-1 text-sm text-slate-300">{resolvedCount} resolved markers</p>
+                  <p className="text-xs uppercase tracking-[0.24em] text-slate-400">
+                    Exception queue
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold text-white">
+                    {lane.projectedOpenExceptions}
+                  </p>
+                  <p className="mt-1 text-sm text-slate-300">
+                    {lane.projectedResolvedExceptions} resolved or cleared
+                  </p>
+                  <div className="mt-3 flex flex-wrap gap-2 text-[11px] uppercase tracking-[0.18em] text-slate-400">
+                    <span>{resolvedInPreview} clears</span>
+                    <span>{softenedInPreview} softened</span>
+                    <span>{introducedRisks} new risk</span>
+                  </div>
                 </div>
-                <button className="rounded-full bg-amber-300 px-4 py-2.5 text-sm font-semibold text-slate-950 transition hover:bg-amber-200" onClick={() => onInspectLane(lane.id)} type="button">
-                  {lane.exceptionIds.length > 0 ? "Open exception drawer" : "Review lane status"}
+                <button
+                  aria-label={`Inspect ${lane.laneCode} lane`}
+                  className="rounded-full bg-amber-300 px-4 py-2.5 text-sm font-semibold text-slate-950 transition hover:bg-amber-200"
+                  onClick={() => onInspectLane(lane.id)}
+                  type="button"
+                >
+                  {lane.projectedExceptions.length > 0
+                    ? "Open exception drawer"
+                    : "Review lane status"}
                 </button>
               </div>
             </div>
-            <div className="mt-5 grid gap-3 sm:grid-cols-3">
-              {lane.parcelGroups.map((group) => (
-                <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-4" key={group.id}>
-                  <p className="text-sm font-medium text-white">{group.label}</p>
-                  <div className="mt-3 flex items-end justify-between gap-3">
-                    <p className="text-2xl font-semibold text-slate-100">{group.count}</p>
-                    <span className={`rounded-full px-3 py-1 text-xs font-medium ${groupStatusClasses[group.statusLabel] ?? "bg-white/10 text-slate-100"}`}>{group.statusLabel}</span>
+
+            <div className="mt-5 grid gap-3 lg:grid-cols-4">
+              <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-4">
+                <p className="text-xs uppercase tracking-[0.22em] text-slate-400">
+                  Pressure
+                </p>
+                <p className="mt-2 text-2xl font-semibold text-white">
+                  {lane.pressurePercent}%
+                </p>
+                <p className="mt-2 text-sm text-slate-300">
+                  {lane.basePressurePercent}% current / {formatSigned(lane.pressureDelta)} pts
+                </p>
+              </div>
+              <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-4">
+                <p className="text-xs uppercase tracking-[0.22em] text-slate-400">
+                  Headroom
+                </p>
+                <p className="mt-2 text-2xl font-semibold text-white">
+                  {lane.headroomParcels}
+                </p>
+                <p className="mt-2 text-sm text-slate-300">
+                  parcels before hitting lane capacity
+                </p>
+              </div>
+              <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-4">
+                <p className="text-xs uppercase tracking-[0.22em] text-slate-400">
+                  SLA risk
+                </p>
+                <p className="mt-2 text-2xl font-semibold text-white">
+                  {lane.projectedSlaRiskParcels}
+                </p>
+                <p className="mt-2 text-sm text-slate-300">
+                  {formatSigned(lane.slaRiskDelta)} vs current
+                </p>
+              </div>
+              <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-4">
+                <p className="text-xs uppercase tracking-[0.22em] text-slate-400">
+                  Delay swing
+                </p>
+                <p className="mt-2 text-2xl font-semibold text-white">
+                  {lane.projectedDelayedParcels}
+                </p>
+                <p className="mt-2 text-sm text-slate-300">
+                  {formatSigned(lane.delayedDelta)} vs current
+                </p>
+              </div>
+            </div>
+
+            {isScenarioTouched ? (
+              <div className="mt-5 grid gap-3 xl:grid-cols-2">
+                {lane.outboundMoves.length > 0 ? (
+                  <div className="rounded-[1.5rem] border border-amber-300/15 bg-amber-300/10 p-4">
+                    <p className="text-xs uppercase tracking-[0.22em] text-amber-100/80">
+                      Outbound reassignment
+                    </p>
+                    <div className="mt-3 space-y-2">
+                      {lane.outboundMoves.map((move) => (
+                        <div key={move.id}>
+                          <p className="text-sm font-medium text-white">
+                            {move.parcelCount} {move.label}
+                          </p>
+                          <p className="mt-1 text-sm text-amber-50/90">
+                            {move.reason}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
                   </div>
-                  <p className="mt-2 text-xs uppercase tracking-[0.22em] text-slate-400">{group.zone}</p>
+                ) : null}
+
+                {lane.inboundMoves.length > 0 ? (
+                  <div className="rounded-[1.5rem] border border-emerald-300/15 bg-emerald-300/10 p-4">
+                    <p className="text-xs uppercase tracking-[0.22em] text-emerald-100/80">
+                      Inbound reassignment
+                    </p>
+                    <div className="mt-3 space-y-2">
+                      {lane.inboundMoves.map((move) => (
+                        <div key={move.id}>
+                          <p className="text-sm font-medium text-white">
+                            {move.parcelCount} {move.label}
+                          </p>
+                          <p className="mt-1 text-sm text-emerald-50/90">
+                            {move.reason}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+
+            <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              {lane.parcelGroups.map((group) => (
+                <div
+                  className="rounded-[1.5rem] border border-white/10 bg-white/5 p-4"
+                  key={group.id}
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <p className="text-sm font-medium text-white">{group.label}</p>
+                    <span className="text-xs uppercase tracking-[0.18em] text-slate-400">
+                      {formatSigned(group.delta)}
+                    </span>
+                  </div>
+                  <div className="mt-3 flex items-end justify-between gap-3">
+                    <p className="text-2xl font-semibold text-slate-100">
+                      {group.count}
+                    </p>
+                    <span
+                      className={`rounded-full px-3 py-1 text-xs font-medium ${groupStatusClasses[group.statusLabel] ?? "bg-white/10 text-slate-100"}`}
+                    >
+                      {group.statusLabel}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-xs uppercase tracking-[0.22em] text-slate-400">
+                    {group.zone}
+                  </p>
+                  <p className="mt-2 text-xs text-slate-400">
+                    {group.baselineCount} current
+                  </p>
                 </div>
               ))}
             </div>

--- a/src/components/parcel-hub/lane-filter-bar.tsx
+++ b/src/components/parcel-hub/lane-filter-bar.tsx
@@ -8,7 +8,7 @@ type LaneFilterBarProps = {
 
 const filterLabels: Record<LaneFilter, string> = {
   all: "All lanes",
-  watch: "Delay watch",
+  watch: "Watch lanes",
   steady: "Clear lanes",
 };
 

--- a/src/components/parcel-hub/parcel-hub-data.ts
+++ b/src/components/parcel-hub/parcel-hub-data.ts
@@ -1,15 +1,115 @@
 export type ShipmentLaneTone = "steady" | "watch" | "exception";
-export type ParcelGroup = { id: string; label: string; count: number; statusLabel: string; zone: string };
+export type PackageSummaryId = "priority" | "satchels" | "returns" | "oversize";
+
+export type ParcelGroup = {
+  id: string;
+  summaryId: PackageSummaryId;
+  label: string;
+  count: number;
+  statusLabel: string;
+  zone: string;
+};
+
 export type ShipmentLane = {
-  id: string; laneCode: string; origin: string; destination: string; departureWindow: string;
-  checkpoint: string; delayedParcels: number; trailerFill: string; tone: ShipmentLaneTone;
-  statusLabel: string; parcelGroups: ParcelGroup[]; exceptionIds: string[];
+  id: string;
+  laneCode: string;
+  origin: string;
+  destination: string;
+  departureWindow: string;
+  checkpoint: string;
+  delayedParcels: number;
+  trailerFill: string;
+  tone: ShipmentLaneTone;
+  statusLabel: string;
+  capacity: number;
+  slaRiskParcels: number;
+  balanceNote: string;
+  parcelGroups: ParcelGroup[];
+  exceptionIds: string[];
 };
+
 export type LaneException = {
-  id: string; laneId: string; type: string; title: string; detail: string;
-  severity: "high" | "medium" | "low"; owner: string; updatedAt: string;
+  id: string;
+  laneId: string;
+  type: string;
+  title: string;
+  detail: string;
+  severity: "high" | "medium" | "low";
+  owner: string;
+  updatedAt: string;
+  affectedParcels: number;
+  slaRiskNote: string;
 };
-export type PackageSummary = { id: string; label: string; count: number; share: string; note: string };
+
+export type PackageSummary = {
+  id: PackageSummaryId;
+  label: string;
+  count: number;
+  share: string;
+  note: string;
+};
+
+export type ScenarioImpactState = "resolve" | "soften" | "introduce";
+
+export type BalancingScenarioMove = {
+  id: string;
+  fromLaneId: string;
+  toLaneId: string;
+  summaryId: PackageSummaryId;
+  label: string;
+  parcelCount: number;
+  etaChange: string;
+  reason: string;
+  toStatusLabel: string;
+  toZone: string;
+};
+
+export type ScenarioExceptionImpact = {
+  id: string;
+  laneId: string;
+  change: ScenarioImpactState;
+  type: string;
+  severity: "high" | "medium" | "low";
+  title: string;
+  detail: string;
+  owner: string;
+  affectedParcels: number;
+  slaRiskNote: string;
+  existingExceptionId?: string;
+};
+
+export type ScenarioPackageEffect = {
+  summaryId: PackageSummaryId;
+  movedParcels: number;
+  slaRiskDelta: number;
+  note: string;
+  status: "steady" | "improved" | "watch";
+};
+
+export type BalancingScenarioLaneEffect = {
+  laneId: string;
+  delayedParcelsDelta: number;
+  slaRiskParcelsDelta: number;
+  checkpoint: string;
+  statusLabel: string;
+  tone: ShipmentLaneTone;
+  balanceNote: string;
+};
+
+export type BalancingScenario = {
+  id: string;
+  label: string;
+  summary: string;
+  posture: "conservative" | "protective" | "aggressive";
+  operator: string;
+  dispatchWindow: string;
+  tradeoff: string;
+  comparisonNote: string;
+  moves: BalancingScenarioMove[];
+  laneEffects: BalancingScenarioLaneEffect[];
+  exceptionImpacts: ScenarioExceptionImpact[];
+  packageEffects: ScenarioPackageEffect[];
+};
 
 export const parcelHubSyncLabel = "Dispatch sync 06:15 local";
 
@@ -18,87 +118,723 @@ export const exceptionTypes = [
   "Address hold",
   "Trailer reweigh",
   "Weather spillover",
+  "Flex handoff",
+  "Manifest resequence",
 ];
 
 export const packageSummaries: PackageSummary[] = [
-  { id: "priority", label: "Priority cartons", count: 684, share: "38%", note: "Most exposed to re-scan misses." },
-  { id: "satchels", label: "Metro satchels", count: 512, share: "28%", note: "Balanced across relays and hub transfers." },
-  { id: "returns", label: "Returns mesh", count: 291, share: "16%", note: "Backhaul volume is mostly clear." },
-  { id: "oversize", label: "Oversize pallets", count: 316, share: "18%", note: "Reweigh checks keep two lanes in watch." },
+  {
+    id: "priority",
+    label: "Priority cartons",
+    count: 684,
+    share: "38%",
+    note: "Most exposed to reroute and label-validation misses.",
+  },
+  {
+    id: "satchels",
+    label: "Metro satchels",
+    count: 512,
+    share: "28%",
+    note: "Fastest pressure relief lever when cage work starts to spike.",
+  },
+  {
+    id: "returns",
+    label: "Returns mesh",
+    count: 291,
+    share: "16%",
+    note: "Usually absorbs balancing changes without changing SLA posture.",
+  },
+  {
+    id: "oversize",
+    label: "Oversize pallets",
+    count: 316,
+    share: "18%",
+    note: "Axle checks and lift sequencing drive the biggest exception swings.",
+  },
 ];
 
 export const shipmentLanes: ShipmentLane[] = [
   {
-    id: "den-chi", laneCode: "DEN -> CHI", origin: "Denver Hub", destination: "Chicago Sort",
-    departureWindow: "05:55-06:25", checkpoint: "Dock 4 closes in 18 min", delayedParcels: 148,
-    trailerFill: "84% trailer fill", tone: "watch", statusLabel: "Delay watch", exceptionIds: ["lane-ex-1", "lane-ex-2"],
+    id: "den-chi",
+    laneCode: "DEN -> CHI",
+    origin: "Denver Hub",
+    destination: "Chicago Sort",
+    departureWindow: "05:55-06:25",
+    checkpoint: "Dock 4 closes in 18 min",
+    delayedParcels: 148,
+    trailerFill: "84% trailer fill",
+    tone: "watch",
+    statusLabel: "Delay watch",
+    capacity: 220,
+    slaRiskParcels: 64,
+    balanceNote: "Priority cartons are stacking faster than the north-belt sweep can absorb.",
+    exceptionIds: ["lane-ex-1", "lane-ex-2"],
     parcelGroups: [
-      { id: "den-1", label: "Priority cartons", count: 128, statusLabel: "Hold scan", zone: "North belt" },
-      { id: "den-2", label: "Returns mesh", count: 42, statusLabel: "Ready", zone: "Backhaul" },
-      { id: "den-3", label: "Oversize pallets", count: 34, statusLabel: "Reweigh", zone: "Lift zone" },
+      {
+        id: "den-1",
+        summaryId: "priority",
+        label: "Priority cartons",
+        count: 128,
+        statusLabel: "Hold scan",
+        zone: "North belt",
+      },
+      {
+        id: "den-2",
+        summaryId: "returns",
+        label: "Returns mesh",
+        count: 42,
+        statusLabel: "Ready",
+        zone: "Backhaul",
+      },
+      {
+        id: "den-3",
+        summaryId: "oversize",
+        label: "Oversize pallets",
+        count: 34,
+        statusLabel: "Reweigh",
+        zone: "Lift zone",
+      },
     ],
   },
   {
-    id: "phx-dfw", laneCode: "PHX -> DFW", origin: "Phoenix Hub", destination: "Dallas Relay",
-    departureWindow: "06:20-06:55", checkpoint: "Gate 2 staging complete", delayedParcels: 96,
-    trailerFill: "79% trailer fill", tone: "exception", statusLabel: "Exception focus", exceptionIds: ["lane-ex-3", "lane-ex-4"],
+    id: "phx-dfw",
+    laneCode: "PHX -> DFW",
+    origin: "Phoenix Hub",
+    destination: "Dallas Relay",
+    departureWindow: "06:20-06:55",
+    checkpoint: "Gate 2 staging complete",
+    delayedParcels: 96,
+    trailerFill: "79% trailer fill",
+    tone: "exception",
+    statusLabel: "Exception focus",
+    capacity: 245,
+    slaRiskParcels: 58,
+    balanceNote: "Scanner drift is forcing manual tallies through the exception cage.",
+    exceptionIds: ["lane-ex-3", "lane-ex-4"],
     parcelGroups: [
-      { id: "phx-1", label: "Metro satchels", count: 164, statusLabel: "Split sort", zone: "South spur" },
-      { id: "phx-2", label: "Priority cartons", count: 73, statusLabel: "Address hold", zone: "Exception cage" },
-      { id: "phx-3", label: "Oversize pallets", count: 22, statusLabel: "Loaded", zone: "Lift zone" },
+      {
+        id: "phx-1",
+        summaryId: "satchels",
+        label: "Metro satchels",
+        count: 164,
+        statusLabel: "Split sort",
+        zone: "South spur",
+      },
+      {
+        id: "phx-2",
+        summaryId: "priority",
+        label: "Priority cartons",
+        count: 73,
+        statusLabel: "Address hold",
+        zone: "Exception cage",
+      },
+      {
+        id: "phx-3",
+        summaryId: "oversize",
+        label: "Oversize pallets",
+        count: 22,
+        statusLabel: "Loaded",
+        zone: "Lift zone",
+      },
     ],
   },
   {
-    id: "sea-sac", laneCode: "SEA -> SAC", origin: "Seattle Node", destination: "Sacramento Crossdock",
-    departureWindow: "06:45-07:10", checkpoint: "Weather pad in review", delayedParcels: 61,
-    trailerFill: "67% trailer fill", tone: "watch", statusLabel: "Pad extended", exceptionIds: ["lane-ex-5"],
+    id: "sea-sac",
+    laneCode: "SEA -> SAC",
+    origin: "Seattle Node",
+    destination: "Sacramento Crossdock",
+    departureWindow: "06:45-07:10",
+    checkpoint: "Weather pad in review",
+    delayedParcels: 61,
+    trailerFill: "67% trailer fill",
+    tone: "watch",
+    statusLabel: "Pad extended",
+    capacity: 236,
+    slaRiskParcels: 24,
+    balanceNote: "Seattle has headroom, but apron checks limit how far operators can lean on it.",
+    exceptionIds: ["lane-ex-5"],
     parcelGroups: [
-      { id: "sea-1", label: "Metro satchels", count: 121, statusLabel: "Buffered", zone: "West mezzanine" },
-      { id: "sea-2", label: "Returns mesh", count: 38, statusLabel: "Ready", zone: "Backhaul" },
-      { id: "sea-3", label: "Priority cartons", count: 47, statusLabel: "Weather hold", zone: "Outbound belt" },
+      {
+        id: "sea-1",
+        summaryId: "satchels",
+        label: "Metro satchels",
+        count: 121,
+        statusLabel: "Buffered",
+        zone: "West mezzanine",
+      },
+      {
+        id: "sea-2",
+        summaryId: "returns",
+        label: "Returns mesh",
+        count: 38,
+        statusLabel: "Ready",
+        zone: "Backhaul",
+      },
+      {
+        id: "sea-3",
+        summaryId: "priority",
+        label: "Priority cartons",
+        count: 47,
+        statusLabel: "Weather hold",
+        zone: "Outbound belt",
+      },
     ],
   },
   {
-    id: "mia-atl", laneCode: "MIA -> ATL", origin: "Miami Spur", destination: "Atlanta Hub",
-    departureWindow: "07:05-07:35", checkpoint: "Seal check passed", delayedParcels: 0,
-    trailerFill: "91% trailer fill", tone: "steady", statusLabel: "Clear lane", exceptionIds: [],
+    id: "mia-atl",
+    laneCode: "MIA -> ATL",
+    origin: "Miami Spur",
+    destination: "Atlanta Hub",
+    departureWindow: "07:05-07:35",
+    checkpoint: "Seal check passed",
+    delayedParcels: 0,
+    trailerFill: "91% trailer fill",
+    tone: "steady",
+    statusLabel: "Clear lane",
+    capacity: 250,
+    slaRiskParcels: 12,
+    balanceNote: "Atlanta flex sort is the cleanest buffer if the hub needs extra protected capacity.",
+    exceptionIds: [],
     parcelGroups: [
-      { id: "mia-1", label: "Priority cartons", count: 102, statusLabel: "Loaded", zone: "East dock" },
-      { id: "mia-2", label: "Metro satchels", count: 87, statusLabel: "Loaded", zone: "East dock" },
-      { id: "mia-3", label: "Returns mesh", count: 29, statusLabel: "Ready", zone: "Backhaul" },
+      {
+        id: "mia-1",
+        summaryId: "priority",
+        label: "Priority cartons",
+        count: 102,
+        statusLabel: "Loaded",
+        zone: "East dock",
+      },
+      {
+        id: "mia-2",
+        summaryId: "satchels",
+        label: "Metro satchels",
+        count: 87,
+        statusLabel: "Loaded",
+        zone: "East dock",
+      },
+      {
+        id: "mia-3",
+        summaryId: "returns",
+        label: "Returns mesh",
+        count: 29,
+        statusLabel: "Ready",
+        zone: "Backhaul",
+      },
     ],
   },
 ];
 
 export const laneExceptions: LaneException[] = [
   {
-    id: "lane-ex-1", laneId: "den-chi", type: "Sort gap",
+    id: "lane-ex-1",
+    laneId: "den-chi",
+    type: "Sort gap",
     title: "Inbound cage 4 missed the final consolidation sweep",
     detail: "Forty-two priority cartons remained in the recycle buffer after the presort handoff.",
-    severity: "high", owner: "North dock lead", updatedAt: "11m ago",
+    severity: "high",
+    owner: "North dock lead",
+    updatedAt: "11m ago",
+    affectedParcels: 42,
+    slaRiskNote: "Adds 18 priority cartons to the first SLA warning bucket.",
   },
   {
-    id: "lane-ex-2", laneId: "den-chi", type: "Trailer reweigh",
+    id: "lane-ex-2",
+    laneId: "den-chi",
+    type: "Trailer reweigh",
     title: "Oversize pallet pair needs a second axle balance check",
     detail: "The lift zone flagged pallet spacing after the first trailer weight capture came in above plan.",
-    severity: "medium", owner: "Lift zone team", updatedAt: "6m ago",
+    severity: "medium",
+    owner: "Lift zone team",
+    updatedAt: "6m ago",
+    affectedParcels: 14,
+    slaRiskNote: "Could hold two oversize pallets past dock close if reweigh misses the next slot.",
   },
   {
-    id: "lane-ex-3", laneId: "phx-dfw", type: "Address hold",
+    id: "lane-ex-3",
+    laneId: "phx-dfw",
+    type: "Address hold",
     title: "Seven satchels are parked for suite validation before release",
     detail: "The route can still make cutoff, but local validation needs to clear before final manifest close.",
-    severity: "medium", owner: "Address desk", updatedAt: "4m ago",
+    severity: "medium",
+    owner: "Address desk",
+    updatedAt: "4m ago",
+    affectedParcels: 7,
+    slaRiskNote: "Address desk work keeps the fast lane under a manual review threshold.",
   },
   {
-    id: "lane-ex-4", laneId: "phx-dfw", type: "Sort gap",
+    id: "lane-ex-4",
+    laneId: "phx-dfw",
+    type: "Sort gap",
     title: "South spur scanner drifted during metro bundle induction",
     detail: "A temporary manual tally is active while the lane keeps the remaining satchel batch staged nearby.",
-    severity: "high", owner: "Automation specialist", updatedAt: "2m ago",
+    severity: "high",
+    owner: "Automation specialist",
+    updatedAt: "2m ago",
+    affectedParcels: 35,
+    slaRiskNote: "If the lane stays loaded, the manual tally becomes the top SLA exposure in the route.",
   },
   {
-    id: "lane-ex-5", laneId: "sea-sac", type: "Weather spillover",
+    id: "lane-ex-5",
+    laneId: "sea-sac",
+    type: "Weather spillover",
     title: "Pad release is waiting on the marine-layer visibility check",
     detail: "The lane is still viable, but dispatch widened the departure window to absorb apron traffic and moisture checks.",
-    severity: "low", owner: "Dispatch desk", updatedAt: "8m ago",
+    severity: "low",
+    owner: "Dispatch desk",
+    updatedAt: "8m ago",
+    affectedParcels: 11,
+    slaRiskNote: "Low-severity weather risk only turns material if Seattle also receives rerouted work.",
+  },
+];
+
+export const balancingScenarios: BalancingScenario[] = [
+  {
+    id: "priority-protect",
+    label: "Protect priority SLA",
+    summary:
+      "Shift protected cartons into Atlanta flex capacity and peel metro satchels out of the Phoenix cage before the next dispatch cutoff.",
+    posture: "protective",
+    operator: "Hub dispatch lead",
+    dispatchWindow: "Hold 12 minutes for relabel and handoff",
+    tradeoff: "Miami picks up a small relabel check, but the biggest SLA risk leaves Denver and Phoenix.",
+    comparisonNote: "Best SLA improvement with a light new-risk footprint.",
+    moves: [
+      {
+        id: "priority-protect-1",
+        fromLaneId: "den-chi",
+        toLaneId: "mia-atl",
+        summaryId: "priority",
+        label: "Priority cartons",
+        parcelCount: 26,
+        etaChange: "-18 min risk",
+        reason: "Use Atlanta flex sort to clear Denver's north-belt overflow before the final sweep closes.",
+        toStatusLabel: "Flex receive",
+        toZone: "East dock",
+      },
+      {
+        id: "priority-protect-2",
+        fromLaneId: "phx-dfw",
+        toLaneId: "sea-sac",
+        summaryId: "satchels",
+        label: "Metro satchels",
+        parcelCount: 18,
+        etaChange: "-12 min risk",
+        reason: "Reduce the manual tally wave in Phoenix before scanner drift becomes a hard SLA breach.",
+        toStatusLabel: "Flex receive",
+        toZone: "West mezzanine",
+      },
+    ],
+    laneEffects: [
+      {
+        laneId: "den-chi",
+        delayedParcelsDelta: -52,
+        slaRiskParcelsDelta: -24,
+        checkpoint: "North-belt sweep reset for final seal",
+        statusLabel: "Priority protected",
+        tone: "watch",
+        balanceNote: "Denver drops below its last high-risk threshold once the overflow exits the recycle buffer.",
+      },
+      {
+        laneId: "phx-dfw",
+        delayedParcelsDelta: -24,
+        slaRiskParcelsDelta: -16,
+        checkpoint: "Manual tally isolated to the final satchel wave",
+        statusLabel: "Scanner recovery",
+        tone: "watch",
+        balanceNote: "Phoenix is still noisy, but the cage no longer drives the entire route posture.",
+      },
+      {
+        laneId: "sea-sac",
+        delayedParcelsDelta: 10,
+        slaRiskParcelsDelta: 4,
+        checkpoint: "Seattle flex relay opens for satchel spillover",
+        statusLabel: "Flex assist",
+        tone: "watch",
+        balanceNote: "Seattle absorbs the spillover without crossing the weather hold threshold.",
+      },
+      {
+        laneId: "mia-atl",
+        delayedParcelsDelta: 8,
+        slaRiskParcelsDelta: 6,
+        checkpoint: "Atlanta flex trailer staged for protected cartons",
+        statusLabel: "Flex receiver",
+        tone: "watch",
+        balanceNote: "Miami stays inside capacity but needs a quick relabel check for diverted priority volume.",
+      },
+    ],
+    exceptionImpacts: [
+      {
+        id: "priority-protect-impact-1",
+        laneId: "den-chi",
+        change: "resolve",
+        existingExceptionId: "lane-ex-1",
+        type: "Sort gap",
+        severity: "high",
+        title: "Final sweep clears once Denver sheds the protected overflow",
+        detail: "The move reopens enough belt capacity to sweep cage 4 before the seal lock.",
+        owner: "North dock lead",
+        affectedParcels: 42,
+        slaRiskNote: "Removes the highest-priority carton exposure from Denver.",
+      },
+      {
+        id: "priority-protect-impact-2",
+        laneId: "phx-dfw",
+        change: "resolve",
+        existingExceptionId: "lane-ex-3",
+        type: "Address hold",
+        severity: "medium",
+        title: "Address desk queue clears once the satchel batch is split",
+        detail: "Phoenix no longer needs to validate the whole release wave at the same time.",
+        owner: "Address desk",
+        affectedParcels: 7,
+        slaRiskNote: "Takes one manual validation step out of the critical path.",
+      },
+      {
+        id: "priority-protect-impact-3",
+        laneId: "phx-dfw",
+        change: "soften",
+        existingExceptionId: "lane-ex-4",
+        type: "Sort gap",
+        severity: "medium",
+        title: "Scanner drift remains, but the exposed wave is materially smaller",
+        detail: "Operators only need to hand-count the tail of the satchel bundle after the split.",
+        owner: "Automation specialist",
+        affectedParcels: 17,
+        slaRiskNote: "Cuts the remaining scanner-drift exposure roughly in half.",
+      },
+      {
+        id: "priority-protect-impact-4",
+        laneId: "mia-atl",
+        change: "introduce",
+        type: "Flex handoff",
+        severity: "low",
+        title: "Diverted priority cartons need relabel verification at the ATL flex trailer",
+        detail: "The handoff is local and planned, but operators need one extra label audit before seal.",
+        owner: "East dock lead",
+        affectedParcels: 14,
+        slaRiskNote: "Creates a small relabel touchpoint without pushing the lane into hard breach territory.",
+      },
+    ],
+    packageEffects: [
+      {
+        summaryId: "priority",
+        movedParcels: 26,
+        slaRiskDelta: -24,
+        note: "Protected cartons leave the Denver overflow and recover the biggest SLA slice in the hub.",
+        status: "improved",
+      },
+      {
+        summaryId: "satchels",
+        movedParcels: 18,
+        slaRiskDelta: -9,
+        note: "Metro satchels stop driving the Phoenix cage backlog once the wave is split.",
+        status: "improved",
+      },
+      {
+        summaryId: "returns",
+        movedParcels: 0,
+        slaRiskDelta: 0,
+        note: "Returns mesh stays untouched so backhaul remains predictable.",
+        status: "steady",
+      },
+      {
+        summaryId: "oversize",
+        movedParcels: 0,
+        slaRiskDelta: 0,
+        note: "Oversize work still needs the existing Denver axle check.",
+        status: "watch",
+      },
+    ],
+  },
+  {
+    id: "exception-drain",
+    label: "Drain exception cage",
+    summary:
+      "Aggressively empty Phoenix and Denver exception work into flex lanes, trading a cleaner queue for a tighter Atlanta finish.",
+    posture: "aggressive",
+    operator: "Sort recovery manager",
+    dispatchWindow: "Hold 18 minutes for resequencing",
+    tradeoff: "Open exceptions fall fastest, but Miami becomes the new pressure edge.",
+    comparisonNote: "Best exception reduction, highest downstream tradeoff.",
+    moves: [
+      {
+        id: "exception-drain-1",
+        fromLaneId: "phx-dfw",
+        toLaneId: "mia-atl",
+        summaryId: "priority",
+        label: "Priority cartons",
+        parcelCount: 32,
+        etaChange: "-15 min risk",
+        reason: "Bypass the Phoenix exception cage and push protected volume straight into Atlanta flex handling.",
+        toStatusLabel: "Flex receive",
+        toZone: "East dock",
+      },
+      {
+        id: "exception-drain-2",
+        fromLaneId: "den-chi",
+        toLaneId: "sea-sac",
+        summaryId: "oversize",
+        label: "Oversize pallets",
+        parcelCount: 14,
+        etaChange: "-8 min risk",
+        reason: "Use Seattle's spare lift capacity to avoid a second Denver reweigh cycle.",
+        toStatusLabel: "Flex receive",
+        toZone: "Lift zone B",
+      },
+    ],
+    laneEffects: [
+      {
+        laneId: "den-chi",
+        delayedParcelsDelta: -22,
+        slaRiskParcelsDelta: -10,
+        checkpoint: "Axle relief clears before dock lock",
+        statusLabel: "Lift relief",
+        tone: "watch",
+        balanceNote: "Denver stops double-handling its heaviest pallets once Seattle absorbs the overflow.",
+      },
+      {
+        laneId: "phx-dfw",
+        delayedParcelsDelta: -52,
+        slaRiskParcelsDelta: -26,
+        checkpoint: "Phoenix cage reset for final validation pass",
+        statusLabel: "Cage drained",
+        tone: "watch",
+        balanceNote: "Phoenix recovers quickly because the protected wave leaves the manual queue entirely.",
+      },
+      {
+        laneId: "sea-sac",
+        delayedParcelsDelta: 18,
+        slaRiskParcelsDelta: 8,
+        checkpoint: "Secondary lift slot opened for diverted oversize",
+        statusLabel: "Lift assist",
+        tone: "watch",
+        balanceNote: "Seattle stays workable, but lift sequencing becomes a monitored constraint.",
+      },
+      {
+        laneId: "mia-atl",
+        delayedParcelsDelta: 18,
+        slaRiskParcelsDelta: 12,
+        checkpoint: "Manifest resequence needed before ATL close",
+        statusLabel: "SLA watch",
+        tone: "exception",
+        balanceNote: "Atlanta flex sort can take the freight, but the resequence window gets materially tighter.",
+      },
+    ],
+    exceptionImpacts: [
+      {
+        id: "exception-drain-impact-1",
+        laneId: "den-chi",
+        change: "resolve",
+        existingExceptionId: "lane-ex-2",
+        type: "Trailer reweigh",
+        severity: "medium",
+        title: "Denver clears the axle issue once oversize is split to Seattle",
+        detail: "The trailer no longer needs the second balance check after the overflow leaves the lift zone.",
+        owner: "Lift zone team",
+        affectedParcels: 14,
+        slaRiskNote: "Eliminates the only remaining oversize blocker on the lane.",
+      },
+      {
+        id: "exception-drain-impact-2",
+        laneId: "phx-dfw",
+        change: "resolve",
+        existingExceptionId: "lane-ex-3",
+        type: "Address hold",
+        severity: "medium",
+        title: "Address validation queue clears when Phoenix sheds the protected wave",
+        detail: "The address desk can finish the remaining holds without blocking manifest close.",
+        owner: "Address desk",
+        affectedParcels: 7,
+        slaRiskNote: "Turns a manual validation blocker into standard follow-up work.",
+      },
+      {
+        id: "exception-drain-impact-3",
+        laneId: "phx-dfw",
+        change: "resolve",
+        existingExceptionId: "lane-ex-4",
+        type: "Sort gap",
+        severity: "high",
+        title: "Scanner drift becomes non-blocking after the reroute",
+        detail: "Phoenix keeps the drift in place, but the critical satchel load is no longer behind it.",
+        owner: "Automation specialist",
+        affectedParcels: 35,
+        slaRiskNote: "Removes the route's largest active exception queue from dispatch planning.",
+      },
+      {
+        id: "exception-drain-impact-4",
+        laneId: "mia-atl",
+        change: "introduce",
+        type: "Manifest resequence",
+        severity: "medium",
+        title: "Atlanta flex trailer needs a second manifest ordering pass",
+        detail: "The protected freight lands cleanly, but dock control needs to resequence the final trailer map.",
+        owner: "ATL dock control",
+        affectedParcels: 19,
+        slaRiskNote: "Moves exception work downstream and tightens the final dispatch buffer.",
+      },
+    ],
+    packageEffects: [
+      {
+        summaryId: "priority",
+        movedParcels: 32,
+        slaRiskDelta: -20,
+        note: "Priority freight exits the Phoenix cage, but Atlanta becomes the new sequencing edge.",
+        status: "improved",
+      },
+      {
+        summaryId: "satchels",
+        movedParcels: 0,
+        slaRiskDelta: 0,
+        note: "Satchel exposure drops only because the cage is no longer overloaded by protected work.",
+        status: "steady",
+      },
+      {
+        summaryId: "returns",
+        movedParcels: 0,
+        slaRiskDelta: 0,
+        note: "Returns stay stable and keep backhaul handling predictable.",
+        status: "steady",
+      },
+      {
+        summaryId: "oversize",
+        movedParcels: 14,
+        slaRiskDelta: -6,
+        note: "Seattle lift capacity removes Denver's second axle-check loop at the cost of a tighter lift schedule.",
+        status: "watch",
+      },
+    ],
+  },
+  {
+    id: "minimal-touch",
+    label: "Minimal-touch rebalance",
+    summary:
+      "Make the smallest safe moves possible to trim SLA exposure without creating new preview exceptions for dispatch to absorb.",
+    posture: "conservative",
+    operator: "Shift manager",
+    dispatchWindow: "Hold 8 minutes for confirmation",
+    tradeoff: "Exception counts stay mostly flat, but the route does not recover as much pressure as the stronger plans.",
+    comparisonNote: "Safest preview, smallest operational upside.",
+    moves: [
+      {
+        id: "minimal-touch-1",
+        fromLaneId: "den-chi",
+        toLaneId: "mia-atl",
+        summaryId: "priority",
+        label: "Priority cartons",
+        parcelCount: 16,
+        etaChange: "-10 min risk",
+        reason: "Use existing Atlanta slack to soften Denver's protected backlog without changing dock choreography too much.",
+        toStatusLabel: "Flex receive",
+        toZone: "East dock",
+      },
+      {
+        id: "minimal-touch-2",
+        fromLaneId: "phx-dfw",
+        toLaneId: "sea-sac",
+        summaryId: "satchels",
+        label: "Metro satchels",
+        parcelCount: 12,
+        etaChange: "-7 min risk",
+        reason: "Shave the top off the Phoenix satchel wave while keeping Seattle inside its weather buffer.",
+        toStatusLabel: "Flex receive",
+        toZone: "West mezzanine",
+      },
+    ],
+    laneEffects: [
+      {
+        laneId: "den-chi",
+        delayedParcelsDelta: -28,
+        slaRiskParcelsDelta: -14,
+        checkpoint: "Denver sweep regains one full release pass",
+        statusLabel: "Pressure eased",
+        tone: "watch",
+        balanceNote: "Denver improves, but operators still have to watch the oversize check and final sweep timing.",
+      },
+      {
+        laneId: "phx-dfw",
+        delayedParcelsDelta: -18,
+        slaRiskParcelsDelta: -10,
+        checkpoint: "Phoenix satchel wave drops below manual tally peak",
+        statusLabel: "Controlled watch",
+        tone: "exception",
+        balanceNote: "Phoenix is still the noisiest lane, but the hand-count window is smaller and easier to cover.",
+      },
+      {
+        laneId: "sea-sac",
+        delayedParcelsDelta: 6,
+        slaRiskParcelsDelta: 3,
+        checkpoint: "Seattle flex space opens for a single satchel spill",
+        statusLabel: "Buffered assist",
+        tone: "watch",
+        balanceNote: "Seattle keeps enough pad to absorb the spill without escalating weather posture.",
+      },
+      {
+        laneId: "mia-atl",
+        delayedParcelsDelta: 4,
+        slaRiskParcelsDelta: 2,
+        checkpoint: "Atlanta flex sort takes a light protected batch",
+        statusLabel: "Flex ready",
+        tone: "watch",
+        balanceNote: "Miami takes the extra work without introducing a new downstream exception queue.",
+      },
+    ],
+    exceptionImpacts: [
+      {
+        id: "minimal-touch-impact-1",
+        laneId: "den-chi",
+        change: "soften",
+        existingExceptionId: "lane-ex-1",
+        type: "Sort gap",
+        severity: "medium",
+        title: "Denver's missed sweep remains visible, but the exposed parcel count drops",
+        detail: "A smaller overflow wave means the north belt can recover most of the stuck priority cartons.",
+        owner: "North dock lead",
+        affectedParcels: 23,
+        slaRiskNote: "Cuts the size of the priority gap without forcing a new handoff.",
+      },
+      {
+        id: "minimal-touch-impact-2",
+        laneId: "phx-dfw",
+        change: "soften",
+        existingExceptionId: "lane-ex-4",
+        type: "Sort gap",
+        severity: "medium",
+        title: "Phoenix keeps the scanner drift, but the remaining manual wave shrinks",
+        detail: "Operators still hand-count the tail, just not the entire satchel batch.",
+        owner: "Automation specialist",
+        affectedParcels: 23,
+        slaRiskNote: "Lowers the active exposure without creating a new flex-lane review.",
+      },
+    ],
+    packageEffects: [
+      {
+        summaryId: "priority",
+        movedParcels: 16,
+        slaRiskDelta: -14,
+        note: "Priority relief is smaller than the stronger plans, but it does not create a downstream manifest review.",
+        status: "improved",
+      },
+      {
+        summaryId: "satchels",
+        movedParcels: 12,
+        slaRiskDelta: -5,
+        note: "Satchel pressure eases just enough to make the Phoenix queue more predictable.",
+        status: "improved",
+      },
+      {
+        summaryId: "returns",
+        movedParcels: 0,
+        slaRiskDelta: 0,
+        note: "Returns stay on the current plan and remain the cleanest buffer in the route.",
+        status: "steady",
+      },
+      {
+        summaryId: "oversize",
+        movedParcels: 0,
+        slaRiskDelta: 0,
+        note: "Oversize pallets stay in place, so Denver still carries the reweigh risk.",
+        status: "watch",
+      },
+    ],
   },
 ];

--- a/src/components/parcel-hub/parcel-hub-header.tsx
+++ b/src/components/parcel-hub/parcel-hub-header.tsx
@@ -1,37 +1,98 @@
-type ParcelHubHeaderProps = { delayedParcels: number; openExceptions: number; resolvedExceptions: number; syncLabel: string; totalLanes: number; watchLanes: number };
+type ParcelHubHeaderProps = {
+  activeScenarioLabel: string | null;
+  delayedParcels: number;
+  delayedParcelsDelta: number;
+  openExceptions: number;
+  openExceptionsDelta: number;
+  resolvedExceptions: number;
+  resolvedInPreview: number;
+  slaRiskParcels: number;
+  slaRiskDelta: number;
+  syncLabel: string;
+  totalLanes: number;
+  watchLanes: number;
+  watchLanesDelta: number;
+};
+
+function formatDelta(value: number) {
+  if (value === 0) {
+    return "No change from current dispatch";
+  }
+
+  return `${value > 0 ? "+" : ""}${value} vs current dispatch`;
+}
 
 export function ParcelHubHeader({
+  activeScenarioLabel,
   delayedParcels,
+  delayedParcelsDelta,
   openExceptions,
+  openExceptionsDelta,
   resolvedExceptions,
+  resolvedInPreview,
+  slaRiskParcels,
+  slaRiskDelta,
   syncLabel,
   totalLanes,
   watchLanes,
+  watchLanesDelta,
 }: ParcelHubHeaderProps) {
   return (
     <header className="rounded-[2rem] border border-white/10 bg-[linear-gradient(135deg,rgba(15,23,42,0.96),rgba(24,24,27,0.88))] p-6 shadow-[0_28px_100px_rgba(0,0,0,0.42)] sm:p-8">
       <div className="flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
         <div className="max-w-3xl">
           <p className="text-xs font-semibold uppercase tracking-[0.35em] text-amber-300">Parcel Hub</p>
-          <h1 className="mt-4 text-4xl font-semibold tracking-tight text-white sm:text-5xl">Lane health, grouped parcels, and exception handling in one isolated route.</h1>
+          <h1 className="mt-4 text-4xl font-semibold tracking-tight text-white sm:text-5xl">Route pressure, SLA risk, and exception tradeoffs in one dispatch preview.</h1>
           <p className="mt-4 text-sm leading-6 text-slate-300 sm:text-base">
-            Review outbound lanes, spot delay concentration by parcel group, and mark exception work as resolved without touching shared app state.
+            Review outbound lanes, compare simulated balancing paths, and inspect the exception cost of every reassignment before operators touch live dispatch.
           </p>
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-[0.24em] text-slate-200">
+              {activeScenarioLabel ? `Previewing ${activeScenarioLabel}` : "Current dispatch"}
+            </span>
+            <span className="text-sm text-slate-400">{syncLabel}</span>
+          </div>
         </div>
-        <div className="grid gap-3 sm:grid-cols-2 xl:w-[23rem]">
+        <div className="grid gap-3 sm:grid-cols-2 xl:w-[28rem]">
           <div className="rounded-3xl border border-amber-300/20 bg-amber-300/10 p-4 text-amber-50">
-            <p className="text-sm text-amber-100/80">Active lanes</p>
+            <p className="text-sm text-amber-100/80">Lane pressure</p>
             <p className="mt-2 text-3xl font-semibold">{totalLanes}</p>
-            <p className="mt-1 text-sm text-amber-100/80">{watchLanes} in delay watch</p>
+            <p className="mt-1 text-sm text-amber-100/80">
+              {watchLanes} lanes in watch or exception
+            </p>
+            <p className="mt-3 text-xs uppercase tracking-[0.2em] text-amber-100/70">
+              {formatDelta(watchLanesDelta)}
+            </p>
           </div>
           <div className="rounded-3xl border border-rose-300/20 bg-rose-300/10 p-4 text-rose-50">
             <p className="text-sm text-rose-100/80">Delayed parcels</p>
             <p className="mt-2 text-3xl font-semibold">{delayedParcels}</p>
-            <p className="mt-1 text-sm text-rose-100/80">{openExceptions} open exceptions</p>
+            <p className="mt-1 text-sm text-rose-100/80">
+              {openExceptions} projected open exceptions
+            </p>
+            <p className="mt-3 text-xs uppercase tracking-[0.2em] text-rose-100/70">
+              {formatDelta(delayedParcelsDelta)}
+            </p>
           </div>
-          <div className="rounded-3xl border border-emerald-300/20 bg-emerald-300/10 p-4 text-emerald-50 sm:col-span-2">
-            <p className="text-sm text-emerald-100/80">Resolution markers</p>
-            <div className="mt-2 flex flex-wrap items-end justify-between gap-3"><p className="text-2xl font-semibold">{resolvedExceptions} resolved locally</p><p className="text-sm text-emerald-100/80">{syncLabel}</p></div>
+          <div className="rounded-3xl border border-sky-300/20 bg-sky-300/10 p-4 text-sky-50">
+            <p className="text-sm text-sky-100/80">Projected SLA risk</p>
+            <p className="mt-2 text-3xl font-semibold">{slaRiskParcels}</p>
+            <p className="mt-1 text-sm text-sky-100/80">
+              parcels still exposed after preview
+            </p>
+            <p className="mt-3 text-xs uppercase tracking-[0.2em] text-sky-100/70">
+              {formatDelta(slaRiskDelta)}
+            </p>
+          </div>
+          <div className="rounded-3xl border border-emerald-300/20 bg-emerald-300/10 p-4 text-emerald-50">
+            <p className="text-sm text-emerald-100/80">Clears and markers</p>
+            <p className="mt-2 text-3xl font-semibold">{resolvedExceptions}</p>
+            <p className="mt-1 text-sm text-emerald-100/80">
+              resolved or cleared exceptions
+            </p>
+            <p className="mt-3 text-xs uppercase tracking-[0.2em] text-emerald-100/70">
+              {resolvedInPreview} preview clears, {formatDelta(openExceptionsDelta)}
+            </p>
           </div>
         </div>
       </div>

--- a/src/components/parcel-hub/parcel-hub-shell.test.tsx
+++ b/src/components/parcel-hub/parcel-hub-shell.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ParcelHubShell } from "./parcel-hub-shell";
+
+describe("parcel hub shell", () => {
+  it(
+    "updates summary content when a balancing scenario is previewed",
+    () => {
+      render(<ParcelHubShell />);
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /Protect priority SLA/i }),
+      );
+
+      expect(
+        screen.getAllByText(
+          "Best SLA improvement with a light new-risk footprint.",
+        ),
+      ).toHaveLength(2);
+      expect(
+        screen.getByText(
+          "Protected cartons leave the Denver overflow and recover the biggest SLA slice in the hub.",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByText("26 rerouted")).toBeInTheDocument();
+    },
+    15000,
+  );
+
+  it(
+    "shows introduced and cleared exception impacts before reassignment is applied",
+    () => {
+      render(<ParcelHubShell />);
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /Protect priority SLA/i }),
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /Inspect MIA -> ATL lane/i }),
+      );
+
+      expect(screen.getByText("New risk in preview")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Diverted priority cartons need relabel verification at the ATL flex trailer",
+        ),
+      ).toBeInTheDocument();
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /Inspect DEN -> CHI lane/i }),
+      );
+      fireEvent.click(screen.getByRole("button", { name: "Resolved" }));
+
+      expect(screen.getByText("Clears in preview")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Inbound cage 4 missed the final consolidation sweep",
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Removes the highest-priority carton exposure from Denver.",
+        ),
+      ).toBeInTheDocument();
+    },
+    15000,
+  );
+});

--- a/src/components/parcel-hub/parcel-hub-shell.tsx
+++ b/src/components/parcel-hub/parcel-hub-shell.tsx
@@ -7,22 +7,20 @@ import { LaneBoard } from "./lane-board";
 import { LaneFilterBar, type LaneFilter } from "./lane-filter-bar";
 import {
   exceptionTypes,
-  laneExceptions,
-  packageSummaries,
   parcelHubSyncLabel,
-  shipmentLanes,
-  type ShipmentLane,
 } from "./parcel-hub-data";
 import { ParcelHubHeader } from "./parcel-hub-header";
 import { ParcelSummaryPanel } from "./parcel-summary-panel";
+import { buildParcelHubProjection, type ProjectedLane } from "./parcel-hub-simulator";
+import { RouteBalanceSimulator } from "./route-balance-simulator";
 
-function matchesLaneFilter(lane: ShipmentLane, filter: LaneFilter) {
+function matchesLaneFilter(lane: ProjectedLane, filter: LaneFilter) {
   if (filter === "watch") {
-    return lane.tone !== "steady";
+    return lane.projectedTone !== "steady";
   }
 
   if (filter === "steady") {
-    return lane.tone === "steady";
+    return lane.projectedTone === "steady";
   }
 
   return true;
@@ -33,19 +31,16 @@ export function ParcelHubShell() {
   const [selectedLaneId, setSelectedLaneId] = useState<string | null>(null);
   const [drawerScope, setDrawerScope] = useState<DrawerScope>("open");
   const [resolvedIds, setResolvedIds] = useState<Record<string, boolean>>({});
+  const [activeScenarioId, setActiveScenarioId] = useState<string | null>(null);
 
-  const filteredLanes = shipmentLanes.filter((lane) => matchesLaneFilter(lane, laneFilter));
-  const selectedLane = shipmentLanes.find((lane) => lane.id === selectedLaneId) ?? null;
-  const selectedLaneExceptions = laneExceptions.filter((exception) => exception.laneId === selectedLaneId);
-  const totalParcels = packageSummaries.reduce((sum, summary) => sum + summary.count, 0);
-  const delayedParcels = shipmentLanes.reduce((sum, lane) => sum + lane.delayedParcels, 0);
-  const openExceptions = laneExceptions.filter((exception) => !resolvedIds[exception.id]).length;
-  const resolvedExceptions = laneExceptions.filter((exception) => resolvedIds[exception.id]).length;
-  const laneCounts = {
-    all: shipmentLanes.length,
-    watch: shipmentLanes.filter((lane) => matchesLaneFilter(lane, "watch")).length,
-    steady: shipmentLanes.filter((lane) => matchesLaneFilter(lane, "steady")).length,
-  };
+  const projection = buildParcelHubProjection(activeScenarioId, resolvedIds);
+  const filteredLanes = projection.lanes.filter((lane) =>
+    matchesLaneFilter(lane, laneFilter),
+  );
+  const selectedLane =
+    projection.lanes.find((lane) => lane.id === selectedLaneId) ?? null;
+  const selectedLaneExceptions = selectedLane?.projectedExceptions ?? [];
+  const activeScenario = projection.activeScenario;
 
   const handleLaneFilterChange = (filter: LaneFilter) => {
     startTransition(() => {
@@ -64,6 +59,20 @@ export function ParcelHubShell() {
     });
   };
 
+  const handleScenarioChange = (scenarioId: string | null) => {
+    startTransition(() => {
+      setActiveScenarioId(scenarioId);
+
+      const nextProjection = buildParcelHubProjection(scenarioId, resolvedIds);
+      const nextSelectedLane =
+        nextProjection.lanes.find((lane) => lane.id === selectedLaneId) ?? null;
+
+      if (nextSelectedLane && !matchesLaneFilter(nextSelectedLane, laneFilter)) {
+        setSelectedLaneId(null);
+      }
+    });
+  };
+
   const handleToggleResolved = (exceptionId: string) => {
     startTransition(() => {
       setResolvedIds((current) => ({ ...current, [exceptionId]: !current[exceptionId] }));
@@ -74,26 +83,53 @@ export function ParcelHubShell() {
     <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(251,191,36,0.15),transparent_34%),linear-gradient(180deg,#020617_0%,#0f172a_58%,#111827_100%)] px-4 py-6 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-7xl space-y-6">
         <ParcelHubHeader
-          delayedParcels={delayedParcels}
-          openExceptions={openExceptions}
-          resolvedExceptions={resolvedExceptions}
+          activeScenarioLabel={activeScenario?.label ?? null}
+          delayedParcels={projection.summary.projectedDelayedParcels}
+          delayedParcelsDelta={projection.summary.delayedParcelsDelta}
+          openExceptions={projection.summary.projectedOpenExceptions}
+          openExceptionsDelta={projection.summary.openExceptionsDelta}
+          resolvedExceptions={projection.summary.projectedResolvedExceptions}
+          resolvedInPreview={projection.summary.resolvedInPreview}
+          slaRiskParcels={projection.summary.projectedSlaRiskParcels}
+          slaRiskDelta={projection.summary.slaRiskParcelsDelta}
           syncLabel={parcelHubSyncLabel}
-          totalLanes={shipmentLanes.length}
-          watchLanes={laneCounts.watch}
+          totalLanes={projection.laneCounts.all}
+          watchLanes={projection.summary.projectedWatchLanes}
+          watchLanesDelta={projection.summary.watchLanesDelta}
         />
         <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(22rem,0.95fr)]">
           <section className="space-y-5">
-            <LaneFilterBar activeFilter={laneFilter} counts={laneCounts} onChange={handleLaneFilterChange} />
-            <LaneBoard lanes={filteredLanes} onInspectLane={handleInspectLane} resolvedIds={resolvedIds} selectedLaneId={selectedLaneId} />
+            <RouteBalanceSimulator
+              activeScenario={activeScenario}
+              activeScenarioId={activeScenarioId}
+              onSelectScenario={handleScenarioChange}
+              scenarioCards={projection.scenarioCards}
+            />
+            <LaneFilterBar
+              activeFilter={laneFilter}
+              counts={projection.laneCounts}
+              onChange={handleLaneFilterChange}
+            />
+            <LaneBoard
+              activeScenarioLabel={activeScenario?.label ?? null}
+              lanes={filteredLanes}
+              onInspectLane={handleInspectLane}
+              selectedLaneId={selectedLaneId}
+            />
           </section>
           <div className="space-y-6">
-            <ParcelSummaryPanel exceptionTypes={exceptionTypes} openExceptions={openExceptions} packageSummaries={packageSummaries} totalParcels={totalParcels} />
+            <ParcelSummaryPanel
+              activeScenarioLabel={activeScenario?.label ?? null}
+              exceptionTypes={exceptionTypes}
+              packageSummaries={projection.packageSummaries}
+              summary={projection.summary}
+            />
             <ExceptionDrawer
+              activeScenarioLabel={activeScenario?.label ?? null}
               exceptions={selectedLaneExceptions}
               onClearSelection={() => setSelectedLaneId(null)}
               onScopeChange={(scope) => setDrawerScope(scope)}
               onToggleResolved={handleToggleResolved}
-              resolvedIds={resolvedIds}
               scope={drawerScope}
               selectedLane={selectedLane}
             />

--- a/src/components/parcel-hub/parcel-hub-simulator.test.ts
+++ b/src/components/parcel-hub/parcel-hub-simulator.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { buildParcelHubProjection } from "./parcel-hub-simulator";
+
+describe("parcel hub simulator", () => {
+  it("builds the baseline route summary from current dispatch state", () => {
+    const projection = buildParcelHubProjection(null, {});
+    const miaLane = projection.lanes.find((lane) => lane.id === "mia-atl");
+
+    expect(projection.summary.projectedOpenExceptions).toBe(5);
+    expect(projection.summary.projectedSlaRiskParcels).toBe(158);
+    expect(projection.summary.projectedPeakPressure).toBe(106);
+    expect(projection.summary.projectedDelayedParcels).toBe(305);
+    expect(miaLane?.projectedTone).toBe("steady");
+  });
+
+  it("projects priority protection moves into lane pressure and exception changes", () => {
+    const projection = buildParcelHubProjection("priority-protect", {});
+    const denLane = projection.lanes.find((lane) => lane.id === "den-chi");
+    const miaLane = projection.lanes.find((lane) => lane.id === "mia-atl");
+    const prioritySummary = projection.packageSummaries.find(
+      (summary) => summary.id === "priority",
+    );
+
+    expect(projection.summary.projectedOpenExceptions).toBe(4);
+    expect(projection.summary.projectedSlaRiskParcels).toBe(128);
+    expect(projection.summary.projectedPeakPressure).toBe(98);
+    expect(denLane?.stagedParcels).toBe(178);
+    expect(denLane?.projectedOpenExceptions).toBe(1);
+    expect(miaLane?.projectedExceptions.some((item) => item.previewState === "introduced")).toBe(true);
+    expect(prioritySummary?.movedParcels).toBe(26);
+    expect(prioritySummary?.slaRiskDelta).toBe(-24);
+  });
+
+  it("combines local resolution markers with aggressive scenario clears", () => {
+    const projection = buildParcelHubProjection("exception-drain", {
+      "lane-ex-5": true,
+    });
+    const phxLane = projection.lanes.find((lane) => lane.id === "phx-dfw");
+
+    expect(projection.summary.currentOpenExceptions).toBe(4);
+    expect(projection.summary.projectedOpenExceptions).toBe(2);
+    expect(projection.summary.projectedResolvedExceptions).toBe(4);
+    expect(phxLane?.projectedOpenExceptions).toBe(0);
+    expect(phxLane?.projectedExceptions.filter((item) => item.previewState === "resolved")).toHaveLength(2);
+  });
+});

--- a/src/components/parcel-hub/parcel-hub-simulator.ts
+++ b/src/components/parcel-hub/parcel-hub-simulator.ts
@@ -1,0 +1,516 @@
+import {
+  balancingScenarios,
+  laneExceptions,
+  packageSummaries,
+  shipmentLanes,
+  type BalancingScenario,
+  type BalancingScenarioMove,
+  type LaneException,
+  type PackageSummary,
+  type ParcelGroup,
+  type ScenarioExceptionImpact,
+  type ShipmentLane,
+  type ShipmentLaneTone,
+} from "./parcel-hub-data";
+
+export type ProjectedParcelGroup = ParcelGroup & {
+  baselineCount: number;
+  delta: number;
+};
+
+export type ProjectedLaneExceptionState =
+  | "active"
+  | "softened"
+  | "resolved"
+  | "introduced";
+
+export type ProjectedLaneException = LaneException & {
+  previewState: ProjectedLaneExceptionState;
+  isResolved: boolean;
+  isScenarioPreview: boolean;
+  previewLabel: string;
+  previewNote: string;
+  canToggleResolved: boolean;
+};
+
+export type ProjectedPackageSummary = PackageSummary & {
+  movedParcels: number;
+  slaRiskDelta: number;
+  projectionNote: string;
+  projectionStatus: "steady" | "improved" | "watch";
+};
+
+export type ProjectedLane = Omit<ShipmentLane, "parcelGroups" | "tone" | "statusLabel" | "checkpoint" | "balanceNote"> & {
+  parcelGroups: ProjectedParcelGroup[];
+  baseTone: ShipmentLaneTone;
+  projectedTone: ShipmentLaneTone;
+  baseStatusLabel: string;
+  projectedStatusLabel: string;
+  baseCheckpoint: string;
+  projectedCheckpoint: string;
+  baseBalanceNote: string;
+  projectedBalanceNote: string;
+  baseStagedParcels: number;
+  stagedParcels: number;
+  basePressurePercent: number;
+  pressurePercent: number;
+  pressureDelta: number;
+  headroomParcels: number;
+  projectedDelayedParcels: number;
+  delayedDelta: number;
+  projectedSlaRiskParcels: number;
+  slaRiskDelta: number;
+  projectedOpenExceptions: number;
+  projectedResolvedExceptions: number;
+  outboundMoves: BalancingScenarioMove[];
+  inboundMoves: BalancingScenarioMove[];
+  projectedExceptions: ProjectedLaneException[];
+};
+
+export type ScenarioCard = {
+  scenarioId: string | null;
+  label: string;
+  summary: string;
+  postureLabel: string;
+  projectedOpenExceptions: number;
+  openExceptionsDelta: number;
+  projectedSlaRiskParcels: number;
+  slaRiskDelta: number;
+  projectedPeakPressure: number;
+  peakPressureDelta: number;
+  projectedDelayedParcels: number;
+  delayedParcelsDelta: number;
+  introducedRiskCount: number;
+  resolvedInPreview: number;
+  moves: BalancingScenarioMove[];
+  operator: string;
+  dispatchWindow: string;
+  tradeoff: string;
+  comparisonNote: string;
+};
+
+export type ParcelHubProjectionSummary = {
+  totalParcels: number;
+  currentDelayedParcels: number;
+  projectedDelayedParcels: number;
+  delayedParcelsDelta: number;
+  currentOpenExceptions: number;
+  projectedOpenExceptions: number;
+  openExceptionsDelta: number;
+  currentResolvedExceptions: number;
+  projectedResolvedExceptions: number;
+  currentSlaRiskParcels: number;
+  projectedSlaRiskParcels: number;
+  slaRiskParcelsDelta: number;
+  currentPeakPressure: number;
+  projectedPeakPressure: number;
+  peakPressureDelta: number;
+  currentWatchLanes: number;
+  projectedWatchLanes: number;
+  watchLanesDelta: number;
+  introducedRiskCount: number;
+  resolvedInPreview: number;
+  softenedInPreview: number;
+};
+
+export type ParcelHubProjection = {
+  activeScenarioId: string | null;
+  activeScenario: BalancingScenario | null;
+  lanes: ProjectedLane[];
+  packageSummaries: ProjectedPackageSummary[];
+  laneCounts: Record<"all" | "watch" | "steady", number>;
+  summary: ParcelHubProjectionSummary;
+  scenarioCards: ScenarioCard[];
+};
+
+type ProjectScenarioResult = Omit<ParcelHubProjection, "scenarioCards">;
+
+function sumParcelGroups(groups: Pick<ParcelGroup, "count">[]) {
+  return groups.reduce((sum, group) => sum + group.count, 0);
+}
+
+function toPressurePercent(total: number, capacity: number) {
+  return Math.round((total / capacity) * 100);
+}
+
+function clampCount(value: number) {
+  return value < 0 ? 0 : value;
+}
+
+function findScenario(scenarioId: string | null) {
+  if (!scenarioId) {
+    return null;
+  }
+
+  return balancingScenarios.find((scenario) => scenario.id === scenarioId) ?? null;
+}
+
+function buildExceptionModel(
+  laneId: string,
+  resolvedIds: Record<string, boolean>,
+  scenario: BalancingScenario | null,
+) {
+  const impactsByExceptionId = new Map<string, ScenarioExceptionImpact>();
+  const introducedByLaneId = new Map<string, ScenarioExceptionImpact[]>();
+
+  if (scenario) {
+    scenario.exceptionImpacts.forEach((impact) => {
+      if (impact.existingExceptionId) {
+        impactsByExceptionId.set(impact.existingExceptionId, impact);
+        return;
+      }
+
+      const current = introducedByLaneId.get(impact.laneId) ?? [];
+      current.push(impact);
+      introducedByLaneId.set(impact.laneId, current);
+    });
+  }
+
+  const projectedExceptions = laneExceptions
+    .filter((exception) => exception.laneId === laneId)
+    .map<ProjectedLaneException>((exception) => {
+      const impact = impactsByExceptionId.get(exception.id);
+      const resolvedLocally = Boolean(resolvedIds[exception.id]);
+      const previewState: ProjectedLaneExceptionState = impact
+        ? impact.change === "resolve"
+          ? "resolved"
+          : "softened"
+        : "active";
+      const isResolved = resolvedLocally || previewState === "resolved";
+
+      return {
+        ...exception,
+        previewState,
+        isResolved,
+        isScenarioPreview: false,
+        previewLabel: resolvedLocally
+          ? "Resolved locally"
+          : previewState === "resolved"
+            ? "Clears in preview"
+            : previewState === "softened"
+              ? "Risk reduced in preview"
+              : "Current exposure",
+        previewNote: resolvedLocally
+          ? "Local marker is already applied to this exception."
+          : impact?.slaRiskNote ?? exception.slaRiskNote,
+        canToggleResolved: previewState !== "resolved",
+        severity: impact?.severity ?? exception.severity,
+      };
+    });
+
+  const introducedImpacts = introducedByLaneId.get(laneId) ?? [];
+
+  introducedImpacts.forEach((impact) => {
+    projectedExceptions.push({
+      id: impact.id,
+      laneId: impact.laneId,
+      type: impact.type,
+      title: impact.title,
+      detail: impact.detail,
+      severity: impact.severity,
+      owner: impact.owner,
+      updatedAt: "Preview",
+      affectedParcels: impact.affectedParcels,
+      slaRiskNote: impact.slaRiskNote,
+      previewState: "introduced",
+      isResolved: false,
+      isScenarioPreview: true,
+      previewLabel: "New risk in preview",
+      previewNote: impact.slaRiskNote,
+      canToggleResolved: false,
+    });
+  });
+
+  return projectedExceptions;
+}
+
+function applyScenarioMoves(
+  lane: ShipmentLane,
+  moves: BalancingScenarioMove[],
+): ProjectedParcelGroup[] {
+  const projectedGroups = lane.parcelGroups.map<ProjectedParcelGroup>((group) => ({
+    ...group,
+    baselineCount: group.count,
+    delta: 0,
+  }));
+
+  moves.forEach((move) => {
+    if (move.fromLaneId === lane.id) {
+      const sourceGroup = projectedGroups.find(
+        (group) => group.summaryId === move.summaryId,
+      );
+
+      if (sourceGroup) {
+        sourceGroup.count = clampCount(sourceGroup.count - move.parcelCount);
+        sourceGroup.delta = sourceGroup.count - sourceGroup.baselineCount;
+      }
+    }
+
+    if (move.toLaneId === lane.id) {
+      const targetGroup = projectedGroups.find(
+        (group) => group.summaryId === move.summaryId,
+      );
+
+      if (targetGroup) {
+        targetGroup.count += move.parcelCount;
+        targetGroup.delta = targetGroup.count - targetGroup.baselineCount;
+        return;
+      }
+
+      projectedGroups.push({
+        id: `${lane.id}-${move.summaryId}-preview`,
+        summaryId: move.summaryId,
+        label: move.label,
+        count: move.parcelCount,
+        statusLabel: move.toStatusLabel,
+        zone: move.toZone,
+        baselineCount: 0,
+        delta: move.parcelCount,
+      });
+    }
+  });
+
+  return projectedGroups;
+}
+
+function projectScenarioState(
+  scenarioId: string | null,
+  resolvedIds: Record<string, boolean>,
+): ProjectScenarioResult {
+  const activeScenario = findScenario(scenarioId);
+  const moves = activeScenario?.moves ?? [];
+
+  const lanes = shipmentLanes.map<ProjectedLane>((lane) => {
+    const projectedGroups = applyScenarioMoves(lane, moves);
+    const laneEffect = activeScenario?.laneEffects.find(
+      (effect) => effect.laneId === lane.id,
+    );
+    const projectedExceptions = buildExceptionModel(
+      lane.id,
+      resolvedIds,
+      activeScenario,
+    );
+    const baseStagedParcels = sumParcelGroups(lane.parcelGroups);
+    const stagedParcels = sumParcelGroups(projectedGroups);
+    const basePressurePercent = toPressurePercent(baseStagedParcels, lane.capacity);
+    const pressurePercent = toPressurePercent(stagedParcels, lane.capacity);
+    const projectedDelayedParcels = clampCount(
+      lane.delayedParcels + (laneEffect?.delayedParcelsDelta ?? 0),
+    );
+    const projectedSlaRiskParcels = clampCount(
+      lane.slaRiskParcels + (laneEffect?.slaRiskParcelsDelta ?? 0),
+    );
+
+    return {
+      ...lane,
+      parcelGroups: projectedGroups,
+      baseTone: lane.tone,
+      projectedTone: laneEffect?.tone ?? lane.tone,
+      baseStatusLabel: lane.statusLabel,
+      projectedStatusLabel: laneEffect?.statusLabel ?? lane.statusLabel,
+      baseCheckpoint: lane.checkpoint,
+      projectedCheckpoint: laneEffect?.checkpoint ?? lane.checkpoint,
+      baseBalanceNote: lane.balanceNote,
+      projectedBalanceNote: laneEffect?.balanceNote ?? lane.balanceNote,
+      baseStagedParcels,
+      stagedParcels,
+      basePressurePercent,
+      pressurePercent,
+      pressureDelta: pressurePercent - basePressurePercent,
+      headroomParcels: lane.capacity - stagedParcels,
+      projectedDelayedParcels,
+      delayedDelta: projectedDelayedParcels - lane.delayedParcels,
+      projectedSlaRiskParcels,
+      slaRiskDelta: projectedSlaRiskParcels - lane.slaRiskParcels,
+      projectedOpenExceptions: projectedExceptions.filter(
+        (exception) => !exception.isResolved,
+      ).length,
+      projectedResolvedExceptions: projectedExceptions.filter(
+        (exception) => exception.isResolved,
+      ).length,
+      outboundMoves: moves.filter((move) => move.fromLaneId === lane.id),
+      inboundMoves: moves.filter((move) => move.toLaneId === lane.id),
+      projectedExceptions,
+    };
+  });
+
+  const totalParcels = packageSummaries.reduce(
+    (sum, summary) => sum + summary.count,
+    0,
+  );
+  const currentDelayedParcels = shipmentLanes.reduce(
+    (sum, lane) => sum + lane.delayedParcels,
+    0,
+  );
+  const projectedDelayedParcels = lanes.reduce(
+    (sum, lane) => sum + lane.projectedDelayedParcels,
+    0,
+  );
+  const currentOpenExceptions = laneExceptions.filter(
+    (exception) => !resolvedIds[exception.id],
+  ).length;
+  const currentResolvedExceptions = laneExceptions.filter(
+    (exception) => resolvedIds[exception.id],
+  ).length;
+  const projectedOpenExceptions = lanes.reduce(
+    (sum, lane) => sum + lane.projectedOpenExceptions,
+    0,
+  );
+  const projectedResolvedExceptions = lanes.reduce(
+    (sum, lane) => sum + lane.projectedResolvedExceptions,
+    0,
+  );
+  const currentSlaRiskParcels = shipmentLanes.reduce(
+    (sum, lane) => sum + lane.slaRiskParcels,
+    0,
+  );
+  const projectedSlaRiskParcels = lanes.reduce(
+    (sum, lane) => sum + lane.projectedSlaRiskParcels,
+    0,
+  );
+  const currentPeakPressure = Math.max(
+    ...shipmentLanes.map((lane) =>
+      toPressurePercent(sumParcelGroups(lane.parcelGroups), lane.capacity),
+    ),
+  );
+  const projectedPeakPressure = Math.max(
+    ...lanes.map((lane) => lane.pressurePercent),
+  );
+  const currentWatchLanes = shipmentLanes.filter(
+    (lane) => lane.tone !== "steady",
+  ).length;
+  const projectedWatchLanes = lanes.filter(
+    (lane) => lane.projectedTone !== "steady",
+  ).length;
+
+  const packageEffectMap = new Map(
+    (activeScenario?.packageEffects ?? []).map((effect) => [
+      effect.summaryId,
+      effect,
+    ]),
+  );
+
+  const projectedPackageSummaries = packageSummaries.map<ProjectedPackageSummary>(
+    (summary) => {
+      const effect = packageEffectMap.get(summary.id);
+
+      return {
+        ...summary,
+        movedParcels: effect?.movedParcels ?? 0,
+        slaRiskDelta: effect?.slaRiskDelta ?? 0,
+        projectionNote: effect?.note ?? summary.note,
+        projectionStatus: effect?.status ?? "steady",
+      };
+    },
+  );
+
+  return {
+    activeScenarioId: activeScenario?.id ?? null,
+    activeScenario,
+    lanes,
+    packageSummaries: projectedPackageSummaries,
+    laneCounts: {
+      all: lanes.length,
+      watch: lanes.filter((lane) => lane.projectedTone !== "steady").length,
+      steady: lanes.filter((lane) => lane.projectedTone === "steady").length,
+    },
+    summary: {
+      totalParcels,
+      currentDelayedParcels,
+      projectedDelayedParcels,
+      delayedParcelsDelta: projectedDelayedParcels - currentDelayedParcels,
+      currentOpenExceptions,
+      projectedOpenExceptions,
+      openExceptionsDelta: projectedOpenExceptions - currentOpenExceptions,
+      currentResolvedExceptions,
+      projectedResolvedExceptions,
+      currentSlaRiskParcels,
+      projectedSlaRiskParcels,
+      slaRiskParcelsDelta: projectedSlaRiskParcels - currentSlaRiskParcels,
+      currentPeakPressure,
+      projectedPeakPressure,
+      peakPressureDelta: projectedPeakPressure - currentPeakPressure,
+      currentWatchLanes,
+      projectedWatchLanes,
+      watchLanesDelta: projectedWatchLanes - currentWatchLanes,
+      introducedRiskCount:
+        activeScenario?.exceptionImpacts.filter(
+          (impact) => impact.change === "introduce",
+        ).length ?? 0,
+      resolvedInPreview:
+        activeScenario?.exceptionImpacts.filter(
+          (impact) => impact.change === "resolve",
+        ).length ?? 0,
+      softenedInPreview:
+        activeScenario?.exceptionImpacts.filter(
+          (impact) => impact.change === "soften",
+        ).length ?? 0,
+    },
+  };
+}
+
+export function buildParcelHubProjection(
+  scenarioId: string | null,
+  resolvedIds: Record<string, boolean>,
+): ParcelHubProjection {
+  const projection = projectScenarioState(scenarioId, resolvedIds);
+  const scenarioCards: ScenarioCard[] = [
+    {
+      scenarioId: null,
+      label: "Current dispatch",
+      summary:
+        "No simulated reassignments. The route stays on the live queue and exception posture.",
+      postureLabel: "Current state",
+      projectedOpenExceptions: projection.summary.currentOpenExceptions,
+      openExceptionsDelta: 0,
+      projectedSlaRiskParcels: projection.summary.currentSlaRiskParcels,
+      slaRiskDelta: 0,
+      projectedPeakPressure: projection.summary.currentPeakPressure,
+      peakPressureDelta: 0,
+      projectedDelayedParcels: projection.summary.currentDelayedParcels,
+      delayedParcelsDelta: 0,
+      introducedRiskCount: 0,
+      resolvedInPreview: 0,
+      moves: [],
+      operator: "Current staffing",
+      dispatchWindow: "No additional hold",
+      tradeoff: "Keeps the present pressure and exception queue intact.",
+      comparisonNote: "Reference state for all route-balancing previews.",
+    },
+    ...balancingScenarios.map<ScenarioCard>((scenario) => {
+      const snapshot = projectScenarioState(scenario.id, resolvedIds);
+
+      return {
+        scenarioId: scenario.id,
+        label: scenario.label,
+        summary: scenario.summary,
+        postureLabel:
+          scenario.posture === "aggressive"
+            ? "Aggressive"
+            : scenario.posture === "protective"
+              ? "Protective"
+              : "Conservative",
+        projectedOpenExceptions: snapshot.summary.projectedOpenExceptions,
+        openExceptionsDelta: snapshot.summary.openExceptionsDelta,
+        projectedSlaRiskParcels: snapshot.summary.projectedSlaRiskParcels,
+        slaRiskDelta: snapshot.summary.slaRiskParcelsDelta,
+        projectedPeakPressure: snapshot.summary.projectedPeakPressure,
+        peakPressureDelta: snapshot.summary.peakPressureDelta,
+        projectedDelayedParcels: snapshot.summary.projectedDelayedParcels,
+        delayedParcelsDelta: snapshot.summary.delayedParcelsDelta,
+        introducedRiskCount: snapshot.summary.introducedRiskCount,
+        resolvedInPreview: snapshot.summary.resolvedInPreview,
+        moves: scenario.moves,
+        operator: scenario.operator,
+        dispatchWindow: scenario.dispatchWindow,
+        tradeoff: scenario.tradeoff,
+        comparisonNote: scenario.comparisonNote,
+      };
+    }),
+  ];
+
+  return {
+    ...projection,
+    scenarioCards,
+  };
+}

--- a/src/components/parcel-hub/parcel-summary-panel.tsx
+++ b/src/components/parcel-hub/parcel-summary-panel.tsx
@@ -1,37 +1,193 @@
-import type { PackageSummary } from "./parcel-hub-data";
+import type {
+  ParcelHubProjectionSummary,
+  ProjectedPackageSummary,
+} from "./parcel-hub-simulator";
 
-type ParcelSummaryPanelProps = { exceptionTypes: string[]; openExceptions: number; packageSummaries: PackageSummary[]; totalParcels: number };
+type ParcelSummaryPanelProps = {
+  activeScenarioLabel: string | null;
+  exceptionTypes: string[];
+  packageSummaries: ProjectedPackageSummary[];
+  summary: ParcelHubProjectionSummary;
+};
+
+function formatSigned(value: number) {
+  if (value === 0) {
+    return "0";
+  }
+
+  return `${value > 0 ? "+" : ""}${value}`;
+}
 
 export function ParcelSummaryPanel({
+  activeScenarioLabel,
   exceptionTypes,
-  openExceptions,
   packageSummaries,
-  totalParcels,
+  summary,
 }: ParcelSummaryPanelProps) {
   return (
     <section className="rounded-[2rem] border border-white/10 bg-slate-950/72 p-5 shadow-[0_18px_60px_rgba(15,23,42,0.32)] sm:p-6">
       <div className="flex items-end justify-between gap-4">
-        <div><p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Parcel mix</p><h2 className="mt-2 text-2xl font-semibold text-white">Grouped volume summary</h2></div>
-        <div className="text-right"><p className="text-3xl font-semibold text-white">{totalParcels}</p><p className="text-sm text-slate-300">parcels staged</p></div>
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">
+            Parcel mix
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">
+            Grouped volume and scenario impact
+          </h2>
+          <p className="mt-2 text-sm text-slate-300">
+            {activeScenarioLabel
+              ? `Previewing ${activeScenarioLabel} against the current route.`
+              : "Use a simulator card to see how package mix and route summary shift under reassignment."}
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-3xl font-semibold text-white">
+            {summary.totalParcels}
+          </p>
+          <p className="text-sm text-slate-300">parcels staged</p>
+        </div>
       </div>
+
       <div className="mt-5 space-y-3">
         {packageSummaries.map((summary) => (
-          <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-4" key={summary.id}>
+          <div
+            className="rounded-[1.5rem] border border-white/10 bg-white/5 p-4"
+            key={summary.id}
+          >
             <div className="flex items-start justify-between gap-3">
-              <div><p className="font-medium text-white">{summary.label}</p><p className="mt-1 text-sm text-slate-300">{summary.note}</p></div>
-              <div className="text-right"><p className="text-xl font-semibold text-white">{summary.count}</p><p className="text-xs uppercase tracking-[0.22em] text-slate-400">{summary.share}</p></div>
+              <div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="font-medium text-white">{summary.label}</p>
+                  <span
+                    className={`rounded-full px-2.5 py-1 text-[11px] uppercase tracking-[0.2em] ${
+                      summary.projectionStatus === "improved"
+                        ? "bg-emerald-300/10 text-emerald-100"
+                        : summary.projectionStatus === "watch"
+                          ? "bg-amber-300/10 text-amber-100"
+                          : "bg-white/10 text-slate-200"
+                    }`}
+                  >
+                    {summary.projectionStatus}
+                  </span>
+                </div>
+                <p className="mt-2 text-sm text-slate-300">
+                  {summary.projectionNote}
+                </p>
+              </div>
+              <div className="text-right">
+                <p className="text-xl font-semibold text-white">{summary.count}</p>
+                <p className="text-xs uppercase tracking-[0.22em] text-slate-400">
+                  {summary.share}
+                </p>
+              </div>
+            </div>
+            <div className="mt-4 flex flex-wrap gap-2 text-xs uppercase tracking-[0.18em] text-slate-400">
+              <span className="rounded-full border border-white/10 px-3 py-1">
+                {summary.movedParcels} rerouted
+              </span>
+              <span className="rounded-full border border-white/10 px-3 py-1">
+                SLA {formatSigned(summary.slaRiskDelta)}
+              </span>
             </div>
           </div>
         ))}
       </div>
+
+      <div className="mt-5 grid gap-3 sm:grid-cols-2">
+        <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-4">
+          <p className="text-sm font-medium text-white">Projected route outcome</p>
+          <div className="mt-4 grid gap-3">
+            <div className="flex items-end justify-between gap-4">
+              <div>
+                <p className="text-xs uppercase tracking-[0.22em] text-slate-400">
+                  SLA risk
+                </p>
+                <p className="mt-1 text-2xl font-semibold text-white">
+                  {summary.projectedSlaRiskParcels}
+                </p>
+              </div>
+              <p className="text-sm text-slate-300">
+                {formatSigned(summary.slaRiskParcelsDelta)} vs current
+              </p>
+            </div>
+            <div className="flex items-end justify-between gap-4">
+              <div>
+                <p className="text-xs uppercase tracking-[0.22em] text-slate-400">
+                  Open exceptions
+                </p>
+                <p className="mt-1 text-2xl font-semibold text-white">
+                  {summary.projectedOpenExceptions}
+                </p>
+              </div>
+              <p className="text-sm text-slate-300">
+                {formatSigned(summary.openExceptionsDelta)} vs current
+              </p>
+            </div>
+            <div className="flex items-end justify-between gap-4">
+              <div>
+                <p className="text-xs uppercase tracking-[0.22em] text-slate-400">
+                  Peak pressure
+                </p>
+                <p className="mt-1 text-2xl font-semibold text-white">
+                  {summary.projectedPeakPressure}%
+                </p>
+              </div>
+              <p className="text-sm text-slate-300">
+                {formatSigned(summary.peakPressureDelta)} pts vs current
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-[1.5rem] border border-white/10 bg-white/5 p-4">
+          <p className="text-sm font-medium text-white">
+            Previewed exception movement
+          </p>
+          <div className="mt-4 grid gap-3 text-sm text-slate-300">
+            <div className="flex items-center justify-between gap-3">
+              <span>Delayed parcels after move</span>
+              <span className="font-semibold text-white">
+                {summary.projectedDelayedParcels}
+              </span>
+            </div>
+            <div className="flex items-center justify-between gap-3">
+              <span>Exceptions cleared in preview</span>
+              <span className="font-semibold text-white">
+                {summary.resolvedInPreview}
+              </span>
+            </div>
+            <div className="flex items-center justify-between gap-3">
+              <span>Risks softened in preview</span>
+              <span className="font-semibold text-white">
+                {summary.softenedInPreview}
+              </span>
+            </div>
+            <div className="flex items-center justify-between gap-3">
+              <span>New preview risks</span>
+              <span className="font-semibold text-white">
+                {summary.introducedRiskCount}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <div className="mt-5 rounded-[1.5rem] border border-white/10 bg-white/5 p-4">
         <p className="text-sm font-medium text-white">Exception types in rotation</p>
         <div className="mt-3 flex flex-wrap gap-2">
           {exceptionTypes.map((type) => (
-            <span className="rounded-full border border-white/10 bg-slate-900 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-300" key={type}>{type}</span>
+            <span
+              className="rounded-full border border-white/10 bg-slate-900 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-300"
+              key={type}
+            >
+              {type}
+            </span>
           ))}
         </div>
-        <p className="mt-3 text-sm text-slate-300">{openExceptions} unresolved items remain in this local mock queue.</p>
+        <p className="mt-3 text-sm text-slate-300">
+          {summary.projectedOpenExceptions} unresolved items remain after the
+          selected preview is compared against the current route.
+        </p>
       </div>
     </section>
   );

--- a/src/components/parcel-hub/route-balance-simulator.tsx
+++ b/src/components/parcel-hub/route-balance-simulator.tsx
@@ -1,0 +1,257 @@
+import {
+  shipmentLanes,
+  type BalancingScenario,
+} from "./parcel-hub-data";
+import type { ScenarioCard } from "./parcel-hub-simulator";
+
+type RouteBalanceSimulatorProps = {
+  activeScenario: BalancingScenario | null;
+  activeScenarioId: string | null;
+  scenarioCards: ScenarioCard[];
+  onSelectScenario: (scenarioId: string | null) => void;
+};
+
+function formatSigned(value: number) {
+  if (value === 0) {
+    return "0";
+  }
+
+  return `${value > 0 ? "+" : ""}${value}`;
+}
+
+function formatDeltaLabel(
+  value: number,
+  improvedSuffix: string,
+  worsenedSuffix: string,
+) {
+  if (value === 0) {
+    return "No change from current";
+  }
+
+  return `${formatSigned(value)} ${value < 0 ? improvedSuffix : worsenedSuffix}`;
+}
+
+export function RouteBalanceSimulator({
+  activeScenario,
+  activeScenarioId,
+  scenarioCards,
+  onSelectScenario,
+}: RouteBalanceSimulatorProps) {
+  const laneCodeById = new Map(
+    shipmentLanes.map((lane) => [lane.id, lane.laneCode]),
+  );
+  const activeCard =
+    scenarioCards.find((scenario) => scenario.scenarioId === activeScenarioId) ??
+    scenarioCards[0];
+
+  return (
+    <section className="rounded-[2rem] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.9),rgba(15,23,42,0.72))] p-5 shadow-[0_24px_80px_rgba(15,23,42,0.38)] sm:p-6">
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div className="max-w-2xl">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-amber-300">
+            Route-balancing simulator
+          </p>
+          <h2 className="mt-3 text-2xl font-semibold text-white">
+            Compare reassignment paths before dispatch changes go live.
+          </h2>
+          <p className="mt-3 text-sm leading-6 text-slate-300">
+            Each card previews lane pressure, open exception drift, and SLA risk
+            tradeoffs against the current route. Selecting a scenario updates the
+            board, summary, and exception drawer without applying a live change.
+          </p>
+        </div>
+        <div className="rounded-[1.5rem] border border-amber-300/20 bg-amber-300/10 p-4 text-amber-50 lg:max-w-sm">
+          <p className="text-xs uppercase tracking-[0.24em] text-amber-100/80">
+            Active preview
+          </p>
+          <p className="mt-2 text-lg font-semibold">
+            {activeScenario ? activeScenario.label : "Current dispatch"}
+          </p>
+          <p className="mt-2 text-sm text-amber-100/85">
+            {activeScenario
+              ? activeScenario.comparisonNote
+              : "Use the simulator cards to preview reassignment outcomes before operators touch live dispatch."}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-6 grid gap-4 xl:grid-cols-2">
+        {scenarioCards.map((scenario) => {
+          const isActive = scenario.scenarioId === activeScenarioId;
+
+          return (
+            <button
+              aria-pressed={isActive}
+              className={`rounded-[1.75rem] border p-5 text-left transition ${
+                isActive
+                  ? "border-amber-300/50 bg-amber-300/10 shadow-[0_18px_60px_rgba(251,191,36,0.14)]"
+                  : "border-white/10 bg-white/[0.04] hover:border-white/20 hover:bg-white/[0.07]"
+              }`}
+              key={scenario.scenarioId ?? "baseline"}
+              onClick={() => onSelectScenario(scenario.scenarioId)}
+              type="button"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <span className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[11px] uppercase tracking-[0.24em] text-slate-200">
+                    {scenario.postureLabel}
+                  </span>
+                  <h3 className="mt-3 text-xl font-semibold text-white">
+                    {scenario.label}
+                  </h3>
+                </div>
+                {scenario.scenarioId ? (
+                  <span className="rounded-full border border-emerald-300/20 bg-emerald-300/10 px-3 py-1 text-xs font-medium uppercase tracking-[0.2em] text-emerald-100">
+                    {scenario.resolvedInPreview} clears
+                  </span>
+                ) : null}
+              </div>
+
+              <p className="mt-3 text-sm leading-6 text-slate-300">
+                {scenario.summary}
+              </p>
+
+              <div className="mt-5 grid gap-3 sm:grid-cols-2">
+                <div className="rounded-[1.25rem] border border-white/10 bg-slate-950/55 p-3">
+                  <p className="text-xs uppercase tracking-[0.2em] text-slate-400">
+                    Projected SLA risk
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold text-white">
+                    {scenario.projectedSlaRiskParcels}
+                  </p>
+                  <p className="mt-1 text-sm text-slate-300">
+                    {formatDeltaLabel(
+                      scenario.slaRiskDelta,
+                      "lower than current",
+                      "higher than current",
+                    )}
+                  </p>
+                </div>
+                <div className="rounded-[1.25rem] border border-white/10 bg-slate-950/55 p-3">
+                  <p className="text-xs uppercase tracking-[0.2em] text-slate-400">
+                    Open exceptions
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold text-white">
+                    {scenario.projectedOpenExceptions}
+                  </p>
+                  <p className="mt-1 text-sm text-slate-300">
+                    {formatDeltaLabel(
+                      scenario.openExceptionsDelta,
+                      "fewer than current",
+                      "more than current",
+                    )}
+                  </p>
+                </div>
+                <div className="rounded-[1.25rem] border border-white/10 bg-slate-950/55 p-3">
+                  <p className="text-xs uppercase tracking-[0.2em] text-slate-400">
+                    Peak lane pressure
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold text-white">
+                    {scenario.projectedPeakPressure}%
+                  </p>
+                  <p className="mt-1 text-sm text-slate-300">
+                    {formatDeltaLabel(
+                      scenario.peakPressureDelta,
+                      "below current peak",
+                      "above current peak",
+                    )}
+                  </p>
+                </div>
+                <div className="rounded-[1.25rem] border border-white/10 bg-slate-950/55 p-3">
+                  <p className="text-xs uppercase tracking-[0.2em] text-slate-400">
+                    Delayed parcels
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold text-white">
+                    {scenario.projectedDelayedParcels}
+                  </p>
+                  <p className="mt-1 text-sm text-slate-300">
+                    {formatDeltaLabel(
+                      scenario.delayedParcelsDelta,
+                      "fewer than current",
+                      "more than current",
+                    )}
+                  </p>
+                </div>
+              </div>
+
+              <div className="mt-4 flex flex-wrap items-center gap-2 text-xs uppercase tracking-[0.2em] text-slate-400">
+                <span>{scenario.moves.length} route moves</span>
+                <span className="text-slate-600">/</span>
+                <span>{scenario.introducedRiskCount} new preview risks</span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mt-6 rounded-[1.75rem] border border-white/10 bg-slate-950/60 p-5">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="max-w-2xl">
+            <p className="text-xs uppercase tracking-[0.24em] text-slate-400">
+              Reassignment preview
+            </p>
+            <h3 className="mt-2 text-xl font-semibold text-white">
+              {activeCard.label}
+            </h3>
+            <p className="mt-2 text-sm leading-6 text-slate-300">
+              {activeCard.comparisonNote}
+            </p>
+          </div>
+          <div className="grid gap-2 text-sm text-slate-300 sm:grid-cols-2">
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
+              <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                Operator
+              </p>
+              <p className="mt-1 text-white">{activeCard.operator}</p>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-3">
+              <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                Dispatch hold
+              </p>
+              <p className="mt-1 text-white">{activeCard.dispatchWindow}</p>
+            </div>
+          </div>
+        </div>
+
+        {activeCard.moves.length > 0 ? (
+          <div className="mt-5 grid gap-3 xl:grid-cols-2">
+            {activeCard.moves.map((move) => (
+              <article
+                className="rounded-[1.5rem] border border-white/10 bg-white/[0.04] p-4"
+                key={move.id}
+              >
+                <p className="text-xs uppercase tracking-[0.2em] text-slate-400">
+                  {move.label}
+                </p>
+                <h4 className="mt-2 text-lg font-semibold text-white">
+                  {move.parcelCount} parcels from{" "}
+                  {laneCodeById.get(move.fromLaneId) ?? move.fromLaneId} to{" "}
+                  {laneCodeById.get(move.toLaneId) ?? move.toLaneId}
+                </h4>
+                <p className="mt-2 text-sm leading-6 text-slate-300">
+                  {move.reason}
+                </p>
+                <p className="mt-3 text-sm text-emerald-200">{move.etaChange}</p>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <div className="mt-5 rounded-[1.5rem] border border-dashed border-white/12 bg-white/[0.03] p-5 text-center">
+            <p className="text-sm font-medium text-white">
+              The baseline card keeps the current route untouched.
+            </p>
+            <p className="mt-2 text-sm text-slate-300">
+              Pick any balancing scenario to preview which parcel groups move,
+              where they land, and what tradeoffs operators inherit.
+            </p>
+          </div>
+        )}
+
+        <div className="mt-5 rounded-[1.5rem] border border-rose-300/15 bg-rose-300/10 p-4 text-sm leading-6 text-rose-50">
+          <span className="font-semibold text-white">Tradeoff:</span>{" "}
+          {activeCard.tradeoff}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a scenario-driven route-balancing simulator to Parcel Hub with projected lane pressure, SLA risk, and exception previews
- expand the lane board, summary, and drawer surfaces so operators can compare reassignment outcomes before dispatch changes are applied
- add simulator and shell coverage for Parcel Hub and raise the slow MissionBriefingShell test timeout so the full Vitest suite stays green

Closes #69

## Testing
- npm run lint
- npm run typecheck
- npm run test