### PR TITLE
feat: add control room command palette workflow

### DIFF
--- a/src/app/control-room/mock-data.ts
+++ b/src/app/control-room/mock-data.ts
@@ -1,29 +1,168 @@
 export type MetricState = "healthy" | "warning" | "critical";
 export type AlertSeverity = "info" | "warning" | "critical";
-export type ActivityCategory = "deployments" | "incidents" | "traffic" | "automation";
+export type AlertSeverityFilter = AlertSeverity | "all";
+export type ActivityCategory =
+  | "deployments"
+  | "incidents"
+  | "traffic"
+  | "automation";
 export type ActivityFilter = ActivityCategory | "all";
+export type OperatorPosture = "monitor" | "contain" | "escalate";
+export type ControlRoomRegion =
+  | "metrics"
+  | "feed"
+  | "alerts"
+  | "drilldown"
+  | "controls";
 
 type MetricDefinition = {
-  id: string; label: string; description: string; base: number; step: number;
-  precision: number; suffix: string; deltaPrecision: number; deltaSuffix: string;
-  higherBetter: boolean; attention: number; critical: number;
-};
-type TemplateValue = string | ((cycle: number) => string);
-type AlertTemplate = {
-  id: string; title: string; detail: string; severity: AlertSeverity;
-  owner: string; impact: string; minutesAgo: number;
-};
-type FeedTemplate = {
-  id: string; title: string; summary: string; category: ActivityCategory;
-  actor: string; system: string; minutesAgo: number;
-  details: { label: string; value: TemplateValue }[];
+  id: string;
+  label: string;
+  description: string;
+  base: number;
+  step: number;
+  precision: number;
+  suffix: string;
+  deltaPrecision: number;
+  deltaSuffix: string;
+  higherBetter: boolean;
+  attention: number;
+  critical: number;
 };
 
-export type MetricCard = { id: string; label: string; description: string; value: string; delta: string; state: MetricState };
-export type AlertItem = { id: string; title: string; detail: string; severity: AlertSeverity; owner: string; impact: string; ageLabel: string };
-export type FeedDetail = { label: string; value: string };
-export type FeedItem = { id: string; title: string; summary: string; category: ActivityCategory; actor: string; system: string; ageLabel: string; details: FeedDetail[] };
-export type ControlRoomSnapshot = { environment: string; lastUpdated: string; metrics: MetricCard[]; alerts: AlertItem[]; feed: FeedItem[] };
+type TemplateValue = string | ((cycle: number) => string);
+
+export type WorkflowEffect =
+  | { type: "focus-region"; region: ControlRoomRegion }
+  | { type: "refresh-snapshot" }
+  | { type: "select-alert"; alertId: string }
+  | { type: "set-alert-filter"; filter: AlertSeverityFilter }
+  | { type: "set-divert-workers"; value: boolean }
+  | { type: "set-feed-filter"; filter: ActivityFilter }
+  | { type: "set-freeze-deploys"; value: boolean }
+  | { type: "set-posture"; posture: OperatorPosture }
+  | { type: "set-sampling-rate"; value: number }
+  | { type: "set-silence-info-alerts"; value: boolean };
+
+type AlertTimelineTemplate = {
+  id: string;
+  actor: string;
+  detail: string;
+  minutesAgo: number;
+  phase: "detect" | "stabilize" | "mitigate" | "handoff";
+  title: string;
+};
+
+type AlertActionTemplate = {
+  id: string;
+  description: string;
+  effects: WorkflowEffect[];
+  label: string;
+  tone: "default" | "warning" | "critical";
+};
+
+type AlertTemplate = {
+  id: string;
+  title: string;
+  detail: string;
+  severity: AlertSeverity;
+  owner: string;
+  impact: string;
+  minutesAgo: number;
+  region: string;
+  service: string;
+  status: string;
+  summary: string;
+  runbook: string;
+  recommendedPosture: OperatorPosture;
+  relatedMetricIds: string[];
+  tags: string[];
+  remediationActions: AlertActionTemplate[];
+  timeline: AlertTimelineTemplate[];
+};
+
+type FeedTemplate = {
+  id: string;
+  title: string;
+  summary: string;
+  category: ActivityCategory;
+  actor: string;
+  system: string;
+  minutesAgo: number;
+  details: { label: string; value: TemplateValue }[];
+  relatedAlertIds: string[];
+};
+
+export type MetricCard = {
+  id: string;
+  label: string;
+  description: string;
+  value: string;
+  delta: string;
+  state: MetricState;
+};
+
+export type AlertTimelineEntry = {
+  id: string;
+  actor: string;
+  ageLabel: string;
+  detail: string;
+  phase: "detect" | "stabilize" | "mitigate" | "handoff";
+  title: string;
+};
+
+export type AlertRemediationAction = {
+  id: string;
+  description: string;
+  effects: WorkflowEffect[];
+  label: string;
+  tone: "default" | "warning" | "critical";
+};
+
+export type AlertItem = {
+  id: string;
+  title: string;
+  detail: string;
+  severity: AlertSeverity;
+  owner: string;
+  impact: string;
+  ageLabel: string;
+  region: string;
+  service: string;
+  status: string;
+  summary: string;
+  runbook: string;
+  recommendedPosture: OperatorPosture;
+  relatedMetricIds: string[];
+  tags: string[];
+  remediationActions: AlertRemediationAction[];
+  timeline: AlertTimelineEntry[];
+};
+
+export type FeedDetail = {
+  label: string;
+  value: string;
+};
+
+export type FeedItem = {
+  id: string;
+  title: string;
+  summary: string;
+  category: ActivityCategory;
+  actor: string;
+  system: string;
+  ageLabel: string;
+  details: FeedDetail[];
+  relatedAlertIds: string[];
+};
+
+export type ControlRoomSnapshot = {
+  environment: string;
+  lastUpdated: string;
+  metrics: MetricCard[];
+  alerts: AlertItem[];
+  feed: FeedItem[];
+};
 
 export const activityFilters = [
   { id: "all", label: "All" },
@@ -33,76 +172,713 @@ export const activityFilters = [
   { id: "automation", label: "Automation" },
 ] satisfies { id: ActivityFilter; label: string }[];
 
+export const alertSeverityFilters = [
+  { id: "all", label: "All severities" },
+  { id: "critical", label: "Critical" },
+  { id: "warning", label: "Warning" },
+  { id: "info", label: "Info" },
+] satisfies { id: AlertSeverityFilter; label: string }[];
+
+export const controlRoomRegions = [
+  { id: "metrics", label: "Metrics Grid" },
+  { id: "feed", label: "Activity Feed" },
+  { id: "alerts", label: "Alert Queue" },
+  { id: "drilldown", label: "Alert Drilldown" },
+  { id: "controls", label: "Drill Controls" },
+] satisfies { id: ControlRoomRegion; label: string }[];
+
+export const operatorPostureOptions = [
+  "monitor",
+  "contain",
+  "escalate",
+] as const;
+
 const metricDefinitions: MetricDefinition[] = [
-  { id: "availability", label: "Availability", description: "Successful edge responses across the primary mesh.", base: 99.982, step: 0.008, precision: 3, suffix: "%", deltaPrecision: 3, deltaSuffix: "%", higherBetter: true, attention: 99.975, critical: 99.96 },
-  { id: "latency", label: "P95 latency", description: "Application edge to origin response time.", base: 184, step: 7, precision: 0, suffix: "ms", deltaPrecision: 0, deltaSuffix: "ms", higherBetter: false, attention: 195, critical: 208 },
-  { id: "burn", label: "Error budget burn", description: "Rolling burn rate over the last 60 minutes.", base: 21, step: 3.5, precision: 1, suffix: "%", deltaPrecision: 1, deltaSuffix: "%", higherBetter: false, attention: 25, critical: 31 },
-  { id: "queue", label: "Queue depth", description: "Buffered background jobs waiting on worker capacity.", base: 412, step: 36, precision: 0, suffix: "", deltaPrecision: 0, deltaSuffix: "", higherBetter: false, attention: 460, critical: 520 },
-  { id: "replicas", label: "Replica coverage", description: "Healthy replicas participating in regional failover.", base: 97.4, step: 0.5, precision: 1, suffix: "%", deltaPrecision: 1, deltaSuffix: "%", higherBetter: true, attention: 96, critical: 94.5 },
-  { id: "cadence", label: "Deploy cadence", description: "Production changes cleared through the release lane.", base: 6.4, step: 0.4, precision: 1, suffix: "/hr", deltaPrecision: 1, deltaSuffix: "/hr", higherBetter: true, attention: 5.8, critical: 5.2 },
-  { id: "automation", label: "Automation success", description: "Guardrail tasks completing without intervention.", base: 94.6, step: 0.7, precision: 1, suffix: "%", deltaPrecision: 1, deltaSuffix: "%", higherBetter: true, attention: 92, critical: 89 },
-  { id: "notifications", label: "Notification lag", description: "Median time for paging and timeline fan-out.", base: 42, step: 4, precision: 0, suffix: "s", deltaPrecision: 0, deltaSuffix: "s", higherBetter: false, attention: 48, critical: 56 },
+  {
+    id: "availability",
+    label: "Availability",
+    description: "Successful edge responses across the primary mesh.",
+    base: 99.982,
+    step: 0.008,
+    precision: 3,
+    suffix: "%",
+    deltaPrecision: 3,
+    deltaSuffix: "%",
+    higherBetter: true,
+    attention: 99.975,
+    critical: 99.96,
+  },
+  {
+    id: "latency",
+    label: "P95 latency",
+    description: "Application edge to origin response time.",
+    base: 184,
+    step: 7,
+    precision: 0,
+    suffix: "ms",
+    deltaPrecision: 0,
+    deltaSuffix: "ms",
+    higherBetter: false,
+    attention: 195,
+    critical: 208,
+  },
+  {
+    id: "burn",
+    label: "Error budget burn",
+    description: "Rolling burn rate over the last 60 minutes.",
+    base: 21,
+    step: 3.5,
+    precision: 1,
+    suffix: "%",
+    deltaPrecision: 1,
+    deltaSuffix: "%",
+    higherBetter: false,
+    attention: 25,
+    critical: 31,
+  },
+  {
+    id: "queue",
+    label: "Queue depth",
+    description: "Buffered background jobs waiting on worker capacity.",
+    base: 412,
+    step: 36,
+    precision: 0,
+    suffix: "",
+    deltaPrecision: 0,
+    deltaSuffix: "",
+    higherBetter: false,
+    attention: 460,
+    critical: 520,
+  },
+  {
+    id: "replicas",
+    label: "Replica coverage",
+    description: "Healthy replicas participating in regional failover.",
+    base: 97.4,
+    step: 0.5,
+    precision: 1,
+    suffix: "%",
+    deltaPrecision: 1,
+    deltaSuffix: "%",
+    higherBetter: true,
+    attention: 96,
+    critical: 94.5,
+  },
+  {
+    id: "cadence",
+    label: "Deploy cadence",
+    description: "Production changes cleared through the release lane.",
+    base: 6.4,
+    step: 0.4,
+    precision: 1,
+    suffix: "/hr",
+    deltaPrecision: 1,
+    deltaSuffix: "/hr",
+    higherBetter: true,
+    attention: 5.8,
+    critical: 5.2,
+  },
+  {
+    id: "automation",
+    label: "Automation success",
+    description: "Guardrail tasks completing without intervention.",
+    base: 94.6,
+    step: 0.7,
+    precision: 1,
+    suffix: "%",
+    deltaPrecision: 1,
+    deltaSuffix: "%",
+    higherBetter: true,
+    attention: 92,
+    critical: 89,
+  },
+  {
+    id: "notifications",
+    label: "Notification lag",
+    description: "Median time for paging and timeline fan-out.",
+    base: 42,
+    step: 4,
+    precision: 0,
+    suffix: "s",
+    deltaPrecision: 0,
+    deltaSuffix: "s",
+    higherBetter: false,
+    attention: 48,
+    critical: 56,
+  },
 ];
 
 const alertTemplates: AlertTemplate[] = [
-  { id: "replica-drift", title: "Replica drift exceeds guardrail", detail: "Database follower in us-east-2 is 12s behind after a storage rebalance.", severity: "critical", owner: "Storage Ops", impact: "Write protection may arm if drift keeps climbing.", minutesAgo: 4 },
-  { id: "queue-surge", title: "Background queue rising in canary lane", detail: "Worker saturation is pushing fan-out jobs above their comfort band.", severity: "warning", owner: "Workflow Control", impact: "Customer notifications could slip by one processing window.", minutesAgo: 9 },
-  { id: "synthetic-drill", title: "Synthetic failover drill opens in 12 minutes", detail: "Dry-run policies are preloaded and waiting for operator confirmation.", severity: "info", owner: "Resilience Team", impact: "Status banners will switch to drill mode during the exercise.", minutesAgo: 15 },
-  { id: "tls-window", title: "Certificate rotation overlap narrows", detail: "Two edge clusters are within the final renewal grace period.", severity: "warning", owner: "Edge Platform", impact: "Regional handshakes may degrade if renewal is delayed.", minutesAgo: 21 },
-  { id: "audit-note", title: "Runbook audit snapshot published", detail: "Shift handoff notes were attached to the incident ledger.", severity: "info", owner: "Control Desk", impact: "Operators can cross-check the latest mitigation notes locally.", minutesAgo: 28 },
+  {
+    id: "replica-drift",
+    title: "Replica drift exceeds guardrail",
+    detail:
+      "Database follower in us-east-2 is 12s behind after a storage rebalance.",
+    severity: "critical",
+    owner: "Storage Ops",
+    impact: "Write protection may arm if drift keeps climbing.",
+    minutesAgo: 4,
+    region: "us-east-2 / payments-primary",
+    service: "payments-primary",
+    status: "Follower lag is breaching the SEV-2 watch threshold.",
+    summary:
+      "A shard rebalance completed cleanly, but the promoted follower is now absorbing write amplification and trailing the primary.",
+    runbook: "Runbook 7 · Replica drift containment",
+    recommendedPosture: "escalate",
+    relatedMetricIds: ["replicas", "latency", "availability"],
+    tags: ["database", "replication", "guardrail"],
+    remediationActions: [
+      {
+        id: "replica-freeze-deploys",
+        label: "Freeze deploy lane",
+        description:
+          "Stop new promotions while storage validates follower health.",
+        tone: "critical",
+        effects: [
+          { type: "set-freeze-deploys", value: true },
+          { type: "focus-region", region: "controls" },
+        ],
+      },
+      {
+        id: "replica-escalate-posture",
+        label: "Escalate operator posture",
+        description:
+          "Promote the desk into escalation mode and prepare bridge comms.",
+        tone: "warning",
+        effects: [{ type: "set-posture", posture: "escalate" }],
+      },
+      {
+        id: "replica-filter-incidents",
+        label: "Filter timeline to incidents",
+        description:
+          "Trim the feed to bridge updates, mitigations, and handoff notes.",
+        tone: "default",
+        effects: [
+          { type: "set-feed-filter", filter: "incidents" },
+          { type: "focus-region", region: "feed" },
+        ],
+      },
+    ],
+    timeline: [
+      {
+        id: "replica-lag-detected",
+        actor: "Storage watcher",
+        detail: "Follower lag crossed 10s for two consecutive telemetry windows.",
+        minutesAgo: 2,
+        phase: "detect",
+        title: "Lag breach detected",
+      },
+      {
+        id: "replica-rebalance-note",
+        actor: "Shard allocator",
+        detail:
+          "Rebalance completed with higher than expected write amplification on shard 14.",
+        minutesAgo: 7,
+        phase: "stabilize",
+        title: "Recent storage rebalance linked",
+      },
+      {
+        id: "replica-write-protect",
+        actor: "Guardrail service",
+        detail:
+          "Write protection will arm if drift rises above 18s for another minute.",
+        minutesAgo: 9,
+        phase: "mitigate",
+        title: "Protective threshold approaching",
+      },
+      {
+        id: "replica-bridge-opened",
+        actor: "Shift lead",
+        detail:
+          "SEV-2 review bridge opened with platform, storage, and release control.",
+        minutesAgo: 12,
+        phase: "handoff",
+        title: "Cross-team bridge staged",
+      },
+    ],
+  },
+  {
+    id: "queue-surge",
+    title: "Background queue rising in canary lane",
+    detail:
+      "Worker saturation is pushing fan-out jobs above their comfort band.",
+    severity: "warning",
+    owner: "Workflow Control",
+    impact: "Customer notifications could slip by one processing window.",
+    minutesAgo: 9,
+    region: "canary lane / fan-out workers",
+    service: "notification-fanout",
+    status: "Queue depth has expanded across two release intervals.",
+    summary:
+      "Autoscaling is trailing canary traffic, leaving retries and timeline fan-out stacked behind the hot lane.",
+    runbook: "Runbook 12 · Queue surge shaping",
+    recommendedPosture: "contain",
+    relatedMetricIds: ["queue", "automation", "notifications"],
+    tags: ["queue", "workers", "fan-out"],
+    remediationActions: [
+      {
+        id: "queue-divert-workers",
+        label: "Divert background workers",
+        description:
+          "Borrow spare capacity from replay workers and feed the canary lane.",
+        tone: "warning",
+        effects: [
+          { type: "set-divert-workers", value: true },
+          { type: "focus-region", region: "controls" },
+        ],
+      },
+      {
+        id: "queue-raise-sampling",
+        label: "Raise event sampling to 84%",
+        description:
+          "Collect more trace coverage before the fan-out window rolls over.",
+        tone: "default",
+        effects: [{ type: "set-sampling-rate", value: 84 }],
+      },
+      {
+        id: "queue-focus-automation",
+        label: "Filter timeline to automation",
+        description:
+          "Surface scaler, de-dupe, and replay events that explain the backlog.",
+        tone: "default",
+        effects: [
+          { type: "set-feed-filter", filter: "automation" },
+          { type: "focus-region", region: "feed" },
+        ],
+      },
+    ],
+    timeline: [
+      {
+        id: "queue-autoscale",
+        actor: "Capacity manager",
+        detail: "Autoscaler requested six workers but only three healthy slots were free.",
+        minutesAgo: 3,
+        phase: "detect",
+        title: "Autoscale shortfall recorded",
+      },
+      {
+        id: "queue-notifications",
+        actor: "Fan-out scheduler",
+        detail:
+          "Notification replay jobs were deprioritized behind canary verification tasks.",
+        minutesAgo: 6,
+        phase: "stabilize",
+        title: "Replay work deprioritized",
+      },
+      {
+        id: "queue-dedupe",
+        actor: "Signal reducer",
+        detail:
+          "Duplicate-warning suppression trimmed 18 events but the backlog remains above band.",
+        minutesAgo: 10,
+        phase: "mitigate",
+        title: "Noise suppression reduced pressure",
+      },
+      {
+        id: "queue-handoff",
+        actor: "Workflow lead",
+        detail:
+          "Oncoming shift asked for an operator decision before the next canary gate.",
+        minutesAgo: 14,
+        phase: "handoff",
+        title: "Decision checkpoint scheduled",
+      },
+    ],
+  },
+  {
+    id: "synthetic-drill",
+    title: "Synthetic failover drill opens in 12 minutes",
+    detail:
+      "Dry-run policies are preloaded and waiting for operator confirmation.",
+    severity: "info",
+    owner: "Resilience Team",
+    impact: "Status banners will switch to drill mode during the exercise.",
+    minutesAgo: 15,
+    region: "global ingress / dry-run rail",
+    service: "resilience-simulator",
+    status: "Drill scaffolding is staged and awaiting operator launch.",
+    summary:
+      "The exercise is ready to open with route, cache, and notification mocks already pinned into rehearsal mode.",
+    runbook: "Drill Pack 3 · Synthetic failover rehearsal",
+    recommendedPosture: "monitor",
+    relatedMetricIds: ["availability", "cadence", "notifications"],
+    tags: ["drill", "failover", "simulation"],
+    remediationActions: [
+      {
+        id: "drill-run-failover",
+        label: "Run dry failover sequence",
+        description:
+          "Advance the rehearsal and capture the operator decision in the local command log.",
+        tone: "default",
+        effects: [{ type: "focus-region", region: "controls" }],
+      },
+      {
+        id: "drill-silence-info",
+        label: "Silence info alerts locally",
+        description:
+          "Mute the lower-severity rehearsal noise while the exercise banner is active.",
+        tone: "default",
+        effects: [{ type: "set-silence-info-alerts", value: true }],
+      },
+      {
+        id: "drill-refresh-snapshot",
+        label: "Refresh desk snapshot",
+        description:
+          "Rotate the mock desk state before the rehearsal begins.",
+        tone: "default",
+        effects: [{ type: "refresh-snapshot" }],
+      },
+    ],
+    timeline: [
+      {
+        id: "drill-policies",
+        actor: "Resilience bot",
+        detail: "Dry-run policies were loaded into the rehearsal rail without touching production.",
+        minutesAgo: 4,
+        phase: "detect",
+        title: "Exercise policies staged",
+      },
+      {
+        id: "drill-route-check",
+        actor: "Ingress controller",
+        detail:
+          "Synthetic route checks passed against the standby edge map in 46 seconds.",
+        minutesAgo: 8,
+        phase: "stabilize",
+        title: "Standby route check passed",
+      },
+      {
+        id: "drill-comms",
+        actor: "Control desk",
+        detail:
+          "Drill comms draft is ready if operators want timeline breadcrumbs during the run.",
+        minutesAgo: 11,
+        phase: "mitigate",
+        title: "Comms draft prepared",
+      },
+      {
+        id: "drill-handoff",
+        actor: "Resilience lead",
+        detail:
+          "Shift lead needs to acknowledge the rehearsal before banners flip to drill mode.",
+        minutesAgo: 16,
+        phase: "handoff",
+        title: "Approval checkpoint open",
+      },
+    ],
+  },
+  {
+    id: "tls-window",
+    title: "Certificate rotation overlap narrows",
+    detail:
+      "Two edge clusters are within the final renewal grace period.",
+    severity: "warning",
+    owner: "Edge Platform",
+    impact: "Regional handshakes may degrade if renewal is delayed.",
+    minutesAgo: 21,
+    region: "eu-west-1 / edge batch b14",
+    service: "edge-handshake",
+    status: "Renewal overlap is shrinking faster than the expected rollout pace.",
+    summary:
+      "The next certificate bundle is signed, but two edge clusters are still serving the expiring chain while the new batch drains forward.",
+    runbook: "Runbook 19 · Edge cert overlap recovery",
+    recommendedPosture: "contain",
+    relatedMetricIds: ["availability", "latency", "cadence"],
+    tags: ["tls", "edge", "renewal"],
+    remediationActions: [
+      {
+        id: "tls-freeze-promotions",
+        label: "Freeze lane before edge batch",
+        description:
+          "Pause promotions until the final certificate overlap expands again.",
+        tone: "warning",
+        effects: [
+          { type: "set-freeze-deploys", value: true },
+          { type: "set-alert-filter", filter: "warning" },
+        ],
+      },
+      {
+        id: "tls-focus-alerts",
+        label: "Focus alert queue on warnings",
+        description:
+          "Reduce the queue to operator-reviewable warnings for the next handoff.",
+        tone: "default",
+        effects: [
+          { type: "set-alert-filter", filter: "warning" },
+          { type: "focus-region", region: "alerts" },
+        ],
+      },
+      {
+        id: "tls-open-drilldown",
+        label: "Jump back to drilldown",
+        description:
+          "Re-center the operator on the certificate context pane.",
+        tone: "default",
+        effects: [{ type: "focus-region", region: "drilldown" }],
+      },
+    ],
+    timeline: [
+      {
+        id: "tls-expiry",
+        actor: "Certificate monitor",
+        detail: "Two clusters entered the final overlap window with 31 minutes to spare.",
+        minutesAgo: 5,
+        phase: "detect",
+        title: "Final overlap window entered",
+      },
+      {
+        id: "tls-bundle",
+        actor: "Release signer",
+        detail: "Bundle `edge-b14-r3` was signed and queued for promotion.",
+        minutesAgo: 9,
+        phase: "stabilize",
+        title: "Updated bundle prepared",
+      },
+      {
+        id: "tls-promotion",
+        actor: "Edge platform",
+        detail:
+          "Promotion is waiting on the canary gate to clear before moving to the remaining clusters.",
+        minutesAgo: 13,
+        phase: "mitigate",
+        title: "Promotion blocked on canary gate",
+      },
+      {
+        id: "tls-handoff",
+        actor: "Edge on-call",
+        detail: "Next checkpoint is aligned with the 10:30 UTC promotion window.",
+        minutesAgo: 18,
+        phase: "handoff",
+        title: "Renewal checkpoint pinned",
+      },
+    ],
+  },
+  {
+    id: "audit-note",
+    title: "Runbook audit snapshot published",
+    detail:
+      "Shift handoff notes were attached to the incident ledger.",
+    severity: "info",
+    owner: "Control Desk",
+    impact: "Operators can cross-check the latest mitigation notes locally.",
+    minutesAgo: 28,
+    region: "control desk / ledger",
+    service: "incident-ledger",
+    status: "A fresh audit bundle is available for local review.",
+    summary:
+      "The desk now has a packaged handoff note with decision history, command log entries, and mitigation outcomes from the last rotation.",
+    runbook: "Desk note · Shift ledger audit",
+    recommendedPosture: "monitor",
+    relatedMetricIds: ["automation", "notifications", "cadence"],
+    tags: ["audit", "handoff", "ledger"],
+    remediationActions: [
+      {
+        id: "audit-filter-feed",
+        label: "Filter feed to deployments",
+        description:
+          "Cross-check the signed bundle and handoff against release activity.",
+        tone: "default",
+        effects: [{ type: "set-feed-filter", filter: "deployments" }],
+      },
+      {
+        id: "audit-focus-controls",
+        label: "Focus drill controls",
+        description:
+          "Move the operator to local switches before the next shift note is staged.",
+        tone: "default",
+        effects: [{ type: "focus-region", region: "controls" }],
+      },
+      {
+        id: "audit-silence-info",
+        label: "Mute audit noise",
+        description:
+          "Keep the note in the queue, but locally mute info-only chatter.",
+        tone: "default",
+        effects: [{ type: "set-silence-info-alerts", value: true }],
+      },
+    ],
+    timeline: [
+      {
+        id: "audit-ledger",
+        actor: "Control desk",
+        detail: "Latest mitigation notes were bundled into the shift ledger for local review.",
+        minutesAgo: 6,
+        phase: "detect",
+        title: "Ledger bundle published",
+      },
+      {
+        id: "audit-signoff",
+        actor: "Review bot",
+        detail: "Audit sign-off linked release approvals, command logs, and mitigation decisions.",
+        minutesAgo: 11,
+        phase: "stabilize",
+        title: "Cross-links assembled",
+      },
+      {
+        id: "audit-gaps",
+        actor: "Responder notes",
+        detail: "No missing reviewer acknowledgements were found in the prior shift sample.",
+        minutesAgo: 15,
+        phase: "mitigate",
+        title: "Handoff gaps cleared",
+      },
+      {
+        id: "audit-ready",
+        actor: "Shift lead",
+        detail: "Desk can reference the note during the next incident drilldown without leaving Control Room.",
+        minutesAgo: 21,
+        phase: "handoff",
+        title: "Local review path confirmed",
+      },
+    ],
+  },
 ];
 
 const feedTemplates: FeedTemplate[] = [
   {
-    id: "deploy-wave", title: "Canary wave 09 advanced to 20% traffic",
-    summary: "Release control widened exposure after the guardrail sweep stayed green.", category: "deployments",
-    actor: "Release control", system: "Deploy lane", minutesAgo: 3,
-    details: [{ label: "Change set", value: (cycle) => `cfg-${912 + cycle}` }, { label: "Target", value: "payments-api" }, { label: "Next gate", value: "40% traffic after 2 healthy intervals" }],
+    id: "deploy-wave",
+    title: "Canary wave 09 advanced to 20% traffic",
+    summary:
+      "Release control widened exposure after the guardrail sweep stayed green.",
+    category: "deployments",
+    actor: "Release control",
+    system: "Deploy lane",
+    minutesAgo: 3,
+    details: [
+      { label: "Change set", value: (cycle) => `cfg-${912 + cycle}` },
+      { label: "Target", value: "payments-api" },
+      { label: "Next gate", value: "40% traffic after 2 healthy intervals" },
+    ],
+    relatedAlertIds: ["tls-window", "replica-drift"],
   },
   {
-    id: "incident-escalation", title: "Runbook 7 escalated to platform on-call",
-    summary: "Operator requested manual review after replica drift crossed the paging threshold.", category: "incidents",
-    actor: "Shift lead", system: "Incident desk", minutesAgo: 8,
-    details: [{ label: "Escalation", value: "SEV-2 review bridge opened" }, { label: "Primary on-call", value: "P. Alvarez" }, { label: "Mitigation", value: "Follower restart held pending storage snapshot" }],
+    id: "incident-escalation",
+    title: "Runbook 7 escalated to platform on-call",
+    summary:
+      "Operator requested manual review after replica drift crossed the paging threshold.",
+    category: "incidents",
+    actor: "Shift lead",
+    system: "Incident desk",
+    minutesAgo: 8,
+    details: [
+      { label: "Escalation", value: "SEV-2 review bridge opened" },
+      { label: "Primary on-call", value: "P. Alvarez" },
+      {
+        label: "Mitigation",
+        value: "Follower restart held pending storage snapshot",
+      },
+    ],
+    relatedAlertIds: ["replica-drift"],
   },
   {
-    id: "traffic-policy", title: "Routing policy widened on eu-west ingress",
-    summary: "Traffic steering compensated for regional cold starts after cache churn.", category: "traffic",
-    actor: "Auto-balancer", system: "Global ingress", minutesAgo: 12,
-    details: [{ label: "Region", value: "eu-west-1" }, { label: "Shift", value: (cycle) => `${6 + cycle}% to standby pool` }, { label: "Observation", value: "Tail latency recovered within one interval" }],
+    id: "traffic-policy",
+    title: "Routing policy widened on eu-west ingress",
+    summary:
+      "Traffic steering compensated for regional cold starts after cache churn.",
+    category: "traffic",
+    actor: "Auto-balancer",
+    system: "Global ingress",
+    minutesAgo: 12,
+    details: [
+      { label: "Region", value: "eu-west-1" },
+      { label: "Shift", value: (cycle) => `${6 + cycle}% to standby pool` },
+      { label: "Observation", value: "Tail latency recovered within one interval" },
+    ],
+    relatedAlertIds: ["synthetic-drill", "tls-window"],
   },
   {
-    id: "rollback-sim", title: "Rollback simulator cleared dry-run guardrails",
-    summary: "Automation replay validated recovery steps without changing production state.", category: "automation",
-    actor: "Control bot", system: "Runbook simulator", minutesAgo: 17,
-    details: [{ label: "Scenario", value: "Canary rollback with queue drain" }, { label: "Execution", value: (cycle) => `dry-run-${305 + cycle}` }, { label: "Result", value: "No blocking checks found" }],
+    id: "rollback-sim",
+    title: "Rollback simulator cleared dry-run guardrails",
+    summary:
+      "Automation replay validated recovery steps without changing production state.",
+    category: "automation",
+    actor: "Control bot",
+    system: "Runbook simulator",
+    minutesAgo: 17,
+    details: [
+      { label: "Scenario", value: "Canary rollback with queue drain" },
+      { label: "Execution", value: (cycle) => `dry-run-${305 + cycle}` },
+      { label: "Result", value: "No blocking checks found" },
+    ],
+    relatedAlertIds: ["synthetic-drill", "queue-surge"],
   },
   {
-    id: "signing-bundle", title: "Configuration bundle signed for edge batch B14",
-    summary: "Edge policies were packaged for the next promotion window.", category: "deployments",
-    actor: "Release signer", system: "Policy vault", minutesAgo: 22,
-    details: [{ label: "Bundle", value: (cycle) => `edge-b14-r${cycle + 1}` }, { label: "Approvers", value: "2 of 2 collected" }, { label: "Window", value: "Next handoff at 10:30 UTC" }],
+    id: "signing-bundle",
+    title: "Configuration bundle signed for edge batch B14",
+    summary:
+      "Edge policies were packaged for the next promotion window.",
+    category: "deployments",
+    actor: "Release signer",
+    system: "Policy vault",
+    minutesAgo: 22,
+    details: [
+      { label: "Bundle", value: (cycle) => `edge-b14-r${cycle + 1}` },
+      { label: "Approvers", value: "2 of 2 collected" },
+      { label: "Window", value: "Next handoff at 10:30 UTC" },
+    ],
+    relatedAlertIds: ["tls-window", "audit-note"],
   },
   {
-    id: "replay-trace", title: "Trace replay trimmed duplicate notifications",
-    summary: "Automation de-duped timeline noise after the queue surge warning.", category: "automation",
-    actor: "Signal reducer", system: "Timeline fan-out", minutesAgo: 29,
-    details: [{ label: "Muted events", value: (cycle) => `${18 + cycle}` }, { label: "Scope", value: "warning-only duplicate bursts" }, { label: "Retention", value: "Raw trace preserved for audit" }],
+    id: "replay-trace",
+    title: "Trace replay trimmed duplicate notifications",
+    summary:
+      "Automation de-duped timeline noise after the queue surge warning.",
+    category: "automation",
+    actor: "Signal reducer",
+    system: "Timeline fan-out",
+    minutesAgo: 29,
+    details: [
+      { label: "Muted events", value: (cycle) => `${18 + cycle}` },
+      { label: "Scope", value: "warning-only duplicate bursts" },
+      { label: "Retention", value: "Raw trace preserved for audit" },
+    ],
+    relatedAlertIds: ["queue-surge", "audit-note"],
   },
 ];
 
-const timestampFormatter = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit", hour12: false, timeZone: "UTC" });
-const rotate = <T,>(items: T[], cycle: number) => [...items.slice(cycle % items.length), ...items.slice(0, cycle % items.length)];
-const formatAge = (minutes: number) => (minutes < 60 ? `${minutes}m ago` : `${Math.floor(minutes / 60)}h ago`);
+const timestampFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+  timeZone: "UTC",
+});
 
-function getMetricState(definition: MetricDefinition, value: number): MetricState {
-  if (definition.higherBetter) return value <= definition.critical ? "critical" : value <= definition.attention ? "warning" : "healthy";
-  return value >= definition.critical ? "critical" : value >= definition.attention ? "warning" : "healthy";
+const rotate = <T,>(items: T[], cycle: number) => [
+  ...items.slice(cycle % items.length),
+  ...items.slice(0, cycle % items.length),
+];
+
+const formatAge = (minutes: number) =>
+  minutes < 60 ? `${minutes}m ago` : `${Math.floor(minutes / 60)}h ago`;
+
+function getMetricState(
+  definition: MetricDefinition,
+  value: number,
+): MetricState {
+  if (definition.higherBetter) {
+    return value <= definition.critical
+      ? "critical"
+      : value <= definition.attention
+        ? "warning"
+        : "healthy";
+  }
+
+  return value >= definition.critical
+    ? "critical"
+    : value >= definition.attention
+      ? "warning"
+      : "healthy";
 }
 
-export const formatLastUpdated = (timestamp: string) => `${timestampFormatter.format(new Date(timestamp))} UTC`;
+export const formatLastUpdated = (timestamp: string) =>
+  `${timestampFormatter.format(new Date(timestamp))} UTC`;
 
-export function buildControlRoomSnapshot(cycle: number, referenceTime = new Date()): ControlRoomSnapshot {
+export function buildControlRoomSnapshot(
+  cycle: number,
+  referenceTime = new Date(),
+): ControlRoomSnapshot {
   const updatedAt = new Date(referenceTime.getTime() + cycle * 45_000);
 
   return {
@@ -112,7 +888,9 @@ export function buildControlRoomSnapshot(cycle: number, referenceTime = new Date
       const swing = ((cycle + index * 2) % 5) - 2;
       const value = definition.base + swing * definition.step;
       const delta = swing * definition.step;
-      const signedDelta = `${delta > 0 ? "+" : ""}${delta.toFixed(definition.deltaPrecision)}${definition.deltaSuffix} vs baseline`;
+      const signedDelta = `${delta > 0 ? "+" : ""}${delta.toFixed(
+        definition.deltaPrecision,
+      )}${definition.deltaSuffix} vs baseline`;
 
       return {
         id: definition.id,
@@ -123,7 +901,32 @@ export function buildControlRoomSnapshot(cycle: number, referenceTime = new Date
         state: getMetricState(definition, value),
       };
     }),
-    alerts: rotate(alertTemplates, cycle).map((alert, index) => ({ ...alert, ageLabel: formatAge(alert.minutesAgo + index * 2 + cycle) })),
+    alerts: rotate(alertTemplates, cycle).map((alert, index) => ({
+      id: alert.id,
+      title: alert.title,
+      detail: alert.detail,
+      severity: alert.severity,
+      owner: alert.owner,
+      impact: alert.impact,
+      ageLabel: formatAge(alert.minutesAgo + index * 2 + cycle),
+      region: alert.region,
+      service: alert.service,
+      status: alert.status,
+      summary: alert.summary,
+      runbook: alert.runbook,
+      recommendedPosture: alert.recommendedPosture,
+      relatedMetricIds: alert.relatedMetricIds,
+      tags: alert.tags,
+      remediationActions: alert.remediationActions,
+      timeline: alert.timeline.map((entry) => ({
+        id: entry.id,
+        actor: entry.actor,
+        ageLabel: formatAge(entry.minutesAgo + cycle),
+        detail: entry.detail,
+        phase: entry.phase,
+        title: entry.title,
+      })),
+    })),
     feed: rotate(feedTemplates, cycle).map((entry, index) => ({
       id: entry.id,
       title: entry.title,
@@ -132,7 +935,12 @@ export function buildControlRoomSnapshot(cycle: number, referenceTime = new Date
       actor: entry.actor,
       system: entry.system,
       ageLabel: formatAge(entry.minutesAgo + index * 2 + cycle),
-      details: entry.details.map((detail) => ({ label: detail.label, value: typeof detail.value === "function" ? detail.value(cycle) : detail.value })),
+      details: entry.details.map((detail) => ({
+        label: detail.label,
+        value:
+          typeof detail.value === "function" ? detail.value(cycle) : detail.value,
+      })),
+      relatedAlertIds: entry.relatedAlertIds,
     })),
   };
 }

--- a/src/components/control-room/activity-feed.tsx
+++ b/src/components/control-room/activity-feed.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type Ref } from "react";
 import {
   activityFilters,
   type ActivityFilter,
@@ -15,19 +15,50 @@ const categoryClasses = {
 };
 
 type ActivityFeedProps = {
+  activeFilter: ActivityFilter;
+  highlightAlertId: string | null;
+  isSpotlighted: boolean;
   items: FeedItem[];
+  onFilterChange: (filter: ActivityFilter) => void;
+  sectionRef?: Ref<HTMLElement>;
 };
 
-export function ActivityFeed({ items }: ActivityFeedProps) {
-  const [activeFilter, setActiveFilter] = useState<ActivityFilter>("all");
-  const [expandedId, setExpandedId] = useState<string | null>(items[0]?.id ?? null);
+export function ActivityFeed({
+  activeFilter,
+  highlightAlertId,
+  isSpotlighted,
+  items,
+  onFilterChange,
+  sectionRef,
+}: ActivityFeedProps) {
+  const [manualExpandedId, setManualExpandedId] = useState<string | null>(
+    items[0]?.id ?? null,
+  );
 
   const visibleItems = items.filter(
     (item) => activeFilter === "all" || item.category === activeFilter,
   );
+  const highlightedEntryId = highlightAlertId
+    ? visibleItems.find((item) => item.relatedAlertIds.includes(highlightAlertId))
+        ?.id ?? null
+    : null;
+  const expandedId =
+    highlightedEntryId ??
+    (visibleItems.some((item) => item.id === manualExpandedId)
+      ? manualExpandedId
+      : visibleItems[0]?.id ?? null);
 
   return (
-    <section className="rounded-[2rem] border border-white/10 bg-slate-950/65 p-6 backdrop-blur sm:p-8">
+    <section
+      aria-label="Activity feed"
+      className={`rounded-[2rem] border bg-slate-950/65 p-6 backdrop-blur transition sm:p-8 ${
+        isSpotlighted
+          ? "border-cyan-300/45 shadow-[0_0_0_1px_rgba(103,232,249,0.15),0_18px_70px_rgba(34,211,238,0.18)]"
+          : "border-white/10"
+      }`}
+      ref={sectionRef}
+      tabIndex={-1}
+    >
       <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div>
           <p className="text-xs uppercase tracking-[0.24em] text-cyan-200/70">
@@ -50,7 +81,7 @@ export function ActivityFeed({ items }: ActivityFeedProps) {
                     : "border-white/12 bg-white/[0.04] text-slate-300 hover:border-white/20 hover:text-white"
                 }`}
                 key={filter.id}
-                onClick={() => setActiveFilter(filter.id)}
+                onClick={() => onFilterChange(filter.id)}
                 type="button"
               >
                 {filter.label}
@@ -59,63 +90,82 @@ export function ActivityFeed({ items }: ActivityFeedProps) {
           })}
         </div>
       </div>
-      <ol className="mt-6 space-y-3">
-        {visibleItems.map((item) => {
-          const isExpanded = expandedId === item.id;
 
-          return (
-            <li
-              className="overflow-hidden rounded-[1.5rem] border border-white/8 bg-white/[0.04]"
-              key={item.id}
-            >
-              <button
-                aria-expanded={isExpanded}
-                className="w-full px-5 py-4 text-left"
-                onClick={() =>
-                  setExpandedId(isExpanded ? null : item.id)
-                }
-                type="button"
+      {visibleItems.length === 0 ? (
+        <div className="mt-6 rounded-[1.5rem] border border-dashed border-white/12 bg-white/[0.03] p-6 text-sm text-slate-400">
+          No activity rows match the current timeline lens.
+        </div>
+      ) : (
+        <ol className="mt-6 space-y-3">
+          {visibleItems.map((item) => {
+            const isExpanded = expandedId === item.id;
+            const isRelated = highlightAlertId
+              ? item.relatedAlertIds.includes(highlightAlertId)
+              : false;
+
+            return (
+              <li
+                className={`overflow-hidden rounded-[1.5rem] border ${
+                  isRelated
+                    ? "border-cyan-300/30 bg-cyan-400/[0.07]"
+                    : "border-white/8 bg-white/[0.04]"
+                }`}
+                key={item.id}
               >
-                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                  <div>
-                    <span
-                      className={`inline-flex rounded-full border px-3 py-1 text-xs uppercase tracking-[0.22em] ${categoryClasses[item.category]}`}
-                    >
-                      {item.category}
-                    </span>
-                    <h3 className="mt-3 text-lg font-medium text-white">
-                      {item.title}
-                    </h3>
-                    <p className="mt-2 text-sm leading-6 text-slate-300">
-                      {item.summary}
-                    </p>
-                  </div>
-                  <div className="text-sm text-slate-400 sm:text-right">
-                    <p>{item.ageLabel}</p>
-                    <p className="mt-1">{item.system}</p>
-                    <p className="mt-1 text-slate-500">{item.actor}</p>
-                  </div>
-                </div>
-              </button>
-              {isExpanded ? (
-                <div className="grid gap-3 border-t border-white/8 px-5 py-4 text-sm sm:grid-cols-3">
-                  {item.details.map((detail) => (
-                    <div
-                      className="rounded-2xl border border-white/8 bg-slate-950/55 p-3"
-                      key={`${item.id}-${detail.label}`}
-                    >
-                      <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
-                        {detail.label}
+                <button
+                  aria-expanded={isExpanded}
+                  className="w-full px-5 py-4 text-left"
+                  onClick={() => setManualExpandedId(isExpanded ? null : item.id)}
+                  type="button"
+                >
+                  <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span
+                          className={`inline-flex rounded-full border px-3 py-1 text-xs uppercase tracking-[0.22em] ${categoryClasses[item.category]}`}
+                        >
+                          {item.category}
+                        </span>
+                        {isRelated ? (
+                          <span className="rounded-full border border-cyan-300/30 bg-cyan-300/12 px-3 py-1 text-[11px] uppercase tracking-[0.24em] text-cyan-100">
+                            linked to drilldown
+                          </span>
+                        ) : null}
+                      </div>
+                      <h3 className="mt-3 text-lg font-medium text-white">
+                        {item.title}
+                      </h3>
+                      <p className="mt-2 text-sm leading-6 text-slate-300">
+                        {item.summary}
                       </p>
-                      <p className="mt-2 text-slate-200">{detail.value}</p>
                     </div>
-                  ))}
-                </div>
-              ) : null}
-            </li>
-          );
-        })}
-      </ol>
+                    <div className="text-sm text-slate-400 sm:text-right">
+                      <p>{item.ageLabel}</p>
+                      <p className="mt-1">{item.system}</p>
+                      <p className="mt-1 text-slate-500">{item.actor}</p>
+                    </div>
+                  </div>
+                </button>
+                {isExpanded ? (
+                  <div className="grid gap-3 border-t border-white/8 px-5 py-4 text-sm sm:grid-cols-3">
+                    {item.details.map((detail) => (
+                      <div
+                        className="rounded-2xl border border-white/8 bg-slate-950/55 p-3"
+                        key={`${item.id}-${detail.label}`}
+                      >
+                        <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                          {detail.label}
+                        </p>
+                        <p className="mt-2 text-slate-200">{detail.value}</p>
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+              </li>
+            );
+          })}
+        </ol>
+      )}
     </section>
   );
 }

--- a/src/components/control-room/alert-drilldown-panel.tsx
+++ b/src/components/control-room/alert-drilldown-panel.tsx
@@ -1,0 +1,284 @@
+import type { Ref } from "react";
+import type {
+  AlertItem,
+  AlertRemediationAction,
+  MetricCard,
+} from "@/app/control-room/mock-data";
+
+const severityClasses = {
+  info: "border-sky-300/20 bg-sky-400/10 text-sky-100",
+  warning: "border-amber-300/25 bg-amber-400/10 text-amber-100",
+  critical: "border-rose-400/25 bg-rose-500/10 text-rose-100",
+};
+
+const remediationToneClasses = {
+  default:
+    "border-white/10 bg-white/[0.04] text-slate-100 hover:border-white/20 hover:text-white",
+  warning:
+    "border-amber-300/20 bg-amber-400/[0.08] text-amber-50 hover:border-amber-300/28",
+  critical:
+    "border-rose-300/20 bg-rose-500/[0.08] text-rose-50 hover:border-rose-300/28",
+};
+
+const timelinePhaseClasses = {
+  detect: "border-sky-300/18 bg-sky-400/[0.08] text-sky-100",
+  stabilize: "border-cyan-300/18 bg-cyan-400/[0.08] text-cyan-100",
+  mitigate: "border-amber-300/18 bg-amber-400/[0.08] text-amber-100",
+  handoff: "border-emerald-300/18 bg-emerald-400/[0.08] text-emerald-100",
+};
+
+type AlertDrilldownPanelProps = {
+  alert: AlertItem | null;
+  isInfoSilenced: boolean;
+  isSpotlighted: boolean;
+  relatedMetrics: MetricCard[];
+  stagedActionIds: string[];
+  onRunRemediation: (action: AlertRemediationAction) => void;
+  sectionRef?: Ref<HTMLElement>;
+};
+
+export function AlertDrilldownPanel({
+  alert,
+  isInfoSilenced,
+  isSpotlighted,
+  relatedMetrics,
+  stagedActionIds,
+  onRunRemediation,
+  sectionRef,
+}: AlertDrilldownPanelProps) {
+  return (
+    <section
+      aria-label="Alert drilldown"
+      className={`rounded-[2rem] border bg-slate-950/65 p-6 backdrop-blur transition sm:p-8 ${
+        isSpotlighted
+          ? "border-cyan-300/45 shadow-[0_0_0_1px_rgba(103,232,249,0.15),0_18px_70px_rgba(34,211,238,0.18)]"
+          : "border-white/10"
+      }`}
+      ref={sectionRef}
+      tabIndex={-1}
+    >
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.24em] text-cyan-200/70">
+            Alert Drilldown
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">
+            Incident context
+          </h2>
+        </div>
+        {alert ? (
+          <p className="text-sm text-slate-400">Runbook: {alert.runbook}</p>
+        ) : null}
+      </div>
+
+      {!alert ? (
+        <div className="mt-6 rounded-[1.6rem] border border-dashed border-white/12 bg-white/[0.03] p-6 text-sm leading-6 text-slate-400">
+          Select an alert from the queue or command palette to review context,
+          related signals, and staged remediation shortcuts.
+        </div>
+      ) : (
+        <>
+          <div className="mt-6 rounded-[1.6rem] border border-white/8 bg-white/[0.04] p-5">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="flex flex-wrap gap-2">
+                <span
+                  className={`rounded-full border px-3 py-1 text-xs uppercase tracking-[0.22em] ${severityClasses[alert.severity]}`}
+                >
+                  {alert.severity}
+                </span>
+                <span className="rounded-full border border-white/10 px-3 py-1 text-[11px] uppercase tracking-[0.24em] text-slate-300">
+                  posture {alert.recommendedPosture}
+                </span>
+                {isInfoSilenced && alert.severity === "info" ? (
+                  <span className="rounded-full border border-slate-400/20 bg-slate-400/10 px-3 py-1 text-[11px] uppercase tracking-[0.24em] text-slate-200">
+                    muted locally
+                  </span>
+                ) : null}
+              </div>
+              <span className="text-xs uppercase tracking-[0.2em] text-slate-400">
+                {alert.ageLabel}
+              </span>
+            </div>
+
+            <h3 className="mt-4 text-2xl font-semibold text-white">{alert.title}</h3>
+            <p className="mt-3 text-sm leading-6 text-slate-300">{alert.summary}</p>
+
+            <div className="mt-5 grid gap-3 text-sm sm:grid-cols-2 xl:grid-cols-4">
+              <div className="rounded-2xl border border-white/8 bg-slate-950/60 p-4">
+                <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                  Service
+                </p>
+                <p className="mt-2 text-slate-100">{alert.service}</p>
+              </div>
+              <div className="rounded-2xl border border-white/8 bg-slate-950/60 p-4">
+                <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                  Region
+                </p>
+                <p className="mt-2 text-slate-100">{alert.region}</p>
+              </div>
+              <div className="rounded-2xl border border-white/8 bg-slate-950/60 p-4">
+                <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                  Owner
+                </p>
+                <p className="mt-2 text-slate-100">{alert.owner}</p>
+              </div>
+              <div className="rounded-2xl border border-white/8 bg-slate-950/60 p-4">
+                <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                  Impact
+                </p>
+                <p className="mt-2 text-slate-100">{alert.impact}</p>
+              </div>
+            </div>
+
+            <div className="mt-5 rounded-[1.3rem] border border-white/8 bg-slate-950/55 p-4">
+              <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                Current status
+              </p>
+              <p className="mt-2 text-sm leading-6 text-slate-200">{alert.status}</p>
+            </div>
+
+            <div className="mt-5 flex flex-wrap gap-2">
+              {alert.tags.map((tag) => (
+                <span
+                  className="rounded-full border border-white/10 px-3 py-1 text-[11px] uppercase tracking-[0.24em] text-slate-300"
+                  key={tag}
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-6 grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(280px,0.9fr)]">
+            <div className="space-y-6">
+              <div className="rounded-[1.6rem] border border-white/8 bg-white/[0.04] p-5">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                      Timeline context
+                    </p>
+                    <h4 className="mt-2 text-lg font-semibold text-white">
+                      Recent context chain
+                    </h4>
+                  </div>
+                  <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                    {alert.timeline.length} events
+                  </p>
+                </div>
+
+                <ol className="mt-5 space-y-3">
+                  {alert.timeline.map((entry) => (
+                    <li
+                      className="rounded-[1.4rem] border border-white/8 bg-slate-950/55 p-4"
+                      key={entry.id}
+                    >
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <span
+                          className={`rounded-full border px-3 py-1 text-[11px] uppercase tracking-[0.24em] ${timelinePhaseClasses[entry.phase]}`}
+                        >
+                          {entry.phase}
+                        </span>
+                        <span className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                          {entry.ageLabel}
+                        </span>
+                      </div>
+                      <h5 className="mt-3 text-base font-medium text-white">
+                        {entry.title}
+                      </h5>
+                      <p className="mt-2 text-sm leading-6 text-slate-300">
+                        {entry.detail}
+                      </p>
+                      <p className="mt-3 text-xs uppercase tracking-[0.2em] text-slate-500">
+                        {entry.actor}
+                      </p>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+
+              <div className="rounded-[1.6rem] border border-white/8 bg-white/[0.04] p-5">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                      Remediation shortcuts
+                    </p>
+                    <h4 className="mt-2 text-lg font-semibold text-white">
+                      Operator shortcuts
+                    </h4>
+                  </div>
+                  <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                    {alert.remediationActions.length} actions
+                  </p>
+                </div>
+
+                <div className="mt-5 grid gap-3">
+                  {alert.remediationActions.map((action) => {
+                    const isStaged = stagedActionIds.includes(action.id);
+
+                    return (
+                      <button
+                        className={`rounded-[1.4rem] border p-4 text-left transition ${remediationToneClasses[action.tone]}`}
+                        key={action.id}
+                        onClick={() => onRunRemediation(action)}
+                        type="button"
+                      >
+                        <div className="flex flex-wrap items-center justify-between gap-3">
+                          <p className="text-base font-medium">{action.label}</p>
+                          {isStaged ? (
+                            <span className="rounded-full border border-cyan-300/30 bg-cyan-300/12 px-3 py-1 text-[11px] uppercase tracking-[0.24em] text-cyan-100">
+                              staged
+                            </span>
+                          ) : null}
+                        </div>
+                        <p className="mt-2 text-sm leading-6 text-slate-300">
+                          {action.description}
+                        </p>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-6">
+              <div className="rounded-[1.6rem] border border-white/8 bg-white/[0.04] p-5">
+                <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                  Related signals
+                </p>
+                <h4 className="mt-2 text-lg font-semibold text-white">
+                  Metrics in play
+                </h4>
+                <div className="mt-5 space-y-3">
+                  {relatedMetrics.map((metric) => (
+                    <div
+                      className="rounded-[1.3rem] border border-white/8 bg-slate-950/55 p-4"
+                      key={metric.id}
+                    >
+                      <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                        {metric.label}
+                      </p>
+                      <p className="mt-2 text-xl font-semibold text-white">
+                        {metric.value}
+                      </p>
+                      <p className="mt-2 text-sm text-cyan-100">{metric.delta}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="rounded-[1.6rem] border border-white/8 bg-white/[0.04] p-5">
+                <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+                  Detail
+                </p>
+                <h4 className="mt-2 text-lg font-semibold text-white">
+                  Operator note
+                </h4>
+                <p className="mt-3 text-sm leading-6 text-slate-300">{alert.detail}</p>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/components/control-room/alert-list.tsx
+++ b/src/components/control-room/alert-list.tsx
@@ -1,4 +1,9 @@
-import type { AlertItem } from "@/app/control-room/mock-data";
+import type { Ref } from "react";
+import {
+  alertSeverityFilters,
+  type AlertItem,
+  type AlertSeverityFilter,
+} from "@/app/control-room/mock-data";
 
 const severityClasses = {
   info: "border-sky-300/20 bg-sky-400/10 text-sky-100",
@@ -7,52 +12,150 @@ const severityClasses = {
 };
 
 type AlertListProps = {
+  activeSeverityFilter: AlertSeverityFilter;
   alerts: AlertItem[];
+  isInfoSilenced: boolean;
+  isSpotlighted: boolean;
+  selectedAlertId: string | null;
+  onSelectAlert: (alertId: string) => void;
+  onSeverityFilterChange: (filter: AlertSeverityFilter) => void;
+  sectionRef?: Ref<HTMLElement>;
 };
 
-export function AlertList({ alerts }: AlertListProps) {
+export function AlertList({
+  activeSeverityFilter,
+  alerts,
+  isInfoSilenced,
+  isSpotlighted,
+  selectedAlertId,
+  onSelectAlert,
+  onSeverityFilterChange,
+  sectionRef,
+}: AlertListProps) {
+  const visibleAlerts = alerts.filter(
+    (alert) =>
+      activeSeverityFilter === "all" || alert.severity === activeSeverityFilter,
+  );
+
   return (
-    <section className="rounded-[2rem] border border-white/10 bg-slate-950/65 p-6 backdrop-blur sm:p-8">
-      <div className="flex items-end justify-between gap-4">
-        <div>
-          <p className="text-xs uppercase tracking-[0.24em] text-cyan-200/70">
-            Alerts
-          </p>
-          <h2 className="mt-2 text-2xl font-semibold text-white">
-            Priority queue
-          </h2>
+    <section
+      aria-label="Alert queue"
+      className={`rounded-[2rem] border bg-slate-950/65 p-6 backdrop-blur transition sm:p-8 ${
+        isSpotlighted
+          ? "border-cyan-300/45 shadow-[0_0_0_1px_rgba(103,232,249,0.15),0_18px_70px_rgba(34,211,238,0.18)]"
+          : "border-white/10"
+      }`}
+      ref={sectionRef}
+      tabIndex={-1}
+    >
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-[0.24em] text-cyan-200/70">
+              Alerts
+            </p>
+            <h2 className="mt-2 text-2xl font-semibold text-white">
+              Priority queue
+            </h2>
+          </div>
+          <p className="text-sm text-slate-400">{visibleAlerts.length} active items</p>
         </div>
-        <p className="text-sm text-slate-400">{alerts.length} active items</p>
-      </div>
-      <ol className="mt-6 space-y-3">
-        {alerts.map((alert) => (
-          <li
-            className="rounded-[1.5rem] border border-white/8 bg-white/[0.04] p-4"
-            key={alert.id}
-          >
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <span
-                className={`rounded-full border px-3 py-1 text-xs uppercase tracking-[0.22em] ${severityClasses[alert.severity]}`}
+        <div className="flex flex-wrap gap-2">
+          {alertSeverityFilters.map((filter) => {
+            const isActive = activeSeverityFilter === filter.id;
+
+            return (
+              <button
+                aria-pressed={isActive}
+                className={`rounded-full border px-4 py-2 text-sm transition ${
+                  isActive
+                    ? "border-cyan-200 bg-cyan-200 text-slate-950"
+                    : "border-white/12 bg-white/[0.04] text-slate-300 hover:border-white/20 hover:text-white"
+                }`}
+                key={filter.id}
+                onClick={() => onSeverityFilterChange(filter.id)}
+                type="button"
               >
-                {alert.severity}
-              </span>
-              <span className="text-xs uppercase tracking-[0.18em] text-slate-400">
-                {alert.ageLabel}
-              </span>
-            </div>
-            <h3 className="mt-4 text-lg font-medium text-white">{alert.title}</h3>
-            <p className="mt-2 text-sm leading-6 text-slate-300">{alert.detail}</p>
-            <div className="mt-4 grid gap-3 text-sm text-slate-400 sm:grid-cols-2">
-              <p>
-                <span className="text-slate-200">Owner:</span> {alert.owner}
-              </p>
-              <p>
-                <span className="text-slate-200">Impact:</span> {alert.impact}
-              </p>
-            </div>
-          </li>
-        ))}
-      </ol>
+                {filter.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {visibleAlerts.length === 0 ? (
+        <div className="mt-6 rounded-[1.5rem] border border-dashed border-white/12 bg-white/[0.03] p-6 text-sm text-slate-400">
+          No alerts match the current queue filter.
+        </div>
+      ) : (
+        <ol className="mt-6 space-y-3">
+          {visibleAlerts.map((alert) => {
+            const isSelected = selectedAlertId === alert.id;
+            const isMutedInfo = isInfoSilenced && alert.severity === "info";
+
+            return (
+              <li
+                className={`rounded-[1.5rem] border p-4 transition ${
+                  isSelected
+                    ? "border-cyan-300/35 bg-cyan-400/[0.08]"
+                    : "border-white/8 bg-white/[0.04]"
+                } ${isMutedInfo ? "opacity-80" : ""}`}
+                key={alert.id}
+              >
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="flex flex-wrap gap-2">
+                    <span
+                      className={`rounded-full border px-3 py-1 text-xs uppercase tracking-[0.22em] ${severityClasses[alert.severity]}`}
+                    >
+                      {alert.severity}
+                    </span>
+                    {isMutedInfo ? (
+                      <span className="rounded-full border border-slate-400/20 bg-slate-400/10 px-3 py-1 text-[11px] uppercase tracking-[0.24em] text-slate-200">
+                        muted locally
+                      </span>
+                    ) : null}
+                    {isSelected ? (
+                      <span className="rounded-full border border-cyan-300/30 bg-cyan-300/12 px-3 py-1 text-[11px] uppercase tracking-[0.24em] text-cyan-100">
+                        drilldown open
+                      </span>
+                    ) : null}
+                  </div>
+                  <span className="text-xs uppercase tracking-[0.18em] text-slate-400">
+                    {alert.ageLabel}
+                  </span>
+                </div>
+                <h3 className="mt-4 text-lg font-medium text-white">{alert.title}</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-300">{alert.detail}</p>
+                <div className="mt-4 grid gap-3 text-sm text-slate-400 sm:grid-cols-2">
+                  <p>
+                    <span className="text-slate-200">Owner:</span> {alert.owner}
+                  </p>
+                  <p>
+                    <span className="text-slate-200">Impact:</span> {alert.impact}
+                  </p>
+                  <p>
+                    <span className="text-slate-200">Service:</span> {alert.service}
+                  </p>
+                  <p>
+                    <span className="text-slate-200">Runbook:</span> {alert.runbook}
+                  </p>
+                </div>
+                <button
+                  className={`mt-5 rounded-full px-4 py-2 text-sm font-medium transition ${
+                    isSelected
+                      ? "bg-cyan-300 text-slate-950"
+                      : "border border-white/12 bg-white/[0.04] text-slate-100 hover:border-cyan-300/30 hover:text-white"
+                  }`}
+                  onClick={() => onSelectAlert(alert.id)}
+                  type="button"
+                >
+                  {isSelected ? "Drilldown selected" : "Open alert drilldown"}
+                </button>
+              </li>
+            );
+          })}
+        </ol>
+      )}
     </section>
   );
 }

--- a/src/components/control-room/command-palette.tsx
+++ b/src/components/control-room/command-palette.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useDeferredValue, useEffect, useId, useRef, useState } from "react";
+
+export type PaletteAction = {
+  id: string;
+  group: string;
+  label: string;
+  description: string;
+  keywords?: string[];
+  tone?: "default" | "warning" | "critical";
+  onSelect: () => void;
+};
+
+type CommandPaletteProps = {
+  actions: PaletteAction[];
+  selectedAlertTitle: string | null;
+  onClose: () => void;
+};
+
+function filterActions(actions: PaletteAction[], query: string) {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  if (!normalizedQuery) {
+    return actions;
+  }
+
+  return actions.filter((action) => {
+    const searchBody = [
+      action.group,
+      action.label,
+      action.description,
+      ...(action.keywords ?? []),
+    ]
+      .join(" ")
+      .toLowerCase();
+
+    return normalizedQuery
+      .split(/\s+/)
+      .every((term) => searchBody.includes(term));
+  });
+}
+
+const toneClasses = {
+  default:
+    "border-white/8 bg-white/[0.04] text-slate-100 hover:border-white/15 hover:bg-white/[0.06]",
+  warning:
+    "border-amber-300/18 bg-amber-400/[0.08] text-amber-50 hover:border-amber-300/28 hover:bg-amber-400/[0.12]",
+  critical:
+    "border-rose-300/18 bg-rose-500/[0.08] text-rose-50 hover:border-rose-300/28 hover:bg-rose-500/[0.12]",
+};
+
+export function CommandPalette({
+  actions,
+  selectedAlertTitle,
+  onClose,
+}: CommandPaletteProps) {
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const deferredQuery = useDeferredValue(query);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const titleId = useId();
+  const listId = useId();
+  const filteredActions = filterActions(actions, deferredQuery);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      inputRef.current?.focus();
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, []);
+
+  const selectedIndex =
+    filteredActions.length === 0
+      ? -1
+      : Math.min(activeIndex, filteredActions.length - 1);
+  const activeAction =
+    selectedIndex === -1 ? null : filteredActions[selectedIndex] ?? null;
+
+  function executeAction(action: PaletteAction) {
+    action.onSelect();
+    onClose();
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-slate-950/72 px-4 py-8 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        aria-describedby={`${titleId}-description`}
+        aria-labelledby={titleId}
+        aria-modal="true"
+        className="mx-auto max-w-3xl overflow-hidden rounded-[2rem] border border-white/10 bg-[#04131a]/95 shadow-[0_32px_120px_rgba(0,0,0,0.5)]"
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+      >
+        <div className="border-b border-white/8 px-6 py-5">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <p className="text-xs uppercase tracking-[0.24em] text-cyan-200/70">
+                Command Center
+              </p>
+              <h2 className="mt-2 text-2xl font-semibold text-white" id={titleId}>
+                Control Room command palette
+              </h2>
+              <p
+                className="mt-2 text-sm leading-6 text-slate-300"
+                id={`${titleId}-description`}
+              >
+                Search quick actions, queue filters, desk controls, and alert
+                drilldowns from one keyboard-first surface.
+              </p>
+            </div>
+            <button
+              className="rounded-full border border-white/10 bg-white/[0.04] px-4 py-2 text-sm text-slate-300 transition hover:border-white/20 hover:text-white"
+              onClick={onClose}
+              type="button"
+            >
+              Esc
+            </button>
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-2 text-xs uppercase tracking-[0.22em] text-slate-400">
+            <span className="rounded-full border border-cyan-300/25 bg-cyan-300/10 px-3 py-1 text-cyan-100">
+              {actions.length} commands loaded
+            </span>
+            <span className="rounded-full border border-white/10 px-3 py-1">
+              selected alert {selectedAlertTitle ?? "none"}
+            </span>
+          </div>
+
+          <label className="mt-5 block">
+            <span className="sr-only">Search commands</span>
+            <input
+              aria-activedescendant={
+                activeAction ? `${listId}-${activeAction.id}` : undefined
+              }
+              aria-controls={listId}
+              className="w-full rounded-[1.4rem] border border-white/10 bg-white/[0.04] px-4 py-3 text-base text-white outline-none transition placeholder:text-slate-500 focus:border-cyan-300/45"
+              onChange={(event) => {
+                setQuery(event.target.value);
+                setActiveIndex(0);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "ArrowDown") {
+                  event.preventDefault();
+                  if (filteredActions.length === 0) {
+                    return;
+                  }
+
+                  setActiveIndex((currentIndex) =>
+                    Math.min(currentIndex, filteredActions.length - 1) >=
+                    filteredActions.length - 1
+                      ? 0
+                      : Math.min(currentIndex, filteredActions.length - 1) + 1,
+                  );
+                }
+
+                if (event.key === "ArrowUp") {
+                  event.preventDefault();
+                  if (filteredActions.length === 0) {
+                    return;
+                  }
+
+                  setActiveIndex((currentIndex) =>
+                    Math.min(currentIndex, filteredActions.length - 1) <= 0
+                      ? filteredActions.length - 1
+                      : Math.min(currentIndex, filteredActions.length - 1) - 1,
+                  );
+                }
+
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  if (activeAction) {
+                    executeAction(activeAction);
+                  }
+                }
+
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  onClose();
+                }
+              }}
+              placeholder="Search commands, alerts, filters, or remediation shortcuts..."
+              ref={inputRef}
+              type="text"
+              value={query}
+            />
+          </label>
+        </div>
+
+        <div className="max-h-[60vh] overflow-y-auto px-4 py-4">
+          {filteredActions.length === 0 ? (
+            <div className="rounded-[1.6rem] border border-dashed border-white/12 bg-white/[0.03] p-6 text-sm text-slate-400">
+              No commands match your search.
+            </div>
+          ) : (
+            <div aria-label="Command palette results" className="space-y-2" id={listId} role="listbox">
+              {filteredActions.map((action, index) => {
+                const isActive = index === selectedIndex;
+                const tone = action.tone ?? "default";
+
+                return (
+                  <button
+                    aria-selected={isActive}
+                    className={`w-full rounded-[1.6rem] border px-4 py-4 text-left transition ${toneClasses[tone]} ${
+                      isActive ? "shadow-[0_0_0_1px_rgba(103,232,249,0.25)]" : ""
+                    }`}
+                    id={`${listId}-${action.id}`}
+                    key={action.id}
+                    onClick={() => executeAction(action)}
+                    onMouseEnter={() => setActiveIndex(index)}
+                    role="option"
+                    type="button"
+                  >
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                      <div>
+                        <p className="text-xs uppercase tracking-[0.22em] text-slate-400">
+                          {action.group}
+                        </p>
+                        <h3 className="mt-2 text-base font-medium">{action.label}</h3>
+                        <p className="mt-2 text-sm leading-6 text-slate-300">
+                          {action.description}
+                        </p>
+                      </div>
+                      {isActive ? (
+                        <span className="rounded-full border border-cyan-300/30 bg-cyan-300/12 px-3 py-1 text-[11px] uppercase tracking-[0.24em] text-cyan-100">
+                          Enter to run
+                        </span>
+                      ) : null}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <div className="border-t border-white/8 px-6 py-4 text-xs uppercase tracking-[0.22em] text-slate-500">
+          Use arrow keys to move, Enter to execute, and Escape to dismiss.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/control-room/control-room-dashboard.tsx
+++ b/src/components/control-room/control-room-dashboard.tsx
@@ -1,12 +1,29 @@
 "use client";
 
-import { useState, useTransition } from "react";
 import {
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
+import {
+  activityFilters,
+  alertSeverityFilters,
   buildControlRoomSnapshot,
+  controlRoomRegions,
+  type AlertRemediationAction,
+  type AlertSeverityFilter,
+  type ActivityFilter,
+  type ControlRoomRegion,
   type ControlRoomSnapshot,
+  type OperatorPosture,
+  type WorkflowEffect,
 } from "@/app/control-room/mock-data";
-import { AlertList } from "./alert-list";
 import { ActivityFeed } from "./activity-feed";
+import { AlertDrilldownPanel } from "./alert-drilldown-panel";
+import { AlertList } from "./alert-list";
+import { CommandPalette, type PaletteAction } from "./command-palette";
 import { ControlRoomHeader } from "./control-room-header";
 import { MetricsGrid } from "./metrics-grid";
 import { QuickActions } from "./quick-actions";
@@ -15,12 +32,101 @@ type ControlRoomDashboardProps = {
   initialSnapshot: ControlRoomSnapshot;
 };
 
+type ActionLogEntry = {
+  id: string;
+  label: string;
+  source: string;
+  timeLabel: string;
+};
+
+type WorkflowState = {
+  actionLog: ActionLogEntry[];
+  divertWorkers: boolean;
+  freezeDeploys: boolean;
+  lastAction: string;
+  posture: OperatorPosture;
+  samplingRate: number;
+  silenceInfoAlerts: boolean;
+  stagedActionIds: string[];
+};
+
+const commandClock = new Intl.DateTimeFormat("en-US", {
+  hour: "2-digit",
+  minute: "2-digit",
+  hour12: false,
+});
+
+const initialWorkflowState: WorkflowState = {
+  actionLog: [],
+  divertWorkers: false,
+  freezeDeploys: true,
+  lastAction: "Awaiting operator input. Controls are browser-only.",
+  posture: "contain",
+  samplingRate: 72,
+  silenceInfoAlerts: false,
+  stagedActionIds: [],
+};
+
+function getDefaultAlertId(snapshot: ControlRoomSnapshot) {
+  return (
+    snapshot.alerts.find((alert) => alert.severity === "critical")?.id ??
+    snapshot.alerts[0]?.id ??
+    null
+  );
+}
+
+function getRegionLabel(region: ControlRoomRegion) {
+  return (
+    controlRoomRegions.find((candidate) => candidate.id === region)?.label ??
+    "Desk"
+  );
+}
+
+function getFeedFilterLabel(filter: ActivityFilter) {
+  return (
+    activityFilters.find((candidate) => candidate.id === filter)?.label ?? "All"
+  );
+}
+
+function getAlertFilterLabel(filter: AlertSeverityFilter) {
+  return (
+    alertSeverityFilters.find((candidate) => candidate.id === filter)?.label ??
+    "All severities"
+  );
+}
+
+function getSeverityTone(severity: "info" | "warning" | "critical") {
+  switch (severity) {
+    case "critical":
+      return "critical" as const;
+    case "warning":
+      return "warning" as const;
+    default:
+      return "default" as const;
+  }
+}
+
 export function ControlRoomDashboard({
   initialSnapshot,
 }: ControlRoomDashboardProps) {
   const [snapshot, setSnapshot] = useState(initialSnapshot);
   const [cycle, setCycle] = useState(0);
+  const [activityFilter, setActivityFilter] = useState<ActivityFilter>("all");
+  const [alertFilter, setAlertFilter] = useState<AlertSeverityFilter>("all");
+  const [selectedAlertId, setSelectedAlertId] = useState<string | null>(
+    getDefaultAlertId(initialSnapshot),
+  );
+  const [focusedRegion, setFocusedRegion] =
+    useState<ControlRoomRegion>("alerts");
+  const [isPaletteOpen, setPaletteOpen] = useState(false);
+  const [workflowState, setWorkflowState] =
+    useState<WorkflowState>(initialWorkflowState);
   const [isRefreshing, startTransition] = useTransition();
+  const metricsSectionRef = useRef<HTMLElement | null>(null);
+  const feedSectionRef = useRef<HTMLElement | null>(null);
+  const alertsSectionRef = useRef<HTMLElement | null>(null);
+  const drilldownSectionRef = useRef<HTMLElement | null>(null);
+  const controlsSectionRef = useRef<HTMLElement | null>(null);
 
   const warningCount = snapshot.alerts.filter(
     (alert) => alert.severity === "warning",
@@ -28,6 +134,82 @@ export function ControlRoomDashboard({
   const criticalCount = snapshot.alerts.filter(
     (alert) => alert.severity === "critical",
   ).length;
+  const visibleAlerts = snapshot.alerts.filter(
+    (alert) => alertFilter === "all" || alert.severity === alertFilter,
+  );
+
+  useEffect(() => {
+    if (!isPaletteOpen) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isPaletteOpen]);
+
+  const handleGlobalKeydown = useEffectEvent((event: KeyboardEvent) => {
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+      event.preventDefault();
+      setPaletteOpen((currentValue) => !currentValue);
+      return;
+    }
+
+    if (event.key === "Escape" && isPaletteOpen) {
+      event.preventDefault();
+      setPaletteOpen(false);
+    }
+  });
+
+  useEffect(() => {
+    function onKeydown(event: KeyboardEvent) {
+      handleGlobalKeydown(event);
+    }
+
+    document.addEventListener("keydown", onKeydown);
+
+    return () => {
+      document.removeEventListener("keydown", onKeydown);
+    };
+  }, []);
+
+  const resolvedSelectedAlertId = snapshot.alerts.some(
+    (alert) => alert.id === selectedAlertId,
+  )
+    ? selectedAlertId
+    : getDefaultAlertId(snapshot);
+  const selectedAlert =
+    snapshot.alerts.find((alert) => alert.id === resolvedSelectedAlertId) ??
+    null;
+  const relatedMetrics = selectedAlert
+    ? snapshot.metrics.filter((metric) =>
+        selectedAlert.relatedMetricIds.includes(metric.id),
+      )
+    : [];
+
+  function focusRegion(region: ControlRoomRegion) {
+    setFocusedRegion(region);
+
+    const node =
+      region === "metrics"
+        ? metricsSectionRef.current
+        : region === "feed"
+          ? feedSectionRef.current
+          : region === "alerts"
+            ? alertsSectionRef.current
+            : region === "drilldown"
+              ? drilldownSectionRef.current
+              : controlsSectionRef.current;
+    if (!node) {
+      return;
+    }
+
+    node.scrollIntoView?.({ behavior: "smooth", block: "start" });
+    node.focus();
+  }
 
   function refreshSnapshot() {
     const nextCycle = cycle + 1;
@@ -38,28 +220,536 @@ export function ControlRoomDashboard({
     });
   }
 
+  function stageOperatorAction(
+    label: string,
+    source: string,
+    effects: WorkflowEffect[],
+    stagedActionId?: string,
+  ) {
+    const issuedAt = commandClock.format(new Date());
+    let nextFeedFilter: ActivityFilter | null = null;
+    let nextAlertFilter: AlertSeverityFilter | null = null;
+    let nextFocusRegion: ControlRoomRegion | null = null;
+    let nextAlertId: string | null = null;
+    let shouldRefresh = false;
+
+    setWorkflowState((currentState) => {
+      let nextFreezeDeploys = currentState.freezeDeploys;
+      let nextDivertWorkers = currentState.divertWorkers;
+      let nextSamplingRate = currentState.samplingRate;
+      let nextPosture = currentState.posture;
+      let nextSilenceInfoAlerts = currentState.silenceInfoAlerts;
+
+      for (const effect of effects) {
+        switch (effect.type) {
+          case "focus-region":
+            nextFocusRegion = effect.region;
+            break;
+          case "refresh-snapshot":
+            shouldRefresh = true;
+            break;
+          case "select-alert":
+            nextAlertId = effect.alertId;
+            if (nextFocusRegion === null) {
+              nextFocusRegion = "drilldown";
+            }
+            break;
+          case "set-alert-filter":
+            nextAlertFilter = effect.filter;
+            break;
+          case "set-divert-workers":
+            nextDivertWorkers = effect.value;
+            break;
+          case "set-feed-filter":
+            nextFeedFilter = effect.filter;
+            break;
+          case "set-freeze-deploys":
+            nextFreezeDeploys = effect.value;
+            break;
+          case "set-posture":
+            nextPosture = effect.posture;
+            break;
+          case "set-sampling-rate":
+            nextSamplingRate = effect.value;
+            break;
+          case "set-silence-info-alerts":
+            nextSilenceInfoAlerts = effect.value;
+            break;
+        }
+      }
+
+      return {
+        actionLog: [
+          {
+            id: `log-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+            label,
+            source,
+            timeLabel: issuedAt,
+          },
+          ...currentState.actionLog,
+        ].slice(0, 5),
+        divertWorkers: nextDivertWorkers,
+        freezeDeploys: nextFreezeDeploys,
+        lastAction: `${label} staged at ${issuedAt} via ${source}. No request sent.`,
+        posture: nextPosture,
+        samplingRate: nextSamplingRate,
+        silenceInfoAlerts: nextSilenceInfoAlerts,
+        stagedActionIds:
+          stagedActionId && !currentState.stagedActionIds.includes(stagedActionId)
+            ? [stagedActionId, ...currentState.stagedActionIds]
+            : currentState.stagedActionIds,
+      };
+    });
+
+    if (nextFeedFilter !== null) {
+      setActivityFilter(nextFeedFilter);
+    }
+
+    if (nextAlertFilter !== null) {
+      setAlertFilter(nextAlertFilter);
+    }
+
+    if (nextAlertId !== null) {
+      setSelectedAlertId(nextAlertId);
+    }
+
+    if (shouldRefresh) {
+      refreshSnapshot();
+    }
+
+    if (nextFocusRegion !== null) {
+      window.setTimeout(() => {
+        focusRegion(nextFocusRegion as ControlRoomRegion);
+      }, 0);
+    }
+  }
+
+  function openAlertDrilldown(alertId: string, source: string) {
+    const targetAlert = snapshot.alerts.find((alert) => alert.id === alertId);
+
+    stageOperatorAction(
+      `Opened drilldown for ${targetAlert?.title ?? "selected alert"}`,
+      source,
+      [
+        { type: "select-alert", alertId },
+        { type: "focus-region", region: "drilldown" },
+      ],
+    );
+  }
+
+  function handleActivityFilterChange(filter: ActivityFilter, source: string) {
+    stageOperatorAction(
+      filter === "all" ? "Cleared activity filter" : `Filtered activity to ${filter}`,
+      source,
+      [
+        { type: "set-feed-filter", filter },
+        { type: "focus-region", region: "feed" },
+      ],
+    );
+  }
+
+  function handleAlertFilterChange(
+    filter: AlertSeverityFilter,
+    source: string,
+  ) {
+    stageOperatorAction(
+      filter === "all"
+        ? "Cleared alert severity filter"
+        : `Filtered queue to ${filter} alerts`,
+      source,
+      [
+        { type: "set-alert-filter", filter },
+        { type: "focus-region", region: "alerts" },
+      ],
+    );
+  }
+
+  function handleRemediation(action: AlertRemediationAction) {
+    if (!selectedAlert) {
+      return;
+    }
+
+    stageOperatorAction(
+      `${selectedAlert.title}: ${action.label}`,
+      "Alert drilldown",
+      action.effects,
+      action.id,
+    );
+  }
+
+  const paletteActions: PaletteAction[] = [
+    {
+      id: "desk-refresh",
+      group: "Desk",
+      label: "Refresh mock metrics",
+      description: "Rotate the desk snapshot and advance all local mock signals.",
+      keywords: ["refresh", "reload", "snapshot", "desk"],
+      onSelect: () =>
+        stageOperatorAction("Refreshed desk snapshot", "Command palette", [
+          { type: "refresh-snapshot" },
+        ]),
+    },
+    {
+      id: "nav-metrics",
+      group: "Navigate",
+      label: "Focus metrics grid",
+      description: "Jump to the live health signals and related metric cards.",
+      keywords: ["metrics", "signals", "availability", "latency"],
+      onSelect: () =>
+        stageOperatorAction("Focused metrics grid", "Command palette", [
+          { type: "focus-region", region: "metrics" },
+        ]),
+    },
+    {
+      id: "nav-feed",
+      group: "Navigate",
+      label: "Focus activity feed",
+      description: "Move directly to the operator timeline and active feed lens.",
+      keywords: ["feed", "timeline", "activity"],
+      onSelect: () =>
+        stageOperatorAction("Focused activity feed", "Command palette", [
+          { type: "focus-region", region: "feed" },
+        ]),
+    },
+    {
+      id: "nav-alerts",
+      group: "Navigate",
+      label: "Focus alert queue",
+      description: "Jump to the current alert list and severity filters.",
+      keywords: ["alerts", "queue", "severity"],
+      onSelect: () =>
+        stageOperatorAction("Focused alert queue", "Command palette", [
+          { type: "focus-region", region: "alerts" },
+        ]),
+    },
+    {
+      id: "nav-drilldown",
+      group: "Navigate",
+      label: "Focus alert drilldown",
+      description: "Center the desk on the selected alert context panel.",
+      keywords: ["drilldown", "incident", "context"],
+      onSelect: () =>
+        stageOperatorAction("Focused alert drilldown", "Command palette", [
+          { type: "focus-region", region: "drilldown" },
+        ]),
+    },
+    {
+      id: "nav-controls",
+      group: "Navigate",
+      label: "Focus drill controls",
+      description: "Jump to local operator controls and the command log.",
+      keywords: ["controls", "quick actions", "posture"],
+      onSelect: () =>
+        stageOperatorAction("Focused drill controls", "Command palette", [
+          { type: "focus-region", region: "controls" },
+        ]),
+    },
+    {
+      id: "filter-feed-all",
+      group: "Filters",
+      label: "Show all activity",
+      description: "Reset the timeline lens and reveal every feed category.",
+      keywords: ["timeline", "all", "activity"],
+      onSelect: () => handleActivityFilterChange("all", "Command palette"),
+    },
+    {
+      id: "filter-feed-incidents",
+      group: "Filters",
+      label: "Filter timeline to incidents",
+      description: "Trim the feed to incident escalations and bridge updates.",
+      keywords: ["incidents", "timeline", "feed"],
+      tone: "warning",
+      onSelect: () => handleActivityFilterChange("incidents", "Command palette"),
+    },
+    {
+      id: "filter-feed-automation",
+      group: "Filters",
+      label: "Filter timeline to automation",
+      description: "Surface bots, replays, and guardrail automation decisions.",
+      keywords: ["automation", "timeline", "feed"],
+      onSelect: () => handleActivityFilterChange("automation", "Command palette"),
+    },
+    {
+      id: "filter-alerts-all",
+      group: "Filters",
+      label: "Show all alerts",
+      description: "Clear the severity filter for the operator queue.",
+      keywords: ["alerts", "all", "queue"],
+      onSelect: () => handleAlertFilterChange("all", "Command palette"),
+    },
+    {
+      id: "filter-alerts-critical",
+      group: "Filters",
+      label: "Show critical alerts only",
+      description: "Reduce the queue to the highest-severity incidents.",
+      keywords: ["alerts", "critical", "queue"],
+      tone: "critical",
+      onSelect: () => handleAlertFilterChange("critical", "Command palette"),
+    },
+    {
+      id: "filter-alerts-warning",
+      group: "Filters",
+      label: "Show warning alerts only",
+      description: "Focus the queue on warnings that still need operator review.",
+      keywords: ["alerts", "warning", "queue"],
+      tone: "warning",
+      onSelect: () => handleAlertFilterChange("warning", "Command palette"),
+    },
+    {
+      id: "control-freeze",
+      group: "Controls",
+      label: workflowState.freezeDeploys
+        ? "Reopen deploy lane"
+        : "Freeze deploy lane",
+      description: workflowState.freezeDeploys
+        ? "Lift the local deploy freeze staged in the drill controls."
+        : "Stage a local deploy freeze for the canary lane.",
+      keywords: ["deploy", "freeze", "lane"],
+      tone: workflowState.freezeDeploys ? "default" : "warning",
+      onSelect: () =>
+        stageOperatorAction(
+          workflowState.freezeDeploys
+            ? "Reopened deploy lane"
+            : "Froze deploy lane",
+          "Command palette",
+          [
+            {
+              type: "set-freeze-deploys",
+              value: !workflowState.freezeDeploys,
+            },
+            { type: "focus-region", region: "controls" },
+          ],
+        ),
+    },
+    {
+      id: "control-divert-workers",
+      group: "Controls",
+      label: workflowState.divertWorkers
+        ? "Normalize background workers"
+        : "Divert background workers",
+      description: workflowState.divertWorkers
+        ? "Return workers to normal routing."
+        : "Borrow spare capacity for the canary fan-out lane.",
+      keywords: ["workers", "queue", "background"],
+      tone: workflowState.divertWorkers ? "default" : "warning",
+      onSelect: () =>
+        stageOperatorAction(
+          workflowState.divertWorkers
+            ? "Normalized background workers"
+            : "Diverted background workers",
+          "Command palette",
+          [
+            {
+              type: "set-divert-workers",
+              value: !workflowState.divertWorkers,
+            },
+            { type: "focus-region", region: "controls" },
+          ],
+        ),
+    },
+    {
+      id: "control-info-alerts",
+      group: "Controls",
+      label: workflowState.silenceInfoAlerts
+        ? "Resume info alerts"
+        : "Silence info alerts",
+      description: workflowState.silenceInfoAlerts
+        ? "Restore lower-severity info alerts to the local workflow."
+        : "Mute lower-severity info alerts locally while triaging incidents.",
+      keywords: ["info", "mute", "silence"],
+      onSelect: () =>
+        stageOperatorAction(
+          workflowState.silenceInfoAlerts
+            ? "Resumed info alerts"
+            : "Silenced info alerts",
+          "Command palette",
+          [
+            {
+              type: "set-silence-info-alerts",
+              value: !workflowState.silenceInfoAlerts,
+            },
+            { type: "focus-region", region: "controls" },
+          ],
+        ),
+    },
+    {
+      id: "control-dry-failover",
+      group: "Controls",
+      label: "Run dry failover",
+      description: "Stage the local failover drill without leaving Control Room.",
+      keywords: ["drill", "failover", "dry run"],
+      onSelect: () =>
+        stageOperatorAction("Dry failover sequence queued", "Command palette", [
+          { type: "focus-region", region: "controls" },
+        ]),
+    },
+    ...snapshot.alerts.map((alert) => ({
+      id: `alert-${alert.id}`,
+      group: "Alert drilldowns",
+      label: `Open ${alert.title}`,
+      description: `${alert.severity} alert owned by ${alert.owner}. ${alert.impact}`,
+      keywords: [alert.service, alert.region, ...alert.tags],
+      tone: getSeverityTone(alert.severity),
+      onSelect: () => openAlertDrilldown(alert.id, "Command palette"),
+    })),
+    ...(selectedAlert
+      ? selectedAlert.remediationActions.map((action) => ({
+          id: `remediation-${action.id}`,
+          group: "Selected alert",
+          label: action.label,
+          description: `${selectedAlert.title}: ${action.description}`,
+          keywords: [selectedAlert.title, ...selectedAlert.tags],
+          tone: action.tone,
+          onSelect: () => handleRemediation(action),
+        }))
+      : []),
+  ];
+
   return (
-    <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(6,95,70,0.18),transparent_32%),linear-gradient(180deg,#021014_0%,#031a21_55%,#01070c_100%)] px-4 py-6 sm:px-6 lg:px-8">
-      <div className="mx-auto max-w-7xl space-y-6">
-        <ControlRoomHeader
-          criticalCount={criticalCount}
-          environment={snapshot.environment}
-          isRefreshing={isRefreshing}
-          lastUpdated={snapshot.lastUpdated}
-          warningCount={warningCount}
-          onRefresh={refreshSnapshot}
-        />
-        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.75fr)_minmax(320px,0.95fr)]">
-          <div className="space-y-6">
-            <MetricsGrid metrics={snapshot.metrics} />
-            <ActivityFeed items={snapshot.feed} />
-          </div>
-          <div className="space-y-6">
-            <AlertList alerts={snapshot.alerts} />
-            <QuickActions />
+    <>
+      <main className="min-h-screen bg-[radial-gradient(circle_at_top,rgba(6,95,70,0.18),transparent_32%),linear-gradient(180deg,#021014_0%,#031a21_55%,#01070c_100%)] px-4 py-6 sm:px-6 lg:px-8">
+        <div className="mx-auto max-w-7xl space-y-6">
+          <ControlRoomHeader
+            activeAlertFilterLabel={getAlertFilterLabel(alertFilter)}
+            activeFeedFilterLabel={getFeedFilterLabel(activityFilter)}
+            activeRegionLabel={getRegionLabel(focusedRegion)}
+            criticalCount={criticalCount}
+            environment={snapshot.environment}
+            filteredAlertCount={visibleAlerts.length}
+            isRefreshing={isRefreshing}
+            lastUpdated={snapshot.lastUpdated}
+            selectedAlertTitle={selectedAlert?.title ?? null}
+            warningCount={warningCount}
+            onOpenPalette={() => setPaletteOpen(true)}
+            onRefresh={refreshSnapshot}
+          />
+          <div className="grid gap-6 xl:grid-cols-[minmax(0,1.55fr)_minmax(340px,1fr)]">
+            <div className="space-y-6">
+              <MetricsGrid
+                activeMetricIds={selectedAlert?.relatedMetricIds ?? []}
+                isSpotlighted={focusedRegion === "metrics"}
+                metrics={snapshot.metrics}
+                sectionRef={metricsSectionRef}
+              />
+              <ActivityFeed
+                activeFilter={activityFilter}
+                highlightAlertId={selectedAlert?.id ?? null}
+                isSpotlighted={focusedRegion === "feed"}
+                items={snapshot.feed}
+                onFilterChange={(filter) =>
+                  handleActivityFilterChange(filter, "Activity feed")
+                }
+                sectionRef={feedSectionRef}
+              />
+            </div>
+            <div className="space-y-6">
+              <AlertList
+                activeSeverityFilter={alertFilter}
+                alerts={snapshot.alerts}
+                isInfoSilenced={workflowState.silenceInfoAlerts}
+                isSpotlighted={focusedRegion === "alerts"}
+                selectedAlertId={selectedAlert?.id ?? null}
+                onSelectAlert={(alertId) => openAlertDrilldown(alertId, "Alert queue")}
+                onSeverityFilterChange={(filter) =>
+                  handleAlertFilterChange(filter, "Alert queue")
+                }
+                sectionRef={alertsSectionRef}
+              />
+              <AlertDrilldownPanel
+                alert={selectedAlert}
+                isInfoSilenced={workflowState.silenceInfoAlerts}
+                isSpotlighted={focusedRegion === "drilldown"}
+                relatedMetrics={relatedMetrics}
+                stagedActionIds={workflowState.stagedActionIds}
+                onRunRemediation={handleRemediation}
+                sectionRef={drilldownSectionRef}
+              />
+              <QuickActions
+                actionLog={workflowState.actionLog}
+                divertWorkers={workflowState.divertWorkers}
+                freezeDeploys={workflowState.freezeDeploys}
+                isSpotlighted={focusedRegion === "controls"}
+                lastAction={workflowState.lastAction}
+                posture={workflowState.posture}
+                samplingRate={workflowState.samplingRate}
+                silenceInfoAlerts={workflowState.silenceInfoAlerts}
+                onRunDryFailover={() =>
+                  stageOperatorAction(
+                    "Dry failover sequence queued",
+                    "Drill controls",
+                    [{ type: "focus-region", region: "controls" }],
+                  )
+                }
+                onSetPosture={(posture) =>
+                  stageOperatorAction(
+                    `Set operator posture to ${posture}`,
+                    "Drill controls",
+                    [{ type: "set-posture", posture }],
+                  )
+                }
+                onSetSamplingRate={(value) =>
+                  stageOperatorAction(
+                    `Adjusted event sampling to ${value}%`,
+                    "Drill controls",
+                    [{ type: "set-sampling-rate", value }],
+                  )
+                }
+                onToggleDivertWorkers={() =>
+                  stageOperatorAction(
+                    workflowState.divertWorkers
+                      ? "Normalized background workers"
+                      : "Diverted background workers",
+                    "Drill controls",
+                    [
+                      {
+                        type: "set-divert-workers",
+                        value: !workflowState.divertWorkers,
+                      },
+                    ],
+                  )
+                }
+                onToggleFreezeDeploys={() =>
+                  stageOperatorAction(
+                    workflowState.freezeDeploys
+                      ? "Reopened deploy lane"
+                      : "Froze deploy lane",
+                    "Drill controls",
+                    [
+                      {
+                        type: "set-freeze-deploys",
+                        value: !workflowState.freezeDeploys,
+                      },
+                    ],
+                  )
+                }
+                onToggleSilenceInfoAlerts={() =>
+                  stageOperatorAction(
+                    workflowState.silenceInfoAlerts
+                      ? "Resumed info alerts"
+                      : "Silenced info alerts",
+                    "Drill controls",
+                    [
+                      {
+                        type: "set-silence-info-alerts",
+                        value: !workflowState.silenceInfoAlerts,
+                      },
+                    ],
+                  )
+                }
+                sectionRef={controlsSectionRef}
+              />
+            </div>
           </div>
         </div>
-      </div>
-    </main>
+      </main>
+
+      {isPaletteOpen ? (
+        <CommandPalette
+          actions={paletteActions}
+          selectedAlertTitle={selectedAlert?.title ?? null}
+          onClose={() => setPaletteOpen(false)}
+        />
+      ) : null}
+    </>
   );
 }

--- a/src/components/control-room/control-room-header.tsx
+++ b/src/components/control-room/control-room-header.tsx
@@ -1,20 +1,32 @@
 import { formatLastUpdated } from "@/app/control-room/mock-data";
 
 type ControlRoomHeaderProps = {
+  activeAlertFilterLabel: string;
+  activeFeedFilterLabel: string;
+  activeRegionLabel: string;
   criticalCount: number;
   environment: string;
+  filteredAlertCount: number;
   isRefreshing: boolean;
   lastUpdated: string;
+  selectedAlertTitle: string | null;
   warningCount: number;
+  onOpenPalette: () => void;
   onRefresh: () => void;
 };
 
 export function ControlRoomHeader({
+  activeAlertFilterLabel,
+  activeFeedFilterLabel,
+  activeRegionLabel,
   criticalCount,
   environment,
+  filteredAlertCount,
   isRefreshing,
   lastUpdated,
+  selectedAlertTitle,
   warningCount,
+  onOpenPalette,
   onRefresh,
 }: ControlRoomHeaderProps) {
   return (
@@ -28,14 +40,18 @@ export function ControlRoomHeader({
             <span className="rounded-full border border-amber-300/25 bg-amber-300/10 px-4 py-2 text-amber-100">
               local mock telemetry
             </span>
+            <span className="rounded-full border border-cyan-300/25 bg-cyan-300/10 px-4 py-2 text-cyan-100">
+              focus {activeRegionLabel}
+            </span>
           </div>
           <h1 className="mt-5 text-4xl font-semibold tracking-tight text-white sm:text-5xl">
             Control Room
           </h1>
           <p className="mt-4 max-w-3xl text-sm leading-6 text-slate-300 sm:text-base">
-            Isolated operations dashboard for route-level testing. Metrics,
-            alerts, and activity feed entries refresh in place with no server
-            calls or shared dependencies.
+            Keyboard-first operations desk for fast incident triage. Open the
+            command palette to jump between regions, filter the live timeline,
+            and stage alert-specific remediation shortcuts without leaving the
+            dashboard.
           </p>
         </div>
         <div className="space-y-3 lg:text-right">
@@ -53,6 +69,16 @@ export function ControlRoomHeader({
               {warningCount} warning
             </span>
             <button
+              className="rounded-full border border-cyan-300/30 bg-cyan-300/12 px-5 py-2.5 text-sm font-semibold text-cyan-50 transition hover:border-cyan-200 hover:bg-cyan-300/18"
+              onClick={onOpenPalette}
+              type="button"
+            >
+              Open command palette
+              <span className="ml-2 text-xs font-medium uppercase tracking-[0.24em] text-cyan-100/80">
+                Ctrl/Cmd + K
+              </span>
+            </button>
+            <button
               className="rounded-full bg-cyan-300 px-5 py-2.5 text-sm font-semibold text-slate-950 transition hover:bg-cyan-200 disabled:cursor-wait disabled:bg-cyan-100"
               disabled={isRefreshing}
               onClick={onRefresh}
@@ -61,6 +87,44 @@ export function ControlRoomHeader({
               {isRefreshing ? "Refreshing..." : "Refresh mock metrics"}
             </button>
           </div>
+        </div>
+      </div>
+
+      <div className="mt-6 grid gap-3 text-sm text-slate-300 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,0.8fr)_minmax(0,0.9fr)]">
+        <div className="rounded-[1.4rem] border border-white/8 bg-white/[0.04] p-4">
+          <p className="text-xs uppercase tracking-[0.22em] text-slate-500">
+            Selected alert
+          </p>
+          <p className="mt-2 text-base font-medium text-white">
+            {selectedAlertTitle ?? "No alert drilldown armed"}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-slate-400">
+            Palette and queue actions keep the drilldown pane aligned with the
+            current operator focus.
+          </p>
+        </div>
+        <div className="rounded-[1.4rem] border border-white/8 bg-white/[0.04] p-4">
+          <p className="text-xs uppercase tracking-[0.22em] text-slate-500">
+            Queue state
+          </p>
+          <p className="mt-2 text-base font-medium text-white">
+            {filteredAlertCount} alerts in view
+          </p>
+          <p className="mt-2 text-sm text-slate-400">
+            Severity filter: <span className="text-slate-200">{activeAlertFilterLabel}</span>
+          </p>
+        </div>
+        <div className="rounded-[1.4rem] border border-white/8 bg-white/[0.04] p-4">
+          <p className="text-xs uppercase tracking-[0.22em] text-slate-500">
+            Timeline lens
+          </p>
+          <p className="mt-2 text-base font-medium text-white">
+            {activeFeedFilterLabel}
+          </p>
+          <p className="mt-2 text-sm text-slate-400">
+            Activity filtering is shared between the timeline panel and command
+            palette.
+          </p>
         </div>
       </div>
     </header>

--- a/src/components/control-room/control-room.test.tsx
+++ b/src/components/control-room/control-room.test.tsx
@@ -1,7 +1,16 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { buildControlRoomSnapshot } from "@/app/control-room/mock-data";
-import { ActivityFeed } from "./activity-feed";
+import { ControlRoomDashboard } from "./control-room-dashboard";
+
+function renderDashboard() {
+  const snapshot = buildControlRoomSnapshot(
+    0,
+    new Date("2026-04-19T10:00:00.000Z"),
+  );
+
+  render(<ControlRoomDashboard initialSnapshot={snapshot} />);
+}
 
 describe("control room feature", () => {
   it("rotates snapshot values across refresh cycles", () => {
@@ -14,28 +23,90 @@ describe("control room feature", () => {
     expect(first.alerts[0]?.title).not.toBe(second.alerts[0]?.title);
   });
 
-  it("filters and expands activity rows on the client", () => {
-    const snapshot = buildControlRoomSnapshot(
-      0,
-      new Date("2026-04-19T10:00:00.000Z"),
+  it("opens the command palette with the keyboard and focuses the activity feed", async () => {
+    renderDashboard();
+
+    fireEvent.keyDown(document, { ctrlKey: true, key: "k" });
+
+    const searchInput = screen.getByRole("textbox", {
+      name: /search commands/i,
+    });
+
+    fireEvent.change(searchInput, { target: { value: "focus activity feed" } });
+    fireEvent.click(
+      screen.getByRole("option", { name: /focus activity feed/i }),
     );
 
-    render(<ActivityFeed items={snapshot.feed} />);
+    await waitFor(() => {
+      expect(screen.getByText(/focus Activity Feed/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
 
-    expect(
-      screen.getByText("Routing policy widened on eu-west ingress"),
-    ).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: "Incidents" }));
-
-    expect(
-      screen.queryByText("Routing policy widened on eu-west ingress"),
-    ).not.toBeInTheDocument();
+  it("filters the alert queue from the command palette", () => {
+    renderDashboard();
 
     fireEvent.click(
-      screen.getByRole("button", { name: /Runbook 7 escalated to platform on-call/i }),
+      screen.getByRole("button", { name: /open command palette/i }),
     );
 
-    expect(screen.getByText("Primary on-call")).toBeInTheDocument();
+    const searchInput = screen.getByRole("textbox", {
+      name: /search commands/i,
+    });
+
+    fireEvent.change(searchInput, { target: { value: "show critical alerts only" } });
+    fireEvent.click(
+      screen.getByRole("option", { name: /show critical alerts only/i }),
+    );
+
+    const alertQueue = screen.getByLabelText(/alert queue/i);
+
+    expect(
+      within(alertQueue).queryByText("Background queue rising in canary lane"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(alertQueue).getByText("Replica drift exceeds guardrail"),
+    ).toBeInTheDocument();
+  });
+
+  it("opens an alert drilldown and stages remediation shortcuts", () => {
+    renderDashboard();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /open command palette/i }),
+    );
+
+    const searchInput = screen.getByRole("textbox", {
+      name: /search commands/i,
+    });
+
+    fireEvent.change(searchInput, { target: { value: "background queue" } });
+    fireEvent.click(
+      screen.getByRole("option", {
+        name: /open background queue rising in canary lane/i,
+      }),
+    );
+
+    const drilldown = screen.getByLabelText(/alert drilldown/i);
+    expect(
+      within(drilldown).getByText("Background queue rising in canary lane"),
+    ).toBeInTheDocument();
+    expect(
+      within(drilldown).getByText("Autoscale shortfall recorded"),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      within(drilldown).getByRole("button", {
+        name: /divert background workers/i,
+      }),
+    );
+
+    expect(screen.getByText("workers diverted")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Background queue rising in canary lane: Divert background workers",
+      ),
+    ).toBeInTheDocument();
+    expect(within(drilldown).getByText("staged")).toBeInTheDocument();
   });
 });

--- a/src/components/control-room/metrics-grid.tsx
+++ b/src/components/control-room/metrics-grid.tsx
@@ -1,3 +1,4 @@
+import type { Ref } from "react";
 import type { MetricCard } from "@/app/control-room/mock-data";
 
 const toneClasses = {
@@ -7,12 +8,29 @@ const toneClasses = {
 };
 
 type MetricsGridProps = {
+  activeMetricIds: string[];
+  isSpotlighted: boolean;
   metrics: MetricCard[];
+  sectionRef?: Ref<HTMLElement>;
 };
 
-export function MetricsGrid({ metrics }: MetricsGridProps) {
+export function MetricsGrid({
+  activeMetricIds,
+  isSpotlighted,
+  metrics,
+  sectionRef,
+}: MetricsGridProps) {
   return (
-    <section className="rounded-[2rem] border border-white/10 bg-slate-950/65 p-6 backdrop-blur sm:p-8">
+    <section
+      aria-label="Metrics grid"
+      className={`rounded-[2rem] border bg-slate-950/65 p-6 backdrop-blur transition sm:p-8 ${
+        isSpotlighted
+          ? "border-cyan-300/45 shadow-[0_0_0_1px_rgba(103,232,249,0.15),0_18px_70px_rgba(34,211,238,0.18)]"
+          : "border-white/10"
+      }`}
+      ref={sectionRef}
+      tabIndex={-1}
+    >
       <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <p className="text-xs uppercase tracking-[0.24em] text-cyan-200/70">
@@ -23,33 +41,49 @@ export function MetricsGrid({ metrics }: MetricsGridProps) {
           </h2>
         </div>
         <p className="max-w-xl text-sm text-slate-300">
-          Signals rotate on manual refresh to simulate a busy operations desk
-          without leaving the route.
+          Signals rotate on manual refresh to simulate a busy operations desk.
+          Selected alert drilldowns highlight related metrics without leaving
+          the route.
         </p>
       </div>
       <div className="mt-6 grid gap-4 sm:grid-cols-2 2xl:grid-cols-4">
-        {metrics.map((metric) => (
-          <article
-            className="rounded-[1.6rem] border border-white/8 bg-white/[0.04] p-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]"
-            key={metric.id}
-          >
-            <div
-              className={`inline-flex rounded-full border px-3 py-1 text-xs uppercase tracking-[0.24em] ${toneClasses[metric.state]}`}
+        {metrics.map((metric) => {
+          const isRelated = activeMetricIds.includes(metric.id);
+
+          return (
+            <article
+              className={`rounded-[1.6rem] border p-5 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] transition ${
+                isRelated
+                  ? "border-cyan-300/35 bg-cyan-400/[0.08]"
+                  : "border-white/8 bg-white/[0.04]"
+              }`}
+              key={metric.id}
             >
-              {metric.state}
-            </div>
-            <h3 className="mt-4 text-sm uppercase tracking-[0.16em] text-slate-300">
-              {metric.label}
-            </h3>
-            <p className="mt-3 text-3xl font-semibold text-white">
-              {metric.value}
-            </p>
-            <p className="mt-2 text-sm text-cyan-100">{metric.delta}</p>
-            <p className="mt-4 text-sm leading-6 text-slate-400">
-              {metric.description}
-            </p>
-          </article>
-        ))}
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div
+                  className={`inline-flex rounded-full border px-3 py-1 text-xs uppercase tracking-[0.24em] ${toneClasses[metric.state]}`}
+                >
+                  {metric.state}
+                </div>
+                {isRelated ? (
+                  <span className="rounded-full border border-cyan-300/30 bg-cyan-300/12 px-3 py-1 text-[11px] uppercase tracking-[0.24em] text-cyan-100">
+                    drilldown signal
+                  </span>
+                ) : null}
+              </div>
+              <h3 className="mt-4 text-sm uppercase tracking-[0.16em] text-slate-300">
+                {metric.label}
+              </h3>
+              <p className="mt-3 text-3xl font-semibold text-white">
+                {metric.value}
+              </p>
+              <p className="mt-2 text-sm text-cyan-100">{metric.delta}</p>
+              <p className="mt-4 text-sm leading-6 text-slate-400">
+                {metric.description}
+              </p>
+            </article>
+          );
+        })}
       </div>
     </section>
   );

--- a/src/components/control-room/quick-actions.tsx
+++ b/src/components/control-room/quick-actions.tsx
@@ -1,62 +1,133 @@
-"use client";
+import type { Ref } from "react";
+import {
+  operatorPostureOptions,
+  type OperatorPosture,
+} from "@/app/control-room/mock-data";
 
-import { useState } from "react";
+type QuickActionsProps = {
+  actionLog: {
+    id: string;
+    label: string;
+    source: string;
+    timeLabel: string;
+  }[];
+  divertWorkers: boolean;
+  freezeDeploys: boolean;
+  isSpotlighted: boolean;
+  lastAction: string;
+  posture: OperatorPosture;
+  samplingRate: number;
+  silenceInfoAlerts: boolean;
+  onRunDryFailover: () => void;
+  onSetPosture: (posture: OperatorPosture) => void;
+  onSetSamplingRate: (value: number) => void;
+  onToggleDivertWorkers: () => void;
+  onToggleFreezeDeploys: () => void;
+  onToggleSilenceInfoAlerts: () => void;
+  sectionRef?: Ref<HTMLElement>;
+};
 
-const postureOptions = ["monitor", "contain", "escalate"] as const;
-const clock = new Intl.DateTimeFormat("en-US", {
-  hour: "2-digit",
-  minute: "2-digit",
-  hour12: false,
-});
-
-export function QuickActions() {
-  const [freezeDeploys, setFreezeDeploys] = useState(true);
-  const [divertWorkers, setDivertWorkers] = useState(false);
-  const [samplingRate, setSamplingRate] = useState(72);
-  const [posture, setPosture] = useState<(typeof postureOptions)[number]>("contain");
-  const [lastAction, setLastAction] = useState("Awaiting operator input. Controls are browser-only.");
-
-  function stageAction(label: string) {
-    setLastAction(`${label} staged at ${clock.format(new Date())}. No request sent.`);
-  }
-
+export function QuickActions({
+  actionLog,
+  divertWorkers,
+  freezeDeploys,
+  isSpotlighted,
+  lastAction,
+  posture,
+  samplingRate,
+  silenceInfoAlerts,
+  onRunDryFailover,
+  onSetPosture,
+  onSetSamplingRate,
+  onToggleDivertWorkers,
+  onToggleFreezeDeploys,
+  onToggleSilenceInfoAlerts,
+  sectionRef,
+}: QuickActionsProps) {
   return (
-    <section className="rounded-[2rem] border border-white/10 bg-slate-950/65 p-6 backdrop-blur sm:p-8">
-      <p className="text-xs uppercase tracking-[0.24em] text-cyan-200/70">Quick Actions</p>
-      <h2 className="mt-2 text-2xl font-semibold text-white">Drill controls</h2>
-      <p className="mt-3 text-sm leading-6 text-slate-300">Dummy controls for staging operator intent. State stays local to this panel.</p>
+    <section
+      aria-label="Quick actions"
+      className={`rounded-[2rem] border bg-slate-950/65 p-6 backdrop-blur transition sm:p-8 ${
+        isSpotlighted
+          ? "border-cyan-300/45 shadow-[0_0_0_1px_rgba(103,232,249,0.15),0_18px_70px_rgba(34,211,238,0.18)]"
+          : "border-white/10"
+      }`}
+      ref={sectionRef}
+      tabIndex={-1}
+    >
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.24em] text-cyan-200/70">
+            Quick Actions
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold text-white">
+            Drill controls
+          </h2>
+        </div>
+        <p className="max-w-lg text-sm text-slate-300">
+          Command palette actions and alert remediation shortcuts stage changes
+          into the same local control surface.
+        </p>
+      </div>
 
       <div className="mt-6 grid gap-3 sm:grid-cols-2">
         <button
           aria-pressed={freezeDeploys}
-          className={`rounded-[1.4rem] border px-4 py-4 text-left text-sm transition ${freezeDeploys ? "border-amber-300/30 bg-amber-400/12 text-amber-100" : "border-white/10 bg-white/[0.04] text-slate-300"}`}
-          onClick={() => setFreezeDeploys((value) => !value)}
+          className={`rounded-[1.4rem] border px-4 py-4 text-left text-sm transition ${
+            freezeDeploys
+              ? "border-amber-300/30 bg-amber-400/12 text-amber-100"
+              : "border-white/10 bg-white/[0.04] text-slate-300"
+          }`}
+          onClick={onToggleFreezeDeploys}
           type="button"
         >
           Freeze deploy lane
         </button>
         <button
           aria-pressed={divertWorkers}
-          className={`rounded-[1.4rem] border px-4 py-4 text-left text-sm transition ${divertWorkers ? "border-emerald-300/25 bg-emerald-400/12 text-emerald-100" : "border-white/10 bg-white/[0.04] text-slate-300"}`}
-          onClick={() => setDivertWorkers((value) => !value)}
+          className={`rounded-[1.4rem] border px-4 py-4 text-left text-sm transition ${
+            divertWorkers
+              ? "border-emerald-300/25 bg-emerald-400/12 text-emerald-100"
+              : "border-white/10 bg-white/[0.04] text-slate-300"
+          }`}
+          onClick={onToggleDivertWorkers}
           type="button"
         >
           Divert background workers
         </button>
       </div>
 
+      <button
+        aria-pressed={silenceInfoAlerts}
+        className={`mt-4 w-full rounded-[1.4rem] border px-4 py-4 text-left text-sm transition ${
+          silenceInfoAlerts
+            ? "border-sky-300/25 bg-sky-400/12 text-sky-100"
+            : "border-white/10 bg-white/[0.04] text-slate-300"
+        }`}
+        onClick={onToggleSilenceInfoAlerts}
+        type="button"
+      >
+        Silence info alerts
+      </button>
+
       <div className="mt-6">
-        <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Incident posture</p>
+        <p className="text-xs uppercase tracking-[0.2em] text-slate-500">
+          Incident posture
+        </p>
         <div className="mt-3 flex flex-wrap gap-2">
-          {postureOptions.map((option) => {
+          {operatorPostureOptions.map((option) => {
             const isActive = posture === option;
 
             return (
               <button
                 aria-pressed={isActive}
-                className={`rounded-full border px-4 py-2 text-sm capitalize ${isActive ? "border-cyan-200 bg-cyan-200 text-slate-950" : "border-white/10 bg-white/[0.04] text-slate-300"}`}
+                className={`rounded-full border px-4 py-2 text-sm capitalize ${
+                  isActive
+                    ? "border-cyan-200 bg-cyan-200 text-slate-950"
+                    : "border-white/10 bg-white/[0.04] text-slate-300"
+                }`}
                 key={option}
-                onClick={() => setPosture(option)}
+                onClick={() => onSetPosture(option)}
                 type="button"
               >
                 {option}
@@ -72,7 +143,7 @@ export function QuickActions() {
           className="mt-3 w-full accent-cyan-300"
           max={100}
           min={10}
-          onChange={(event) => setSamplingRate(Number(event.target.value))}
+          onChange={(event) => onSetSamplingRate(Number(event.target.value))}
           type="range"
           value={samplingRate}
         />
@@ -81,27 +152,65 @@ export function QuickActions() {
       <div className="mt-6 flex flex-wrap gap-3">
         <button
           className="rounded-full bg-cyan-300 px-5 py-2.5 text-sm font-semibold text-slate-950"
-          onClick={() => stageAction("Dry failover")}
+          onClick={onRunDryFailover}
           type="button"
         >
           Run dry failover
         </button>
         <button
           className="rounded-full border border-white/12 bg-white/[0.04] px-5 py-2.5 text-sm font-semibold text-slate-200"
-          onClick={() => stageAction("Info alert silence")}
+          onClick={onToggleSilenceInfoAlerts}
           type="button"
         >
-          Silence info alerts
+          {silenceInfoAlerts ? "Resume info alerts" : "Silence info alerts"}
         </button>
       </div>
 
       <div className="mt-6 rounded-[1.5rem] border border-white/8 bg-white/[0.04] p-4">
         <div className="flex flex-wrap gap-2 text-xs uppercase tracking-[0.18em]">
-          <span className="rounded-full border border-white/10 px-3 py-1 text-slate-300">{freezeDeploys ? "deploys frozen" : "deploys open"}</span>
-          <span className="rounded-full border border-white/10 px-3 py-1 text-slate-300">{divertWorkers ? "workers diverted" : "workers normal"}</span>
-          <span className="rounded-full border border-white/10 px-3 py-1 text-slate-300">posture {posture}</span>
+          <span className="rounded-full border border-white/10 px-3 py-1 text-slate-300">
+            {freezeDeploys ? "deploys frozen" : "deploys open"}
+          </span>
+          <span className="rounded-full border border-white/10 px-3 py-1 text-slate-300">
+            {divertWorkers ? "workers diverted" : "workers normal"}
+          </span>
+          <span className="rounded-full border border-white/10 px-3 py-1 text-slate-300">
+            posture {posture}
+          </span>
+          <span className="rounded-full border border-white/10 px-3 py-1 text-slate-300">
+            {silenceInfoAlerts ? "info muted" : "info live"}
+          </span>
         </div>
         <p className="mt-4 text-sm leading-6 text-slate-300">{lastAction}</p>
+      </div>
+
+      <div className="mt-6 rounded-[1.5rem] border border-white/8 bg-slate-950/55 p-4">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs uppercase tracking-[0.22em] text-slate-500">
+            Recent command log
+          </p>
+          <p className="text-xs text-slate-500">{actionLog.length} staged</p>
+        </div>
+        <ol className="mt-4 space-y-3">
+          {actionLog.length === 0 ? (
+            <li className="rounded-2xl border border-dashed border-white/12 bg-white/[0.03] p-3 text-sm text-slate-400">
+              No staged commands yet.
+            </li>
+          ) : (
+            actionLog.map((entry) => (
+              <li
+                className="rounded-2xl border border-white/8 bg-white/[0.04] p-3"
+                key={entry.id}
+              >
+                <div className="flex items-center justify-between gap-3 text-xs uppercase tracking-[0.2em] text-slate-500">
+                  <span>{entry.source}</span>
+                  <span>{entry.timeLabel}</span>
+                </div>
+                <p className="mt-2 text-sm text-slate-200">{entry.label}</p>
+              </li>
+            ))
+          )}
+        </ol>
       </div>
     </section>
   );

--- a/src/components/mission-briefing/MissionBriefingShell.test.tsx
+++ b/src/components/mission-briefing/MissionBriefingShell.test.tsx
@@ -6,25 +6,31 @@ import { missionScenarios } from "@/app/mission-briefing/mission-data";
 import { MissionBriefingShell } from "./MissionBriefingShell";
 
 describe("MissionBriefingShell", () => {
-  it("updates the selected scenario and keeps notes in local state", () => {
-    render(<MissionBriefingShell scenarios={missionScenarios} />);
+  it(
+    "updates the selected scenario and keeps notes in local state",
+    () => {
+      render(<MissionBriefingShell scenarios={missionScenarios} />);
 
-    fireEvent.click(screen.getByRole("button", { name: /harbor echo/i }));
-    expect(
-      screen.getByText(/Cargo timing is healthy, but pier access stays fragile/i),
-    ).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: /harbor echo/i }));
+      expect(
+        screen.getByText(
+          /Cargo timing is healthy, but pier access stays fragile/i,
+        ),
+      ).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText(/decision notes/i), {
-      target: { value: "Delay insertion until the patrol overlap clears." },
-    });
+      fireEvent.change(screen.getByLabelText(/decision notes/i), {
+        target: { value: "Delay insertion until the patrol overlap clears." },
+      });
 
-    fireEvent.click(screen.getByRole("button", { name: /polar relay/i }));
-    fireEvent.click(screen.getByRole("button", { name: /harbor echo/i }));
+      fireEvent.click(screen.getByRole("button", { name: /polar relay/i }));
+      fireEvent.click(screen.getByRole("button", { name: /harbor echo/i }));
 
-    expect(screen.getByLabelText(/decision notes/i)).toHaveValue(
-      "Delay insertion until the patrol overlap clears.",
-    );
-  });
+      expect(screen.getByLabelText(/decision notes/i)).toHaveValue(
+        "Delay insertion until the patrol overlap clears.",
+      );
+    },
+    20_000,
+  );
 
   it("shows empty-state copy for filtered and deselected views", () => {
     render(<MissionBriefingShell scenarios={missionScenarios} />);


### PR DESCRIPTION
## Summary
- add a keyboard-first Control Room command palette with navigation, filtering, and alert-specific actions
- add alert drilldown panels with timeline context, remediation shortcuts, and shared operator control state
- expand mock data and integration coverage for the new workflows, plus stabilize the existing Mission Briefing timeout under Vitest

## Testing
- npm run lint
- npm run typecheck
- npm test

Closes #64