### PR TITLE
feat: add operations center dashboard route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2122,6 +2122,70 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "next": "16.2.4",

--- a/src/app/operations-center/_components/activity-feed.tsx
+++ b/src/app/operations-center/_components/activity-feed.tsx
@@ -1,0 +1,49 @@
+import type { ActivityItem, ActivityTone } from "../_data/dashboard-data";
+import styles from "../operations-center.module.css";
+
+const activityToneClasses: Record<ActivityTone, string> = {
+  automated: "border-teal-200 bg-teal-50 text-teal-800",
+  coordinated: "border-indigo-200 bg-indigo-50 text-indigo-800",
+  resolved: "border-emerald-200 bg-emerald-50 text-emerald-800",
+};
+
+export function ActivityFeed({ items }: { items: ActivityItem[] }) {
+  return (
+    <ol aria-label="Recent activity" className={styles.activityFeed}>
+      {items.map((item) => (
+        <li key={item.id} className={styles.activityNode}>
+          <article className={`${styles.surfaceCard} p-5`}>
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <span
+                className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] ${activityToneClasses[item.tone]}`}
+              >
+                {item.channel}
+              </span>
+              <time className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                {item.timestamp}
+              </time>
+            </div>
+
+            <div className="mt-4 space-y-2">
+              <h3 className="text-lg font-semibold tracking-tight text-slate-950">
+                {item.title}
+              </h3>
+              <p className="text-sm leading-6 text-slate-600">{item.summary}</p>
+            </div>
+
+            <div className="mt-4 flex flex-col gap-2 border-t border-slate-200/80 pt-4 text-sm text-slate-700">
+              <p>
+                <span className="font-semibold text-slate-950">Actor:</span>{" "}
+                {item.actor}
+              </p>
+              <p>
+                <span className="font-semibold text-slate-950">Outcome:</span>{" "}
+                {item.outcome}
+              </p>
+            </div>
+          </article>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/app/operations-center/_components/alert-list.tsx
+++ b/src/app/operations-center/_components/alert-list.tsx
@@ -1,0 +1,86 @@
+import type { AlertSeverity, LiveAlert } from "../_data/dashboard-data";
+import styles from "../operations-center.module.css";
+
+const severityToneClasses: Record<AlertSeverity, string> = {
+  critical: "border-rose-200 bg-rose-50 text-rose-800",
+  elevated: "border-amber-200 bg-amber-50 text-amber-800",
+  watch: "border-sky-200 bg-sky-50 text-sky-800",
+};
+
+const severityAccentClasses: Record<AlertSeverity, string> = {
+  critical: styles.alertCritical,
+  elevated: styles.alertElevated,
+  watch: styles.alertWatch,
+};
+
+const severityLabel: Record<AlertSeverity, string> = {
+  critical: "Critical",
+  elevated: "Elevated",
+  watch: "Watch",
+};
+
+export function AlertList({ alerts }: { alerts: LiveAlert[] }) {
+  return (
+    <ul aria-label="Live alerts" className="space-y-4">
+      {alerts.map((alert) => (
+        <li key={alert.id}>
+          <article
+            className={`${styles.surfaceCard} ${styles.alertItem} ${severityAccentClasses[alert.severity]} p-5 sm:p-6`}
+          >
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-3">
+                <div className="flex flex-wrap items-center gap-3">
+                  <span
+                    className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] ${severityToneClasses[alert.severity]}`}
+                  >
+                    {severityLabel[alert.severity]}
+                  </span>
+                  <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                    {alert.site}
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <h3 className="text-xl font-semibold tracking-tight text-slate-950">
+                    {alert.title}
+                  </h3>
+                  <p className="max-w-2xl text-sm leading-6 text-slate-600">
+                    {alert.description}
+                  </p>
+                </div>
+              </div>
+
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                {alert.updatedAt}
+              </p>
+            </div>
+
+            <div className="mt-5 grid gap-3 text-sm text-slate-700 sm:grid-cols-[1fr_1fr]">
+              <div className="rounded-2xl bg-white/80 px-4 py-3 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.14)]">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  Owner
+                </p>
+                <p className="mt-2 font-medium">{alert.owner}</p>
+              </div>
+              <div className="rounded-2xl bg-white/80 px-4 py-3 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.14)]">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  Impact
+                </p>
+                <p className="mt-2 font-medium">{alert.impact}</p>
+              </div>
+            </div>
+
+            <div className="mt-5 rounded-2xl border border-dashed border-slate-300/90 bg-slate-950/[0.03] px-4 py-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                Recommended playbook
+              </p>
+              <p className="mt-2 text-sm font-medium text-slate-800">
+                {alert.playbook}
+              </p>
+            </div>
+          </article>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/app/operations-center/_components/metric-card.tsx
+++ b/src/app/operations-center/_components/metric-card.tsx
@@ -1,0 +1,57 @@
+import type { DashboardMetric, MetricTone } from "../_data/dashboard-data";
+import styles from "../operations-center.module.css";
+
+const metricToneClasses: Record<MetricTone, string> = {
+  positive:
+    "border-emerald-200 bg-emerald-50/80 text-emerald-800 shadow-[0_0_0_1px_rgba(16,185,129,0.08)]",
+  caution:
+    "border-amber-200 bg-amber-50/90 text-amber-800 shadow-[0_0_0_1px_rgba(245,158,11,0.08)]",
+  neutral:
+    "border-slate-200 bg-slate-100/90 text-slate-700 shadow-[0_0_0_1px_rgba(100,116,139,0.08)]",
+};
+
+const metricFillClasses: Record<MetricTone, string> = {
+  positive: styles.metricFillPositive,
+  caution: styles.metricFillCaution,
+  neutral: styles.metricFillNeutral,
+};
+
+export function MetricCard({ metric }: { metric: DashboardMetric }) {
+  return (
+    <article
+      role="listitem"
+      className={`${styles.surfaceCard} ${styles.metricCard} flex h-full flex-col gap-5 p-6`}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+            {metric.label}
+          </p>
+          <p className="text-4xl font-semibold tracking-tight text-slate-950">
+            {metric.value}
+          </p>
+        </div>
+        <span
+          className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold ${metricToneClasses[metric.tone]}`}
+        >
+          {metric.delta}
+        </span>
+      </div>
+
+      <p className="text-sm leading-6 text-slate-600">{metric.context}</p>
+
+      <div className="mt-auto space-y-3">
+        <div className="flex items-center justify-between text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+          <span>{metric.highlight}</span>
+          <span>{metric.progress}%</span>
+        </div>
+        <div className={styles.metricRail}>
+          <span
+            className={`${styles.metricFill} ${metricFillClasses[metric.tone]}`}
+            style={{ width: `${metric.progress}%` }}
+          />
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/app/operations-center/_data/dashboard-data.ts
+++ b/src/app/operations-center/_data/dashboard-data.ts
@@ -1,0 +1,208 @@
+export type SummaryTone = "stable" | "watch" | "focused";
+export type MetricTone = "positive" | "caution" | "neutral";
+export type AlertSeverity = "critical" | "elevated" | "watch";
+export type ActivityTone = "automated" | "coordinated" | "resolved";
+
+export interface DashboardStat {
+  label: string;
+  value: string;
+  tone: SummaryTone;
+}
+
+export interface DashboardMetric {
+  id: string;
+  label: string;
+  value: string;
+  delta: string;
+  tone: MetricTone;
+  context: string;
+  highlight: string;
+  progress: number;
+}
+
+export interface LiveAlert {
+  id: string;
+  severity: AlertSeverity;
+  title: string;
+  site: string;
+  description: string;
+  owner: string;
+  updatedAt: string;
+  playbook: string;
+  impact: string;
+}
+
+export interface ActivityItem {
+  id: string;
+  title: string;
+  actor: string;
+  channel: string;
+  timestamp: string;
+  summary: string;
+  outcome: string;
+  tone: ActivityTone;
+}
+
+export const operationsCenterSummary = {
+  eyebrow: "Operations Center",
+  title: "Keep critical lanes, crews, and customer promises in sync.",
+  description:
+    "A route-level dashboard for operators monitoring live network health, dispatch risk, and intervention velocity across the current shift.",
+  shiftLabel: "Shift 02 · Global command desk",
+  refreshLabel: "Updated 2 minutes ago",
+  stats: [
+    {
+      label: "Network availability",
+      value: "99.982%",
+      tone: "stable",
+    },
+    {
+      label: "Auto-remediations landed",
+      value: "12 / 14",
+      tone: "focused",
+    },
+    {
+      label: "Active watch regions",
+      value: "3",
+      tone: "watch",
+    },
+    {
+      label: "Median acknowledgement",
+      value: "7 min",
+      tone: "stable",
+    },
+  ] satisfies DashboardStat[],
+};
+
+export const operationsCenterMetrics = [
+  {
+    id: "on-time-departures",
+    label: "On-time departures",
+    value: "97.4%",
+    delta: "+1.8% vs 7-day average",
+    tone: "positive",
+    context:
+      "Linehaul departures held steady even with the pre-noon wave building across east coast hubs.",
+    highlight: "Morning linehaul release",
+    progress: 97,
+  },
+  {
+    id: "fleet-utilization",
+    label: "Fleet utilization",
+    value: "84%",
+    delta: "+6 tractors staged",
+    tone: "positive",
+    context:
+      "Overflow units are staged in Newark and Joliet, keeping reserve capacity available for weather diversions.",
+    highlight: "Reserve fleet readiness",
+    progress: 84,
+  },
+  {
+    id: "exception-backlog",
+    label: "Exception backlog",
+    value: "18 cases",
+    delta: "6 cases over target",
+    tone: "caution",
+    context:
+      "Most unresolved exceptions are concentrated in two cold-chain handoffs and one customs hold.",
+    highlight: "Manual interventions queued",
+    progress: 62,
+  },
+  {
+    id: "response-time",
+    label: "Escalation response",
+    value: "7 min",
+    delta: "Target under 10 minutes",
+    tone: "neutral",
+    context:
+      "Shift leads are clearing inbound escalation requests fast enough to protect premium customer commitments.",
+    highlight: "Median acknowledgement window",
+    progress: 76,
+  },
+] satisfies DashboardMetric[];
+
+export const operationsCenterAlerts = [
+  {
+    id: "memphis-cold-chain",
+    severity: "critical",
+    title: "Memphis cold-chain temperature drift",
+    site: "Memphis Hub · Cold storage lane",
+    description:
+      "Trailer CX-218 crossed the acceptable storage threshold for nine minutes before backup cooling engaged.",
+    owner: "Facilities + Cold Chain",
+    updatedAt: "Updated 4 minutes ago",
+    playbook: "Dispatch reefer swap and quarantine scan",
+    impact: "42 high-value cartons require recertification.",
+  },
+  {
+    id: "gulf-reroutes",
+    severity: "elevated",
+    title: "Storm reroutes building across the Gulf corridor",
+    site: "I-10 East network",
+    description:
+      "Inbound weather cells are forcing staged detours for southbound freight moving through Houston and Mobile.",
+    owner: "Linehaul control",
+    updatedAt: "Updated 11 minutes ago",
+    playbook: "Re-sequence linehaul and activate reserve drivers",
+    impact: "11 loads are absorbing an average 27-minute detour.",
+  },
+  {
+    id: "newark-scan-latency",
+    severity: "watch",
+    title: "Outbound barcode scan latency spike",
+    site: "Newark outbound mezzanine",
+    description:
+      "Scanner response time climbed above baseline after the latest warehouse ruleset sync completed.",
+    owner: "Fulfillment systems",
+    updatedAt: "Updated 18 minutes ago",
+    playbook: "Rollback scanner ruleset and monitor error queue",
+    impact: "P95 scan time is sitting at 1.8 seconds.",
+  },
+] satisfies LiveAlert[];
+
+export const operationsCenterActivity = [
+  {
+    id: "phoenix-reroute",
+    title: "Auto-reroute triggered for Phoenix to Dallas lane",
+    actor: "Route automation",
+    channel: "Automation",
+    timestamp: "08:04 UTC",
+    summary:
+      "The routing engine detected congestion around El Paso and shifted two premium loads onto the Amarillo bypass.",
+    outcome: "Recovered 23 minutes for premium freight.",
+    tone: "automated",
+  },
+  {
+    id: "newark-overflow",
+    title: "Shift lead approved overflow dispatch in Newark",
+    actor: "Maya Chen",
+    channel: "Coordination",
+    timestamp: "07:52 UTC",
+    summary:
+      "A reserve sort team was activated to absorb the outbound spike before the 09:00 pickup window opened.",
+    outcome: "Protected three same-day customer commitments.",
+    tone: "coordinated",
+  },
+  {
+    id: "cooling-unit-swap",
+    title: "Cooling unit swapped on trailer CX-218",
+    actor: "R. Patel",
+    channel: "Field action",
+    timestamp: "07:39 UTC",
+    summary:
+      "Field maintenance completed the reefer replacement and uploaded a clean temperature trace for the last checkpoint.",
+    outcome: "Cold-chain route restored and monitoring tightened.",
+    tone: "resolved",
+  },
+  {
+    id: "customer-briefing",
+    title: "Enterprise support briefed on Houston transfer delay",
+    actor: "Customer success desk",
+    channel: "Customer comms",
+    timestamp: "07:24 UTC",
+    summary:
+      "High-touch accounts received updated arrival windows plus a single escalation contact for follow-up requests.",
+    outcome: "Inbound support volume stayed below expected threshold.",
+    tone: "coordinated",
+  },
+] satisfies ActivityItem[];

--- a/src/app/operations-center/operations-center.module.css
+++ b/src/app/operations-center/operations-center.module.css
@@ -1,0 +1,168 @@
+.shell {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  min-height: 100vh;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(240, 245, 239, 0.98)),
+    linear-gradient(135deg, rgba(56, 189, 248, 0.12), transparent 38%),
+    linear-gradient(215deg, rgba(20, 184, 166, 0.08), transparent 42%);
+}
+
+.shell::before {
+  content: "";
+  position: absolute;
+  inset: -10% -30% auto auto;
+  width: 34rem;
+  height: 34rem;
+  border-radius: 9999px;
+  background:
+    radial-gradient(circle, rgba(45, 212, 191, 0.18), transparent 58%);
+  filter: blur(12px);
+  z-index: -2;
+}
+
+.shell::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(148, 163, 184, 0.12) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.12) 1px, transparent 1px);
+  background-position: center;
+  background-size: 4.75rem 4.75rem;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.5), transparent 85%);
+  z-index: -1;
+}
+
+.surfaceCard {
+  border: 1px solid rgba(255, 255, 255, 0.78);
+  background: rgba(255, 255, 255, 0.8);
+  box-shadow:
+    0 20px 60px rgba(15, 23, 42, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  backdrop-filter: blur(14px);
+  border-radius: 1.75rem;
+}
+
+.heroPanel {
+  background:
+    linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(22, 78, 99, 0.88)),
+    radial-gradient(circle at top right, rgba(244, 114, 182, 0.25), transparent 40%);
+  color: #f8fafc;
+}
+
+.heroPanel .surfaceCard {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.metricCard {
+  position: relative;
+}
+
+.metricCard::before {
+  content: "";
+  position: absolute;
+  inset: 1.2rem 1.2rem auto auto;
+  width: 5rem;
+  height: 5rem;
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgba(15, 23, 42, 0.08), transparent 70%);
+  pointer-events: none;
+}
+
+.metricRail {
+  height: 0.7rem;
+  overflow: hidden;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.metricFill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+}
+
+.metricFillPositive {
+  background: linear-gradient(90deg, #10b981, #0f766e);
+}
+
+.metricFillCaution {
+  background: linear-gradient(90deg, #f59e0b, #ea580c);
+}
+
+.metricFillNeutral {
+  background: linear-gradient(90deg, #64748b, #334155);
+}
+
+.alertItem {
+  position: relative;
+}
+
+.alertItem::before {
+  content: "";
+  position: absolute;
+  inset: 1.1rem auto 1.1rem 1.1rem;
+  width: 0.35rem;
+  border-radius: 9999px;
+  opacity: 0.95;
+}
+
+.alertCritical::before {
+  background: linear-gradient(180deg, #fb7185, #be123c);
+}
+
+.alertElevated::before {
+  background: linear-gradient(180deg, #f59e0b, #d97706);
+}
+
+.alertWatch::before {
+  background: linear-gradient(180deg, #38bdf8, #0284c7);
+}
+
+.activityFeed {
+  position: relative;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.activityFeed::before {
+  content: "";
+  position: absolute;
+  left: 0.55rem;
+  top: 0.75rem;
+  bottom: 0.75rem;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.18), rgba(20, 184, 166, 0.2));
+}
+
+.activityNode {
+  position: relative;
+  padding-left: 2.25rem;
+}
+
+.activityNode::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 1.25rem;
+  width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 9999px;
+  border: 4px solid rgba(240, 245, 239, 1);
+  background: linear-gradient(135deg, #0f766e, #38bdf8);
+  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.08);
+}
+
+@media (max-width: 640px) {
+  .shell::before {
+    inset: -15% -40% auto auto;
+    width: 24rem;
+    height: 24rem;
+  }
+
+  .activityNode {
+    padding-left: 1.9rem;
+  }
+}

--- a/src/app/operations-center/page.test.tsx
+++ b/src/app/operations-center/page.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  operationsCenterActivity,
+  operationsCenterAlerts,
+  operationsCenterMetrics,
+} from "./_data/dashboard-data";
+import OperationsCenterPage from "./page";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("OperationsCenterPage", () => {
+  it("renders the dashboard shell independently from the home page", () => {
+    render(<OperationsCenterPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: /keep critical lanes, crews, and customer promises in sync\./i,
+      }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: /kpi snapshot/i }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: /live alerts/i }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: /recent activity/i }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText(/to get started, edit the page\.tsx file\./i),
+    ).toBeNull();
+  });
+
+  it("renders each metric card from mock content", () => {
+    render(<OperationsCenterPage />);
+
+    const metricList = screen.getByRole("list", { name: /kpi metrics/i });
+    expect(within(metricList).getAllByRole("listitem")).toHaveLength(
+      operationsCenterMetrics.length,
+    );
+
+    for (const metric of operationsCenterMetrics) {
+      const metricCard = within(metricList)
+        .getByText(metric.label)
+        .closest('[role="listitem"]');
+
+      expect(metricCard).toBeTruthy();
+      expect(metricCard?.textContent).toContain(metric.value);
+      expect(metricCard?.textContent).toContain(metric.delta);
+    }
+  });
+
+  it("renders alert and activity sections with mock items and responsive layout hooks", () => {
+    render(<OperationsCenterPage />);
+
+    const alertList = screen.getByRole("list", { name: /live alerts/i });
+    const activityList = screen.getByRole("list", { name: /recent activity/i });
+    const panels = screen.getByTestId("operations-center-panels");
+
+    expect(within(alertList).getAllByRole("listitem")).toHaveLength(
+      operationsCenterAlerts.length,
+    );
+    expect(within(activityList).getAllByRole("listitem")).toHaveLength(
+      operationsCenterActivity.length,
+    );
+    expect(screen.getByText(operationsCenterAlerts[0].playbook)).toBeTruthy();
+    expect(screen.getByText(operationsCenterActivity[0].outcome)).toBeTruthy();
+    expect(panels.className).toContain("xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.95fr)]");
+  });
+});

--- a/src/app/operations-center/page.tsx
+++ b/src/app/operations-center/page.tsx
@@ -1,54 +1,175 @@
 import type { Metadata } from "next";
 
+import { ActivityFeed } from "./_components/activity-feed";
+import { AlertList } from "./_components/alert-list";
+import { MetricCard } from "./_components/metric-card";
+import {
+  operationsCenterActivity,
+  operationsCenterAlerts,
+  operationsCenterMetrics,
+  operationsCenterSummary,
+  type SummaryTone,
+} from "./_data/dashboard-data";
+import styles from "./operations-center.module.css";
+
 export const metadata: Metadata = {
   title: "Operations Center",
-  description: "Initial shell for the operations center dashboard route.",
+  description:
+    "Dashboard route highlighting KPIs, live alerts, and recent operational activity.",
+};
+
+const summaryToneClasses: Record<SummaryTone, string> = {
+  stable: "border-emerald-300/30 bg-emerald-300/15 text-emerald-50",
+  watch: "border-amber-300/30 bg-amber-300/15 text-amber-50",
+  focused: "border-sky-300/30 bg-sky-300/15 text-sky-50",
 };
 
 export default function OperationsCenterPage() {
   return (
-    <main className="flex min-h-screen bg-slate-950 px-5 py-8 text-white sm:px-8 sm:py-10">
-      <section className="mx-auto flex w-full max-w-6xl flex-col gap-8 rounded-[2rem] border border-white/10 bg-white/5 p-6 shadow-[0_24px_80px_rgba(15,23,42,0.35)] backdrop-blur sm:p-8 lg:p-10">
-        <div className="space-y-4">
-          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-200/80">
-            Operations Center
-          </p>
-          <h1 className="max-w-3xl text-4xl font-semibold tracking-tight sm:text-5xl">
-            Dashboard route shell
-          </h1>
-          <p className="max-w-2xl text-base leading-7 text-slate-300 sm:text-lg">
-            KPI cards, live alerts, and the recent activity feed will be added
-            in follow-up commits on this branch.
-          </p>
-        </div>
+    <main className={styles.shell}>
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-5 py-8 sm:px-8 sm:py-10 lg:px-10 lg:py-12">
+        <section className={`${styles.surfaceCard} ${styles.heroPanel} p-6 sm:p-8 lg:p-10`}>
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,1.5fr)_minmax(280px,0.95fr)] lg:items-start">
+            <div className="space-y-6">
+              <div className="space-y-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-sky-100/75">
+                  {operationsCenterSummary.eyebrow}
+                </p>
+                <div className="space-y-4">
+                  <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
+                    {operationsCenterSummary.title}
+                  </h1>
+                  <p className="max-w-2xl text-base leading-7 text-slate-100/78 sm:text-lg">
+                    {operationsCenterSummary.description}
+                  </p>
+                </div>
+              </div>
 
-        <div className="grid gap-4 sm:grid-cols-3">
-          <div className="rounded-3xl border border-white/10 bg-white/6 p-5">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
-              KPI zone
-            </p>
-            <p className="mt-3 text-sm leading-6 text-slate-300">
-              Reserved for metric cards and performance indicators.
+              <div className="flex flex-wrap gap-3">
+                {operationsCenterSummary.stats.map((stat) => (
+                  <div
+                    key={stat.label}
+                    className={`inline-flex min-w-[11rem] flex-col rounded-2xl border px-4 py-3 ${summaryToneClasses[stat.tone]}`}
+                  >
+                    <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/72">
+                      {stat.label}
+                    </span>
+                    <span className="mt-2 text-2xl font-semibold text-white">
+                      {stat.value}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <aside className={`${styles.surfaceCard} rounded-[1.5rem] bg-white/12 p-5 sm:p-6`}>
+              <div className="space-y-5">
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-white/65">
+                    Shift posture
+                  </p>
+                  <p className="mt-3 text-3xl font-semibold tracking-tight text-white">
+                    Steady with targeted watchpoints
+                  </p>
+                </div>
+
+                <div className="space-y-3 text-sm leading-6 text-slate-100/78">
+                  <p>{operationsCenterSummary.shiftLabel}</p>
+                  <p>{operationsCenterSummary.refreshLabel}</p>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
+                  <div className="rounded-2xl bg-white/10 px-4 py-3">
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/60">
+                      Immediate focus
+                    </p>
+                    <p className="mt-2 text-sm font-medium text-white">
+                      Clear Memphis cold-chain risk before the noon premium dispatch cutoff.
+                    </p>
+                  </div>
+                  <div className="rounded-2xl bg-white/10 px-4 py-3">
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/60">
+                      Coverage note
+                    </p>
+                    <p className="mt-2 text-sm font-medium text-white">
+                      Reserve drivers are staged in Newark, Joliet, and Ontario for rapid reroute support.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </aside>
+          </div>
+        </section>
+
+        <section aria-labelledby="operations-center-metrics" className="space-y-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                Dashboard pulse
+              </p>
+              <h2
+                id="operations-center-metrics"
+                className="text-3xl font-semibold tracking-tight text-slate-950"
+              >
+                KPI snapshot
+              </h2>
+            </div>
+            <p className="max-w-2xl text-sm leading-6 text-slate-600">
+              Each card is fueled by mock data so the route can stand alone without any dependency on the home page or backend services.
             </p>
           </div>
-          <div className="rounded-3xl border border-white/10 bg-white/6 p-5">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
-              Alert zone
-            </p>
-            <p className="mt-3 text-sm leading-6 text-slate-300">
-              Reserved for live operational alerts and intervention status.
-            </p>
+
+          <div
+            aria-label="KPI metrics"
+            className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4"
+            role="list"
+          >
+            {operationsCenterMetrics.map((metric) => (
+              <MetricCard key={metric.id} metric={metric} />
+            ))}
           </div>
-          <div className="rounded-3xl border border-white/10 bg-white/6 p-5">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
-              Activity zone
-            </p>
-            <p className="mt-3 text-sm leading-6 text-slate-300">
-              Reserved for the recent activity feed and shift timeline.
-            </p>
-          </div>
+        </section>
+
+        <div
+          className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.95fr)]"
+          data-testid="operations-center-panels"
+        >
+          <section aria-labelledby="operations-center-alerts" className="space-y-5">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                  Intervention queue
+                </p>
+                <h2
+                  id="operations-center-alerts"
+                  className="text-3xl font-semibold tracking-tight text-slate-950"
+                >
+                  Live alerts
+                </h2>
+              </div>
+              <p className="text-sm leading-6 text-slate-600">
+                Prioritized by severity, owner, and expected customer impact.
+              </p>
+            </div>
+            <AlertList alerts={operationsCenterAlerts} />
+          </section>
+
+          <section aria-labelledby="operations-center-activity" className="space-y-5">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                Shift log
+              </p>
+              <h2
+                id="operations-center-activity"
+                className="text-3xl font-semibold tracking-tight text-slate-950"
+              >
+                Recent activity
+              </h2>
+            </div>
+            <ActivityFeed items={operationsCenterActivity} />
+          </section>
         </div>
-      </section>
+      </div>
     </main>
   );
 }

--- a/src/app/operations-center/page.tsx
+++ b/src/app/operations-center/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Operations Center",
+  description: "Initial shell for the operations center dashboard route.",
+};
+
+export default function OperationsCenterPage() {
+  return (
+    <main className="flex min-h-screen bg-slate-950 px-5 py-8 text-white sm:px-8 sm:py-10">
+      <section className="mx-auto flex w-full max-w-6xl flex-col gap-8 rounded-[2rem] border border-white/10 bg-white/5 p-6 shadow-[0_24px_80px_rgba(15,23,42,0.35)] backdrop-blur sm:p-8 lg:p-10">
+        <div className="space-y-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-200/80">
+            Operations Center
+          </p>
+          <h1 className="max-w-3xl text-4xl font-semibold tracking-tight sm:text-5xl">
+            Dashboard route shell
+          </h1>
+          <p className="max-w-2xl text-base leading-7 text-slate-300 sm:text-lg">
+            KPI cards, live alerts, and the recent activity feed will be added
+            in follow-up commits on this branch.
+          </p>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-3">
+          <div className="rounded-3xl border border-white/10 bg-white/6 p-5">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
+              KPI zone
+            </p>
+            <p className="mt-3 text-sm leading-6 text-slate-300">
+              Reserved for metric cards and performance indicators.
+            </p>
+          </div>
+          <div className="rounded-3xl border border-white/10 bg-white/6 p-5">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
+              Alert zone
+            </p>
+            <p className="mt-3 text-sm leading-6 text-slate-300">
+              Reserved for live operational alerts and intervention status.
+            </p>
+          </div>
+          <div className="rounded-3xl border border-white/10 bg-white/6 p-5">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
+              Activity zone
+            </p>
+            <p className="mt-3 text-sm leading-6 text-slate-300">
+              Reserved for the recent activity feed and shift timeline.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"],
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Summary
- add the initial `operations-center` route shell
- open the PR early to match the issue workflow comment
- follow with dashboard data, components, styling, and tests in subsequent commits

Closes #84

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new static Next.js page with placeholder UI and metadata, without touching shared logic, auth, or data flows.
> 
> **Overview**
> Adds a new `operations-center` route (`src/app/operations-center/page.tsx`) as an initial dashboard shell.
> 
> The page sets route `metadata` and renders a static layout with placeholder sections for KPIs, alerts, and activity to be filled in later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60fed356226e57f99313c0417fabce66b6914609. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->