### PR TITLE
feat: add asset inventory catalog route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -2122,6 +2123,70 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
@@ -2255,6 +2320,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "next": "16.2.4",
@@ -18,6 +19,7 @@
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/app/asset-inventory/page.test.tsx
+++ b/src/app/asset-inventory/page.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import AssetInventoryPage from "./page";
+
+describe("AssetInventoryPage", () => {
+  it("renders the inventory route with category navigation, catalog sections, and detail panel", () => {
+    render(<AssetInventoryPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: /catalog route for field hardware, live stock signals, and selected-item detail/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /all inventory/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Sensors" })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Safety" })).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/selected inventory item details/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows status and availability information for inventory cards", () => {
+    render(<AssetInventoryPage />);
+
+    const primaryCard = screen.getByRole("button", { name: /aether drone beacon/i });
+    const lowStockCard = screen.getByRole("button", { name: /pulse rack reader/i });
+
+    expect(primaryCard).toHaveTextContent("Operational");
+    expect(primaryCard).toHaveTextContent("24 units ready for dispatch");
+    expect(lowStockCard).toHaveTextContent("Low Stock");
+    expect(lowStockCard).toHaveTextContent("4 readers left before reorder");
+  });
+
+  it("filters the catalog by category and keeps a visible detail panel", async () => {
+    const user = userEvent.setup();
+
+    render(<AssetInventoryPage />);
+
+    const categoryNav = screen.getByRole("navigation", {
+      name: /inventory categories/i,
+    });
+
+    await user.click(
+      within(categoryNav).getByRole("button", {
+        name: /protective systems and incident-response hardware staged for crews/i,
+      }),
+    );
+
+    expect(screen.getByRole("region", { name: "Safety" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("region", { name: "Sensors" }),
+    ).not.toBeInTheDocument();
+
+    const detailPanel = screen.getByLabelText(/selected inventory item details/i);
+
+    expect(
+      within(detailPanel).getByRole("heading", {
+        name: "Ember Suppression Canister",
+      }),
+    ).toBeInTheDocument();
+    expect(detailPanel).toBeInTheDocument();
+  });
+
+  it("updates the detail panel when a different inventory card is selected", async () => {
+    const user = userEvent.setup();
+
+    render(<AssetInventoryPage />);
+
+    await user.click(screen.getByRole("button", { name: /flux response kit/i }));
+
+    const detailPanel = screen.getByLabelText(/selected inventory item details/i);
+
+    expect(
+      within(detailPanel).getByRole("heading", { name: "Flux Response Kit" }),
+    ).toBeInTheDocument();
+    expect(within(detailPanel).getByText("Emergency power locker")).toBeInTheDocument();
+    expect(
+      within(detailPanel).getByText("3 kits remain before replenishment"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/asset-inventory/page.tsx
+++ b/src/app/asset-inventory/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Asset Inventory",
+  description: "Initial shell for the asset inventory catalog route.",
+};
+
+export default function AssetInventoryPage() {
+  return (
+    <main className="flex min-h-screen flex-col bg-slate-100 px-5 py-8 text-slate-950 sm:px-8 lg:px-10">
+      <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-6">
+        <section className="rounded-[2rem] border border-slate-200 bg-slate-950 px-6 py-8 text-white shadow-[0_24px_80px_-32px_rgba(15,23,42,0.7)] sm:px-8">
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-sky-300">
+            Asset Inventory
+          </p>
+          <h1 className="mt-4 text-4xl font-semibold tracking-tight sm:text-5xl">
+            Inventory catalog route shell
+          </h1>
+          <p className="mt-5 max-w-3xl text-base leading-8 text-slate-300 sm:text-lg">
+            This route is reserved for the inventory catalog experience. The
+            next steps will populate it with category sections, item cards,
+            stock indicators, and a selected-item detail panel.
+          </p>
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-[minmax(0,1.4fr)_320px]">
+          <div className="rounded-[2rem] border border-dashed border-slate-300 bg-white p-6 shadow-[0_18px_60px_-40px_rgba(15,23,42,0.45)]">
+            <h2 className="text-2xl font-semibold">Catalog Placeholder</h2>
+            <p className="mt-3 text-sm leading-7 text-slate-600">
+              Inventory sections and asset cards will render here once the mock
+              data and reusable catalog components are wired in.
+            </p>
+          </div>
+          <aside className="rounded-[2rem] border border-dashed border-slate-300 bg-white p-6 shadow-[0_18px_60px_-40px_rgba(15,23,42,0.45)]">
+            <h2 className="text-2xl font-semibold">Detail Panel Placeholder</h2>
+            <p className="mt-3 text-sm leading-7 text-slate-600">
+              A persistent panel for the selected inventory item will live here.
+            </p>
+          </aside>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/asset-inventory/page.tsx
+++ b/src/app/asset-inventory/page.tsx
@@ -1,44 +1,19 @@
 import type { Metadata } from "next";
 
+import { AssetInventoryExperience } from "@/components/asset-inventory/asset-inventory-experience";
+import { inventoryCategories, inventoryItems } from "@/data/asset-inventory";
+
 export const metadata: Metadata = {
-  title: "Asset Inventory",
-  description: "Initial shell for the asset inventory catalog route.",
+  title: "Asset Inventory Catalog",
+  description:
+    "Browse inventory categories, stock status indicators, and selected-item detail for mock operational assets.",
 };
 
 export default function AssetInventoryPage() {
   return (
-    <main className="flex min-h-screen flex-col bg-slate-100 px-5 py-8 text-slate-950 sm:px-8 lg:px-10">
-      <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-6">
-        <section className="rounded-[2rem] border border-slate-200 bg-slate-950 px-6 py-8 text-white shadow-[0_24px_80px_-32px_rgba(15,23,42,0.7)] sm:px-8">
-          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-sky-300">
-            Asset Inventory
-          </p>
-          <h1 className="mt-4 text-4xl font-semibold tracking-tight sm:text-5xl">
-            Inventory catalog route shell
-          </h1>
-          <p className="mt-5 max-w-3xl text-base leading-8 text-slate-300 sm:text-lg">
-            This route is reserved for the inventory catalog experience. The
-            next steps will populate it with category sections, item cards,
-            stock indicators, and a selected-item detail panel.
-          </p>
-        </section>
-
-        <section className="grid gap-6 lg:grid-cols-[minmax(0,1.4fr)_320px]">
-          <div className="rounded-[2rem] border border-dashed border-slate-300 bg-white p-6 shadow-[0_18px_60px_-40px_rgba(15,23,42,0.45)]">
-            <h2 className="text-2xl font-semibold">Catalog Placeholder</h2>
-            <p className="mt-3 text-sm leading-7 text-slate-600">
-              Inventory sections and asset cards will render here once the mock
-              data and reusable catalog components are wired in.
-            </p>
-          </div>
-          <aside className="rounded-[2rem] border border-dashed border-slate-300 bg-white p-6 shadow-[0_18px_60px_-40px_rgba(15,23,42,0.45)]">
-            <h2 className="text-2xl font-semibold">Detail Panel Placeholder</h2>
-            <p className="mt-3 text-sm leading-7 text-slate-600">
-              A persistent panel for the selected inventory item will live here.
-            </p>
-          </aside>
-        </section>
-      </div>
-    </main>
+    <AssetInventoryExperience
+      categories={inventoryCategories}
+      items={inventoryItems}
+    />
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -26,7 +26,7 @@ body {
   background-image:
     radial-gradient(circle at top, rgba(251, 191, 36, 0.22), transparent 36%),
     linear-gradient(180deg, #fcf8ef 0%, #f4efe7 52%, #ebe5d9 100%);
-  font-family: var(--font-geist-sans), sans-serif;
+  font-family: var(--font-geist-sans), Arial, Helvetica, sans-serif;
 }
 
 a {

--- a/src/components/asset-inventory/asset-inventory-experience.tsx
+++ b/src/components/asset-inventory/asset-inventory-experience.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState } from "react";
+
+import {
+  getInventoryCategoryOptions,
+  getInventorySections,
+  type InventoryCategory,
+  type InventoryItem,
+} from "@/data/asset-inventory";
+
+import { CategoryNavigation } from "./category-navigation";
+import { InventoryCatalogSection } from "./inventory-catalog-section";
+import { InventoryDetailPanel } from "./inventory-detail-panel";
+
+type AssetInventoryExperienceProps = {
+  categories: InventoryCategory[];
+  items: InventoryItem[];
+};
+
+export function AssetInventoryExperience({
+  categories,
+  items,
+}: AssetInventoryExperienceProps) {
+  const [activeCategoryId, setActiveCategoryId] = useState("all");
+  const [selectedItemId, setSelectedItemId] = useState(items[0]?.id ?? "");
+
+  const categoryOptions = getInventoryCategoryOptions(items, categories);
+  const sections = getInventorySections(items, categories, activeCategoryId);
+  const visibleItems = sections.flatMap((section) => section.items);
+  const selectedItem =
+    visibleItems.find((item) => item.id === selectedItemId) ??
+    items.find((item) => item.id === selectedItemId) ??
+    visibleItems[0];
+
+  const operationalCount = items.filter((item) => item.status === "Operational").length;
+  const attentionCount = items.filter((item) => item.status !== "Operational").length;
+  const totalUnits = items.reduce((sum, item) => sum + item.availableUnits, 0);
+
+  function handleCategoryChange(categoryId: string) {
+    const nextSections = getInventorySections(items, categories, categoryId);
+    const nextVisibleItems = nextSections.flatMap((section) => section.items);
+
+    setActiveCategoryId(categoryId);
+
+    if (!nextVisibleItems.some((item) => item.id === selectedItemId)) {
+      setSelectedItemId(nextVisibleItems[0]?.id ?? "");
+    }
+  }
+
+  if (!selectedItem) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,_rgba(56,189,248,0.18),_transparent_28%),linear-gradient(180deg,#f8fafc_0%,#eef6f1_46%,#f8fafc_100%)] font-sans text-slate-950">
+      <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
+        <section className="overflow-hidden rounded-[2.5rem] border border-slate-200/80 bg-slate-950 px-6 py-8 text-white shadow-[0_32px_100px_-40px_rgba(15,23,42,0.85)] sm:px-8 lg:px-10">
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,1.6fr)_minmax(260px,0.8fr)]">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.32em] text-sky-300">
+                Asset Inventory
+              </p>
+              <h1 className="mt-4 max-w-3xl text-4xl font-semibold tracking-tight sm:text-5xl">
+                Catalog route for field hardware, live stock signals, and
+                selected-item detail.
+              </h1>
+              <p className="mt-5 max-w-3xl text-base leading-8 text-slate-300 sm:text-lg">
+                This isolated route tracks inventory groups across sensors,
+                safety systems, mobility rigs, and power modules. Category
+                filters keep the catalog focused while the detail panel stays
+                pinned to the active asset.
+              </p>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1">
+              <div className="rounded-[1.75rem] border border-white/10 bg-white/6 p-5">
+                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-400">
+                  Categories
+                </p>
+                <p className="mt-3 text-3xl font-semibold">{categories.length}</p>
+                <p className="mt-2 text-sm text-slate-300">
+                  Organized catalog sections
+                </p>
+              </div>
+              <div className="rounded-[1.75rem] border border-white/10 bg-white/6 p-5">
+                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-400">
+                  Tracked Units
+                </p>
+                <p className="mt-3 text-3xl font-semibold">{totalUnits}</p>
+                <p className="mt-2 text-sm text-slate-300">
+                  Available across every item
+                </p>
+              </div>
+              <div className="rounded-[1.75rem] border border-white/10 bg-white/6 p-5">
+                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-400">
+                  Attention Needed
+                </p>
+                <p className="mt-3 text-3xl font-semibold">{attentionCount}</p>
+                <p className="mt-2 text-sm text-slate-300">
+                  Non-operational or constrained assets
+                </p>
+              </div>
+            </div>
+          </div>
+          <div className="mt-6 flex flex-wrap gap-3 text-sm text-slate-300">
+            <span className="rounded-full border border-white/10 bg-white/6 px-3 py-1.5">
+              {operationalCount} operational items
+            </span>
+            <span className="rounded-full border border-white/10 bg-white/6 px-3 py-1.5">
+              Detail panel is always visible
+            </span>
+            <span className="rounded-full border border-white/10 bg-white/6 px-3 py-1.5">
+              Inventory data is fully mocked for isolated development
+            </span>
+          </div>
+        </section>
+
+        <CategoryNavigation
+          options={categoryOptions}
+          activeCategoryId={activeCategoryId}
+          onSelect={handleCategoryChange}
+        />
+
+        <div className="grid gap-8 xl:grid-cols-[minmax(0,1.55fr)_380px]">
+          <div className="space-y-6">
+            {sections.map((section) => (
+              <InventoryCatalogSection
+                key={section.id}
+                section={section}
+                selectedItemId={selectedItem.id}
+                onSelectItem={setSelectedItemId}
+              />
+            ))}
+          </div>
+          <InventoryDetailPanel item={selectedItem} />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/components/asset-inventory/category-navigation.tsx
+++ b/src/components/asset-inventory/category-navigation.tsx
@@ -1,0 +1,76 @@
+import type { InventoryCategoryOption } from "@/data/asset-inventory";
+
+type CategoryNavigationProps = {
+  options: InventoryCategoryOption[];
+  activeCategoryId: string;
+  onSelect: (categoryId: string) => void;
+};
+
+export function CategoryNavigation({
+  options,
+  activeCategoryId,
+  onSelect,
+}: CategoryNavigationProps) {
+  return (
+    <nav
+      aria-label="Inventory categories"
+      className="rounded-[2rem] border border-slate-200/80 bg-white/85 p-4 shadow-[0_18px_60px_-40px_rgba(15,23,42,0.45)] backdrop-blur"
+    >
+      <div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-500">
+            Category Navigation
+          </p>
+          <h2 className="text-xl font-semibold text-slate-950">
+            Shift between catalog groups
+          </h2>
+        </div>
+        <p className="max-w-2xl text-sm text-slate-600">
+          Each filter preserves the current selection when possible and keeps
+          the detail panel aligned with the visible catalog.
+        </p>
+      </div>
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+        {options.map((option) => {
+          const isActive = option.id === activeCategoryId;
+
+          return (
+            <button
+              key={option.id}
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => onSelect(option.id)}
+              className={`rounded-[1.5rem] border px-4 py-4 text-left transition ${
+                isActive
+                  ? "border-slate-950 bg-slate-950 text-white shadow-lg shadow-slate-950/15"
+                  : "border-slate-200 bg-slate-50/80 text-slate-900 hover:border-slate-300 hover:bg-white"
+              }`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-sm font-semibold">{option.name}</div>
+                  <div
+                    className={`mt-1 text-xs leading-5 ${
+                      isActive ? "text-slate-300" : "text-slate-500"
+                    }`}
+                  >
+                    {option.description}
+                  </div>
+                </div>
+                <span
+                  className={`inline-flex min-w-10 justify-center rounded-full px-2.5 py-1 text-xs font-semibold ${
+                    isActive
+                      ? "bg-white/12 text-white"
+                      : "bg-slate-900 text-white"
+                  }`}
+                >
+                  {option.count}
+                </span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/asset-inventory/inventory-card.tsx
+++ b/src/components/asset-inventory/inventory-card.tsx
@@ -1,0 +1,88 @@
+import {
+  getInventoryCategoryById,
+  inventoryStatusStyles,
+  type InventoryItem,
+} from "@/data/asset-inventory";
+
+type InventoryCardProps = {
+  item: InventoryItem;
+  selected: boolean;
+  onSelect: (itemId: string) => void;
+};
+
+export function InventoryCard({
+  item,
+  selected,
+  onSelect,
+}: InventoryCardProps) {
+  const category = getInventoryCategoryById(item.categoryId);
+  const statusStyle = inventoryStatusStyles[item.status];
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(item.id)}
+      className={`w-full rounded-[1.75rem] border p-5 text-left transition ${
+        selected
+          ? "border-slate-950 bg-slate-950 text-white shadow-[0_24px_60px_-32px_rgba(15,23,42,0.75)]"
+          : "border-slate-200 bg-white/90 text-slate-950 hover:border-slate-300 hover:bg-white"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p
+            className={`text-xs font-semibold uppercase tracking-[0.22em] ${
+              selected ? "text-slate-300" : "text-slate-500"
+            }`}
+          >
+            {category?.name ?? "Uncategorized"}
+          </p>
+          <h3 className="mt-2 text-lg font-semibold">{item.name}</h3>
+        </div>
+        <span
+          className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold ${
+            selected
+              ? "border-white/20 bg-white/8 text-white"
+              : statusStyle.badge
+          }`}
+        >
+          <span
+            className={`h-2 w-2 rounded-full ${
+              selected ? "bg-white" : statusStyle.dot
+            }`}
+          />
+          {item.status}
+        </span>
+      </div>
+      <p
+        className={`mt-3 text-sm leading-6 ${
+          selected ? "text-slate-200" : "text-slate-600"
+        }`}
+      >
+        {item.description}
+      </p>
+      <dl className="mt-5 grid gap-3 sm:grid-cols-2">
+        <div className="rounded-2xl border border-black/5 bg-black/[0.04] px-4 py-3">
+          <dt
+            className={`text-xs font-semibold uppercase tracking-[0.18em] ${
+              selected ? "text-slate-300" : "text-slate-500"
+            }`}
+          >
+            Status
+          </dt>
+          <dd className="mt-2 text-sm font-medium">{item.status}</dd>
+        </div>
+        <div className="rounded-2xl border border-black/5 bg-black/[0.04] px-4 py-3">
+          <dt
+            className={`text-xs font-semibold uppercase tracking-[0.18em] ${
+              selected ? "text-slate-300" : "text-slate-500"
+            }`}
+          >
+            Availability
+          </dt>
+          <dd className="mt-2 text-sm font-medium">{item.availability}</dd>
+        </div>
+      </dl>
+    </button>
+  );
+}

--- a/src/components/asset-inventory/inventory-card.tsx
+++ b/src/components/asset-inventory/inventory-card.tsx
@@ -62,7 +62,11 @@ export function InventoryCard({
         {item.description}
       </p>
       <dl className="mt-5 grid gap-3 sm:grid-cols-2">
-        <div className="rounded-2xl border border-black/5 bg-black/[0.04] px-4 py-3">
+        <div
+          className={`rounded-2xl border px-4 py-3 ${
+            selected ? "border-white/10 bg-white/8" : "border-black/5 bg-black/[0.04]"
+          }`}
+        >
           <dt
             className={`text-xs font-semibold uppercase tracking-[0.18em] ${
               selected ? "text-slate-300" : "text-slate-500"
@@ -72,7 +76,11 @@ export function InventoryCard({
           </dt>
           <dd className="mt-2 text-sm font-medium">{item.status}</dd>
         </div>
-        <div className="rounded-2xl border border-black/5 bg-black/[0.04] px-4 py-3">
+        <div
+          className={`rounded-2xl border px-4 py-3 ${
+            selected ? "border-white/10 bg-white/8" : "border-black/5 bg-black/[0.04]"
+          }`}
+        >
           <dt
             className={`text-xs font-semibold uppercase tracking-[0.18em] ${
               selected ? "text-slate-300" : "text-slate-500"

--- a/src/components/asset-inventory/inventory-catalog-section.tsx
+++ b/src/components/asset-inventory/inventory-catalog-section.tsx
@@ -1,0 +1,56 @@
+import type { InventorySection } from "@/data/asset-inventory";
+
+import { InventoryCard } from "./inventory-card";
+
+type InventoryCatalogSectionProps = {
+  section: InventorySection;
+  selectedItemId: string;
+  onSelectItem: (itemId: string) => void;
+};
+
+export function InventoryCatalogSection({
+  section,
+  selectedItemId,
+  onSelectItem,
+}: InventoryCatalogSectionProps) {
+  return (
+    <section
+      aria-labelledby={`${section.id}-section-title`}
+      className="rounded-[2rem] border border-slate-200/80 bg-white/85 p-5 shadow-[0_18px_60px_-40px_rgba(15,23,42,0.45)] backdrop-blur"
+    >
+      <div
+        className={`rounded-[1.5rem] border border-transparent bg-gradient-to-r px-5 py-5 ${section.accent}`}
+      >
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">
+              Catalog Section
+            </p>
+            <h2
+              id={`${section.id}-section-title`}
+              className="mt-2 text-2xl font-semibold text-slate-950"
+            >
+              {section.name}
+            </h2>
+          </div>
+          <p className="text-sm font-medium text-slate-600">
+            {section.items.length} items • {section.totalUnits} units tracked
+          </p>
+        </div>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-700">
+          {section.description}
+        </p>
+      </div>
+      <div className="mt-5 grid gap-4 lg:grid-cols-2">
+        {section.items.map((item) => (
+          <InventoryCard
+            key={item.id}
+            item={item}
+            selected={item.id === selectedItemId}
+            onSelect={onSelectItem}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/asset-inventory/inventory-detail-panel.tsx
+++ b/src/components/asset-inventory/inventory-detail-panel.tsx
@@ -1,0 +1,109 @@
+import {
+  getInventoryCategoryById,
+  inventoryStatusStyles,
+  type InventoryItem,
+} from "@/data/asset-inventory";
+
+type InventoryDetailPanelProps = {
+  item: InventoryItem;
+};
+
+export function InventoryDetailPanel({ item }: InventoryDetailPanelProps) {
+  const category = getInventoryCategoryById(item.categoryId);
+  const statusStyle = inventoryStatusStyles[item.status];
+
+  return (
+    <aside
+      aria-label="Selected inventory item details"
+      className="rounded-[2rem] border border-slate-200/80 bg-slate-950 p-6 text-white shadow-[0_24px_80px_-32px_rgba(15,23,42,0.85)] xl:sticky xl:top-6"
+    >
+      <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">
+        Selected Asset
+      </p>
+      <div className="mt-4 flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold">{item.name}</h2>
+          <p className="mt-2 text-sm text-slate-300">
+            {category?.name ?? "Inventory"} • SKU {item.sku}
+          </p>
+        </div>
+        <span
+          className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold ${statusStyle.badge}`}
+        >
+          <span className={`h-2 w-2 rounded-full ${statusStyle.dot}`} />
+          {item.status}
+        </span>
+      </div>
+
+      <p className="mt-5 text-sm leading-7 text-slate-300">{item.description}</p>
+
+      <dl className="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+        <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+          <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+            Availability
+          </dt>
+          <dd className="mt-2 text-sm font-medium text-white">
+            {item.availability}
+          </dd>
+        </div>
+        <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+          <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+            Available Units
+          </dt>
+          <dd className="mt-2 text-sm font-medium text-white">
+            {item.availableUnits}
+          </dd>
+        </div>
+        <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+          <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+            Location
+          </dt>
+          <dd className="mt-2 text-sm font-medium text-white">{item.location}</dd>
+        </div>
+        <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+          <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+            Owner
+          </dt>
+          <dd className="mt-2 text-sm font-medium text-white">{item.owner}</dd>
+        </div>
+        <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+          <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+            Last Checked
+          </dt>
+          <dd className="mt-2 text-sm font-medium text-white">
+            {item.lastChecked}
+          </dd>
+        </div>
+        <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+          <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+            Service Window
+          </dt>
+          <dd className="mt-2 text-sm font-medium text-white">
+            {item.serviceWindow}
+          </dd>
+        </div>
+      </dl>
+
+      <div className="mt-6 rounded-[1.5rem] border border-white/10 bg-white/5 p-4">
+        <h3 className="text-sm font-semibold text-white">Operational Notes</h3>
+        <p className="mt-3 text-sm leading-7 text-slate-300">{item.notes}</p>
+      </div>
+
+      <div className="mt-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+          Tags
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {item.tags.map((tag) => (
+            <span
+              key={tag}
+              className="rounded-full border border-white/10 bg-white/8 px-3 py-1 text-xs font-medium text-slate-200"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/asset-inventory/inventory-detail-panel.tsx
+++ b/src/components/asset-inventory/inventory-detail-panel.tsx
@@ -8,6 +8,17 @@ type InventoryDetailPanelProps = {
   item: InventoryItem;
 };
 
+const inventoryStateNotes = {
+  Operational:
+    "Asset is ready for immediate deployment and is currently above the local reorder threshold.",
+  "Low Stock":
+    "Supply is below the preferred threshold and should be replenished before the next shift rotation.",
+  Reserved:
+    "Inventory is healthy, but units are earmarked for a scheduled project or team allocation.",
+  Maintenance:
+    "Asset is intentionally unavailable while service work is completed and verified.",
+} satisfies Record<InventoryItem["status"], string>;
+
 export function InventoryDetailPanel({ item }: InventoryDetailPanelProps) {
   const category = getInventoryCategoryById(item.categoryId);
   const statusStyle = inventoryStatusStyles[item.status];
@@ -37,6 +48,13 @@ export function InventoryDetailPanel({ item }: InventoryDetailPanelProps) {
 
       <p className="mt-5 text-sm leading-7 text-slate-300">{item.description}</p>
 
+      <div className={`mt-6 rounded-[1.5rem] border px-4 py-4 ${statusStyle.badge}`}>
+        <p className="text-xs font-semibold uppercase tracking-[0.2em]">
+          Inventory State
+        </p>
+        <p className="mt-2 text-sm leading-7">{inventoryStateNotes[item.status]}</p>
+      </div>
+
       <dl className="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
         <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
           <dt className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
@@ -51,7 +69,7 @@ export function InventoryDetailPanel({ item }: InventoryDetailPanelProps) {
             Available Units
           </dt>
           <dd className="mt-2 text-sm font-medium text-white">
-            {item.availableUnits}
+            {item.availableUnits} available • reorder point {item.reorderPoint}
           </dd>
         </div>
         <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">

--- a/src/data/asset-inventory.ts
+++ b/src/data/asset-inventory.ts
@@ -1,0 +1,296 @@
+export type InventoryStatus =
+  | "Operational"
+  | "Low Stock"
+  | "Reserved"
+  | "Maintenance";
+
+export type InventoryCategory = {
+  id: string;
+  name: string;
+  description: string;
+  accent: string;
+};
+
+export type InventoryItem = {
+  id: string;
+  name: string;
+  sku: string;
+  categoryId: string;
+  status: InventoryStatus;
+  availability: string;
+  availableUnits: number;
+  reorderPoint: number;
+  location: string;
+  owner: string;
+  lastChecked: string;
+  serviceWindow: string;
+  description: string;
+  notes: string;
+  tags: string[];
+};
+
+export type InventoryCategoryOption = {
+  id: string;
+  name: string;
+  description: string;
+  count: number;
+};
+
+export type InventorySection = InventoryCategory & {
+  items: InventoryItem[];
+  totalUnits: number;
+};
+
+export const inventoryCategories: InventoryCategory[] = [
+  {
+    id: "sensors",
+    name: "Sensors",
+    description: "Telemetry beacons, readers, and monitoring units for yard ops.",
+    accent: "from-sky-500/20 via-cyan-400/15 to-transparent",
+  },
+  {
+    id: "safety",
+    name: "Safety",
+    description: "Protective systems and incident-response hardware staged for crews.",
+    accent: "from-amber-500/20 via-orange-400/15 to-transparent",
+  },
+  {
+    id: "mobility",
+    name: "Mobility",
+    description: "Lift rigs, movement assists, and field-ready transport hardware.",
+    accent: "from-emerald-500/20 via-lime-400/15 to-transparent",
+  },
+  {
+    id: "power",
+    name: "Power",
+    description: "Portable energy modules and rapid-response power recovery kits.",
+    accent: "from-rose-500/20 via-fuchsia-400/15 to-transparent",
+  },
+];
+
+export const inventoryItems: InventoryItem[] = [
+  {
+    id: "aether-drone-beacon",
+    name: "Aether Drone Beacon",
+    sku: "SEN-1148",
+    categoryId: "sensors",
+    status: "Operational",
+    availability: "24 units ready for dispatch",
+    availableUnits: 24,
+    reorderPoint: 10,
+    location: "Dock A3 telemetry cage",
+    owner: "Flight Operations",
+    lastChecked: "2026-04-18",
+    serviceWindow: "Quarterly calibration",
+    description:
+      "Long-range telemetry beacon used to trace drone movement across cargo lanes.",
+    notes:
+      "Paired with the yard mesh gateway. Latest calibration cycle cleared without drift.",
+    tags: ["UWB", "IP67", "Mesh enabled"],
+  },
+  {
+    id: "pulse-rack-reader",
+    name: "Pulse Rack Reader",
+    sku: "SEN-2011",
+    categoryId: "sensors",
+    status: "Low Stock",
+    availability: "4 readers left before reorder",
+    availableUnits: 4,
+    reorderPoint: 6,
+    location: "Control room secure shelf",
+    owner: "Warehouse Automation",
+    lastChecked: "2026-04-17",
+    serviceWindow: "Battery refresh every 60 days",
+    description:
+      "Portable rack scanner for verifying tagged pallets during nightly put-away.",
+    notes:
+      "Demand increased after late-shift intake expansion. Reorder request is queued.",
+    tags: ["RFID", "Handheld", "Dock sync"],
+  },
+  {
+    id: "ember-suppression-canister",
+    name: "Ember Suppression Canister",
+    sku: "SAF-4023",
+    categoryId: "safety",
+    status: "Reserved",
+    availability: "Allocated to loading bay retrofit",
+    availableUnits: 6,
+    reorderPoint: 4,
+    location: "Hazmat cage row 2",
+    owner: "Site Safety Team",
+    lastChecked: "2026-04-16",
+    serviceWindow: "Pressure test every 30 days",
+    description:
+      "Compact fire-suppression canister designed for high-heat electrical incidents.",
+    notes:
+      "Units are earmarked for Bay 7 retrofit and should remain staged through inspection.",
+    tags: ["Fire safety", "Electrical", "Rapid deploy"],
+  },
+  {
+    id: "sparrow-harness-rack",
+    name: "Sparrow Harness Rack",
+    sku: "SAF-5530",
+    categoryId: "safety",
+    status: "Operational",
+    availability: "12 racks staged near assembly floor",
+    availableUnits: 12,
+    reorderPoint: 5,
+    location: "Assembly mezzanine",
+    owner: "Crew Enablement",
+    lastChecked: "2026-04-19",
+    serviceWindow: "Visual check every shift",
+    description:
+      "Modular rack system that keeps fall-protection harnesses serialized and deployment ready.",
+    notes:
+      "Crew leads requested a second rack bundle after overtime expansion last week.",
+    tags: ["Harness", "Serialized", "Shift ready"],
+  },
+  {
+    id: "atlas-lift-harness",
+    name: "Atlas Lift Harness",
+    sku: "MOB-3074",
+    categoryId: "mobility",
+    status: "Maintenance",
+    availability: "Unavailable until 24 Apr service closeout",
+    availableUnits: 0,
+    reorderPoint: 2,
+    location: "Repair bench 2",
+    owner: "Heavy Lift Crew",
+    lastChecked: "2026-04-20",
+    serviceWindow: "Load test after every repair",
+    description:
+      "Assisted lift harness for oversize inventory moves in the west loading corridor.",
+    notes:
+      "Pulled from rotation after buckle fatigue alert. Waiting on replacement bracket install.",
+    tags: ["Lift assist", "Repair hold", "Heavy cargo"],
+  },
+  {
+    id: "rover-battery-sled",
+    name: "Rover Battery Sled",
+    sku: "MOB-3186",
+    categoryId: "mobility",
+    status: "Operational",
+    availability: "7 sleds charged and ready",
+    availableUnits: 7,
+    reorderPoint: 3,
+    location: "Autonomy garage",
+    owner: "Ground Robotics",
+    lastChecked: "2026-04-18",
+    serviceWindow: "Motor tune every 90 days",
+    description:
+      "Swap-ready battery sled that keeps inspection rovers moving through long shifts.",
+    notes:
+      "Charge retention stabilized after firmware patch. No heat events in the last cycle.",
+    tags: ["Robotics", "Battery swap", "Field ready"],
+  },
+  {
+    id: "flux-response-kit",
+    name: "Flux Response Kit",
+    sku: "PWR-6502",
+    categoryId: "power",
+    status: "Low Stock",
+    availability: "3 kits remain before replenishment",
+    availableUnits: 3,
+    reorderPoint: 5,
+    location: "Emergency power locker",
+    owner: "Grid Resilience Team",
+    lastChecked: "2026-04-17",
+    serviceWindow: "Seal inspection monthly",
+    description:
+      "Rapid-response kit for restoring temporary power during rack maintenance windows.",
+    notes:
+      "Two kits were consumed during overnight switchgear tests. Supplier ETA is two days.",
+    tags: ["Backup power", "Portable", "Incident response"],
+  },
+  {
+    id: "grid-capacitor-bank",
+    name: "Grid Capacitor Bank",
+    sku: "PWR-7190",
+    categoryId: "power",
+    status: "Operational",
+    availability: "9 modules staged for surge balancing",
+    availableUnits: 9,
+    reorderPoint: 4,
+    location: "South utility spine",
+    owner: "Facilities Engineering",
+    lastChecked: "2026-04-19",
+    serviceWindow: "Balance check every 45 days",
+    description:
+      "Modular capacitor bank used to smooth temporary load spikes during maintenance events.",
+    notes:
+      "Recent load-balance report showed improved recovery time after installing the latest pair.",
+    tags: ["Capacitor", "Load balancing", "Facilities"],
+  },
+];
+
+export const inventoryStatusStyles: Record<
+  InventoryStatus,
+  { badge: string; dot: string }
+> = {
+  Operational: {
+    badge: "border-emerald-200 bg-emerald-50 text-emerald-700",
+    dot: "bg-emerald-500",
+  },
+  "Low Stock": {
+    badge: "border-amber-200 bg-amber-50 text-amber-700",
+    dot: "bg-amber-500",
+  },
+  Reserved: {
+    badge: "border-sky-200 bg-sky-50 text-sky-700",
+    dot: "bg-sky-500",
+  },
+  Maintenance: {
+    badge: "border-rose-200 bg-rose-50 text-rose-700",
+    dot: "bg-rose-500",
+  },
+};
+
+export function getInventoryCategoryById(categoryId: string) {
+  return inventoryCategories.find((category) => category.id === categoryId);
+}
+
+export function getInventoryCategoryOptions(
+  items: InventoryItem[],
+  categories: InventoryCategory[],
+): InventoryCategoryOption[] {
+  return [
+    {
+      id: "all",
+      name: "All Inventory",
+      description: "Every asset currently tracked by the catalog.",
+      count: items.length,
+    },
+    ...categories.map((category) => ({
+      id: category.id,
+      name: category.name,
+      description: category.description,
+      count: items.filter((item) => item.categoryId === category.id).length,
+    })),
+  ];
+}
+
+export function getInventorySections(
+  items: InventoryItem[],
+  categories: InventoryCategory[],
+  activeCategoryId: string,
+): InventorySection[] {
+  const visibleCategories =
+    activeCategoryId === "all"
+      ? categories
+      : categories.filter((category) => category.id === activeCategoryId);
+
+  return visibleCategories
+    .map((category) => {
+      const sectionItems = items.filter((item) => item.categoryId === category.id);
+
+      return {
+        ...category,
+        items: sectionItems,
+        totalUnits: sectionItems.reduce(
+          (sum, item) => sum + item.availableUnits,
+          0,
+        ),
+      };
+    })
+    .filter((section) => section.items.length > 0);
+}

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,7 @@
+import { cleanup } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
## Summary
- add the initial `/asset-inventory` route shell required by the issue plan
- reserve space for the future catalog sections and selected-item detail panel
- stage the branch and PR early so the remaining work can land in visible follow-up commits

## Testing
- not run yet

Closes #86

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new route and static mock data/helpers only, with no changes to auth, persistence, or existing flows.
> 
> **Overview**
> Adds a new `/asset-inventory` Next.js route with page-level `metadata` and a styled placeholder layout that reserves space for a future catalog area and selected-item detail panel.
> 
> Introduces `src/data/asset-inventory.ts` with typed mock inventory categories/items plus small helper utilities (`getInventoryCategoryOptions`, `getInventorySections`) and status-to-style mappings to support upcoming UI work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 985a19bc7a9615251230e75903f43bac6d7fb534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->