### PR TITLE
feat: build command log route

### DIFF
--- a/src/app/command-log/_components/command-event-detail.tsx
+++ b/src/app/command-log/_components/command-event-detail.tsx
@@ -1,0 +1,150 @@
+import type { CommandLogEvent } from "../_lib/command-log-data";
+
+type CommandEventDetailProps = {
+  event: CommandLogEvent;
+  requestedEventId?: string;
+  selectionFound: boolean;
+};
+
+export function CommandEventDetail({
+  event,
+  requestedEventId,
+  selectionFound,
+}: CommandEventDetailProps) {
+  return (
+    <aside className="xl:sticky xl:top-8 xl:self-start">
+      <section
+        aria-label="Event detail"
+        className="rounded-[2rem] border border-white/10 bg-slate-950 p-5 text-slate-100 shadow-[0_24px_90px_rgba(15,23,42,0.18)] sm:p-6"
+      >
+        <div className="space-y-5">
+          <div className="space-y-3">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-amber-200/80">
+              Detail panel
+            </p>
+            <div className="space-y-3">
+              <h2 className="text-3xl font-semibold tracking-tight text-white">
+                {event.title}
+              </h2>
+              <p className="text-base leading-7 text-slate-300">
+                {event.detail}
+              </p>
+            </div>
+          </div>
+
+          {!selectionFound && requestedEventId ? (
+            <p
+              role="status"
+              className="rounded-[1.25rem] border border-amber-300/40 bg-amber-300/10 px-4 py-3 text-sm leading-6 text-amber-100"
+            >
+              Event ID{" "}
+              <span className="font-semibold text-amber-50">
+                {requestedEventId}
+              </span>{" "}
+              was not found. Showing the latest command entry instead.
+            </p>
+          ) : null}
+
+          <div className="rounded-[1.5rem] border border-white/10 bg-white/6 p-4">
+            <div className="flex flex-wrap gap-2">
+              <span className="inline-flex rounded-full border border-rose-300/30 bg-rose-500/12 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-rose-100">
+                {event.severity}
+              </span>
+              <span className="inline-flex rounded-full border border-white/10 bg-white/8 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-slate-100">
+                {event.category}
+              </span>
+              <span className="inline-flex rounded-full border border-cyan-300/30 bg-cyan-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-100">
+                {event.status}
+              </span>
+            </div>
+
+            <dl className="mt-4 grid gap-3 sm:grid-cols-2">
+              <div className="rounded-[1rem] border border-white/10 bg-slate-900/80 p-4">
+                <dt className="text-xs uppercase tracking-[0.18em] text-slate-400">
+                  Timestamp
+                </dt>
+                <dd className="mt-2 text-sm font-medium text-white">
+                  {event.occurredLabel}
+                </dd>
+              </div>
+              <div className="rounded-[1rem] border border-white/10 bg-slate-900/80 p-4">
+                <dt className="text-xs uppercase tracking-[0.18em] text-slate-400">
+                  Team
+                </dt>
+                <dd className="mt-2 text-sm font-medium text-white">
+                  {event.team}
+                </dd>
+              </div>
+              <div className="rounded-[1rem] border border-white/10 bg-slate-900/80 p-4">
+                <dt className="text-xs uppercase tracking-[0.18em] text-slate-400">
+                  Actor
+                </dt>
+                <dd className="mt-2 text-sm font-medium text-white">
+                  {event.actor}
+                </dd>
+              </div>
+              <div className="rounded-[1rem] border border-white/10 bg-slate-900/80 p-4">
+                <dt className="text-xs uppercase tracking-[0.18em] text-slate-400">
+                  Environment
+                </dt>
+                <dd className="mt-2 text-sm font-medium text-white">
+                  {event.environment}
+                </dd>
+              </div>
+            </dl>
+          </div>
+
+          <section className="rounded-[1.5rem] border border-white/10 bg-white/6 p-4">
+            <h3 className="text-xl font-semibold text-white">Command context</h3>
+            <p className="mt-3 text-sm leading-6 text-slate-300">
+              {event.summary}
+            </p>
+            <div className="mt-4 rounded-[1rem] border border-white/10 bg-slate-900/80 p-4">
+              <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
+                Executed command
+              </p>
+              <code className="mt-3 block whitespace-pre-wrap text-sm leading-6 text-cyan-100">
+                {event.command}
+              </code>
+            </div>
+          </section>
+
+          <section className="rounded-[1.5rem] border border-white/10 bg-white/6 p-4">
+            <h3 className="text-xl font-semibold text-white">Related services</h3>
+            <div className="mt-4 flex flex-wrap gap-2">
+              {event.relatedServices.map((service) => (
+                <span
+                  key={`${event.id}-${service}`}
+                  className="inline-flex rounded-full border border-white/10 bg-slate-900/80 px-3 py-1 text-sm font-medium text-slate-100"
+                >
+                  {service}
+                </span>
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-[1.5rem] border border-white/10 bg-white/6 p-4">
+            <h3 className="text-xl font-semibold text-white">Operator notes</h3>
+            <ul className="mt-4 space-y-3">
+              {event.notes.map((note) => (
+                <li
+                  key={`${event.id}-${note}`}
+                  className="rounded-[1rem] border border-white/10 bg-slate-900/80 px-4 py-3 text-sm leading-6 text-slate-200"
+                >
+                  {note}
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="rounded-[1.5rem] border border-white/10 bg-white/6 p-4">
+            <h3 className="text-xl font-semibold text-white">Next action</h3>
+            <p className="mt-3 text-sm leading-6 text-slate-200">
+              {event.nextAction}
+            </p>
+          </section>
+        </div>
+      </section>
+    </aside>
+  );
+}

--- a/src/app/command-log/_components/command-event-list.tsx
+++ b/src/app/command-log/_components/command-event-list.tsx
@@ -1,0 +1,142 @@
+import Link from "next/link";
+
+import type {
+  CommandEventCategory,
+  CommandEventSeverity,
+  CommandLogEvent,
+} from "../_lib/command-log-data";
+
+const severityClasses: Record<CommandEventSeverity, string> = {
+  Critical: "border-rose-300/50 bg-rose-500/12 text-rose-100",
+  High: "border-amber-300/50 bg-amber-500/12 text-amber-100",
+  Moderate: "border-sky-300/50 bg-sky-500/12 text-sky-100",
+  Low: "border-emerald-300/50 bg-emerald-500/12 text-emerald-100",
+};
+
+const categoryClasses: Record<CommandEventCategory, string> = {
+  Deploy: "bg-white/10 text-white",
+  Mitigation: "bg-cyan-500/12 text-cyan-100",
+  Investigation: "bg-indigo-500/12 text-indigo-100",
+  Escalation: "bg-rose-500/12 text-rose-100",
+  Automation: "bg-emerald-500/12 text-emerald-100",
+  Handoff: "bg-amber-500/12 text-amber-100",
+};
+
+type CommandEventListProps = {
+  events: CommandLogEvent[];
+  selectedEventId: string;
+};
+
+export function CommandEventList({
+  events,
+  selectedEventId,
+}: CommandEventListProps) {
+  return (
+    <section
+      aria-labelledby="command-event-list-title"
+      className="rounded-[2rem] border border-white/10 bg-slate-950/88 p-5 shadow-[0_24px_90px_rgba(15,23,42,0.2)] sm:p-6"
+    >
+      <div className="space-y-3">
+        <p className="text-sm font-semibold uppercase tracking-[0.24em] text-cyan-200/75">
+          Chronological feed
+        </p>
+        <div className="space-y-2">
+          <h2
+            id="command-event-list-title"
+            className="text-3xl font-semibold tracking-tight text-white"
+          >
+            Review command activity in order
+          </h2>
+          <p className="max-w-2xl text-base leading-7 text-slate-300">
+            Each event links into the detail panel so the route stays focused on
+            a single selected command record at a time.
+          </p>
+        </div>
+      </div>
+
+      <ol aria-label="Chronological events" className="mt-6 space-y-4">
+        {events.map((event) => {
+          const isSelected = event.id === selectedEventId;
+
+          return (
+            <li key={event.id}>
+              <Link
+                aria-current={isSelected ? "page" : undefined}
+                aria-label={`${isSelected ? "Viewing detail for" : "View detail for"} ${event.title}`}
+                href={`/command-log?event=${event.id}`}
+                className={`block rounded-[1.6rem] border p-5 transition hover:-translate-y-0.5 hover:border-cyan-300/40 hover:bg-slate-900/90 ${
+                  isSelected
+                    ? "border-cyan-300/45 bg-slate-900 text-white shadow-[0_18px_60px_rgba(8,145,178,0.18)]"
+                    : "border-white/10 bg-slate-900/65 text-slate-100"
+                }`}
+              >
+                <article className="space-y-4">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div className="flex flex-wrap gap-2">
+                      <span
+                        className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] ${severityClasses[event.severity]}`}
+                      >
+                        {event.severity}
+                      </span>
+                      <span
+                        className={`inline-flex rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] ${categoryClasses[event.category]}`}
+                      >
+                        {event.category}
+                      </span>
+                      <span className="inline-flex rounded-full border border-white/10 bg-white/6 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-slate-200">
+                        {event.status}
+                      </span>
+                    </div>
+                    <time
+                      dateTime={event.occurredAt}
+                      className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400"
+                    >
+                      {event.occurredLabel}
+                    </time>
+                  </div>
+
+                  <div className="space-y-2">
+                    <h3 className="text-xl font-semibold tracking-tight text-white">
+                      {event.title}
+                    </h3>
+                    <p className="text-sm leading-6 text-slate-300">
+                      {event.summary}
+                    </p>
+                  </div>
+
+                  <div className="grid gap-3 text-sm text-slate-300 sm:grid-cols-2">
+                    <p>
+                      <span className="font-semibold text-white">Actor:</span>{" "}
+                      {event.actor}
+                    </p>
+                    <p>
+                      <span className="font-semibold text-white">Scope:</span>{" "}
+                      {event.environment}
+                    </p>
+                    <p className="sm:col-span-2">
+                      <span className="font-semibold text-white">Command:</span>{" "}
+                      <code className="rounded bg-white/8 px-2 py-1 text-[13px] text-cyan-100">
+                        {event.command}
+                      </code>
+                    </p>
+                  </div>
+
+                  <div className="flex flex-wrap gap-2">
+                    {event.tags.map((tag) => (
+                      <span
+                        key={`${event.id}-${tag}`}
+                        className="inline-flex rounded-full border border-white/10 bg-white/6 px-3 py-1 text-xs font-medium text-slate-200"
+                      >
+                        #{tag}
+                      </span>
+                    ))}
+                  </div>
+                </article>
+              </Link>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}

--- a/src/app/command-log/_components/command-log-shell.tsx
+++ b/src/app/command-log/_components/command-log-shell.tsx
@@ -1,0 +1,80 @@
+import { CommandEventDetail } from "./command-event-detail";
+import { CommandEventList } from "./command-event-list";
+import { CommandTagSummary } from "./command-tag-summary";
+import type { CommandLogView } from "../_lib/command-log";
+
+type CommandLogShellProps = {
+  view: CommandLogView;
+};
+
+export function CommandLogShell({ view }: CommandLogShellProps) {
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8 px-6 py-8 sm:px-10 lg:px-12">
+      <section className="overflow-hidden rounded-[2rem] border border-slate-200/80 bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.08)]">
+        <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1.15fr)_minmax(280px,0.85fr)] lg:px-12 lg:py-10">
+          <div className="space-y-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-amber-700">
+              Command log
+            </p>
+            <div className="space-y-3">
+              <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
+                Chronological command events, grouped signals, and one focused
+                detail panel.
+              </h1>
+              <p className="max-w-3xl text-lg leading-8 text-slate-600">
+                The route stays self-contained with route-local mock data:
+                newest-first event review, recurring tag summaries, and a
+                selection model driven by the query string instead of client
+                state.
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Shift snapshot
+            </p>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
+              {view.summaryMetrics.map((metric) => (
+                <div
+                  key={metric.label}
+                  className="rounded-[1.2rem] border border-slate-200 bg-white/80 p-4"
+                >
+                  <p className="text-xs uppercase tracking-[0.18em] text-slate-500">
+                    {metric.label}
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">
+                    {metric.value}
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-slate-600">
+                    {metric.note}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <CommandTagSummary
+        groups={view.tagSummary}
+        totalEvents={view.events.length}
+      />
+
+      <div
+        className="grid gap-8 xl:grid-cols-[minmax(0,1.1fr)_minmax(360px,0.9fr)]"
+        data-testid="command-log-panels"
+      >
+        <CommandEventList
+          events={view.events}
+          selectedEventId={view.selectedEvent.id}
+        />
+        <CommandEventDetail
+          event={view.selectedEvent}
+          requestedEventId={view.requestedEventId}
+          selectionFound={view.selectionFound}
+        />
+      </div>
+    </main>
+  );
+}

--- a/src/app/command-log/_components/command-tag-summary.tsx
+++ b/src/app/command-log/_components/command-tag-summary.tsx
@@ -1,15 +1,4 @@
-import type {
-  CommandEventCategory,
-  CommandEventSeverity,
-} from "../_lib/command-log-data";
-
-export type CommandTagSummaryItem = {
-  tag: string;
-  eventCount: number;
-  latestEventLabel: string;
-  severities: CommandEventSeverity[];
-  categories: CommandEventCategory[];
-};
+import type { CommandTagSummaryItem } from "../_lib/command-log";
 
 type CommandTagSummaryProps = {
   groups: CommandTagSummaryItem[];
@@ -66,8 +55,9 @@ export function CommandTagSummary({
             <div className="mt-4 space-y-3 text-sm text-slate-600">
               <p>
                 <span className="font-semibold text-slate-950">Latest event:</span>{" "}
-                {group.latestEventLabel}
+                {group.latestEventTitle}
               </p>
+              <p>{group.latestEventLabel}</p>
               <p>
                 <span className="font-semibold text-slate-950">Severity mix:</span>{" "}
                 {group.severities.join(", ")}

--- a/src/app/command-log/_components/command-tag-summary.tsx
+++ b/src/app/command-log/_components/command-tag-summary.tsx
@@ -1,0 +1,85 @@
+import type {
+  CommandEventCategory,
+  CommandEventSeverity,
+} from "../_lib/command-log-data";
+
+export type CommandTagSummaryItem = {
+  tag: string;
+  eventCount: number;
+  latestEventLabel: string;
+  severities: CommandEventSeverity[];
+  categories: CommandEventCategory[];
+};
+
+type CommandTagSummaryProps = {
+  groups: CommandTagSummaryItem[];
+  totalEvents: number;
+};
+
+export function CommandTagSummary({
+  groups,
+  totalEvents,
+}: CommandTagSummaryProps) {
+  return (
+    <section
+      aria-labelledby="command-tag-summary-title"
+      className="rounded-[2rem] border border-slate-200/70 bg-[var(--surface)] p-5 shadow-[0_18px_65px_rgba(15,23,42,0.08)] sm:p-6"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-2">
+          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
+            Tag grouping
+          </p>
+          <h2
+            id="command-tag-summary-title"
+            className="text-3xl font-semibold tracking-tight text-slate-950"
+          >
+            Repeated patterns across {totalEvents} events
+          </h2>
+        </div>
+        <p className="max-w-xl text-sm leading-6 text-slate-600">
+          Tags cluster operational themes so reviewers can spot recurring
+          rollout, mitigation, and escalation patterns quickly.
+        </p>
+      </div>
+
+      <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {groups.map((group) => (
+          <article
+            key={group.tag}
+            className="rounded-[1.5rem] border border-slate-200 bg-white/78 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">
+                  Tag
+                </p>
+                <h3 className="mt-2 text-xl font-semibold tracking-tight text-slate-950">
+                  #{group.tag}
+                </h3>
+              </div>
+              <span className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-slate-700">
+                {group.eventCount} events
+              </span>
+            </div>
+
+            <div className="mt-4 space-y-3 text-sm text-slate-600">
+              <p>
+                <span className="font-semibold text-slate-950">Latest event:</span>{" "}
+                {group.latestEventLabel}
+              </p>
+              <p>
+                <span className="font-semibold text-slate-950">Severity mix:</span>{" "}
+                {group.severities.join(", ")}
+              </p>
+              <p>
+                <span className="font-semibold text-slate-950">Categories:</span>{" "}
+                {group.categories.join(", ")}
+              </p>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/command-log/_lib/command-log-data.ts
+++ b/src/app/command-log/_lib/command-log-data.ts
@@ -1,0 +1,246 @@
+export type CommandEventSeverity = "Critical" | "High" | "Moderate" | "Low";
+
+export type CommandEventCategory =
+  | "Deploy"
+  | "Mitigation"
+  | "Investigation"
+  | "Escalation"
+  | "Automation"
+  | "Handoff";
+
+export type CommandEventStatus =
+  | "Completed"
+  | "Watching"
+  | "Needs follow-up"
+  | "Blocked";
+
+export type CommandLogEvent = {
+  id: string;
+  occurredAt: string;
+  occurredLabel: string;
+  title: string;
+  summary: string;
+  detail: string;
+  command: string;
+  actor: string;
+  team: string;
+  severity: CommandEventSeverity;
+  category: CommandEventCategory;
+  status: CommandEventStatus;
+  environment: string;
+  tags: string[];
+  relatedServices: string[];
+  notes: string[];
+  nextAction: string;
+};
+
+export const commandLogEvents: CommandLogEvent[] = [
+  {
+    id: "evt-0934",
+    occurredAt: "2026-04-20T09:34:00Z",
+    occurredLabel: "Apr 20, 2026 · 09:34 UTC",
+    title: "Rollback held after post-deploy queue drift",
+    summary:
+      "A scheduled rollback was paused when queue depth stabilized faster than expected after the latest worker deploy.",
+    detail:
+      "Command reviewed queue telemetry from the last two deploy steps and kept the worker rollout live after backlog growth flattened under the watch threshold.",
+    command: "hold rollback workflow-engine@2026.04.20.2",
+    actor: "Mara Chen",
+    team: "Command",
+    severity: "High",
+    category: "Mitigation",
+    status: "Watching",
+    environment: "Production / us-east-1",
+    tags: ["rollback-watch", "queue-depth", "worker-fleet"],
+    relatedServices: ["Workflow Engine", "Import API"],
+    notes: [
+      "Backlog growth fell from 14% to 3% over the final five-minute window.",
+      "Canary tenants stayed within the run-start SLA after the hold decision.",
+      "Rollback remains armed if queue age crosses the 12-minute threshold again.",
+    ],
+    nextAction:
+      "Re-evaluate rollback posture after the next autoscaling interval completes.",
+  },
+  {
+    id: "evt-0918",
+    occurredAt: "2026-04-20T09:18:00Z",
+    occurredLabel: "Apr 20, 2026 · 09:18 UTC",
+    title: "Escalation opened for certificate parity mismatch",
+    summary:
+      "A regional edge cluster failed parity checks during the morning cert validation sweep.",
+    detail:
+      "The identity edge team escalated after one cluster continued serving an older certificate bundle while adjacent regions had already rotated to the signed replacement chain.",
+    command: "open escalation identity-edge cert-rotation-apac",
+    actor: "Dana Brooks",
+    team: "Edge Operations",
+    severity: "Critical",
+    category: "Escalation",
+    status: "Needs follow-up",
+    environment: "Production / ap-southeast-1",
+    tags: ["cert-rotation", "identity-edge", "regional-drift"],
+    relatedServices: ["Identity Edge", "Session Broker"],
+    notes: [
+      "Parity mismatch affected one of six APAC clusters.",
+      "Forced re-login rate remained below the incident trigger threshold.",
+      "Manual verification was requested before automated re-propagation proceeds.",
+    ],
+    nextAction:
+      "Confirm signed bundle lineage and release the replacement package to the affected edge cluster.",
+  },
+  {
+    id: "evt-0852",
+    occurredAt: "2026-04-20T08:52:00Z",
+    occurredLabel: "Apr 20, 2026 · 08:52 UTC",
+    title: "Automation replay drained delayed export jobs",
+    summary:
+      "The export replay run completed and cleared the overnight queue without requiring manual tenant intervention.",
+    detail:
+      "An automated replay worker re-issued pending export jobs in controlled batches and confirmed successful delivery for the delayed EU workspace set.",
+    command: "run replay exports --batch-size 40 --region eu-west",
+    actor: "Inez Alvarez",
+    team: "Automation",
+    severity: "Moderate",
+    category: "Automation",
+    status: "Completed",
+    environment: "Production / eu-west-1",
+    tags: ["export-replay", "automation", "batch-recovery"],
+    relatedServices: ["Data Exporter", "Blob Archive"],
+    notes: [
+      "312 export jobs were replayed across eight batches.",
+      "No data integrity mismatches were detected during checksum comparison.",
+      "Support macros were updated to close affected customer threads.",
+    ],
+    nextAction:
+      "Remove the temporary replay throttle once the next scheduled export window passes cleanly.",
+  },
+  {
+    id: "evt-0827",
+    occurredAt: "2026-04-20T08:27:00Z",
+    occurredLabel: "Apr 20, 2026 · 08:27 UTC",
+    title: "Deploy approved for queue balancer patch",
+    summary:
+      "Command approved a patch deployment after the queue balancer fix passed soak checks on the staging lane.",
+    detail:
+      "The patch modifies partition rebalance heuristics so bursty imports cannot monopolize the hottest worker lane during morning ingest spikes.",
+    command: "deploy workflow-engine --release queue-balancer-r12",
+    actor: "Luis Ortega",
+    team: "Runtime Engineering",
+    severity: "High",
+    category: "Deploy",
+    status: "Completed",
+    environment: "Staging -> Production",
+    tags: ["deploy-window", "queue-balancer", "staging-soak"],
+    relatedServices: ["Workflow Engine", "Worker Fleet"],
+    notes: [
+      "Soak checks covered synthetic import traffic and live replay samples.",
+      "Memory headroom improved by 11% during the staging verification pass.",
+      "The patch is pinned behind the morning command review window for all regions.",
+    ],
+    nextAction:
+      "Monitor queue age and worker utilization through the first production burst cycle.",
+  },
+  {
+    id: "evt-0759",
+    occurredAt: "2026-04-20T07:59:00Z",
+    occurredLabel: "Apr 20, 2026 · 07:59 UTC",
+    title: "Investigation linked cold-start latency to cache miss fanout",
+    summary:
+      "Operators isolated a cold-start regression to a fanout path in the config cache warmup routine.",
+    detail:
+      "The investigation compared traces across three regions and found that warmup requests multiplied against a stale config shard, increasing startup latency for background workers.",
+    command: "inspect traces cache-warmup --compare us-east eu-west ap-southeast",
+    actor: "Priya Shah",
+    team: "Platform Reliability",
+    severity: "Moderate",
+    category: "Investigation",
+    status: "Watching",
+    environment: "Production / multi-region",
+    tags: ["cold-start", "cache-fanout", "trace-compare"],
+    relatedServices: ["Config Cache", "Worker Runtime"],
+    notes: [
+      "Latency impact was measurable only during worker cold starts.",
+      "No customer error spike accompanied the warmup regression.",
+      "A cache key compaction patch is under review to reduce fanout pressure.",
+    ],
+    nextAction:
+      "Validate the candidate cache-key fix against replay traces before the noon deploy window.",
+  },
+  {
+    id: "evt-0724",
+    occurredAt: "2026-04-20T07:24:00Z",
+    occurredLabel: "Apr 20, 2026 · 07:24 UTC",
+    title: "Handoff transferred APAC search lag watch to day shift",
+    summary:
+      "Night command handed the remaining APAC indexing lag watch to the incoming regional team.",
+    detail:
+      "The handoff captured queue age, shard rebalance posture, and the exact trigger for reopening mitigation if freshness drift resumes during regional traffic growth.",
+    command: "handoff search-pipeline apac-lag-watch --to day-shift",
+    actor: "Jonas Weber",
+    team: "Regional Operations",
+    severity: "Low",
+    category: "Handoff",
+    status: "Watching",
+    environment: "Production / apac",
+    tags: ["shift-handoff", "search-freshness", "regional-watch"],
+    relatedServices: ["Search Pipeline", "Indexer Fleet"],
+    notes: [
+      "Freshness lag recovered to 6 minutes before shift transfer.",
+      "A low-priority rebalance remains paused pending the day-shift review.",
+      "The handoff packet includes the exact shard IDs affected overnight.",
+    ],
+    nextAction:
+      "Resume the paused rebalance only if freshness remains under the eight-minute watch threshold.",
+  },
+  {
+    id: "evt-0651",
+    occurredAt: "2026-04-20T06:51:00Z",
+    occurredLabel: "Apr 20, 2026 · 06:51 UTC",
+    title: "Automation blocked on missing storage policy approval",
+    summary:
+      "A storage policy sync job was halted because the required compliance approval token was missing from the run context.",
+    detail:
+      "The automation flow correctly stopped before applying a lifecycle policy update to archival buckets, preventing unreviewed retention changes from moving forward.",
+    command: "sync storage-policy archive-retention-2026-q2",
+    actor: "Milo Novak",
+    team: "Data Platform",
+    severity: "High",
+    category: "Automation",
+    status: "Blocked",
+    environment: "Compliance staging",
+    tags: ["approval-token", "storage-policy", "automation-block"],
+    relatedServices: ["Blob Archive", "Policy Control"],
+    notes: [
+      "The blocked run exited before mutating any storage configuration.",
+      "Compliance approval metadata was present in the ticket but absent from the execution context.",
+      "Retry is safe once the approval token is attached to the job envelope.",
+    ],
+    nextAction:
+      "Inject the signed approval token into the queued sync job and re-run the policy check.",
+  },
+  {
+    id: "evt-0612",
+    occurredAt: "2026-04-20T06:12:00Z",
+    occurredLabel: "Apr 20, 2026 · 06:12 UTC",
+    title: "Mitigation started for elevated checkout retry pressure",
+    summary:
+      "Command capped retry concurrency after checkout write pressure crossed the early mitigation threshold.",
+    detail:
+      "Payments operators reduced duplicate retry traffic against the authorization pool and staged a narrower merchant allowlist while deeper analysis continued.",
+    command: "apply retry-cap payments-core --limit 2x --scope merchant-burst",
+    actor: "Nadia Reyes",
+    team: "Payments Operations",
+    severity: "Critical",
+    category: "Mitigation",
+    status: "Completed",
+    environment: "Production / global",
+    tags: ["retry-cap", "payments-core", "merchant-burst"],
+    relatedServices: ["Payments Core", "Authorization Pool"],
+    notes: [
+      "Early mitigation reduced duplicate writes within three minutes.",
+      "Two high-volume merchants remained on a narrowed allowlist during the cap.",
+      "Authorization success improved before the first external advisory went out.",
+    ],
+    nextAction:
+      "Compare post-cap latency against the previous incident baseline and decide whether to keep the cap through peak hours.",
+  },
+];

--- a/src/app/command-log/_lib/command-log-data.ts
+++ b/src/app/command-log/_lib/command-log-data.ts
@@ -51,7 +51,7 @@ export const commandLogEvents: CommandLogEvent[] = [
     category: "Mitigation",
     status: "Watching",
     environment: "Production / us-east-1",
-    tags: ["rollback-watch", "queue-depth", "worker-fleet"],
+    tags: ["rollback-watch", "queue-depth", "deploy-window"],
     relatedServices: ["Workflow Engine", "Import API"],
     notes: [
       "Backlog growth fell from 14% to 3% over the final five-minute window.",
@@ -77,7 +77,7 @@ export const commandLogEvents: CommandLogEvent[] = [
     category: "Escalation",
     status: "Needs follow-up",
     environment: "Production / ap-southeast-1",
-    tags: ["cert-rotation", "identity-edge", "regional-drift"],
+    tags: ["regional-drift", "identity-edge", "follow-up"],
     relatedServices: ["Identity Edge", "Session Broker"],
     notes: [
       "Parity mismatch affected one of six APAC clusters.",
@@ -103,7 +103,7 @@ export const commandLogEvents: CommandLogEvent[] = [
     category: "Automation",
     status: "Completed",
     environment: "Production / eu-west-1",
-    tags: ["export-replay", "automation", "batch-recovery"],
+    tags: ["automation", "export-recovery", "follow-up"],
     relatedServices: ["Data Exporter", "Blob Archive"],
     notes: [
       "312 export jobs were replayed across eight batches.",
@@ -129,7 +129,7 @@ export const commandLogEvents: CommandLogEvent[] = [
     category: "Deploy",
     status: "Completed",
     environment: "Staging -> Production",
-    tags: ["deploy-window", "queue-balancer", "staging-soak"],
+    tags: ["deploy-window", "queue-depth", "worker-fleet"],
     relatedServices: ["Workflow Engine", "Worker Fleet"],
     notes: [
       "Soak checks covered synthetic import traffic and live replay samples.",
@@ -155,7 +155,7 @@ export const commandLogEvents: CommandLogEvent[] = [
     category: "Investigation",
     status: "Watching",
     environment: "Production / multi-region",
-    tags: ["cold-start", "cache-fanout", "trace-compare"],
+    tags: ["cache-fanout", "multi-region", "follow-up"],
     relatedServices: ["Config Cache", "Worker Runtime"],
     notes: [
       "Latency impact was measurable only during worker cold starts.",
@@ -181,7 +181,7 @@ export const commandLogEvents: CommandLogEvent[] = [
     category: "Handoff",
     status: "Watching",
     environment: "Production / apac",
-    tags: ["shift-handoff", "search-freshness", "regional-watch"],
+    tags: ["shift-handoff", "regional-drift", "follow-up"],
     relatedServices: ["Search Pipeline", "Indexer Fleet"],
     notes: [
       "Freshness lag recovered to 6 minutes before shift transfer.",
@@ -207,7 +207,7 @@ export const commandLogEvents: CommandLogEvent[] = [
     category: "Automation",
     status: "Blocked",
     environment: "Compliance staging",
-    tags: ["approval-token", "storage-policy", "automation-block"],
+    tags: ["automation", "approval-block", "storage-policy"],
     relatedServices: ["Blob Archive", "Policy Control"],
     notes: [
       "The blocked run exited before mutating any storage configuration.",
@@ -233,7 +233,7 @@ export const commandLogEvents: CommandLogEvent[] = [
     category: "Mitigation",
     status: "Completed",
     environment: "Production / global",
-    tags: ["retry-cap", "payments-core", "merchant-burst"],
+    tags: ["queue-depth", "merchant-burst", "mitigation-watch"],
     relatedServices: ["Payments Core", "Authorization Pool"],
     notes: [
       "Early mitigation reduced duplicate writes within three minutes.",

--- a/src/app/command-log/_lib/command-log.ts
+++ b/src/app/command-log/_lib/command-log.ts
@@ -1,0 +1,149 @@
+import { commandLogEvents, type CommandLogEvent } from "./command-log-data";
+
+export type CommandTagSummaryItem = {
+  tag: string;
+  eventCount: number;
+  latestEventLabel: string;
+  latestEventTitle: string;
+  severities: string[];
+  categories: string[];
+};
+
+export type CommandLogSummaryMetric = {
+  label: string;
+  value: string;
+  note: string;
+};
+
+export type CommandLogView = {
+  events: CommandLogEvent[];
+  selectedEvent: CommandLogEvent;
+  requestedEventId?: string;
+  selectionFound: boolean;
+  tagSummary: CommandTagSummaryItem[];
+  summaryMetrics: CommandLogSummaryMetric[];
+};
+
+const numberFormatter = new Intl.NumberFormat("en-US");
+
+function normalizeEventId(eventId?: string) {
+  return eventId?.trim().toLowerCase();
+}
+
+function sortChronologically(events: CommandLogEvent[]) {
+  return [...events].sort(
+    (left, right) =>
+      new Date(right.occurredAt).getTime() - new Date(left.occurredAt).getTime(),
+  );
+}
+
+function buildTagSummary(events: CommandLogEvent[]): CommandTagSummaryItem[] {
+  const groups = new Map<
+    string,
+    {
+      tag: string;
+      eventCount: number;
+      latestEventLabel: string;
+      latestEventTitle: string;
+      severities: Set<string>;
+      categories: Set<string>;
+    }
+  >();
+
+  for (const event of events) {
+    for (const tag of event.tags) {
+      const existing = groups.get(tag);
+
+      if (!existing) {
+        groups.set(tag, {
+          tag,
+          eventCount: 1,
+          latestEventLabel: event.occurredLabel,
+          latestEventTitle: event.title,
+          severities: new Set([event.severity]),
+          categories: new Set([event.category]),
+        });
+        continue;
+      }
+
+      existing.eventCount += 1;
+      existing.severities.add(event.severity);
+      existing.categories.add(event.category);
+    }
+  }
+
+  return [...groups.values()]
+    .filter((group) => group.eventCount > 1)
+    .sort((left, right) => {
+      if (right.eventCount !== left.eventCount) {
+        return right.eventCount - left.eventCount;
+      }
+
+      return left.tag.localeCompare(right.tag);
+    })
+    .map((group) => ({
+      tag: group.tag,
+      eventCount: group.eventCount,
+      latestEventLabel: group.latestEventLabel,
+      latestEventTitle: group.latestEventTitle,
+      severities: [...group.severities],
+      categories: [...group.categories],
+    }));
+}
+
+function buildSummaryMetrics(events: CommandLogEvent[]): CommandLogSummaryMetric[] {
+  const teamsEngaged = new Set(events.map((event) => event.team)).size;
+  const highAttentionCount = events.filter(
+    (event) => event.severity === "Critical" || event.severity === "High",
+  ).length;
+  const recurringTags = buildTagSummary(events).length;
+
+  return [
+    {
+      label: "Logged events",
+      value: numberFormatter.format(events.length),
+      note: "Most recent entries stay selected by default.",
+    },
+    {
+      label: "High-attention items",
+      value: numberFormatter.format(highAttentionCount),
+      note: "Critical and high-severity actions across the shift.",
+    },
+    {
+      label: "Teams engaged",
+      value: numberFormatter.format(teamsEngaged),
+      note: "Distinct groups contributing notes or commands.",
+    },
+    {
+      label: "Recurring tags",
+      value: numberFormatter.format(recurringTags),
+      note: "Cross-event groupings surfaced in the summary band.",
+    },
+  ];
+}
+
+export function readRequestedEventId(value: string | string[] | undefined) {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
+}
+
+export function resolveCommandLogView(eventId?: string): CommandLogView {
+  const requestedEventId = normalizeEventId(eventId);
+  const events = sortChronologically(commandLogEvents);
+  const selectedEvent =
+    events.find((event) => event.id === requestedEventId) ?? events[0];
+
+  return {
+    events,
+    selectedEvent,
+    requestedEventId,
+    selectionFound: requestedEventId
+      ? events.some((event) => event.id === requestedEventId)
+      : true,
+    tagSummary: buildTagSummary(events),
+    summaryMetrics: buildSummaryMetrics(events),
+  };
+}

--- a/src/app/command-log/page.tsx
+++ b/src/app/command-log/page.tsx
@@ -1,0 +1,66 @@
+import type { Metadata } from "next";
+
+const shellSections = [
+  {
+    title: "Chronological event feed",
+    description:
+      "The main column will render command activity in timestamp order so operators can review the latest changes first.",
+  },
+  {
+    title: "Tag-based grouping",
+    description:
+      "Event tags will surface repeatable patterns such as deploys, escalations, and handoffs without depending on any shared data source.",
+  },
+  {
+    title: "Selected event detail",
+    description:
+      "A dedicated detail panel will expand the current event with owners, notes, and follow-up context on the same route.",
+  },
+];
+
+export const metadata: Metadata = {
+  title: "Command Log",
+  description:
+    "Route shell for reviewing chronological command events, tag groupings, and event detail.",
+};
+
+export default function CommandLogPage() {
+  return (
+    <main className="min-h-screen bg-slate-950 px-6 py-12 text-slate-50 sm:px-10 lg:px-14">
+      <div className="mx-auto flex max-w-6xl flex-col gap-10">
+        <header className="rounded-[2rem] border border-white/10 bg-white/5 p-8 shadow-2xl shadow-black/20 backdrop-blur">
+          <p className="text-sm font-medium uppercase tracking-[0.28em] text-cyan-300">
+            Event Review Surface
+          </p>
+          <h1 className="mt-4 text-4xl font-semibold tracking-tight sm:text-5xl">
+            Command Log
+          </h1>
+          <p className="mt-4 max-w-3xl text-base leading-7 text-slate-300 sm:text-lg">
+            This first scaffold establishes the dedicated route for issue #106.
+            The next subtasks will attach mock command events, tag-group
+            summaries, and a focused event detail panel inside this layout.
+          </p>
+        </header>
+
+        <section className="grid gap-4 lg:grid-cols-3">
+          {shellSections.map((section) => (
+            <article
+              key={section.title}
+              className="rounded-[1.75rem] border border-white/10 bg-slate-900/80 p-6"
+            >
+              <p className="text-xs font-medium uppercase tracking-[0.24em] text-slate-400">
+                Planned section
+              </p>
+              <h2 className="mt-3 text-2xl font-semibold text-white">
+                {section.title}
+              </h2>
+              <p className="mt-3 text-sm leading-6 text-slate-300">
+                {section.description}
+              </p>
+            </article>
+          ))}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/command-log/page.tsx
+++ b/src/app/command-log/page.tsx
@@ -1,66 +1,28 @@
 import type { Metadata } from "next";
 
-const shellSections = [
-  {
-    title: "Chronological event feed",
-    description:
-      "The main column will render command activity in timestamp order so operators can review the latest changes first.",
-  },
-  {
-    title: "Tag-based grouping",
-    description:
-      "Event tags will surface repeatable patterns such as deploys, escalations, and handoffs without depending on any shared data source.",
-  },
-  {
-    title: "Selected event detail",
-    description:
-      "A dedicated detail panel will expand the current event with owners, notes, and follow-up context on the same route.",
-  },
-];
+import { CommandLogShell } from "./_components/command-log-shell";
+import {
+  readRequestedEventId,
+  resolveCommandLogView,
+} from "./_lib/command-log";
+
+type CommandLogPageProps = {
+  searchParams: Promise<{
+    event?: string | string[] | undefined;
+  }>;
+};
 
 export const metadata: Metadata = {
   title: "Command Log",
   description:
-    "Route shell for reviewing chronological command events, tag groupings, and event detail.",
+    "Review chronological command events, recurring tags, and focused event detail on a dedicated route.",
 };
 
-export default function CommandLogPage() {
-  return (
-    <main className="min-h-screen bg-slate-950 px-6 py-12 text-slate-50 sm:px-10 lg:px-14">
-      <div className="mx-auto flex max-w-6xl flex-col gap-10">
-        <header className="rounded-[2rem] border border-white/10 bg-white/5 p-8 shadow-2xl shadow-black/20 backdrop-blur">
-          <p className="text-sm font-medium uppercase tracking-[0.28em] text-cyan-300">
-            Event Review Surface
-          </p>
-          <h1 className="mt-4 text-4xl font-semibold tracking-tight sm:text-5xl">
-            Command Log
-          </h1>
-          <p className="mt-4 max-w-3xl text-base leading-7 text-slate-300 sm:text-lg">
-            This first scaffold establishes the dedicated route for issue #106.
-            The next subtasks will attach mock command events, tag-group
-            summaries, and a focused event detail panel inside this layout.
-          </p>
-        </header>
+export default async function CommandLogPage({
+  searchParams,
+}: CommandLogPageProps) {
+  const requestedEventId = readRequestedEventId((await searchParams).event);
+  const view = resolveCommandLogView(requestedEventId);
 
-        <section className="grid gap-4 lg:grid-cols-3">
-          {shellSections.map((section) => (
-            <article
-              key={section.title}
-              className="rounded-[1.75rem] border border-white/10 bg-slate-900/80 p-6"
-            >
-              <p className="text-xs font-medium uppercase tracking-[0.24em] text-slate-400">
-                Planned section
-              </p>
-              <h2 className="mt-3 text-2xl font-semibold text-white">
-                {section.title}
-              </h2>
-              <p className="mt-3 text-sm leading-6 text-slate-300">
-                {section.description}
-              </p>
-            </article>
-          ))}
-        </section>
-      </div>
-    </main>
-  );
+  return <CommandLogShell view={view} />;
 }


### PR DESCRIPTION
## Summary
- scaffold the dedicated `command-log` route for issue #106
- establish placeholders for the chronological feed, tag grouping, and detail panel
- keep follow-up data, components, styling, and tests for subsequent commits on this PR

## Testing
- not run (scaffold-only subtask)

Closes #106