### PR TITLE
feat: build mission planner route

### DIFF
--- a/src/app/mission-planner/_components/readiness-summary.tsx
+++ b/src/app/mission-planner/_components/readiness-summary.tsx
@@ -10,6 +10,15 @@ const signalToneStyles: Record<MissionReadinessTone, string> = {
   blocked: "border-rose-300/25 bg-rose-300/10 text-rose-50",
 };
 
+const signalSurfaceStyles: Record<MissionReadinessTone, string> = {
+  ready:
+    "border-emerald-300/14 bg-[linear-gradient(180deg,rgba(16,185,129,0.14),rgba(15,23,42,0.45))]",
+  watch:
+    "border-amber-300/14 bg-[linear-gradient(180deg,rgba(245,158,11,0.14),rgba(15,23,42,0.45))]",
+  blocked:
+    "border-rose-300/14 bg-[linear-gradient(180deg,rgba(244,63,94,0.14),rgba(15,23,42,0.45))]",
+};
+
 const signalToneLabels: Record<MissionReadinessTone, string> = {
   ready: "Ready",
   watch: "Watch",
@@ -28,7 +37,7 @@ export function ReadinessSummary({
   return (
     <section
       aria-label="Mission readiness summary"
-      className="rounded-[2rem] border border-white/10 bg-white/7 p-6 shadow-[0_28px_80px_rgba(2,6,23,0.28)] backdrop-blur"
+      className="rounded-[2rem] border border-white/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.08),rgba(15,23,42,0.16))] p-6 shadow-[0_28px_80px_rgba(2,6,23,0.28)] backdrop-blur xl:sticky xl:top-8"
     >
       <div className="space-y-3">
         <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-300">
@@ -44,11 +53,11 @@ export function ReadinessSummary({
         </p>
       </div>
 
-      <div className="mt-6 grid gap-3">
+      <div className="mt-6 grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
         {stats.map((stat) => (
           <div
             key={stat.label}
-            className="rounded-[1.5rem] border border-white/8 bg-slate-950/45 px-4 py-4"
+            className="rounded-[1.5rem] border border-white/8 bg-[linear-gradient(180deg,rgba(15,23,42,0.78),rgba(9,15,28,0.92))] px-4 py-4"
           >
             <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
               {stat.label}
@@ -65,7 +74,7 @@ export function ReadinessSummary({
         {signals.map((signal) => (
           <article
             key={signal.id}
-            className="rounded-[1.5rem] border border-white/8 bg-slate-950/40 px-4 py-4"
+            className={`rounded-[1.5rem] border px-4 py-4 ${signalSurfaceStyles[signal.tone]}`}
           >
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div>

--- a/src/app/mission-planner/_components/readiness-summary.tsx
+++ b/src/app/mission-planner/_components/readiness-summary.tsx
@@ -1,0 +1,89 @@
+import type {
+  MissionReadinessTone,
+  PlannerStat,
+  ReadinessSignal,
+} from "../_data/mission-planner-data";
+
+const signalToneStyles: Record<MissionReadinessTone, string> = {
+  ready: "border-emerald-300/25 bg-emerald-300/10 text-emerald-50",
+  watch: "border-amber-300/25 bg-amber-300/10 text-amber-50",
+  blocked: "border-rose-300/25 bg-rose-300/10 text-rose-50",
+};
+
+const signalToneLabels: Record<MissionReadinessTone, string> = {
+  ready: "Ready",
+  watch: "Watch",
+  blocked: "Blocked",
+};
+
+type ReadinessSummaryProps = {
+  stats: PlannerStat[];
+  signals: ReadinessSignal[];
+};
+
+export function ReadinessSummary({
+  stats,
+  signals,
+}: ReadinessSummaryProps) {
+  return (
+    <section
+      aria-label="Mission readiness summary"
+      className="rounded-[2rem] border border-white/10 bg-white/7 p-6 shadow-[0_28px_80px_rgba(2,6,23,0.28)] backdrop-blur"
+    >
+      <div className="space-y-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-300">
+          Readiness highlights
+        </p>
+        <h2 className="text-3xl font-semibold tracking-tight text-white">
+          Mission posture at a glance
+        </h2>
+        <p className="text-sm leading-6 text-slate-300">
+          Summary metrics show the planning baseline, while the readiness list
+          calls out where the launch window is secure and where it still needs
+          intervention.
+        </p>
+      </div>
+
+      <div className="mt-6 grid gap-3">
+        {stats.map((stat) => (
+          <div
+            key={stat.label}
+            className="rounded-[1.5rem] border border-white/8 bg-slate-950/45 px-4 py-4"
+          >
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+              {stat.label}
+            </p>
+            <p className="mt-3 text-3xl font-semibold tracking-tight text-white">
+              {stat.value}
+            </p>
+            <p className="mt-2 text-sm leading-6 text-slate-300">{stat.detail}</p>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-6 space-y-3">
+        {signals.map((signal) => (
+          <article
+            key={signal.id}
+            className="rounded-[1.5rem] border border-white/8 bg-slate-950/40 px-4 py-4"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p className="text-sm font-semibold text-white">{signal.label}</p>
+                <p className="mt-1 text-base font-medium text-slate-100">
+                  {signal.value}
+                </p>
+              </div>
+              <span
+                className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${signalToneStyles[signal.tone]}`}
+              >
+                {signalToneLabels[signal.tone]}
+              </span>
+            </div>
+            <p className="mt-3 text-sm leading-6 text-slate-300">{signal.note}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/mission-planner/_components/scenario-card.tsx
+++ b/src/app/mission-planner/_components/scenario-card.tsx
@@ -18,6 +18,12 @@ const priorityLabels: Record<MissionPriority, string> = {
   watch: "Watch branch",
 };
 
+const priorityGlowStyles: Record<MissionPriority, string> = {
+  critical: "bg-rose-300/30",
+  timed: "bg-amber-300/26",
+  watch: "bg-sky-300/24",
+};
+
 type ScenarioCardProps = {
   scenario: MissionScenario;
 };
@@ -25,19 +31,35 @@ type ScenarioCardProps = {
 export function ScenarioCard({ scenario }: ScenarioCardProps) {
   return (
     <article
-      className="rounded-[1.8rem] border border-white/10 bg-slate-950/55 p-6 shadow-[0_24px_60px_rgba(2,6,23,0.28)] backdrop-blur"
+      className="group relative overflow-hidden rounded-[1.8rem] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.82),rgba(9,15,28,0.9))] p-6 shadow-[0_24px_60px_rgba(2,6,23,0.28)] backdrop-blur transition-transform duration-300 hover:-translate-y-1"
       role="listitem"
     >
+      <div
+        aria-hidden
+        className={`absolute left-6 top-0 h-24 w-32 -translate-y-1/3 rounded-full blur-3xl transition-opacity duration-300 group-hover:opacity-100 ${priorityGlowStyles[scenario.priority]}`}
+      />
+      <div
+        aria-hidden
+        className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent"
+      />
+
       <div className="flex flex-wrap items-start justify-between gap-3">
         <span
           className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] ${priorityStyles[scenario.priority]}`}
         >
           {priorityLabels[scenario.priority]}
         </span>
-        <p className="text-sm font-medium text-slate-300">{scenario.launchWindow}</p>
+        <div className="text-right">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+            Window
+          </p>
+          <p className="mt-1 text-sm font-medium text-slate-200">
+            {scenario.launchWindow}
+          </p>
+        </div>
       </div>
 
-      <div className="mt-5 space-y-3">
+      <div className="relative mt-5 space-y-3">
         <h3 className="text-2xl font-semibold tracking-tight text-white">
           {scenario.title}
         </h3>
@@ -70,9 +92,13 @@ export function ScenarioCard({ scenario }: ScenarioCardProps) {
           {scenario.checkpoints.map((checkpoint) => (
             <li
               key={checkpoint}
-              className="rounded-2xl border border-white/8 bg-slate-900/80 px-4 py-3 text-sm leading-6 text-slate-200"
+              className="flex gap-3 rounded-2xl border border-white/8 bg-slate-900/80 px-4 py-3 text-sm leading-6 text-slate-200"
             >
-              {checkpoint}
+              <span
+                aria-hidden
+                className={`mt-2 h-2.5 w-2.5 shrink-0 rounded-full ${priorityGlowStyles[scenario.priority]}`}
+              />
+              <span>{checkpoint}</span>
             </li>
           ))}
         </ul>

--- a/src/app/mission-planner/_components/scenario-card.tsx
+++ b/src/app/mission-planner/_components/scenario-card.tsx
@@ -1,0 +1,82 @@
+import type {
+  MissionPriority,
+  MissionScenario,
+} from "../_data/mission-planner-data";
+
+const priorityStyles: Record<MissionPriority, string> = {
+  critical:
+    "border-rose-300/35 bg-rose-300/14 text-rose-50 shadow-[0_12px_30px_rgba(244,63,94,0.2)]",
+  timed:
+    "border-amber-300/35 bg-amber-300/14 text-amber-50 shadow-[0_12px_30px_rgba(245,158,11,0.2)]",
+  watch:
+    "border-sky-300/35 bg-sky-300/14 text-sky-50 shadow-[0_12px_30px_rgba(56,189,248,0.16)]",
+};
+
+const priorityLabels: Record<MissionPriority, string> = {
+  critical: "Critical path",
+  timed: "Timed branch",
+  watch: "Watch branch",
+};
+
+type ScenarioCardProps = {
+  scenario: MissionScenario;
+};
+
+export function ScenarioCard({ scenario }: ScenarioCardProps) {
+  return (
+    <article
+      className="rounded-[1.8rem] border border-white/10 bg-slate-950/55 p-6 shadow-[0_24px_60px_rgba(2,6,23,0.28)] backdrop-blur"
+      role="listitem"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <span
+          className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] ${priorityStyles[scenario.priority]}`}
+        >
+          {priorityLabels[scenario.priority]}
+        </span>
+        <p className="text-sm font-medium text-slate-300">{scenario.launchWindow}</p>
+      </div>
+
+      <div className="mt-5 space-y-3">
+        <h3 className="text-2xl font-semibold tracking-tight text-white">
+          {scenario.title}
+        </h3>
+        <p className="text-sm font-medium uppercase tracking-[0.16em] text-slate-400">
+          {scenario.objective}
+        </p>
+        <p className="text-sm leading-6 text-slate-300">{scenario.summary}</p>
+      </div>
+
+      <dl className="mt-6 grid gap-3 sm:grid-cols-2">
+        <div className="rounded-2xl border border-white/8 bg-white/6 px-4 py-3">
+          <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+            Lead
+          </dt>
+          <dd className="mt-2 text-sm font-medium text-slate-100">{scenario.lead}</dd>
+        </div>
+        <div className="rounded-2xl border border-white/8 bg-white/6 px-4 py-3">
+          <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+            Support
+          </dt>
+          <dd className="mt-2 text-sm font-medium text-slate-100">{scenario.support}</dd>
+        </div>
+      </dl>
+
+      <div className="mt-6">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+          Required checkpoints
+        </p>
+        <ul className="mt-3 space-y-3">
+          {scenario.checkpoints.map((checkpoint) => (
+            <li
+              key={checkpoint}
+              className="rounded-2xl border border-white/8 bg-slate-900/80 px-4 py-3 text-sm leading-6 text-slate-200"
+            >
+              {checkpoint}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </article>
+  );
+}

--- a/src/app/mission-planner/_components/staged-checklist.tsx
+++ b/src/app/mission-planner/_components/staged-checklist.tsx
@@ -22,6 +22,12 @@ const taskStatusStyles: Record<TaskStatus, string> = {
   pending: "border-slate-300/18 bg-slate-200/8 text-slate-100",
 };
 
+const taskStatusDotStyles: Record<TaskStatus, string> = {
+  done: "bg-emerald-300",
+  watch: "bg-amber-300",
+  pending: "bg-slate-300/70",
+};
+
 const taskStatusLabels: Record<TaskStatus, string> = {
   done: "Done",
   watch: "Watch",
@@ -54,18 +60,27 @@ export function StagedChecklist({ stages }: StagedChecklistProps) {
       </div>
 
       <div className="grid gap-5 xl:grid-cols-3" role="list" aria-label="Mission stages">
-        {stages.map((stage) => (
+        {stages.map((stage, index) => (
           <article
             key={stage.id}
-            className="rounded-[1.8rem] border border-white/10 bg-slate-950/55 p-6 shadow-[0_24px_60px_rgba(2,6,23,0.26)]"
+            className="relative overflow-hidden rounded-[1.8rem] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.82),rgba(9,15,28,0.94))] p-6 shadow-[0_24px_60px_rgba(2,6,23,0.26)]"
             role="listitem"
           >
+            <div
+              aria-hidden
+              className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/35 to-transparent"
+            />
             <div className="flex flex-wrap items-start justify-between gap-3">
-              <div>
-                <p className="text-sm font-medium text-slate-300">{stage.window}</p>
-                <h3 className="mt-2 text-2xl font-semibold tracking-tight text-white">
-                  {stage.name}
-                </h3>
+              <div className="flex items-start gap-4">
+                <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-white/10 bg-white/6 text-sm font-semibold text-white">
+                  {index + 1}
+                </span>
+                <div>
+                  <p className="text-sm font-medium text-slate-300">{stage.window}</p>
+                  <h3 className="mt-2 text-2xl font-semibold tracking-tight text-white">
+                    {stage.name}
+                  </h3>
+                </div>
               </div>
               <span
                 className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${stageStatusStyles[stage.status]}`}
@@ -74,7 +89,12 @@ export function StagedChecklist({ stages }: StagedChecklistProps) {
               </span>
             </div>
 
-            <p className="mt-4 text-sm leading-6 text-slate-300">{stage.focus}</p>
+            <div className="mt-4 rounded-[1.4rem] border border-white/8 bg-white/5 px-4 py-4">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                Stage focus
+              </p>
+              <p className="mt-2 text-sm leading-6 text-slate-300">{stage.focus}</p>
+            </div>
 
             <ul className="mt-5 space-y-3">
               {stage.tasks.map((task) => (
@@ -83,11 +103,17 @@ export function StagedChecklist({ stages }: StagedChecklistProps) {
                   className="rounded-[1.4rem] border border-white/8 bg-white/5 px-4 py-4"
                 >
                   <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div>
-                      <p className="text-sm font-semibold text-white">{task.label}</p>
-                      <p className="mt-1 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-                        {task.owner}
-                      </p>
+                    <div className="flex items-start gap-3">
+                      <span
+                        aria-hidden
+                        className={`mt-2 h-2.5 w-2.5 shrink-0 rounded-full ${taskStatusDotStyles[task.status]}`}
+                      />
+                      <div>
+                        <p className="text-sm font-semibold text-white">{task.label}</p>
+                        <p className="mt-1 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                          {task.owner}
+                        </p>
+                      </div>
                     </div>
                     <span
                       className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${taskStatusStyles[task.status]}`}

--- a/src/app/mission-planner/_components/staged-checklist.tsx
+++ b/src/app/mission-planner/_components/staged-checklist.tsx
@@ -1,0 +1,107 @@
+import type {
+  MissionStage,
+  StageStatus,
+  TaskStatus,
+} from "../_data/mission-planner-data";
+
+const stageStatusStyles: Record<StageStatus, string> = {
+  complete: "border-emerald-300/25 bg-emerald-300/10 text-emerald-50",
+  active: "border-sky-300/25 bg-sky-300/10 text-sky-50",
+  queued: "border-slate-300/18 bg-slate-200/8 text-slate-100",
+};
+
+const stageStatusLabels: Record<StageStatus, string> = {
+  complete: "Complete",
+  active: "Active",
+  queued: "Queued",
+};
+
+const taskStatusStyles: Record<TaskStatus, string> = {
+  done: "border-emerald-300/22 bg-emerald-300/10 text-emerald-50",
+  watch: "border-amber-300/22 bg-amber-300/10 text-amber-50",
+  pending: "border-slate-300/18 bg-slate-200/8 text-slate-100",
+};
+
+const taskStatusLabels: Record<TaskStatus, string> = {
+  done: "Done",
+  watch: "Watch",
+  pending: "Pending",
+};
+
+type StagedChecklistProps = {
+  stages: MissionStage[];
+};
+
+export function StagedChecklist({ stages }: StagedChecklistProps) {
+  return (
+    <section aria-labelledby="mission-stage-checklist" className="space-y-5">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-300">
+            Staged checklist
+          </p>
+          <h2
+            id="mission-stage-checklist"
+            className="text-3xl font-semibold tracking-tight text-white sm:text-4xl"
+          >
+            Walk the crew through the mission in sequence
+          </h2>
+        </div>
+        <p className="max-w-2xl text-sm leading-6 text-slate-300">
+          Each stage preserves timing, ownership, and task status so the route
+          reads like an actual execution plan rather than a static memo.
+        </p>
+      </div>
+
+      <div className="grid gap-5 xl:grid-cols-3" role="list" aria-label="Mission stages">
+        {stages.map((stage) => (
+          <article
+            key={stage.id}
+            className="rounded-[1.8rem] border border-white/10 bg-slate-950/55 p-6 shadow-[0_24px_60px_rgba(2,6,23,0.26)]"
+            role="listitem"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p className="text-sm font-medium text-slate-300">{stage.window}</p>
+                <h3 className="mt-2 text-2xl font-semibold tracking-tight text-white">
+                  {stage.name}
+                </h3>
+              </div>
+              <span
+                className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${stageStatusStyles[stage.status]}`}
+              >
+                {stageStatusLabels[stage.status]}
+              </span>
+            </div>
+
+            <p className="mt-4 text-sm leading-6 text-slate-300">{stage.focus}</p>
+
+            <ul className="mt-5 space-y-3">
+              {stage.tasks.map((task) => (
+                <li
+                  key={task.id}
+                  className="rounded-[1.4rem] border border-white/8 bg-white/5 px-4 py-4"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-white">{task.label}</p>
+                      <p className="mt-1 text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+                        {task.owner}
+                      </p>
+                    </div>
+                    <span
+                      className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${taskStatusStyles[task.status]}`}
+                    >
+                      {taskStatusLabels[task.status]}
+                    </span>
+                  </div>
+                  <p className="mt-3 text-sm leading-6 text-slate-300">{task.note}</p>
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/mission-planner/_data/mission-planner-data.ts
+++ b/src/app/mission-planner/_data/mission-planner-data.ts
@@ -1,0 +1,246 @@
+export type MissionPriority = "critical" | "timed" | "watch";
+export type MissionReadinessTone = "ready" | "watch" | "blocked";
+export type StageStatus = "complete" | "active" | "queued";
+export type TaskStatus = "done" | "watch" | "pending";
+
+export interface PlannerStat {
+  label: string;
+  value: string;
+  detail: string;
+}
+
+export interface MissionScenario {
+  id: string;
+  title: string;
+  priority: MissionPriority;
+  launchWindow: string;
+  objective: string;
+  lead: string;
+  support: string;
+  summary: string;
+  checkpoints: string[];
+}
+
+export interface ReadinessSignal {
+  id: string;
+  label: string;
+  value: string;
+  note: string;
+  tone: MissionReadinessTone;
+}
+
+export interface ChecklistTask {
+  id: string;
+  label: string;
+  owner: string;
+  status: TaskStatus;
+  note: string;
+}
+
+export interface MissionStage {
+  id: string;
+  name: string;
+  status: StageStatus;
+  window: string;
+  focus: string;
+  tasks: ChecklistTask[];
+}
+
+export const missionPlannerSummary = {
+  eyebrow: "Mission Planner",
+  title: "Sequence launch-day contingencies before they become field delays.",
+  description:
+    "A planning surface for comparing scenarios, reading readiness posture, and walking the crew through the staged mission checklist.",
+  stats: [
+    {
+      label: "Scenarios in play",
+      value: "3",
+      detail: "Two high-confidence paths and one contingency branch",
+    },
+    {
+      label: "Readiness posture",
+      value: "82%",
+      detail: "Primary teams cleared, weather and comms under watch",
+    },
+    {
+      label: "Active stage",
+      value: "Stage 2",
+      detail: "Payload locking and final route synchronization",
+    },
+  ] satisfies PlannerStat[],
+};
+
+export const missionScenarios = [
+  {
+    id: "aurora-lift",
+    title: "Aurora Lift",
+    priority: "critical",
+    launchWindow: "06:40-07:25 UTC",
+    objective: "Move the sensor package to the northern ridge before thermal drift spikes.",
+    lead: "Flight operations",
+    support: "Telemetry + ground relay",
+    summary:
+      "Primary launch path optimized for the earliest stable weather pocket with minimal relay congestion.",
+    checkpoints: [
+      "Confirm ridge relay handoff 18 minutes before release",
+      "Lock payload temperature band to cold-start profile",
+      "Hold alternate descent lane in reserve until payload clears ridge line",
+    ],
+  },
+  {
+    id: "ember-coast",
+    title: "Ember Coast",
+    priority: "timed",
+    launchWindow: "07:40-08:10 UTC",
+    objective: "Delay the sortie to protect line-of-sight comms without missing the resupply corridor.",
+    lead: "Mission control",
+    support: "Weather desk + logistics",
+    summary:
+      "A delayed departure scenario that trades launch speed for stronger comms stability and cleaner coastal routing.",
+    checkpoints: [
+      "Reconfirm sea-band interference floor at T-minus 35",
+      "Stage backup battery cradle in west hangar",
+      "Shift dock crew to delayed dispatch rhythm if launch slips beyond 07:55 UTC",
+    ],
+  },
+  {
+    id: "nightglass-divert",
+    title: "Nightglass Divert",
+    priority: "watch",
+    launchWindow: "Standby branch",
+    objective: "Route the mission through the inland corridor if the shoreline cell expands.",
+    lead: "Contingency planning",
+    support: "Navigation + field response",
+    summary:
+      "Fallback route prepared for rapid activation if the coastal weather shelf moves into the primary flight band.",
+    checkpoints: [
+      "Keep inland fuel cache topped off and signed",
+      "Validate alternate waypoint package in the nav console",
+      "Prepare field recovery crew for a longer return window",
+    ],
+  },
+] satisfies MissionScenario[];
+
+export const readinessSignals = [
+  {
+    id: "crew-availability",
+    label: "Crew availability",
+    value: "11 / 12 ready",
+    note: "Recovery specialist is on delayed arrival but cross-trained backup is already briefed.",
+    tone: "ready",
+  },
+  {
+    id: "weather-window",
+    label: "Weather window",
+    value: "Narrow but usable",
+    note: "Crosswind is inside threshold through the first launch slot, then shifts to watch status.",
+    tone: "watch",
+  },
+  {
+    id: "payload-health",
+    label: "Payload health",
+    value: "Stable",
+    note: "Thermal envelope is flat and the calibration sweep completed without variance alerts.",
+    tone: "ready",
+  },
+  {
+    id: "relay-network",
+    label: "Relay network",
+    value: "Fallback pending",
+    note: "Primary uplink is healthy, but the inland relay certificate rotation still needs verification.",
+    tone: "blocked",
+  },
+] satisfies ReadinessSignal[];
+
+export const missionStages = [
+  {
+    id: "stage-1",
+    name: "Stage 1 · Preflight alignment",
+    status: "complete",
+    window: "05:30-06:00 UTC",
+    focus: "Crew briefing, system confirmation, and launch corridor review.",
+    tasks: [
+      {
+        id: "crew-briefing",
+        label: "Run final crew briefing",
+        owner: "Ops lead",
+        status: "done",
+        note: "All teams signed off on the weather-adjusted timing plan.",
+      },
+      {
+        id: "payload-calibration",
+        label: "Complete payload calibration sweep",
+        owner: "Payload tech",
+        status: "done",
+        note: "Sweep closed with no deviation beyond the green tolerance band.",
+      },
+      {
+        id: "corridor-review",
+        label: "Confirm primary and alternate corridor locks",
+        owner: "Navigation desk",
+        status: "done",
+        note: "Aurora Lift remains primary, Nightglass Divert remains armed as fallback.",
+      },
+    ],
+  },
+  {
+    id: "stage-2",
+    name: "Stage 2 · Launch window control",
+    status: "active",
+    window: "06:00-07:10 UTC",
+    focus: "Protect the primary launch slot while reducing dependency risk.",
+    tasks: [
+      {
+        id: "relay-verification",
+        label: "Verify inland relay certificate rotation",
+        owner: "Comms engineer",
+        status: "watch",
+        note: "Waiting on the final certificate propagation check from the edge node.",
+      },
+      {
+        id: "battery-cradle",
+        label: "Stage backup battery cradle",
+        owner: "Hangar crew",
+        status: "pending",
+        note: "Must be in position before the delayed Ember Coast branch can be activated.",
+      },
+      {
+        id: "crosswind-monitoring",
+        label: "Track crosswind shift at five-minute intervals",
+        owner: "Weather desk",
+        status: "watch",
+        note: "Threshold is acceptable now, but conditions tighten after 07:20 UTC.",
+      },
+    ],
+  },
+  {
+    id: "stage-3",
+    name: "Stage 3 · Recovery and handoff",
+    status: "queued",
+    window: "07:10-08:30 UTC",
+    focus: "Secure the package, route the return leg, and hand off for field analysis.",
+    tasks: [
+      {
+        id: "recovery-lane",
+        label: "Reserve the preferred recovery lane",
+        owner: "Field response",
+        status: "pending",
+        note: "Will open once the final mission branch is locked.",
+      },
+      {
+        id: "analysis-handoff",
+        label: "Prepare analysis handoff packet",
+        owner: "Mission analyst",
+        status: "pending",
+        note: "Packet template is ready; final telemetry summary populates after landing.",
+      },
+      {
+        id: "return-fuel",
+        label: "Confirm inland return fuel cache",
+        owner: "Logistics",
+        status: "pending",
+        note: "Only required if Nightglass Divert is activated during launch control.",
+      },
+    ],
+  },
+] satisfies MissionStage[];

--- a/src/app/mission-planner/page.test.tsx
+++ b/src/app/mission-planner/page.test.tsx
@@ -1,0 +1,106 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  missionPlannerSummary,
+  missionScenarios,
+  missionStages,
+  readinessSignals,
+} from "./_data/mission-planner-data";
+import MissionPlannerPage from "./page";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("MissionPlannerPage", () => {
+  it("renders the route headings and entry points for planning sections", () => {
+    render(<MissionPlannerPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: /sequence launch-day contingencies before they become field delays\./i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /live mission snapshot/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        name: /choose the path that best protects the launch window/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        name: /walk the crew through the mission in sequence/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /open staged checklist/i }),
+    ).toHaveAttribute("href", "#mission-stage-checklist");
+  });
+
+  it("renders scenario cards from mock data with owners and checkpoints", () => {
+    render(<MissionPlannerPage />);
+
+    const scenarioList = screen.getByRole("list", { name: /mission scenarios/i });
+
+    expect(scenarioList.querySelectorAll(':scope > [role="listitem"]')).toHaveLength(
+      missionScenarios.length,
+    );
+
+    for (const scenario of missionScenarios) {
+      const card = within(scenarioList)
+        .getByRole("heading", { name: scenario.title })
+        .closest('[role="listitem"]');
+
+      expect(card).toBeTruthy();
+      expect(card?.textContent).toContain(scenario.lead);
+      expect(card?.textContent).toContain(scenario.support);
+      expect(card?.textContent).toContain(scenario.checkpoints[0]);
+    }
+  });
+
+  it("shows readiness metrics and signal states for the planner summary rail", () => {
+    render(<MissionPlannerPage />);
+
+    const readinessSummary = screen.getByLabelText(/mission readiness summary/i);
+
+    for (const stat of missionPlannerSummary.stats) {
+      expect(within(readinessSummary).getByText(stat.label)).toBeInTheDocument();
+      expect(within(readinessSummary).getByText(stat.value)).toBeInTheDocument();
+    }
+
+    for (const signal of readinessSignals) {
+      expect(within(readinessSummary).getByText(signal.label)).toBeInTheDocument();
+      expect(within(readinessSummary).getByText(signal.value)).toBeInTheDocument();
+    }
+
+    expect(within(readinessSummary).getByText("Blocked")).toBeInTheDocument();
+    expect(within(readinessSummary).getAllByText("Ready")).toHaveLength(2);
+  });
+
+  it("renders the staged checklist with every stage and task status", () => {
+    render(<MissionPlannerPage />);
+
+    const stageList = screen.getByRole("list", { name: /mission stages/i });
+
+    expect(stageList.querySelectorAll(':scope > [role="listitem"]')).toHaveLength(
+      missionStages.length,
+    );
+
+    for (const stage of missionStages) {
+      const stageCard = within(stageList)
+        .getByRole("heading", { name: stage.name })
+        .closest('[role="listitem"]');
+
+      expect(stageCard).toBeTruthy();
+      expect(stageCard?.textContent).toContain(stage.focus);
+
+      for (const task of stage.tasks) {
+        expect(within(stageCard as HTMLElement).getByText(task.label)).toBeInTheDocument();
+        expect(within(stageCard as HTMLElement).getByText(task.owner)).toBeInTheDocument();
+      }
+    }
+  });
+});

--- a/src/app/mission-planner/page.tsx
+++ b/src/app/mission-planner/page.tsx
@@ -1,31 +1,32 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
+import { ReadinessSummary } from "./_components/readiness-summary";
+import { ScenarioCard } from "./_components/scenario-card";
+import { StagedChecklist } from "./_components/staged-checklist";
+import {
+  missionPlannerSummary,
+  missionScenarios,
+  missionStages,
+  readinessSignals,
+} from "./_data/mission-planner-data";
+
 export const metadata: Metadata = {
   title: "Mission Planner",
   description:
-    "Initial route shell for mission scenarios, readiness highlights, and staged checklist planning.",
+    "Planning route for comparing mission scenarios, reviewing readiness highlights, and following a staged checklist.",
 };
 
-const shellSections = [
-  {
-    title: "Scenario cards",
-    description:
-      "Mission scenario summaries will appear here with priority, timing, and lead ownership context.",
-  },
-  {
-    title: "Readiness highlights",
-    description:
-      "Planner summaries will call out crew posture, equipment status, and launch window confidence.",
-  },
-  {
-    title: "Staged checklist",
-    description:
-      "The staged plan will break preparation into ordered milestones with clear completion states.",
-  },
-];
-
 export default function MissionPlannerPage() {
+  const activeStage =
+    missionStages.find((stage) => stage.status === "active") ?? missionStages[0];
+  const blockedSignals = readinessSignals.filter(
+    (signal) => signal.tone === "blocked",
+  ).length;
+  const watchSignals = readinessSignals.filter(
+    (signal) => signal.tone === "watch",
+  ).length;
+
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top_right,rgba(59,130,246,0.18),transparent_26%),radial-gradient(circle_at_bottom_left,rgba(245,158,11,0.22),transparent_28%),linear-gradient(180deg,#0f172a_0%,#111827_52%,#172033_100%)] px-6 py-12 text-slate-50 sm:px-10 lg:px-14">
       <div className="mx-auto flex max-w-6xl flex-col gap-8">
@@ -33,16 +34,29 @@ export default function MissionPlannerPage() {
           <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
             <div className="max-w-3xl space-y-4">
               <p className="text-sm font-semibold uppercase tracking-[0.3em] text-sky-200/78">
-                Mission Planner
+                {missionPlannerSummary.eyebrow}
               </p>
               <h1 className="text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
-                Planning shell for scenario routing, readiness calls, and staged execution.
+                {missionPlannerSummary.title}
               </h1>
               <p className="max-w-2xl text-base leading-7 text-slate-300 sm:text-lg">
-                This route establishes the standalone workspace for issue #92.
-                The next subtasks will add mock planning data, reusable
-                components, and tests without depending on any other page.
+                {missionPlannerSummary.description}
               </p>
+
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <a
+                  href="#mission-scenarios"
+                  className="inline-flex items-center justify-center rounded-full bg-sky-300 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-sky-200"
+                >
+                  Review scenarios
+                </a>
+                <a
+                  href="#mission-stage-checklist"
+                  className="inline-flex items-center justify-center rounded-full border border-white/14 bg-white/6 px-5 py-3 text-sm font-semibold text-slate-100 transition hover:border-amber-300/40 hover:bg-white/10"
+                >
+                  Open staged checklist
+                </a>
+              </div>
             </div>
 
             <Link
@@ -54,24 +68,133 @@ export default function MissionPlannerPage() {
           </div>
         </header>
 
-        <section className="grid gap-5 lg:grid-cols-3">
-          {shellSections.map((section) => (
-            <article
-              key={section.title}
-              className="rounded-[1.75rem] border border-white/10 bg-slate-950/40 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]"
-            >
-              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
-                Planned module
+        <section className="grid gap-6 xl:grid-cols-[minmax(0,1.18fr)_minmax(320px,0.82fr)]">
+          <div className="rounded-[1.9rem] border border-white/10 bg-slate-950/45 p-6 shadow-[0_28px_80px_rgba(2,6,23,0.28)]">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-300">
+                  Planning baseline
+                </p>
+                <h2 className="text-3xl font-semibold tracking-tight text-white">
+                  Live mission snapshot
+                </h2>
+              </div>
+              <p className="max-w-xl text-sm leading-6 text-slate-300">
+                The planner keeps scenario selection, launch posture, and
+                operational sequencing in one place so handoffs stay explicit.
               </p>
-              <h2 className="mt-3 text-2xl font-semibold text-white">
-                {section.title}
-              </h2>
-              <p className="mt-3 text-sm leading-6 text-slate-300">
-                {section.description}
-              </p>
-            </article>
-          ))}
+            </div>
+
+            <div className="mt-6 grid gap-4 md:grid-cols-3">
+              {missionPlannerSummary.stats.map((stat) => (
+                <article
+                  key={stat.label}
+                  className="rounded-[1.5rem] border border-white/8 bg-white/6 px-5 py-5"
+                >
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+                    {stat.label}
+                  </p>
+                  <p className="mt-3 text-3xl font-semibold tracking-tight text-white">
+                    {stat.value}
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-slate-300">
+                    {stat.detail}
+                  </p>
+                </article>
+              ))}
+            </div>
+          </div>
+
+          <aside className="rounded-[1.9rem] border border-white/10 bg-white/7 p-6 shadow-[0_28px_80px_rgba(2,6,23,0.28)] backdrop-blur">
+            <div className="space-y-5">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-300">
+                  Decision board
+                </p>
+                <h2 className="mt-3 text-3xl font-semibold tracking-tight text-white">
+                  Keep Stage 2 moving
+                </h2>
+              </div>
+
+              <div className="grid gap-3">
+                <div className="rounded-[1.5rem] border border-sky-300/18 bg-sky-300/10 px-4 py-4">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-sky-100/72">
+                    Active stage
+                  </p>
+                  <p className="mt-2 text-lg font-semibold text-white">
+                    {activeStage.name}
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-slate-200">
+                    {activeStage.focus}
+                  </p>
+                </div>
+                <div className="rounded-[1.5rem] border border-amber-300/18 bg-amber-300/10 px-4 py-4">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-amber-100/72">
+                    Watch items
+                  </p>
+                  <p className="mt-2 text-3xl font-semibold text-white">
+                    {watchSignals}
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-slate-200">
+                    Weather and relay timing still need active monitoring before
+                    the full launch window closes.
+                  </p>
+                </div>
+                <div className="rounded-[1.5rem] border border-rose-300/18 bg-rose-300/10 px-4 py-4">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-rose-100/72">
+                    Blockers
+                  </p>
+                  <p className="mt-2 text-3xl font-semibold text-white">
+                    {blockedSignals}
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-slate-200">
+                    Clear the inland relay certificate check to unlock every
+                    alternate route option.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </aside>
         </section>
+
+        <section
+          id="mission-scenarios"
+          className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)] xl:items-start"
+        >
+          <div className="space-y-5">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-300">
+                  Scenario cards
+                </p>
+                <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+                  Choose the path that best protects the launch window
+                </h2>
+              </div>
+              <p className="max-w-xl text-sm leading-6 text-slate-300">
+                Each card frames the launch plan around timing, ownership, and
+                checkpoints so the operator can compare routes quickly.
+              </p>
+            </div>
+
+            <div
+              aria-label="Mission scenarios"
+              className="grid gap-5"
+              role="list"
+            >
+              {missionScenarios.map((scenario) => (
+                <ScenarioCard key={scenario.id} scenario={scenario} />
+              ))}
+            </div>
+          </div>
+
+          <ReadinessSummary
+            signals={readinessSignals}
+            stats={missionPlannerSummary.stats}
+          />
+        </section>
+
+        <StagedChecklist stages={missionStages} />
       </div>
     </main>
   );

--- a/src/app/mission-planner/page.tsx
+++ b/src/app/mission-planner/page.tsx
@@ -1,0 +1,78 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Mission Planner",
+  description:
+    "Initial route shell for mission scenarios, readiness highlights, and staged checklist planning.",
+};
+
+const shellSections = [
+  {
+    title: "Scenario cards",
+    description:
+      "Mission scenario summaries will appear here with priority, timing, and lead ownership context.",
+  },
+  {
+    title: "Readiness highlights",
+    description:
+      "Planner summaries will call out crew posture, equipment status, and launch window confidence.",
+  },
+  {
+    title: "Staged checklist",
+    description:
+      "The staged plan will break preparation into ordered milestones with clear completion states.",
+  },
+];
+
+export default function MissionPlannerPage() {
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_right,rgba(59,130,246,0.18),transparent_26%),radial-gradient(circle_at_bottom_left,rgba(245,158,11,0.22),transparent_28%),linear-gradient(180deg,#0f172a_0%,#111827_52%,#172033_100%)] px-6 py-12 text-slate-50 sm:px-10 lg:px-14">
+      <div className="mx-auto flex max-w-6xl flex-col gap-8">
+        <header className="overflow-hidden rounded-[2rem] border border-white/10 bg-white/6 p-8 shadow-[0_32px_120px_rgba(2,6,23,0.45)] backdrop-blur sm:p-10">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+            <div className="max-w-3xl space-y-4">
+              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-sky-200/78">
+                Mission Planner
+              </p>
+              <h1 className="text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
+                Planning shell for scenario routing, readiness calls, and staged execution.
+              </h1>
+              <p className="max-w-2xl text-base leading-7 text-slate-300 sm:text-lg">
+                This route establishes the standalone workspace for issue #92.
+                The next subtasks will add mock planning data, reusable
+                components, and tests without depending on any other page.
+              </p>
+            </div>
+
+            <Link
+              href="/"
+              className="inline-flex items-center justify-center rounded-full border border-white/14 bg-white/8 px-5 py-3 text-sm font-semibold text-slate-100 transition hover:border-sky-300/40 hover:bg-white/12"
+            >
+              Back to route index
+            </Link>
+          </div>
+        </header>
+
+        <section className="grid gap-5 lg:grid-cols-3">
+          {shellSections.map((section) => (
+            <article
+              key={section.title}
+              className="rounded-[1.75rem] border border-white/10 bg-slate-950/40 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]"
+            >
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+                Planned module
+              </p>
+              <h2 className="mt-3 text-2xl font-semibold text-white">
+                {section.title}
+              </h2>
+              <p className="mt-3 text-sm leading-6 text-slate-300">
+                {section.description}
+              </p>
+            </article>
+          ))}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/mission-planner/page.tsx
+++ b/src/app/mission-planner/page.tsx
@@ -28,9 +28,21 @@ export default function MissionPlannerPage() {
   ).length;
 
   return (
-    <main className="min-h-screen bg-[radial-gradient(circle_at_top_right,rgba(59,130,246,0.18),transparent_26%),radial-gradient(circle_at_bottom_left,rgba(245,158,11,0.22),transparent_28%),linear-gradient(180deg,#0f172a_0%,#111827_52%,#172033_100%)] px-6 py-12 text-slate-50 sm:px-10 lg:px-14">
-      <div className="mx-auto flex max-w-6xl flex-col gap-8">
-        <header className="overflow-hidden rounded-[2rem] border border-white/10 bg-white/6 p-8 shadow-[0_32px_120px_rgba(2,6,23,0.45)] backdrop-blur sm:p-10">
+    <main className="relative min-h-screen overflow-hidden bg-[radial-gradient(circle_at_top_right,rgba(59,130,246,0.18),transparent_26%),radial-gradient(circle_at_bottom_left,rgba(245,158,11,0.22),transparent_28%),linear-gradient(180deg,#0f172a_0%,#111827_52%,#172033_100%)] px-6 py-12 text-slate-50 sm:px-10 lg:px-14">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 h-72 bg-[radial-gradient(circle_at_top,rgba(125,211,252,0.16),transparent_46%)]"
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute bottom-0 left-0 h-80 w-80 rounded-full bg-amber-300/10 blur-3xl"
+      />
+      <div className="relative mx-auto flex max-w-6xl flex-col gap-8">
+        <header className="relative overflow-hidden rounded-[2rem] border border-white/10 bg-[linear-gradient(135deg,rgba(255,255,255,0.08),rgba(15,23,42,0.12))] p-8 shadow-[0_32px_120px_rgba(2,6,23,0.45)] backdrop-blur sm:p-10">
+          <div
+            aria-hidden
+            className="absolute -right-12 top-8 h-36 w-36 rounded-full border border-sky-200/12 bg-sky-300/10 blur-2xl"
+          />
           <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
             <div className="max-w-3xl space-y-4">
               <p className="text-sm font-semibold uppercase tracking-[0.3em] text-sky-200/78">
@@ -69,7 +81,7 @@ export default function MissionPlannerPage() {
         </header>
 
         <section className="grid gap-6 xl:grid-cols-[minmax(0,1.18fr)_minmax(320px,0.82fr)]">
-          <div className="rounded-[1.9rem] border border-white/10 bg-slate-950/45 p-6 shadow-[0_28px_80px_rgba(2,6,23,0.28)]">
+          <div className="rounded-[1.9rem] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.68),rgba(9,15,28,0.9))] p-6 shadow-[0_28px_80px_rgba(2,6,23,0.28)]">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
               <div className="space-y-2">
                 <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-300">
@@ -89,7 +101,7 @@ export default function MissionPlannerPage() {
               {missionPlannerSummary.stats.map((stat) => (
                 <article
                   key={stat.label}
-                  className="rounded-[1.5rem] border border-white/8 bg-white/6 px-5 py-5"
+                  className="rounded-[1.5rem] border border-white/8 bg-[linear-gradient(180deg,rgba(255,255,255,0.08),rgba(15,23,42,0.22))] px-5 py-5"
                 >
                   <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
                     {stat.label}
@@ -105,7 +117,7 @@ export default function MissionPlannerPage() {
             </div>
           </div>
 
-          <aside className="rounded-[1.9rem] border border-white/10 bg-white/7 p-6 shadow-[0_28px_80px_rgba(2,6,23,0.28)] backdrop-blur">
+          <aside className="rounded-[1.9rem] border border-white/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.08),rgba(15,23,42,0.2))] p-6 shadow-[0_28px_80px_rgba(2,6,23,0.28)] backdrop-blur">
             <div className="space-y-5">
               <div>
                 <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-300">


### PR DESCRIPTION
## Summary
- add the initial `mission-planner` route shell
- establish the standalone page structure for scenario cards, readiness highlights, and staged checklist work
- open the PR early so the remaining issue subtasks can land incrementally

Closes #92