### PR TITLE
feat: add signal monitor route

### DIFF
--- a/src/app/signal-monitor/_components/anomaly-summary-list.tsx
+++ b/src/app/signal-monitor/_components/anomaly-summary-list.tsx
@@ -1,0 +1,85 @@
+import type {
+  SignalAnomaly,
+  SignalSeverity,
+  SignalStream,
+} from "../_lib/signal-monitor-data";
+
+type AnomalySummaryListProps = {
+  anomalies: SignalAnomaly[];
+  signals: SignalStream[];
+};
+
+const severityClasses: Record<SignalSeverity, string> = {
+  watch: "border-amber-300/70 bg-amber-50 text-amber-900",
+  elevated: "border-rose-300/70 bg-rose-50 text-rose-900",
+  critical: "border-slate-900 bg-slate-950 text-white",
+};
+
+export function AnomalySummaryList({
+  anomalies,
+  signals,
+}: AnomalySummaryListProps) {
+  const signalNameById = new Map(signals.map((signal) => [signal.id, signal.name]));
+
+  return (
+    <div className="space-y-4">
+      {anomalies.map((anomaly) => (
+        <article
+          key={anomaly.id}
+          className={`rounded-[1.5rem] border px-5 py-5 shadow-[0_12px_36px_rgba(15,23,42,0.05)] ${severityClasses[anomaly.severity]}`}
+        >
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-3">
+              <div className="flex flex-wrap gap-2">
+                <span className="inline-flex rounded-full border border-current/20 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em]">
+                  {anomaly.severity}
+                </span>
+                <span className="inline-flex rounded-full bg-white/20 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em]">
+                  {signalNameById.get(anomaly.signalId) ?? anomaly.signalId}
+                </span>
+              </div>
+              <div>
+                <h3 className="text-xl font-semibold tracking-tight">
+                  {anomaly.title}
+                </h3>
+                <p className="mt-2 text-sm leading-6 text-current/78">
+                  {anomaly.summary}
+                </p>
+              </div>
+            </div>
+
+            <div className="min-w-[10rem] rounded-2xl border border-current/15 bg-white/15 px-4 py-3 text-right">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-current/70">
+                Detection window
+              </p>
+              <p className="mt-2 text-sm font-semibold">{anomaly.detectionWindow}</p>
+            </div>
+          </div>
+
+          <dl className="mt-5 grid gap-3 md:grid-cols-3">
+            <div className="rounded-2xl border border-current/15 bg-white/10 px-4 py-3">
+              <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-current/70">
+                Owner
+              </dt>
+              <dd className="mt-2 text-sm font-semibold">{anomaly.owner}</dd>
+            </div>
+            <div className="rounded-2xl border border-current/15 bg-white/10 px-4 py-3">
+              <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-current/70">
+                Impact
+              </dt>
+              <dd className="mt-2 text-sm leading-6">{anomaly.impact}</dd>
+            </div>
+            <div className="rounded-2xl border border-current/15 bg-white/10 px-4 py-3">
+              <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-current/70">
+                Recommended action
+              </dt>
+              <dd className="mt-2 text-sm leading-6">
+                {anomaly.recommendedAction}
+              </dd>
+            </div>
+          </dl>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/src/app/signal-monitor/_components/signal-inspector.tsx
+++ b/src/app/signal-monitor/_components/signal-inspector.tsx
@@ -1,0 +1,162 @@
+import type {
+  SignalAnomaly,
+  SignalStream,
+} from "../_lib/signal-monitor-data";
+
+type SignalInspectorProps = {
+  signal: SignalStream;
+  anomalies: SignalAnomaly[];
+};
+
+const inspectorToneClasses: Record<SignalStream["status"], string> = {
+  tracking: "border-emerald-300/30 bg-emerald-400/14 text-emerald-50",
+  watch: "border-amber-300/30 bg-amber-400/14 text-amber-50",
+  degraded: "border-rose-300/30 bg-rose-400/14 text-rose-50",
+  offline: "border-slate-300/30 bg-white/10 text-slate-100",
+};
+
+export function SignalInspector({
+  signal,
+  anomalies,
+}: SignalInspectorProps) {
+  return (
+    <aside className="overflow-hidden rounded-[2rem] border border-slate-900/80 bg-slate-950 shadow-[0_28px_100px_rgba(15,23,42,0.22)]">
+      <div className="space-y-6 px-6 py-6 sm:px-7 sm:py-7">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-3">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
+              Inspector
+            </p>
+            <div>
+              <h2 className="text-3xl font-semibold tracking-tight text-white">
+                {signal.name}
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-slate-300">
+                {signal.summary}
+              </p>
+            </div>
+          </div>
+
+          <div
+            className={`inline-flex rounded-full border px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.22em] ${inspectorToneClasses[signal.status]}`}
+          >
+            {signal.status}
+          </div>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-3">
+          <div className="rounded-[1.35rem] border border-white/10 bg-white/5 px-4 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+              Region
+            </p>
+            <p className="mt-2 text-lg font-semibold text-white">{signal.region}</p>
+          </div>
+          <div className="rounded-[1.35rem] border border-white/10 bg-white/5 px-4 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+              Throughput
+            </p>
+            <p className="mt-2 text-lg font-semibold text-white">
+              {signal.throughput}
+            </p>
+          </div>
+          <div className="rounded-[1.35rem] border border-white/10 bg-white/5 px-4 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+              Refresh state
+            </p>
+            <p className="mt-2 text-lg font-semibold text-white">
+              {signal.refreshedAt}
+            </p>
+          </div>
+        </div>
+
+        <section aria-label="Inspector detail sections" className="space-y-4">
+          {signal.detailSections.map((section) => (
+            <div
+              key={section.title}
+              className="rounded-[1.45rem] border border-white/10 bg-white/5 px-5 py-5"
+            >
+              <div className="space-y-2">
+                <h3 className="text-xl font-semibold tracking-tight text-white">
+                  {section.title}
+                </h3>
+                <p className="text-sm leading-6 text-slate-300">
+                  {section.description}
+                </p>
+              </div>
+              <dl className="mt-4 space-y-3">
+                {section.entries.map((entry) => (
+                  <div
+                    key={entry.label}
+                    className="flex flex-col gap-1 border-t border-white/8 pt-3 first:border-t-0 first:pt-0"
+                  >
+                    <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+                      {entry.label}
+                    </dt>
+                    <dd className="text-sm font-medium leading-6 text-white">
+                      {entry.value}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          ))}
+        </section>
+
+        <section
+          aria-label="Inspector anomalies"
+          className="rounded-[1.45rem] border border-white/10 bg-white/5 px-5 py-5"
+        >
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h3 className="text-xl font-semibold tracking-tight text-white">
+                Active anomaly stack
+              </h3>
+              <p className="mt-2 text-sm leading-6 text-slate-300">
+                The inspector keeps the current signal's anomaly context adjacent
+                to the detailed operating notes.
+              </p>
+            </div>
+            <div className="rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-200">
+              {anomalies.length} active
+            </div>
+          </div>
+
+          <div className="mt-4 space-y-3">
+            {anomalies.length > 0 ? (
+              anomalies.map((anomaly) => (
+                <article
+                  key={anomaly.id}
+                  className="rounded-2xl border border-white/10 bg-white/6 px-4 py-4"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="space-y-2">
+                      <div className="inline-flex rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-200">
+                        {anomaly.severity}
+                      </div>
+                      <h4 className="text-base font-semibold text-white">
+                        {anomaly.title}
+                      </h4>
+                    </div>
+                    <p className="text-right text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+                      {anomaly.detectionWindow}
+                    </p>
+                  </div>
+                  <p className="mt-3 text-sm leading-6 text-slate-300">
+                    {anomaly.impact}
+                  </p>
+                </article>
+              ))
+            ) : (
+              <div className="rounded-2xl border border-white/10 bg-white/6 px-4 py-4">
+                <p className="text-sm leading-6 text-slate-300">
+                  No active anomalies are mapped to this stream in the current
+                  mock window.
+                </p>
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+    </aside>
+  );
+}

--- a/src/app/signal-monitor/_components/signal-inspector.tsx
+++ b/src/app/signal-monitor/_components/signal-inspector.tsx
@@ -9,9 +9,9 @@ type SignalInspectorProps = {
 };
 
 const inspectorToneClasses: Record<SignalStream["status"], string> = {
-  tracking: "border-emerald-300/30 bg-emerald-400/14 text-emerald-50",
-  watch: "border-amber-300/30 bg-amber-400/14 text-amber-50",
-  degraded: "border-rose-300/30 bg-rose-400/14 text-rose-50",
+  tracking: "border-emerald-300/30 bg-emerald-400/15 text-emerald-50",
+  watch: "border-amber-300/30 bg-amber-400/15 text-amber-50",
+  degraded: "border-rose-300/30 bg-rose-400/15 text-rose-50",
   offline: "border-slate-300/30 bg-white/10 text-slate-100",
 };
 
@@ -87,7 +87,7 @@ export function SignalInspector({
                 {section.entries.map((entry) => (
                   <div
                     key={entry.label}
-                    className="flex flex-col gap-1 border-t border-white/8 pt-3 first:border-t-0 first:pt-0"
+                    className="flex flex-col gap-1 border-t border-white/[0.08] pt-3 first:border-t-0 first:pt-0"
                   >
                     <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
                       {entry.label}
@@ -126,7 +126,7 @@ export function SignalInspector({
               anomalies.map((anomaly) => (
                 <article
                   key={anomaly.id}
-                  className="rounded-2xl border border-white/10 bg-white/6 px-4 py-4"
+                  className="rounded-2xl border border-white/10 bg-white/[0.06] px-4 py-4"
                 >
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="space-y-2">
@@ -147,7 +147,7 @@ export function SignalInspector({
                 </article>
               ))
             ) : (
-              <div className="rounded-2xl border border-white/10 bg-white/6 px-4 py-4">
+              <div className="rounded-2xl border border-white/10 bg-white/[0.06] px-4 py-4">
                 <p className="text-sm leading-6 text-slate-300">
                   No active anomalies are mapped to this stream in the current
                   mock window.

--- a/src/app/signal-monitor/_components/signal-inspector.tsx
+++ b/src/app/signal-monitor/_components/signal-inspector.tsx
@@ -20,7 +20,10 @@ export function SignalInspector({
   anomalies,
 }: SignalInspectorProps) {
   return (
-    <aside className="overflow-hidden rounded-[2rem] border border-slate-900/80 bg-slate-950 shadow-[0_28px_100px_rgba(15,23,42,0.22)]">
+    <aside
+      aria-label="Signal inspector"
+      className="overflow-hidden rounded-[2rem] border border-slate-900/80 bg-slate-950 shadow-[0_28px_100px_rgba(15,23,42,0.22)]"
+    >
       <div className="space-y-6 px-6 py-6 sm:px-7 sm:py-7">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="space-y-3">
@@ -112,8 +115,8 @@ export function SignalInspector({
                 Active anomaly stack
               </h3>
               <p className="mt-2 text-sm leading-6 text-slate-300">
-                The inspector keeps the current signal's anomaly context adjacent
-                to the detailed operating notes.
+                The inspector keeps anomaly context for the current signal
+                adjacent to the detailed operating notes.
               </p>
             </div>
             <div className="rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-200">

--- a/src/app/signal-monitor/_components/signal-monitor-shell.tsx
+++ b/src/app/signal-monitor/_components/signal-monitor-shell.tsx
@@ -1,0 +1,152 @@
+import { AnomalySummaryList } from "./anomaly-summary-list";
+import { SignalInspector } from "./signal-inspector";
+import { SignalStreamCard } from "./signal-stream-card";
+import type { SignalMonitorView } from "../_lib/signal-monitor";
+
+type SignalMonitorShellProps = {
+  view: SignalMonitorView;
+};
+
+const monitorHighlights = [
+  "Live cards stay visible alongside the active inspector selection.",
+  "Anomaly summaries emphasize severity, ownership, and concrete action.",
+  "Mock stream data keeps the route isolated from backend dependencies.",
+];
+
+export function SignalMonitorShell({ view }: SignalMonitorShellProps) {
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8 px-6 py-8 sm:px-10 lg:px-12">
+      <section className="overflow-hidden rounded-[2rem] border border-slate-900/80 bg-slate-950 shadow-[0_30px_110px_rgba(15,23,42,0.24)]">
+        <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1.25fr)_minmax(300px,0.75fr)] lg:px-12 lg:py-10">
+          <div className="space-y-6">
+            <div className="space-y-3">
+              <p className="text-sm font-semibold uppercase tracking-[0.28em] text-cyan-300">
+                Signal monitor
+              </p>
+              <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+                Watch live streams, anomaly pressure, and operator detail in one route.
+              </h1>
+              <p className="max-w-3xl text-lg leading-8 text-slate-300">
+                The monitoring view pairs live signal cards with a standing
+                anomaly rollup and an inspector-style side panel so the route
+                can be validated independently with mock data.
+              </p>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              {view.overviewStats.map((stat) => (
+                <div
+                  key={stat.label}
+                  className="rounded-[1.3rem] border border-white/10 bg-white/8 px-4 py-4"
+                >
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+                    {stat.label}
+                  </p>
+                  <p className="mt-2 text-3xl font-semibold tracking-tight text-white">
+                    {stat.value}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <aside className="rounded-[1.75rem] border border-white/10 bg-white/6 p-6">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
+              Route posture
+            </p>
+            <p className="mt-4 text-3xl font-semibold tracking-tight text-white">
+              Mixed live status with one critical blind spot
+            </p>
+            <ul className="mt-5 space-y-3">
+              {monitorHighlights.map((item) => (
+                <li
+                  key={item}
+                  className="rounded-2xl border border-white/10 bg-white/6 px-4 py-4 text-sm leading-6 text-slate-300"
+                >
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </aside>
+        </div>
+      </section>
+
+      {!view.selectionFound && view.requestedSignalId ? (
+        <div
+          role="status"
+          className="rounded-[1.6rem] border border-amber-300/70 bg-amber-50 px-5 py-4 text-sm font-medium text-amber-900"
+        >
+          The requested signal <code>{view.requestedSignalId}</code> was not
+          found. Showing the highest-priority stream instead.
+        </div>
+      ) : null}
+
+      <div className="grid gap-8 2xl:grid-cols-[minmax(0,1.25fr)_minmax(360px,0.75fr)]">
+        <div className="space-y-8">
+          <section aria-labelledby="signal-monitor-streams" className="space-y-5">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                  Monitoring surface
+                </p>
+                <h2
+                  id="signal-monitor-streams"
+                  className="text-3xl font-semibold tracking-tight text-slate-950"
+                >
+                  Live signal cards
+                </h2>
+              </div>
+              <p className="max-w-2xl text-sm leading-6 text-slate-600">
+                Each card exposes stream posture, throughput, drift markers, and
+                the number of active anomalies tied to that feed.
+              </p>
+            </div>
+
+            <div
+              aria-label="Live signals"
+              className="grid gap-4 xl:grid-cols-2"
+              role="list"
+            >
+              {view.signals.map((signal) => (
+                <div key={signal.id} role="listitem">
+                  <SignalStreamCard
+                    href={`/signal-monitor?signal=${signal.id}`}
+                    isActive={signal.id === view.selectedSignal.id}
+                    signal={signal}
+                  />
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section aria-labelledby="signal-monitor-anomalies" className="space-y-5">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                  Intervention queue
+                </p>
+                <h2
+                  id="signal-monitor-anomalies"
+                  className="text-3xl font-semibold tracking-tight text-slate-950"
+                >
+                  Anomaly summary
+                </h2>
+              </div>
+              <p className="max-w-2xl text-sm leading-6 text-slate-600">
+                Severity, owner, impact, and recommended actions stay visible so
+                the route can be reviewed without opening a second surface.
+              </p>
+            </div>
+
+            <AnomalySummaryList anomalies={view.anomalies} signals={view.signals} />
+          </section>
+        </div>
+
+        <SignalInspector
+          anomalies={view.selectedAnomalies}
+          signal={view.selectedSignal}
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/app/signal-monitor/_components/signal-monitor-shell.tsx
+++ b/src/app/signal-monitor/_components/signal-monitor-shell.tsx
@@ -2,6 +2,7 @@ import { AnomalySummaryList } from "./anomaly-summary-list";
 import { SignalInspector } from "./signal-inspector";
 import { SignalStreamCard } from "./signal-stream-card";
 import type { SignalMonitorView } from "../_lib/signal-monitor";
+import styles from "../signal-monitor.module.css";
 
 type SignalMonitorShellProps = {
   view: SignalMonitorView;
@@ -15,9 +16,12 @@ const monitorHighlights = [
 
 export function SignalMonitorShell({ view }: SignalMonitorShellProps) {
   return (
-    <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8 px-6 py-8 sm:px-10 lg:px-12">
-      <section className="overflow-hidden rounded-[2rem] border border-slate-900/80 bg-slate-950 shadow-[0_30px_110px_rgba(15,23,42,0.24)]">
-        <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1.25fr)_minmax(300px,0.75fr)] lg:px-12 lg:py-10">
+    <main className={styles.shell}>
+      <div className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8 px-6 py-8 sm:px-10 lg:px-12">
+        <section
+          className={`${styles.heroPanel} overflow-hidden rounded-[2rem] border border-slate-900/80 shadow-[0_30px_110px_rgba(15,23,42,0.24)]`}
+        >
+          <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1.25fr)_minmax(300px,0.75fr)] lg:px-12 lg:py-10">
           <div className="space-y-6">
             <div className="space-y-3">
               <p className="text-sm font-semibold uppercase tracking-[0.28em] text-cyan-300">
@@ -37,7 +41,7 @@ export function SignalMonitorShell({ view }: SignalMonitorShellProps) {
               {view.overviewStats.map((stat) => (
                 <div
                   key={stat.label}
-                  className="rounded-[1.3rem] border border-white/10 bg-white/8 px-4 py-4"
+                  className={`${styles.overviewCard} rounded-[1.3rem] border border-white/10 px-4 py-4`}
                 >
                   <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
                     {stat.label}
@@ -50,7 +54,9 @@ export function SignalMonitorShell({ view }: SignalMonitorShellProps) {
             </div>
           </div>
 
-          <aside className="rounded-[1.75rem] border border-white/10 bg-white/6 p-6">
+          <aside
+            className={`${styles.heroAside} rounded-[1.75rem] border border-white/10 p-6`}
+          >
             <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">
               Route posture
             </p>
@@ -61,91 +67,100 @@ export function SignalMonitorShell({ view }: SignalMonitorShellProps) {
               {monitorHighlights.map((item) => (
                 <li
                   key={item}
-                  className="rounded-2xl border border-white/10 bg-white/6 px-4 py-4 text-sm leading-6 text-slate-300"
+                  className="rounded-2xl border border-white/10 bg-white/[0.06] px-4 py-4 text-sm leading-6 text-slate-300"
                 >
                   {item}
                 </li>
               ))}
             </ul>
           </aside>
-        </div>
-      </section>
+          </div>
+        </section>
 
-      {!view.selectionFound && view.requestedSignalId ? (
-        <div
-          role="status"
-          className="rounded-[1.6rem] border border-amber-300/70 bg-amber-50 px-5 py-4 text-sm font-medium text-amber-900"
-        >
-          The requested signal <code>{view.requestedSignalId}</code> was not
-          found. Showing the highest-priority stream instead.
-        </div>
-      ) : null}
+        {!view.selectionFound && view.requestedSignalId ? (
+          <div
+            role="status"
+            className={`${styles.statusBanner} rounded-[1.6rem] border border-amber-300/70 bg-amber-50 px-5 py-4 text-sm font-medium text-amber-900`}
+          >
+            The requested signal <code>{view.requestedSignalId}</code> was not
+            found. Showing the default inspector stream instead.
+          </div>
+        ) : null}
 
-      <div className="grid gap-8 2xl:grid-cols-[minmax(0,1.25fr)_minmax(360px,0.75fr)]">
-        <div className="space-y-8">
-          <section aria-labelledby="signal-monitor-streams" className="space-y-5">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-              <div className="space-y-2">
-                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
-                  Monitoring surface
-                </p>
-                <h2
-                  id="signal-monitor-streams"
-                  className="text-3xl font-semibold tracking-tight text-slate-950"
-                >
-                  Live signal cards
-                </h2>
-              </div>
-              <p className="max-w-2xl text-sm leading-6 text-slate-600">
-                Each card exposes stream posture, throughput, drift markers, and
-                the number of active anomalies tied to that feed.
-              </p>
-            </div>
-
-            <div
-              aria-label="Live signals"
-              className="grid gap-4 xl:grid-cols-2"
-              role="list"
+        <div className={styles.contentGrid}>
+          <div className="space-y-8">
+            <section
+              aria-labelledby="signal-monitor-streams"
+              className={`${styles.surfaceSection} space-y-5 px-6 py-6 sm:px-7 sm:py-7`}
             >
-              {view.signals.map((signal) => (
-                <div key={signal.id} role="listitem">
-                  <SignalStreamCard
-                    href={`/signal-monitor?signal=${signal.id}`}
-                    isActive={signal.id === view.selectedSignal.id}
-                    signal={signal}
-                  />
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                <div className="space-y-2">
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                    Monitoring surface
+                  </p>
+                  <h2
+                    id="signal-monitor-streams"
+                    className="text-3xl font-semibold tracking-tight text-slate-950"
+                  >
+                    Live signal cards
+                  </h2>
                 </div>
-              ))}
-            </div>
-          </section>
-
-          <section aria-labelledby="signal-monitor-anomalies" className="space-y-5">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-              <div className="space-y-2">
-                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
-                  Intervention queue
+                <p className="max-w-2xl text-sm leading-6 text-slate-600">
+                  Each card exposes stream posture, throughput, drift markers,
+                  and the number of active anomalies tied to that feed.
                 </p>
-                <h2
-                  id="signal-monitor-anomalies"
-                  className="text-3xl font-semibold tracking-tight text-slate-950"
-                >
-                  Anomaly summary
-                </h2>
               </div>
-              <p className="max-w-2xl text-sm leading-6 text-slate-600">
-                Severity, owner, impact, and recommended actions stay visible so
-                the route can be reviewed without opening a second surface.
-              </p>
-            </div>
 
-            <AnomalySummaryList anomalies={view.anomalies} signals={view.signals} />
-          </section>
+              <div
+                aria-label="Live signals"
+                className={styles.streamGrid}
+                role="list"
+              >
+                {view.signals.map((signal) => (
+                  <div key={signal.id} role="listitem">
+                    <SignalStreamCard
+                      href={`/signal-monitor?signal=${signal.id}`}
+                      isActive={signal.id === view.selectedSignal.id}
+                      signal={signal}
+                    />
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            <section
+              aria-labelledby="signal-monitor-anomalies"
+              className={`${styles.surfaceSection} space-y-5 px-6 py-6 sm:px-7 sm:py-7`}
+            >
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                <div className="space-y-2">
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                    Intervention queue
+                  </p>
+                  <h2
+                    id="signal-monitor-anomalies"
+                    className="text-3xl font-semibold tracking-tight text-slate-950"
+                  >
+                    Anomaly summary
+                  </h2>
+                </div>
+                <p className="max-w-2xl text-sm leading-6 text-slate-600">
+                  Severity, owner, impact, and recommended actions stay visible
+                  so the route can be reviewed without opening a second surface.
+                </p>
+              </div>
+
+              <AnomalySummaryList anomalies={view.anomalies} signals={view.signals} />
+            </section>
+          </div>
+
+          <div className={styles.inspectorRail}>
+            <SignalInspector
+              anomalies={view.selectedAnomalies}
+              signal={view.selectedSignal}
+            />
+          </div>
         </div>
-
-        <SignalInspector
-          anomalies={view.selectedAnomalies}
-          signal={view.selectedSignal}
-        />
       </div>
     </main>
   );

--- a/src/app/signal-monitor/_components/signal-stream-card.tsx
+++ b/src/app/signal-monitor/_components/signal-stream-card.tsx
@@ -1,0 +1,147 @@
+import Link from "next/link";
+
+import type { SignalStream } from "../_lib/signal-monitor-data";
+
+type SignalStreamCardProps = {
+  signal: SignalStream;
+  href?: string;
+  isActive?: boolean;
+};
+
+const statusLabelClasses: Record<SignalStream["status"], string> = {
+  tracking: "border-emerald-300/70 bg-emerald-100 text-emerald-800",
+  watch: "border-amber-300/70 bg-amber-100 text-amber-800",
+  degraded: "border-rose-300/70 bg-rose-100 text-rose-800",
+  offline: "border-slate-300/70 bg-slate-200 text-slate-800",
+};
+
+const typeLabelClasses: Record<SignalStream["type"], string> = {
+  telemetry: "bg-cyan-100 text-cyan-800",
+  network: "bg-sky-100 text-sky-800",
+  environmental: "bg-emerald-100 text-emerald-800",
+  security: "bg-violet-100 text-violet-800",
+};
+
+export function SignalStreamCard({
+  signal,
+  href,
+  isActive = false,
+}: SignalStreamCardProps) {
+  const content = (
+    <>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-3">
+          <div className="flex flex-wrap gap-2">
+            <span
+              className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${statusLabelClasses[signal.status]}`}
+            >
+              {signal.status}
+            </span>
+            <span
+              className={`inline-flex rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${typeLabelClasses[signal.type]}`}
+            >
+              {signal.type}
+            </span>
+          </div>
+          <div className="space-y-1">
+            <h3 className="text-2xl font-semibold tracking-tight text-slate-950">
+              {signal.name}
+            </h3>
+            <p className="text-sm font-medium text-slate-500">{signal.region}</p>
+          </div>
+        </div>
+
+        <div className="min-w-[9rem] rounded-2xl border border-slate-200/80 bg-slate-50 px-4 py-3 text-right">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Active anomalies
+          </p>
+          <p className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">
+            {signal.anomalyCount}
+          </p>
+        </div>
+      </div>
+
+      <p className="mt-5 text-sm leading-6 text-slate-600">{signal.summary}</p>
+
+      <div className="mt-5 grid gap-3 sm:grid-cols-2">
+        <div className="rounded-2xl border border-slate-200/80 bg-white/80 px-4 py-3">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Throughput
+          </p>
+          <p className="mt-2 text-lg font-semibold text-slate-950">
+            {signal.throughput}
+          </p>
+        </div>
+        <div className="rounded-2xl border border-slate-200/80 bg-white/80 px-4 py-3">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Drift marker
+          </p>
+          <p className="mt-2 text-lg font-semibold text-slate-950">{signal.drift}</p>
+        </div>
+      </div>
+
+      <dl className="mt-5 grid gap-3 sm:grid-cols-3">
+        {signal.headlineStats.map((stat) => (
+          <div
+            key={stat.label}
+            className="rounded-2xl border border-slate-200/70 bg-white/65 px-4 py-3"
+          >
+            <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+              {stat.label}
+            </dt>
+            <dd className="mt-2 text-base font-semibold text-slate-950">
+              {stat.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+
+      <div className="mt-5 flex flex-wrap items-center justify-between gap-3 border-t border-slate-200/80 pt-4">
+        <div className="space-y-1">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Cadence
+          </p>
+          <p className="text-sm font-medium text-slate-700">{signal.cadence}</p>
+        </div>
+        <div className="space-y-1 text-right">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Refreshed
+          </p>
+          <p className="text-sm font-medium text-slate-700">{signal.refreshedAt}</p>
+        </div>
+      </div>
+    </>
+  );
+
+  if (!href) {
+    return (
+      <article
+        className={`rounded-[1.75rem] border p-6 shadow-[0_18px_60px_rgba(15,23,42,0.06)] ${
+          isActive
+            ? "border-slate-900 bg-white"
+            : "border-slate-200/80 bg-white/80"
+        }`}
+      >
+        {content}
+      </article>
+    );
+  }
+
+  return (
+    <article
+      className={`rounded-[1.75rem] border p-6 shadow-[0_18px_60px_rgba(15,23,42,0.06)] ${
+        isActive
+          ? "border-slate-900 bg-white"
+          : "border-slate-200/80 bg-white/80"
+      }`}
+    >
+      <Link
+        aria-current={isActive ? "page" : undefined}
+        className="block focus:outline-none"
+        href={href}
+      >
+        {content}
+      </Link>
+    </article>
+  );
+}

--- a/src/app/signal-monitor/_components/signal-stream-card.tsx
+++ b/src/app/signal-monitor/_components/signal-stream-card.tsx
@@ -136,6 +136,7 @@ export function SignalStreamCard({
       }`}
     >
       <Link
+        aria-label={isActive ? `Inspect ${signal.name} selected` : `Inspect ${signal.name}`}
         aria-current={isActive ? "page" : undefined}
         className="block focus:outline-none"
         href={href}

--- a/src/app/signal-monitor/_lib/signal-monitor-data.ts
+++ b/src/app/signal-monitor/_lib/signal-monitor-data.ts
@@ -1,0 +1,292 @@
+export type SignalStreamType =
+  | "telemetry"
+  | "network"
+  | "environmental"
+  | "security";
+
+export type SignalStreamStatus =
+  | "tracking"
+  | "watch"
+  | "degraded"
+  | "offline";
+
+export type SignalSeverity = "watch" | "elevated" | "critical";
+
+export type SignalStat = {
+  label: string;
+  value: string;
+};
+
+export type SignalDetailEntry = {
+  label: string;
+  value: string;
+};
+
+export type SignalDetailSection = {
+  title: string;
+  description: string;
+  entries: SignalDetailEntry[];
+};
+
+export type SignalAnomaly = {
+  id: string;
+  signalId: string;
+  title: string;
+  severity: SignalSeverity;
+  summary: string;
+  detectionWindow: string;
+  owner: string;
+  impact: string;
+  recommendedAction: string;
+};
+
+export type SignalStream = {
+  id: string;
+  name: string;
+  type: SignalStreamType;
+  status: SignalStreamStatus;
+  region: string;
+  cadence: string;
+  refreshedAt: string;
+  summary: string;
+  throughput: string;
+  drift: string;
+  anomalyCount: number;
+  headlineStats: SignalStat[];
+  detailSections: SignalDetailSection[];
+};
+
+export const signalStreams: SignalStream[] = [
+  {
+    id: "polar-vault-telemetry",
+    name: "Polar Vault Telemetry",
+    type: "telemetry",
+    status: "degraded",
+    region: "Svalbard relay",
+    cadence: "12 second ingest",
+    refreshedAt: "Updated 2 minutes ago",
+    summary:
+      "Cryogenic vault sensors are still reporting, but thermal balancing packets are arriving out of sequence after the morning relay reset.",
+    throughput: "18.4k packets/min",
+    drift: "+14% replay backlog",
+    anomalyCount: 2,
+    headlineStats: [
+      { label: "Signal integrity", value: "91.8%" },
+      { label: "Thermal delta", value: "+4.2 C" },
+      { label: "Replay lag", value: "86 seconds" },
+    ],
+    detailSections: [
+      {
+        title: "Stream posture",
+        description:
+          "Primary sensor packets continue to land, but sequence mismatches are concentrated around the relay handoff boundary.",
+        entries: [
+          { label: "Collector", value: "Vault edge array 3" },
+          { label: "Primary lane", value: "Svalbard uplink / north ring" },
+          { label: "Fallback mode", value: "Buffered replay and checksum stitch" },
+        ],
+      },
+      {
+        title: "Operator notes",
+        description:
+          "The backlog is currently within the containment window, but thermal variance is rising faster than the last cold-start drill.",
+        entries: [
+          { label: "Escalation owner", value: "Lena Solberg" },
+          { label: "Last intervention", value: "Relay reset at 09:12 UTC" },
+          { label: "Review target", value: "Stabilize before next archive seal" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "harbor-mesh-uplink",
+    name: "Harbor Mesh Uplink",
+    type: "network",
+    status: "tracking",
+    region: "Glass Harbor perimeter",
+    cadence: "Real-time mesh heartbeat",
+    refreshedAt: "Updated 47 seconds ago",
+    summary:
+      "Dockside mesh nodes are stable after the overnight firmware roll, with no customer-impacting retransmission burst in the latest window.",
+    throughput: "42.1 Mbps",
+    drift: "-3% packet loss",
+    anomalyCount: 0,
+    headlineStats: [
+      { label: "Node availability", value: "99.97%" },
+      { label: "Median latency", value: "24 ms" },
+      { label: "Burst retries", value: "3 in 6 hr" },
+    ],
+    detailSections: [
+      {
+        title: "Stream posture",
+        description:
+          "The mesh is acting as the route's clean baseline and is useful for contrasting stable cards against degraded and watch states.",
+        entries: [
+          { label: "Collector", value: "Harbor node supervisor" },
+          { label: "Coverage", value: "17 dock and gate nodes" },
+          { label: "Firmware lane", value: "2026.04-hf2" },
+        ],
+      },
+      {
+        title: "Operator notes",
+        description:
+          "No interventions are scheduled. The stream is green but still listed because it anchors the route's live status mix.",
+        entries: [
+          { label: "Escalation owner", value: "Marco Hale" },
+          { label: "Last intervention", value: "Firmware roll at 01:18 UTC" },
+          { label: "Review target", value: "Observe post-roll stability until shift handoff" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "glacier-air-chemistry",
+    name: "Glacier Air Chemistry",
+    type: "environmental",
+    status: "watch",
+    region: "Aurora ridge canopy",
+    cadence: "60 second sample bundle",
+    refreshedAt: "Updated 5 minutes ago",
+    summary:
+      "Atmospheric readings remain within the seasonal band, but methane spikes are clustering close enough together to justify a watch posture.",
+    throughput: "960 sample groups/hr",
+    drift: "+0.9 ppm methane variance",
+    anomalyCount: 1,
+    headlineStats: [
+      { label: "Methane spread", value: "7.3 ppm" },
+      { label: "Humidity range", value: "61-67%" },
+      { label: "Sampler uptime", value: "98.6%" },
+    ],
+    detailSections: [
+      {
+        title: "Stream posture",
+        description:
+          "This stream is not degraded, but the watch state should still stand out in the monitoring route and the anomaly summary.",
+        entries: [
+          { label: "Collector", value: "Ridge chemistry mast" },
+          { label: "Coverage", value: "6 sensor towers" },
+          { label: "Calibration age", value: "11 days" },
+        ],
+      },
+      {
+        title: "Operator notes",
+        description:
+          "Field ops want one more full sample cycle before dispatching a recalibration crew to the ridge.",
+        entries: [
+          { label: "Escalation owner", value: "Inez Mercer" },
+          { label: "Last intervention", value: "Drift review at 07:05 UTC" },
+          { label: "Review target", value: "Confirm clustering pattern by next sunrise pass" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "citadel-access-ring",
+    name: "Citadel Access Ring",
+    type: "security",
+    status: "offline",
+    region: "Citadel east ingress",
+    cadence: "5 second access event sync",
+    refreshedAt: "No update for 19 minutes",
+    summary:
+      "Badge and gate events from the east ingress ring stopped replicating after the last controller failover, leaving the security desk on a blind spot.",
+    throughput: "0 events/min",
+    drift: "+19 minute blackout",
+    anomalyCount: 2,
+    headlineStats: [
+      { label: "Reader coverage", value: "0 of 12 online" },
+      { label: "Audit gap", value: "19 minutes" },
+      { label: "Fallback queue", value: "214 unsent events" },
+    ],
+    detailSections: [
+      {
+        title: "Stream posture",
+        description:
+          "The offline state needs a sharper visual treatment than the degraded telemetry feed because the monitoring team has lost live visibility altogether.",
+        entries: [
+          { label: "Collector", value: "Ingress access controller 4B" },
+          { label: "Coverage", value: "East ingress turnstiles and freight gate" },
+          { label: "Fallback mode", value: "Local device buffering only" },
+        ],
+      },
+      {
+        title: "Operator notes",
+        description:
+          "Security can still inspect local device logs on site, but the centralized monitor is missing live events until the controller recovers.",
+        entries: [
+          { label: "Escalation owner", value: "Rafi Okonkwo" },
+          { label: "Last intervention", value: "Controller failover at 08:58 UTC" },
+          { label: "Review target", value: "Restore centralized event stream before shift change" },
+        ],
+      },
+    ],
+  },
+];
+
+export const signalAnomalies: SignalAnomaly[] = [
+  {
+    id: "thermal-packet-skew",
+    signalId: "polar-vault-telemetry",
+    title: "Thermal packet skew widening",
+    severity: "elevated",
+    summary:
+      "Packet ordering drift crossed the alert threshold twice in the last 20 minutes, pushing replay lag past the expected buffer lane.",
+    detectionWindow: "Detected across the last 20 minutes",
+    owner: "Lena Solberg",
+    impact: "Late thermal snapshots could hide a fast temperature rise inside the vault shell.",
+    recommendedAction:
+      "Keep the relay in buffered replay mode and compare the next checksum cycle before clearing the feed.",
+  },
+  {
+    id: "cooling-delta-rise",
+    signalId: "polar-vault-telemetry",
+    title: "Cooling delta climbing above drill baseline",
+    severity: "watch",
+    summary:
+      "Thermal spread is still below the critical trigger, but it is outpacing the last planned cold-start sequence.",
+    detectionWindow: "Trending upward for 42 minutes",
+    owner: "Lena Solberg",
+    impact: "Operators may need to delay the next archive intake if the spread keeps widening.",
+    recommendedAction:
+      "Compare the next two sensor bundles against the pre-reset baseline before escalating to infrastructure.",
+  },
+  {
+    id: "methane-cluster-repeat",
+    signalId: "glacier-air-chemistry",
+    title: "Methane spike cluster repeating",
+    severity: "watch",
+    summary:
+      "Three closely spaced methane spikes landed in the same canopy quadrant after sunrise, matching the previous day's cluster pattern.",
+    detectionWindow: "Observed in two consecutive sample windows",
+    owner: "Inez Mercer",
+    impact: "A repeat pattern increases the chance that the variance is a site issue rather than transient weather noise.",
+    recommendedAction:
+      "Hold the watch posture and stage a calibration crew if the next sample bundle confirms the same quadrant pattern.",
+  },
+  {
+    id: "controller-blackout",
+    signalId: "citadel-access-ring",
+    title: "Controller blackout at east ingress",
+    severity: "critical",
+    summary:
+      "The controller failover left the east ingress ring offline, so central monitoring has no live access event confirmation from the affected readers.",
+    detectionWindow: "No replicated events for 19 minutes",
+    owner: "Rafi Okonkwo",
+    impact: "Security response now depends on local inspection and cannot verify badge activity from the central desk.",
+    recommendedAction:
+      "Dispatch on-site verification immediately and restore controller replication before the next freight clearance window.",
+  },
+  {
+    id: "unsent-event-queue",
+    signalId: "citadel-access-ring",
+    title: "Buffered access queue rising",
+    severity: "elevated",
+    summary:
+      "Local devices are still logging events, but the unsent queue is climbing as long as the ring stays disconnected from the monitoring plane.",
+    detectionWindow: "Queue grew by 214 events in 19 minutes",
+    owner: "Rafi Okonkwo",
+    impact: "Once the link recovers, the replay burst could obscure the exact order of ingress events during the outage window.",
+    recommendedAction:
+      "Preserve local device clocks and prepare to reconcile replayed events against guard desk notes after recovery.",
+  },
+];

--- a/src/app/signal-monitor/_lib/signal-monitor.ts
+++ b/src/app/signal-monitor/_lib/signal-monitor.ts
@@ -1,0 +1,88 @@
+import {
+  signalAnomalies,
+  signalStreams,
+  type SignalAnomaly,
+  type SignalStat,
+  type SignalStream,
+} from "./signal-monitor-data";
+
+export type SignalMonitorView = {
+  signals: SignalStream[];
+  anomalies: SignalAnomaly[];
+  selectedSignal: SignalStream;
+  selectedAnomalies: SignalAnomaly[];
+  requestedSignalId?: string;
+  selectionFound: boolean;
+  overviewStats: SignalStat[];
+};
+
+const severityWeight: Record<SignalAnomaly["severity"], number> = {
+  critical: 0,
+  elevated: 1,
+  watch: 2,
+};
+
+function normalizeSignalId(signalId?: string) {
+  return signalId?.trim().toLowerCase();
+}
+
+export function readRequestedSignalId(value: string | string[] | undefined) {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
+}
+
+function buildOverviewStats(): SignalStat[] {
+  const affectedSignals = new Set(signalAnomalies.map((anomaly) => anomaly.signalId));
+  const criticalAnomalies = signalAnomalies.filter(
+    (anomaly) => anomaly.severity === "critical",
+  ).length;
+  const watchSignals = signalStreams.filter(
+    (signal) => signal.status === "watch" || signal.status === "degraded",
+  ).length;
+  const offlineSignals = signalStreams.filter(
+    (signal) => signal.status === "offline",
+  ).length;
+
+  return [
+    { label: "Streams online", value: `${signalStreams.length - offlineSignals}/${signalStreams.length}` },
+    { label: "Affected streams", value: `${affectedSignals.size}` },
+    { label: "Critical anomalies", value: `${criticalAnomalies}` },
+    { label: "Signals under watch", value: `${watchSignals}` },
+  ];
+}
+
+export function resolveSignalMonitorView(signalId?: string): SignalMonitorView {
+  const requestedSignalId = normalizeSignalId(signalId);
+  const selectionFound = requestedSignalId
+    ? signalStreams.some((signal) => signal.id === requestedSignalId)
+    : true;
+
+  const selectedSignal =
+    signalStreams.find((signal) => signal.id === requestedSignalId) ??
+    signalStreams[0];
+  const sortedAnomalies = [...signalAnomalies].sort((left, right) => {
+    const severityDelta =
+      severityWeight[left.severity] - severityWeight[right.severity];
+
+    if (severityDelta !== 0) {
+      return severityDelta;
+    }
+
+    return left.title.localeCompare(right.title);
+  });
+
+  return {
+    signals: signalStreams,
+    anomalies: sortedAnomalies,
+    selectedSignal,
+    selectedAnomalies: sortedAnomalies.filter(
+      (anomaly) => anomaly.signalId === selectedSignal.id,
+    ),
+    requestedSignalId,
+    selectionFound,
+    overviewStats: buildOverviewStats(),
+  };
+}

--- a/src/app/signal-monitor/page.test.tsx
+++ b/src/app/signal-monitor/page.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SignalMonitorShell } from "./_components/signal-monitor-shell";
+import { resolveSignalMonitorView } from "./_lib/signal-monitor";
+import { signalStreams } from "./_lib/signal-monitor-data";
+
+describe("SignalMonitorShell", () => {
+  it("renders the live monitoring route with signal cards, anomaly summaries, and the inspector", () => {
+    const view = resolveSignalMonitorView();
+
+    render(<SignalMonitorShell view={view} />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: /watch live streams, anomaly pressure, and operator detail in one route\./i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /live signal cards/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /anomaly summary/i }),
+    ).toBeInTheDocument();
+
+    const liveSignals = screen.getByRole("list", { name: /live signals/i });
+
+    expect(within(liveSignals).getAllByRole("listitem")).toHaveLength(
+      signalStreams.length,
+    );
+    const inspector = screen.getByRole("complementary", {
+      name: /signal inspector/i,
+    });
+
+    expect(inspector).toBeInTheDocument();
+    expect(
+      within(inspector).getByRole("heading", { name: view.selectedSignal.name }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/keep the relay in buffered replay mode/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the requested signal in the inspector and marks its card link as current", () => {
+    const chosenSignal = signalStreams[3];
+    const view = resolveSignalMonitorView(chosenSignal.id);
+
+    render(<SignalMonitorShell view={view} />);
+
+    const inspector = screen.getByRole("complementary", {
+      name: /signal inspector/i,
+    });
+
+    expect(
+      within(inspector).getByRole("heading", { name: chosenSignal.name }),
+    ).toBeInTheDocument();
+
+    const selectedLink = screen.getByRole("link", {
+      name: new RegExp(`inspect ${chosenSignal.name} selected`, "i"),
+    });
+
+    expect(selectedLink).toHaveAttribute(
+      "href",
+      `/signal-monitor?signal=${chosenSignal.id}`,
+    );
+    expect(selectedLink).toHaveAttribute("aria-current", "page");
+    expect(
+      within(inspector).getByText(/controller blackout at east ingress/i),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to the default signal and shows a status message for an unknown selection", () => {
+    const view = resolveSignalMonitorView("missing-signal");
+
+    render(<SignalMonitorShell view={view} />);
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      /missing-signal.*default inspector stream/i,
+    );
+    const inspector = screen.getByRole("complementary", {
+      name: /signal inspector/i,
+    });
+
+    expect(
+      within(inspector).getByRole("heading", { name: signalStreams[0].name }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders severity labels and recommended actions for representative anomalies", () => {
+    const view = resolveSignalMonitorView();
+
+    render(<SignalMonitorShell view={view} />);
+
+    expect(screen.getAllByText(/critical/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/elevated/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/watch/i).length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(/dispatch on-site verification immediately/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/hold the watch posture and stage a calibration crew/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/signal-monitor/page.tsx
+++ b/src/app/signal-monitor/page.tsx
@@ -1,0 +1,85 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Signal Monitor",
+  description:
+    "Monitoring route scaffold for live signals, anomaly summaries, and an inspector panel.",
+};
+
+const placeholderSections = [
+  {
+    title: "Live signal cards",
+    description:
+      "Stream cards will land here once the mock monitoring data model is in place.",
+  },
+  {
+    title: "Anomaly summary",
+    description:
+      "Severity bands and anomaly rollups will be added in the next implementation step.",
+  },
+  {
+    title: "Inspector panel",
+    description:
+      "A detail-focused operator panel will sit alongside the signal grid in the completed route.",
+  },
+];
+
+export default function SignalMonitorPage() {
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8 px-6 py-8 sm:px-10 lg:px-12">
+      <section className="overflow-hidden rounded-[2rem] border border-slate-200/80 bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.08)]">
+        <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1.15fr)_minmax(280px,0.85fr)] lg:px-12 lg:py-10">
+          <div className="space-y-4">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-rose-700">
+              Signal monitor
+            </p>
+            <div className="space-y-3">
+              <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
+                Monitoring route scaffold for live streams and anomaly review.
+              </h1>
+              <p className="max-w-3xl text-lg leading-8 text-slate-600">
+                This shell reserves space for the signal grid, anomaly summaries,
+                and an inspector-style detail panel described in issue 91.
+              </p>
+            </div>
+          </div>
+
+          <aside className="rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Route status
+            </p>
+            <p className="mt-4 text-2xl font-semibold tracking-tight text-slate-950">
+              Scaffolded
+            </p>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              This is the minimal page shell required before the richer mock
+              monitoring UI is layered in.
+            </p>
+          </aside>
+        </div>
+      </section>
+
+      <section
+        aria-label="Signal monitor placeholder sections"
+        className="grid gap-4 lg:grid-cols-3"
+      >
+        {placeholderSections.map((section) => (
+          <article
+            key={section.title}
+            className="rounded-[1.75rem] border border-slate-200/80 bg-white/75 p-6 shadow-[0_18px_50px_rgba(15,23,42,0.05)]"
+          >
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Reserved
+            </p>
+            <h2 className="mt-4 text-2xl font-semibold tracking-tight text-slate-950">
+              {section.title}
+            </h2>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              {section.description}
+            </p>
+          </article>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/src/app/signal-monitor/page.tsx
+++ b/src/app/signal-monitor/page.tsx
@@ -1,85 +1,28 @@
 import type { Metadata } from "next";
 
+import { SignalMonitorShell } from "./_components/signal-monitor-shell";
+import {
+  readRequestedSignalId,
+  resolveSignalMonitorView,
+} from "./_lib/signal-monitor";
+
 export const metadata: Metadata = {
   title: "Signal Monitor",
   description:
-    "Monitoring route scaffold for live signals, anomaly summaries, and an inspector panel.",
+    "Monitoring route with live signal cards, anomaly summaries, and an inspector panel.",
 };
 
-const placeholderSections = [
-  {
-    title: "Live signal cards",
-    description:
-      "Stream cards will land here once the mock monitoring data model is in place.",
-  },
-  {
-    title: "Anomaly summary",
-    description:
-      "Severity bands and anomaly rollups will be added in the next implementation step.",
-  },
-  {
-    title: "Inspector panel",
-    description:
-      "A detail-focused operator panel will sit alongside the signal grid in the completed route.",
-  },
-];
+type SignalMonitorPageProps = {
+  searchParams: Promise<{
+    signal?: string | string[] | undefined;
+  }>;
+};
 
-export default function SignalMonitorPage() {
-  return (
-    <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8 px-6 py-8 sm:px-10 lg:px-12">
-      <section className="overflow-hidden rounded-[2rem] border border-slate-200/80 bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.08)]">
-        <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1.15fr)_minmax(280px,0.85fr)] lg:px-12 lg:py-10">
-          <div className="space-y-4">
-            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-rose-700">
-              Signal monitor
-            </p>
-            <div className="space-y-3">
-              <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-                Monitoring route scaffold for live streams and anomaly review.
-              </h1>
-              <p className="max-w-3xl text-lg leading-8 text-slate-600">
-                This shell reserves space for the signal grid, anomaly summaries,
-                and an inspector-style detail panel described in issue 91.
-              </p>
-            </div>
-          </div>
+export default async function SignalMonitorPage({
+  searchParams,
+}: SignalMonitorPageProps) {
+  const requestedSignalId = readRequestedSignalId((await searchParams).signal);
+  const view = resolveSignalMonitorView(requestedSignalId);
 
-          <aside className="rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-5">
-            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
-              Route status
-            </p>
-            <p className="mt-4 text-2xl font-semibold tracking-tight text-slate-950">
-              Scaffolded
-            </p>
-            <p className="mt-3 text-sm leading-6 text-slate-600">
-              This is the minimal page shell required before the richer mock
-              monitoring UI is layered in.
-            </p>
-          </aside>
-        </div>
-      </section>
-
-      <section
-        aria-label="Signal monitor placeholder sections"
-        className="grid gap-4 lg:grid-cols-3"
-      >
-        {placeholderSections.map((section) => (
-          <article
-            key={section.title}
-            className="rounded-[1.75rem] border border-slate-200/80 bg-white/75 p-6 shadow-[0_18px_50px_rgba(15,23,42,0.05)]"
-          >
-            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">
-              Reserved
-            </p>
-            <h2 className="mt-4 text-2xl font-semibold tracking-tight text-slate-950">
-              {section.title}
-            </h2>
-            <p className="mt-3 text-sm leading-6 text-slate-600">
-              {section.description}
-            </p>
-          </article>
-        ))}
-      </section>
-    </main>
-  );
+  return <SignalMonitorShell view={view} />;
 }

--- a/src/app/signal-monitor/signal-monitor.module.css
+++ b/src/app/signal-monitor/signal-monitor.module.css
@@ -1,0 +1,125 @@
+.shell {
+  position: relative;
+  isolation: isolate;
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+.shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at top left, rgba(34, 211, 238, 0.2), transparent 34%),
+    radial-gradient(circle at top right, rgba(248, 113, 113, 0.16), transparent 32%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.3), rgba(244, 239, 231, 0));
+  pointer-events: none;
+  z-index: -2;
+}
+
+.shell::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(148, 163, 184, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.08) 1px, transparent 1px);
+  background-position: center;
+  background-size: 4.5rem 4.5rem;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.45), transparent 88%);
+  pointer-events: none;
+  z-index: -1;
+}
+
+.heroPanel {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(135deg, rgba(2, 6, 23, 0.98), rgba(15, 23, 42, 0.96)),
+    radial-gradient(circle at top right, rgba(34, 211, 238, 0.16), transparent 34%);
+}
+
+.heroPanel::before {
+  content: "";
+  position: absolute;
+  inset: auto -8rem -10rem auto;
+  width: 22rem;
+  height: 22rem;
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgba(45, 212, 191, 0.24), transparent 70%);
+  filter: blur(18px);
+  pointer-events: none;
+}
+
+.heroAside {
+  position: relative;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.06)),
+    linear-gradient(145deg, rgba(14, 165, 233, 0.08), transparent);
+  backdrop-filter: blur(14px);
+}
+
+.overviewCard {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.08));
+  backdrop-filter: blur(10px);
+}
+
+.surfaceSection {
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 1.9rem;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow:
+    0 20px 68px rgba(15, 23, 42, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.72);
+  backdrop-filter: blur(16px);
+}
+
+.statusBanner {
+  border-left: 0.45rem solid rgba(217, 119, 6, 0.9);
+  box-shadow: 0 12px 34px rgba(217, 119, 6, 0.12);
+}
+
+.contentGrid {
+  display: grid;
+  gap: 2rem;
+  align-items: start;
+}
+
+.streamGrid {
+  display: grid;
+  gap: 1rem;
+}
+
+.inspectorRail {
+  align-self: start;
+}
+
+@media (min-width: 80rem) {
+  .streamGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 96rem) {
+  .contentGrid {
+    grid-template-columns: minmax(0, 1.25fr) minmax(22.5rem, 0.75fr);
+  }
+
+  .inspectorRail {
+    position: sticky;
+    top: 1.5rem;
+  }
+}
+
+@media (max-width: 40rem) {
+  .shell::after {
+    background-size: 3rem 3rem;
+  }
+
+  .heroPanel::before {
+    inset: auto -10rem -12rem auto;
+    width: 18rem;
+    height: 18rem;
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold the new  route for issue #91
- reserve sections for live signal cards, anomaly summaries, and the inspector panel
- open the PR after subtask 1 so the remaining subtasks can land incrementally

Closes #91