### PR TITLE
feat: add queue board workflow route

### DIFF
--- a/src/app/queue-board/_components/queue-column.tsx
+++ b/src/app/queue-board/_components/queue-column.tsx
@@ -1,4 +1,5 @@
 import type { QueueBoardColumn } from "../_data/queue-board-data";
+import styles from "../queue-board.module.css";
 import { QueueItemCard } from "./queue-item-card";
 
 export function QueueColumn({ column }: { column: QueueBoardColumn }) {
@@ -7,7 +8,7 @@ export function QueueColumn({ column }: { column: QueueBoardColumn }) {
   return (
     <section
       aria-labelledby={headingId}
-      className="flex min-h-full flex-col rounded-[1.75rem] border border-slate-200 bg-slate-50/80 p-4 shadow-[0_22px_50px_rgba(15,23,42,0.06)] sm:p-5"
+      className={`flex min-h-full flex-col rounded-[1.75rem] border border-slate-200 p-4 shadow-[0_22px_50px_rgba(15,23,42,0.06)] sm:p-5 ${styles.columnShell}`}
       data-column={column.id}
     >
       <div className="space-y-4 border-b border-slate-200 pb-4">

--- a/src/app/queue-board/_components/queue-column.tsx
+++ b/src/app/queue-board/_components/queue-column.tsx
@@ -1,0 +1,66 @@
+import type { QueueBoardColumn } from "../_data/queue-board-data";
+import { QueueItemCard } from "./queue-item-card";
+
+export function QueueColumn({ column }: { column: QueueBoardColumn }) {
+  const headingId = `${column.id}-heading`;
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      className="flex min-h-full flex-col rounded-[1.75rem] border border-slate-200 bg-slate-50/80 p-4 shadow-[0_22px_50px_rgba(15,23,42,0.06)] sm:p-5"
+      data-column={column.id}
+    >
+      <div className="space-y-4 border-b border-slate-200 pb-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-2">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Workflow stage
+            </p>
+            <h2 id={headingId} className="text-2xl font-semibold tracking-tight text-slate-950">
+              {column.title}
+            </h2>
+          </div>
+          <div className="rounded-2xl bg-white px-4 py-3 text-right shadow-[inset_0_0_0_1px_rgba(148,163,184,0.16)]">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+              Items
+            </p>
+            <p className="mt-1 text-3xl font-semibold tracking-tight text-slate-950">
+              {column.count}
+            </p>
+          </div>
+        </div>
+
+        <p className="text-sm leading-6 text-slate-600">{column.description}</p>
+
+        <dl className="grid gap-3 text-sm text-slate-700 sm:grid-cols-3">
+          <div className="rounded-2xl bg-white px-3 py-3 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.14)]">
+            <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+              WIP limit
+            </dt>
+            <dd className="mt-2 font-medium text-slate-950">{column.wipLimit}</dd>
+          </div>
+          <div className="rounded-2xl bg-white px-3 py-3 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.14)]">
+            <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+              Escalated
+            </dt>
+            <dd className="mt-2 font-medium text-slate-950">{column.escalatedCount}</dd>
+          </div>
+          <div className="rounded-2xl bg-white px-3 py-3 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.14)]">
+            <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+              Blocked
+            </dt>
+            <dd className="mt-2 font-medium text-slate-950">{column.blockedCount}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <ul aria-label={`${column.title} items`} className="mt-4 space-y-4">
+        {column.items.map((item) => (
+          <li key={item.id}>
+            <QueueItemCard item={item} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/app/queue-board/_components/queue-item-card.tsx
+++ b/src/app/queue-board/_components/queue-item-card.tsx
@@ -1,4 +1,9 @@
 import type { QueueBoardColumn } from "../_data/queue-board-data";
+import {
+  queueEscalationLabels,
+  queueStatusLabels,
+} from "../_data/queue-board-data";
+import styles from "../queue-board.module.css";
 
 type QueueBoardCardItem = QueueBoardColumn["items"][number];
 
@@ -6,7 +11,7 @@ export function QueueItemCard({ item }: { item: QueueBoardCardItem }) {
   return (
     <article
       aria-labelledby={`${item.id}-title`}
-      className="rounded-[1.35rem] border border-slate-200 bg-white p-4 shadow-[0_16px_30px_rgba(15,23,42,0.05)]"
+      className={`rounded-[1.35rem] border border-slate-200 bg-white p-4 shadow-[0_16px_30px_rgba(15,23,42,0.05)] ${styles.queueCard}`}
       data-blocked={item.blocked}
       data-escalation={item.escalation}
     >
@@ -19,6 +24,27 @@ export function QueueItemCard({ item }: { item: QueueBoardCardItem }) {
             <span className="rounded-full border border-slate-200 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
               {item.workflow}
             </span>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className={`${styles.pill} ${styles.statusPill}`}>
+              {queueStatusLabels[item.status]}
+            </span>
+            <span
+              className={`${styles.pill} ${
+                item.escalation === "steady"
+                  ? styles.escalationSteady
+                  : item.escalation === "watch"
+                    ? styles.escalationWatch
+                    : item.escalation === "priority"
+                      ? styles.escalationPriority
+                      : styles.escalationSlaRisk
+              }`}
+            >
+              {queueEscalationLabels[item.escalation]}
+            </span>
+            {item.blocked ? (
+              <span className={`${styles.pill} ${styles.blockedPill}`}>Blocked</span>
+            ) : null}
           </div>
           <div className="space-y-1">
             <h3
@@ -90,7 +116,7 @@ export function QueueItemCard({ item }: { item: QueueBoardCardItem }) {
         {item.tags.map((tag) => (
           <li
             key={tag}
-            className="rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-slate-600"
+            className={`rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-slate-600 ${styles.tag}`}
           >
             {tag}
           </li>

--- a/src/app/queue-board/_components/queue-item-card.tsx
+++ b/src/app/queue-board/_components/queue-item-card.tsx
@@ -1,0 +1,101 @@
+import type { QueueBoardColumn } from "../_data/queue-board-data";
+
+type QueueBoardCardItem = QueueBoardColumn["items"][number];
+
+export function QueueItemCard({ item }: { item: QueueBoardCardItem }) {
+  return (
+    <article
+      aria-labelledby={`${item.id}-title`}
+      className="rounded-[1.35rem] border border-slate-200 bg-white p-4 shadow-[0_16px_30px_rgba(15,23,42,0.05)]"
+      data-blocked={item.blocked}
+      data-escalation={item.escalation}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-700">
+              {item.id}
+            </span>
+            <span className="rounded-full border border-slate-200 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+              {item.workflow}
+            </span>
+          </div>
+          <div className="space-y-1">
+            <h3
+              id={`${item.id}-title`}
+              className="text-lg font-semibold tracking-tight text-slate-950"
+            >
+              {item.title}
+            </h3>
+            <p className="text-sm text-slate-600">{item.account}</p>
+          </div>
+        </div>
+
+        <div className="text-right">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Age
+          </p>
+          <p className="mt-1 text-2xl font-semibold tracking-tight text-slate-950">
+            {item.ageHours}h
+          </p>
+        </div>
+      </div>
+
+      <dl className="mt-4 grid gap-3 text-sm text-slate-700 sm:grid-cols-2">
+        <div className="rounded-2xl bg-slate-50 px-3 py-3">
+          <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Owner
+          </dt>
+          <dd className="mt-2">
+            <span className="font-medium text-slate-950">{item.owner.name}</span>
+            <span className="block text-slate-500">{item.owner.team}</span>
+          </dd>
+        </div>
+        <div className="rounded-2xl bg-slate-50 px-3 py-3">
+          <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            SLA window
+          </dt>
+          <dd className="mt-2 font-medium text-slate-900">{item.slaWindow}</dd>
+        </div>
+      </dl>
+
+      <div className="mt-4 space-y-3 rounded-[1.15rem] border border-dashed border-slate-200 px-3 py-3">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Next checkpoint
+          </p>
+          <p className="mt-2 text-sm leading-6 text-slate-700">{item.checkpoint}</p>
+        </div>
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Escalation context
+          </p>
+          <p className="mt-2 text-sm leading-6 text-slate-700">
+            {item.escalationReason}
+          </p>
+        </div>
+        {item.blocker ? (
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+              Blocker
+            </p>
+            <p className="mt-2 text-sm leading-6 text-slate-700">{item.blocker}</p>
+          </div>
+        ) : null}
+      </div>
+
+      <p className="mt-4 text-sm leading-6 text-slate-600">{item.notes}</p>
+
+      <ul aria-label={`${item.id} tags`} className="mt-4 flex flex-wrap gap-2">
+        {item.tags.map((tag) => (
+          <li
+            key={tag}
+            className="rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-slate-600"
+          >
+            {tag}
+          </li>
+        ))}
+      </ul>
+    </article>
+  );
+}

--- a/src/app/queue-board/_components/queue-metric-card.tsx
+++ b/src/app/queue-board/_components/queue-metric-card.tsx
@@ -1,4 +1,5 @@
 import type { QueueBoardMetric } from "../_data/queue-board-data";
+import styles from "../queue-board.module.css";
 
 const metricToneClasses = {
   neutral: "border-slate-200 bg-white text-slate-950",
@@ -10,7 +11,7 @@ export function QueueMetricCard({ metric }: { metric: QueueBoardMetric }) {
   return (
     <article
       role="listitem"
-      className={`flex h-full flex-col gap-4 rounded-[1.5rem] border p-5 shadow-[0_18px_40px_rgba(15,23,42,0.06)] ${metricToneClasses[metric.tone]}`}
+      className={`flex h-full flex-col gap-4 rounded-[1.5rem] border p-5 shadow-[0_18px_40px_rgba(15,23,42,0.06)] ${styles.metricCard} ${metricToneClasses[metric.tone]}`}
     >
       <div className="space-y-2">
         <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-current/65">

--- a/src/app/queue-board/_components/queue-metric-card.tsx
+++ b/src/app/queue-board/_components/queue-metric-card.tsx
@@ -1,0 +1,25 @@
+import type { QueueBoardMetric } from "../_data/queue-board-data";
+
+const metricToneClasses = {
+  neutral: "border-slate-200 bg-white text-slate-950",
+  alert: "border-amber-200 bg-amber-50/80 text-amber-950",
+  critical: "border-rose-200 bg-rose-50/80 text-rose-950",
+} satisfies Record<QueueBoardMetric["tone"], string>;
+
+export function QueueMetricCard({ metric }: { metric: QueueBoardMetric }) {
+  return (
+    <article
+      role="listitem"
+      className={`flex h-full flex-col gap-4 rounded-[1.5rem] border p-5 shadow-[0_18px_40px_rgba(15,23,42,0.06)] ${metricToneClasses[metric.tone]}`}
+    >
+      <div className="space-y-2">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-current/65">
+          {metric.label}
+        </p>
+        <p className="text-4xl font-semibold tracking-tight">{metric.value}</p>
+      </div>
+
+      <p className="text-sm leading-6 text-current/75">{metric.detail}</p>
+    </article>
+  );
+}

--- a/src/app/queue-board/_data/queue-board-data.ts
+++ b/src/app/queue-board/_data/queue-board-data.ts
@@ -1,0 +1,407 @@
+export type QueueStatusId =
+  | "captured"
+  | "triage"
+  | "waiting"
+  | "in-flight"
+  | "ready";
+
+export type QueueEscalation = "steady" | "watch" | "priority" | "sla-risk";
+
+export type QueueOwner = {
+  id: string;
+  name: string;
+  team: string;
+  initials: string;
+};
+
+export type QueueBoardColumnDefinition = {
+  id: QueueStatusId;
+  title: string;
+  description: string;
+  wipLimit: number;
+};
+
+export type QueueBoardItem = {
+  id: string;
+  title: string;
+  account: string;
+  workflow: string;
+  status: QueueStatusId;
+  ownerId: QueueOwner["id"];
+  ageHours: number;
+  checkpoint: string;
+  slaWindow: string;
+  blocked: boolean;
+  blocker?: string;
+  escalation: QueueEscalation;
+  escalationReason: string;
+  notes: string;
+  tags: string[];
+};
+
+export type QueueMetricTone = "neutral" | "alert" | "critical";
+
+export type QueueBoardMetric = {
+  id: string;
+  label: string;
+  value: string;
+  detail: string;
+  tone: QueueMetricTone;
+};
+
+export type QueueBoardColumn = QueueBoardColumnDefinition & {
+  items: (QueueBoardItem & { owner: QueueOwner })[];
+  count: number;
+  escalatedCount: number;
+  blockedCount: number;
+};
+
+export type QueueBoardView = {
+  metrics: QueueBoardMetric[];
+  columns: QueueBoardColumn[];
+  escalatedItems: number;
+  blockedItems: number;
+  totalItems: number;
+};
+
+export const queueBoardColumns: QueueBoardColumnDefinition[] = [
+  {
+    id: "captured",
+    title: "Captured",
+    description: "Freshly created work that still needs the first ownership pass.",
+    wipLimit: 4,
+  },
+  {
+    id: "triage",
+    title: "Triage",
+    description: "Actively being classified, scoped, or reassigned before execution.",
+    wipLimit: 5,
+  },
+  {
+    id: "waiting",
+    title: "Waiting",
+    description: "Paused on an outside handoff, customer reply, or partner system update.",
+    wipLimit: 3,
+  },
+  {
+    id: "in-flight",
+    title: "In Flight",
+    description: "Execution work is underway with owners actively driving the next checkpoint.",
+    wipLimit: 5,
+  },
+  {
+    id: "ready",
+    title: "Ready To Close",
+    description: "Resolved work that needs final verification or customer confirmation.",
+    wipLimit: 4,
+  },
+];
+
+export const queueOwners: QueueOwner[] = [
+  {
+    id: "nina-patel",
+    name: "Nina Patel",
+    team: "Intake Desk",
+    initials: "NP",
+  },
+  {
+    id: "marco-silva",
+    name: "Marco Silva",
+    team: "Workflow Ops",
+    initials: "MS",
+  },
+  {
+    id: "talia-brooks",
+    name: "Talia Brooks",
+    team: "Escalations",
+    initials: "TB",
+  },
+  {
+    id: "owen-cho",
+    name: "Owen Cho",
+    team: "Partner Support",
+    initials: "OC",
+  },
+  {
+    id: "yasmin-rao",
+    name: "Yasmin Rao",
+    team: "Resolution Desk",
+    initials: "YR",
+  },
+];
+
+export const queueBoardItems: QueueBoardItem[] = [
+  {
+    id: "QB-241",
+    title: "Reconcile duplicate shipment hold for Northline Retail",
+    account: "Northline Retail",
+    workflow: "Warehouse exception",
+    status: "captured",
+    ownerId: "nina-patel",
+    ageHours: 2,
+    checkpoint: "Assign triage owner before 10:30 local",
+    slaWindow: "8 hours to first action",
+    blocked: false,
+    escalation: "watch",
+    escalationReason: "Repeated exception from the same facility in the last 24 hours.",
+    notes: "Two replacement orders are waiting for the hold decision before labels can print.",
+    tags: ["Returns", "East hub"],
+  },
+  {
+    id: "QB-244",
+    title: "Validate export paperwork mismatch for Aurora Medical",
+    account: "Aurora Medical",
+    workflow: "Compliance review",
+    status: "captured",
+    ownerId: "nina-patel",
+    ageHours: 1,
+    checkpoint: "Check document set against broker feed",
+    slaWindow: "12 hours to route",
+    blocked: false,
+    escalation: "steady",
+    escalationReason: "No active escalation; paperwork correction can route through standard review.",
+    notes: "Mismatch is limited to package count and can clear with a corrected invoice packet.",
+    tags: ["Exports", "Paperwork"],
+  },
+  {
+    id: "QB-229",
+    title: "Restore missing ASN events for Granite Foods",
+    account: "Granite Foods",
+    workflow: "Integration recovery",
+    status: "triage",
+    ownerId: "marco-silva",
+    ageHours: 9,
+    checkpoint: "Confirm event replay window with EDI monitor",
+    slaWindow: "4 hours to recovery plan",
+    blocked: true,
+    blocker: "Partner EDI logs have not been re-shared since the overnight outage.",
+    escalation: "priority",
+    escalationReason: "High-volume account with stores already asking for arrival confirmation.",
+    notes: "Three distribution centers are affected, but only one needs same-day replay for shelf resets.",
+    tags: ["EDI", "Stores", "Same day"],
+  },
+  {
+    id: "QB-233",
+    title: "Approve cold-chain reroute exception for Arcline Health",
+    account: "Arcline Health",
+    workflow: "Exception approval",
+    status: "triage",
+    ownerId: "talia-brooks",
+    ageHours: 6,
+    checkpoint: "Secure medical advisor approval before noon dispatch cutoff",
+    slaWindow: "6 hours to approval",
+    blocked: false,
+    escalation: "watch",
+    escalationReason: "Temperature-sensitive order with a narrow dispatch window.",
+    notes: "Site team has already accepted the alternate lane if sign-off happens before the truck release.",
+    tags: ["Cold chain", "Dispatch"],
+  },
+  {
+    id: "QB-236",
+    title: "Review warehouse scan variance for Harbor Mart",
+    account: "Harbor Mart",
+    workflow: "Variance review",
+    status: "triage",
+    ownerId: "marco-silva",
+    ageHours: 4,
+    checkpoint: "Compare scanner logs with handheld backup export",
+    slaWindow: "10 hours to disposition",
+    blocked: false,
+    escalation: "steady",
+    escalationReason: "Variance is isolated to one shift and has a clean fallback path.",
+    notes: "Only six cases are unaccounted for, and store replenishment stays inside tolerance if confirmed today.",
+    tags: ["Inventory", "Audit"],
+  },
+  {
+    id: "QB-221",
+    title: "Await signed carrier waiver from Summit Bio",
+    account: "Summit Bio",
+    workflow: "Carrier waiver",
+    status: "waiting",
+    ownerId: "owen-cho",
+    ageHours: 18,
+    checkpoint: "Receive signed waiver before reefer lock expires",
+    slaWindow: "2 hours to breach",
+    blocked: true,
+    blocker: "Customer legal review has not released the final waiver language.",
+    escalation: "sla-risk",
+    escalationReason: "Release window closes this shift and the reefer capacity cannot be held overnight.",
+    notes: "Without the waiver, the load rolls to tomorrow and pushes a lab replenishment order outside target.",
+    tags: ["Legal", "Reefer", "Time critical"],
+  },
+  {
+    id: "QB-227",
+    title: "Waiting on customs release code for Cobalt Devices",
+    account: "Cobalt Devices",
+    workflow: "Border clearance",
+    status: "waiting",
+    ownerId: "owen-cho",
+    ageHours: 14,
+    checkpoint: "Broker to confirm release code and inspection status",
+    slaWindow: "5 hours to detention fees",
+    blocked: true,
+    blocker: "Broker queue is delayed after a customs system maintenance window.",
+    escalation: "priority",
+    escalationReason: "Detention charges begin this evening if the trailer is not released.",
+    notes: "Destination site can absorb a short delay, but detention cost will hit the account if the trailer sits overnight.",
+    tags: ["Broker", "Border", "Fees"],
+  },
+  {
+    id: "QB-214",
+    title: "Rebuild delayed label bundle for Cedar & Co.",
+    account: "Cedar & Co.",
+    workflow: "Label regeneration",
+    status: "in-flight",
+    ownerId: "yasmin-rao",
+    ageHours: 5,
+    checkpoint: "Push regenerated bundle to print station by 11:15",
+    slaWindow: "7 hours to recovery",
+    blocked: false,
+    escalation: "steady",
+    escalationReason: "Owner has the fix in motion and no downstream stop is expected.",
+    notes: "The packaging team already confirmed the printer fleet is healthy after the overnight jam was cleared.",
+    tags: ["Labels", "Packaging"],
+  },
+  {
+    id: "QB-218",
+    title: "Re-run payment capture sync for Northstar Clinics",
+    account: "Northstar Clinics",
+    workflow: "Finance sync",
+    status: "in-flight",
+    ownerId: "yasmin-rao",
+    ageHours: 7,
+    checkpoint: "Validate remittance batch before the next reconciliation sweep",
+    slaWindow: "6 hours to customer statement miss",
+    blocked: false,
+    escalation: "watch",
+    escalationReason: "Customer statement timing is sensitive even though the retry path exists.",
+    notes: "The sync can still land inside the daily statement window if the batch validates on the first replay.",
+    tags: ["Payments", "Retry"],
+  },
+  {
+    id: "QB-220",
+    title: "Escalate missed pickup credit memo for Atlas Home",
+    account: "Atlas Home",
+    workflow: "Credit memo",
+    status: "in-flight",
+    ownerId: "talia-brooks",
+    ageHours: 11,
+    checkpoint: "Finance lead to approve customer credit before 15:00",
+    slaWindow: "3 hours to callback commitment",
+    blocked: false,
+    escalation: "priority",
+    escalationReason: "Customer success has already promised a same-day callback with credit status.",
+    notes: "Approval path is short, but the account team needs an answer before their renewal check-in this afternoon.",
+    tags: ["Credits", "Renewal"],
+  },
+  {
+    id: "QB-205",
+    title: "Confirm reroute credit posted for Luma Outdoor",
+    account: "Luma Outdoor",
+    workflow: "Post-resolution check",
+    status: "ready",
+    ownerId: "yasmin-rao",
+    ageHours: 3,
+    checkpoint: "Verify ledger update and send closure note",
+    slaWindow: "Close today",
+    blocked: false,
+    escalation: "steady",
+    escalationReason: "All corrective work is done; only confirmation remains.",
+    notes: "Finance already sees the adjustment, so this should close as soon as the customer note is sent.",
+    tags: ["Closure", "Finance"],
+  },
+  {
+    id: "QB-209",
+    title: "Close incident after customer sign-off for Helio Labs",
+    account: "Helio Labs",
+    workflow: "Customer confirmation",
+    status: "ready",
+    ownerId: "talia-brooks",
+    ageHours: 8,
+    checkpoint: "Collect final sign-off from site lead",
+    slaWindow: "Waiting on confirmation",
+    blocked: false,
+    escalation: "watch",
+    escalationReason: "Closure is delayed only by customer acknowledgement.",
+    notes: "The fix has been stable since yesterday, but the incident cannot close until the lab manager replies.",
+    tags: ["Customer", "Resolution"],
+  },
+];
+
+function isEscalated(item: QueueBoardItem) {
+  return item.escalation !== "steady";
+}
+
+function getOwner(ownerId: QueueOwner["id"]) {
+  const owner = queueOwners.find((candidate) => candidate.id === ownerId);
+
+  if (!owner) {
+    throw new Error(`Queue owner not found for id: ${ownerId}`);
+  }
+
+  return owner;
+}
+
+export function getQueueBoardView(
+  items: QueueBoardItem[] = queueBoardItems,
+): QueueBoardView {
+  const totalItems = items.length;
+  const escalatedItems = items.filter(isEscalated).length;
+  const blockedItems = items.filter((item) => item.blocked).length;
+  const slaRiskItems = items.filter((item) => item.escalation === "sla-risk").length;
+  const agingItems = items.filter((item) => item.ageHours >= 8).length;
+
+  const columns = queueBoardColumns.map((column) => {
+    const columnItems = items
+      .filter((item) => item.status === column.id)
+      .map((item) => ({
+        ...item,
+        owner: getOwner(item.ownerId),
+      }));
+
+    return {
+      ...column,
+      items: columnItems,
+      count: columnItems.length,
+      escalatedCount: columnItems.filter(isEscalated).length,
+      blockedCount: columnItems.filter((item) => item.blocked).length,
+    };
+  });
+
+  return {
+    metrics: [
+      {
+        id: "open-items",
+        label: "Open items",
+        value: String(totalItems),
+        detail: "Active work currently visible across the board.",
+        tone: "neutral",
+      },
+      {
+        id: "escalated",
+        label: "Escalated now",
+        value: String(escalatedItems),
+        detail: "Items carrying watch, priority, or SLA-risk markers.",
+        tone: "alert",
+      },
+      {
+        id: "blocked",
+        label: "Blocked handoffs",
+        value: String(blockedItems),
+        detail: "Cards paused on partner, broker, or customer dependencies.",
+        tone: blockedItems > 0 ? "alert" : "neutral",
+      },
+      {
+        id: "aging",
+        label: "Aging 8h+",
+        value: String(agingItems),
+        detail: "Work that has been sitting long enough to require visible attention.",
+        tone: agingItems > 2 || slaRiskItems > 0 ? "critical" : "alert",
+      },
+    ],
+    columns,
+    escalatedItems,
+    blockedItems,
+    totalItems,
+  };
+}

--- a/src/app/queue-board/_data/queue-board-data.ts
+++ b/src/app/queue-board/_data/queue-board-data.ts
@@ -64,6 +64,21 @@ export type QueueBoardView = {
   totalItems: number;
 };
 
+export const queueStatusLabels: Record<QueueStatusId, string> = {
+  captured: "Captured",
+  triage: "Triage",
+  waiting: "Waiting",
+  "in-flight": "In Flight",
+  ready: "Ready To Close",
+};
+
+export const queueEscalationLabels: Record<QueueEscalation, string> = {
+  steady: "Steady",
+  watch: "Watch",
+  priority: "Priority",
+  "sla-risk": "SLA Risk",
+};
+
 export const queueBoardColumns: QueueBoardColumnDefinition[] = [
   {
     id: "captured",

--- a/src/app/queue-board/page.test.tsx
+++ b/src/app/queue-board/page.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import QueueBoardPage from "./page";
+import { getQueueBoardView } from "./_data/queue-board-data";
+
+describe("QueueBoardPage", () => {
+  it("renders the queue board route shell and not the home page content", () => {
+    render(<QueueBoardPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /visualize workflow load, escalations, and next actions in one board/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /queue health at a glance/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /workflow board/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/browse sealed archive snapshots without leaving the app shell/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders all summary metrics from the mock queue snapshot", () => {
+    const view = getQueueBoardView();
+
+    render(<QueueBoardPage />);
+
+    const metricList = screen.getByRole("list", {
+      name: /queue summary metrics/i,
+    });
+
+    expect(within(metricList).getAllByRole("listitem")).toHaveLength(view.metrics.length);
+
+    for (const metric of view.metrics) {
+      const metricCard = within(metricList)
+        .getByText(metric.label)
+        .closest('[role="listitem"]');
+
+      expect(metricCard).toBeInTheDocument();
+      expect(metricCard).toHaveTextContent(metric.value);
+      expect(metricCard).toHaveTextContent(metric.detail);
+    }
+  });
+
+  it("renders each queue column with representative escalation and blocker content", () => {
+    const view = getQueueBoardView();
+
+    render(<QueueBoardPage />);
+
+    const board = screen.getByTestId("queue-board-columns");
+
+    for (const column of view.columns) {
+      const columnRegion = within(board).getByRole("region", { name: column.title });
+      const itemList = within(columnRegion).getByRole("list", {
+        name: `${column.title} items`,
+      });
+
+      expect(within(columnRegion).getByText(column.description)).toBeInTheDocument();
+      expect(within(itemList).getAllByRole("article")).toHaveLength(column.items.length);
+    }
+
+    const slaRiskCard = screen
+      .getByRole("heading", {
+        level: 3,
+        name: /await signed carrier waiver from summit bio/i,
+      })
+      .closest("article");
+
+    expect(slaRiskCard).toBeInTheDocument();
+    expect(slaRiskCard).toHaveTextContent("Waiting");
+    expect(slaRiskCard).toHaveTextContent("SLA Risk");
+    expect(slaRiskCard).toHaveTextContent("Blocked");
+    expect(slaRiskCard).toHaveTextContent(
+      /customer legal review has not released the final waiver language/i,
+    );
+
+    const priorityCard = screen
+      .getByRole("heading", {
+        level: 3,
+        name: /escalate missed pickup credit memo for atlas home/i,
+      })
+      .closest("article");
+
+    expect(priorityCard).toBeInTheDocument();
+    expect(priorityCard).toHaveTextContent("Priority");
+    expect(priorityCard).toHaveTextContent(/same-day callback/i);
+  });
+});

--- a/src/app/queue-board/page.tsx
+++ b/src/app/queue-board/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { QueueColumn } from "./_components/queue-column";
 import { QueueMetricCard } from "./_components/queue-metric-card";
 import { getQueueBoardView } from "./_data/queue-board-data";
+import styles from "./queue-board.module.css";
 
 export const metadata: Metadata = {
   title: "Queue Board",
@@ -15,9 +16,11 @@ export default function QueueBoardPage() {
 
   return (
     <main className="mx-auto flex w-full max-w-[96rem] flex-1 flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
-      <section className="overflow-hidden rounded-[2.25rem] border border-slate-200 bg-[linear-gradient(135deg,#f8fafc_0%,#ffffff_42%,#eff6ff_100%)] shadow-[0_30px_100px_rgba(15,23,42,0.1)]">
+      <section
+        className={`overflow-hidden rounded-[2.25rem] border border-slate-200 bg-[linear-gradient(135deg,#f8fafc_0%,#ffffff_42%,#eff6ff_100%)] shadow-[0_30px_100px_rgba(15,23,42,0.1)] ${styles.heroSurface}`}
+      >
         <div className="grid gap-8 px-6 py-8 sm:px-8 sm:py-10 lg:grid-cols-[minmax(0,1.4fr)_minmax(20rem,0.9fr)] lg:px-10 lg:py-12">
-          <div className="space-y-6">
+          <div className={`space-y-6 ${styles.heroPanel}`}>
             <div className="flex flex-wrap items-center gap-3">
               <p className="rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-sky-800">
                 Queue Board
@@ -54,7 +57,9 @@ export default function QueueBoardPage() {
             </div>
           </div>
 
-          <aside className="rounded-[1.75rem] border border-white/80 bg-slate-950 p-6 text-white shadow-[0_24px_60px_rgba(15,23,42,0.22)] sm:p-7">
+          <aside
+            className={`rounded-[1.75rem] border border-white/80 bg-slate-950 p-6 text-white shadow-[0_24px_60px_rgba(15,23,42,0.22)] sm:p-7 ${styles.heroAside}`}
+          >
             <div className="space-y-5">
               <div>
                 <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-sky-200/80">
@@ -99,6 +104,36 @@ export default function QueueBoardPage() {
                   Summary metrics stay above the board while each stage tracks
                   volume, escalations, blockers, and item-level checkpoints.
                 </p>
+              </div>
+
+              <div className="rounded-[1.25rem] border border-white/12 bg-white/6 px-4 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/60">
+                  Escalation scale
+                </p>
+                <ul className={`mt-3 ${styles.legendList}`}>
+                  <li className={styles.legendItem}>
+                    <span className={`${styles.pill} ${styles.escalationWatch}`}>Watch</span>
+                    <span className="text-sm leading-6 text-white/76">
+                      Needs tighter monitoring but still has an expected recovery path.
+                    </span>
+                  </li>
+                  <li className={styles.legendItem}>
+                    <span className={`${styles.pill} ${styles.escalationPriority}`}>
+                      Priority
+                    </span>
+                    <span className="text-sm leading-6 text-white/76">
+                      Requires faster coordination because cost or customer impact is rising.
+                    </span>
+                  </li>
+                  <li className={styles.legendItem}>
+                    <span className={`${styles.pill} ${styles.escalationSlaRisk}`}>
+                      SLA Risk
+                    </span>
+                    <span className="text-sm leading-6 text-white/76">
+                      Nearing or breaching the service window without a safe fallback.
+                    </span>
+                  </li>
+                </ul>
               </div>
             </div>
           </aside>
@@ -151,13 +186,12 @@ export default function QueueBoardPage() {
           </p>
         </div>
 
-        <div
-          className="grid gap-5 xl:grid-cols-5"
-          data-testid="queue-board-columns"
-        >
-          {queueBoardView.columns.map((column) => (
-            <QueueColumn key={column.id} column={column} />
-          ))}
+        <div className={styles.boardScroller}>
+          <div className={styles.boardGrid} data-testid="queue-board-columns">
+            {queueBoardView.columns.map((column) => (
+              <QueueColumn key={column.id} column={column} />
+            ))}
+          </div>
         </div>
       </section>
     </main>

--- a/src/app/queue-board/page.tsx
+++ b/src/app/queue-board/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Queue Board",
+  description:
+    "Workflow board route scaffold for queue items, summary counts, and escalation markers.",
+};
+
+export default function QueueBoardPage() {
+  return (
+    <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
+      <section className="rounded-[2rem] border border-slate-200 bg-white px-6 py-8 shadow-[0_24px_80px_rgba(15,23,42,0.08)] sm:px-8 sm:py-10">
+        <div className="max-w-3xl space-y-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-sky-700">
+            Queue Board
+          </p>
+          <h1 className="text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
+            Monitor workflow items across multiple queue stages.
+          </h1>
+          <p className="text-base leading-7 text-slate-600 sm:text-lg">
+            This route scaffold reserves space for summary metrics, status
+            columns, and escalation states that will be added in follow-up
+            subtasks.
+          </p>
+        </div>
+      </section>
+
+      <section className="grid gap-4 md:grid-cols-3" aria-label="Queue board placeholders">
+        <div className="rounded-[1.5rem] border border-dashed border-slate-300 bg-slate-50 p-6">
+          <h2 className="text-lg font-semibold text-slate-950">Summary metrics</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-600">
+            Placeholder for open-item, escalation, and aging counts.
+          </p>
+        </div>
+        <div className="rounded-[1.5rem] border border-dashed border-slate-300 bg-slate-50 p-6">
+          <h2 className="text-lg font-semibold text-slate-950">Queue columns</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-600">
+            Placeholder for grouped workflow stages and item cards.
+          </p>
+        </div>
+        <div className="rounded-[1.5rem] border border-dashed border-slate-300 bg-slate-50 p-6">
+          <h2 className="text-lg font-semibold text-slate-950">Escalation states</h2>
+          <p className="mt-2 text-sm leading-6 text-slate-600">
+            Placeholder for blocked, priority, and SLA-risk visual treatments.
+          </p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/queue-board/page.tsx
+++ b/src/app/queue-board/page.tsx
@@ -1,4 +1,8 @@
 import type { Metadata } from "next";
+import Link from "next/link";
+import { QueueColumn } from "./_components/queue-column";
+import { QueueMetricCard } from "./_components/queue-metric-card";
+import { getQueueBoardView } from "./_data/queue-board-data";
 
 export const metadata: Metadata = {
   title: "Queue Board",
@@ -7,42 +11,153 @@ export const metadata: Metadata = {
 };
 
 export default function QueueBoardPage() {
+  const queueBoardView = getQueueBoardView();
+
   return (
-    <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
-      <section className="rounded-[2rem] border border-slate-200 bg-white px-6 py-8 shadow-[0_24px_80px_rgba(15,23,42,0.08)] sm:px-8 sm:py-10">
-        <div className="max-w-3xl space-y-4">
-          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-sky-700">
-            Queue Board
-          </p>
-          <h1 className="text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-            Monitor workflow items across multiple queue stages.
-          </h1>
-          <p className="text-base leading-7 text-slate-600 sm:text-lg">
-            This route scaffold reserves space for summary metrics, status
-            columns, and escalation states that will be added in follow-up
-            subtasks.
-          </p>
+    <main className="mx-auto flex w-full max-w-[96rem] flex-1 flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
+      <section className="overflow-hidden rounded-[2.25rem] border border-slate-200 bg-[linear-gradient(135deg,#f8fafc_0%,#ffffff_42%,#eff6ff_100%)] shadow-[0_30px_100px_rgba(15,23,42,0.1)]">
+        <div className="grid gap-8 px-6 py-8 sm:px-8 sm:py-10 lg:grid-cols-[minmax(0,1.4fr)_minmax(20rem,0.9fr)] lg:px-10 lg:py-12">
+          <div className="space-y-6">
+            <div className="flex flex-wrap items-center gap-3">
+              <p className="rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-sky-800">
+                Queue Board
+              </p>
+              <p className="rounded-full bg-white px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.18)]">
+                Mock workflow telemetry
+              </p>
+            </div>
+
+            <div className="space-y-4">
+              <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl lg:text-6xl">
+                Visualize workflow load, escalations, and next actions in one board.
+              </h1>
+              <p className="max-w-3xl text-base leading-8 text-slate-600 sm:text-lg">
+                The queue board groups live mock work into operational stages so
+                teams can scan active volume, blocked handoffs, and time-sensitive
+                escalations without depending on any backend integration.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
+              >
+                Back to overview
+              </Link>
+              <a
+                href="#queue-columns"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+              >
+                Jump to board
+              </a>
+            </div>
+          </div>
+
+          <aside className="rounded-[1.75rem] border border-white/80 bg-slate-950 p-6 text-white shadow-[0_24px_60px_rgba(15,23,42,0.22)] sm:p-7">
+            <div className="space-y-5">
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-sky-200/80">
+                  Shift overview
+                </p>
+                <p className="mt-3 text-3xl font-semibold tracking-tight">
+                  {queueBoardView.totalItems} items across {queueBoardView.columns.length} active
+                  stages
+                </p>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
+                <div className="rounded-[1.25rem] bg-white/10 px-4 py-4">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/60">
+                    Escalated now
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold">
+                    {queueBoardView.escalatedItems}
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-white/72">
+                    Cards marked watch, priority, or SLA-risk.
+                  </p>
+                </div>
+                <div className="rounded-[1.25rem] bg-white/10 px-4 py-4">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/60">
+                    Blocked handoffs
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold">
+                    {queueBoardView.blockedItems}
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-white/72">
+                    Waiting on legal, broker, or partner follow-through.
+                  </p>
+                </div>
+              </div>
+
+              <div className="rounded-[1.25rem] border border-white/12 bg-white/6 px-4 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/60">
+                  Board intent
+                </p>
+                <p className="mt-2 text-sm leading-6 text-white/76">
+                  Summary metrics stay above the board while each stage tracks
+                  volume, escalations, blockers, and item-level checkpoints.
+                </p>
+              </div>
+            </div>
+          </aside>
         </div>
       </section>
 
-      <section className="grid gap-4 md:grid-cols-3" aria-label="Queue board placeholders">
-        <div className="rounded-[1.5rem] border border-dashed border-slate-300 bg-slate-50 p-6">
-          <h2 className="text-lg font-semibold text-slate-950">Summary metrics</h2>
-          <p className="mt-2 text-sm leading-6 text-slate-600">
-            Placeholder for open-item, escalation, and aging counts.
+      <section aria-labelledby="queue-summary" className="space-y-5">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Summary metrics
+            </p>
+            <h2 id="queue-summary" className="text-3xl font-semibold tracking-tight text-slate-950">
+              Queue health at a glance
+            </h2>
+          </div>
+          <p className="max-w-3xl text-sm leading-7 text-slate-600">
+            Counts are derived directly from the local queue dataset so the
+            route can be tested and iterated in isolation.
           </p>
         </div>
-        <div className="rounded-[1.5rem] border border-dashed border-slate-300 bg-slate-50 p-6">
-          <h2 className="text-lg font-semibold text-slate-950">Queue columns</h2>
-          <p className="mt-2 text-sm leading-6 text-slate-600">
-            Placeholder for grouped workflow stages and item cards.
+
+        <div
+          aria-label="Queue summary metrics"
+          className="grid gap-4 md:grid-cols-2 xl:grid-cols-4"
+          role="list"
+        >
+          {queueBoardView.metrics.map((metric) => (
+            <QueueMetricCard key={metric.id} metric={metric} />
+          ))}
+        </div>
+      </section>
+
+      <section id="queue-columns" aria-labelledby="queue-board-columns" className="space-y-5">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Status columns
+            </p>
+            <h2
+              id="queue-board-columns"
+              className="text-3xl font-semibold tracking-tight text-slate-950"
+            >
+              Workflow board
+            </h2>
+          </div>
+          <p className="max-w-3xl text-sm leading-7 text-slate-600">
+            Every column exposes the current load plus a focused breakdown of
+            escalated and blocked work before you drill into the cards.
           </p>
         </div>
-        <div className="rounded-[1.5rem] border border-dashed border-slate-300 bg-slate-50 p-6">
-          <h2 className="text-lg font-semibold text-slate-950">Escalation states</h2>
-          <p className="mt-2 text-sm leading-6 text-slate-600">
-            Placeholder for blocked, priority, and SLA-risk visual treatments.
-          </p>
+
+        <div
+          className="grid gap-5 xl:grid-cols-5"
+          data-testid="queue-board-columns"
+        >
+          {queueBoardView.columns.map((column) => (
+            <QueueColumn key={column.id} column={column} />
+          ))}
         </div>
       </section>
     </main>

--- a/src/app/queue-board/queue-board.module.css
+++ b/src/app/queue-board/queue-board.module.css
@@ -1,0 +1,250 @@
+.heroSurface {
+  position: relative;
+  isolation: isolate;
+}
+
+.heroSurface::before {
+  content: "";
+  position: absolute;
+  inset: auto -6rem -6rem auto;
+  width: 20rem;
+  height: 20rem;
+  border-radius: 9999px;
+  background:
+    radial-gradient(circle, rgba(14, 165, 233, 0.22) 0%, rgba(14, 165, 233, 0) 72%);
+  pointer-events: none;
+}
+
+.heroSurface::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(115deg, rgba(255, 255, 255, 0.75), rgba(255, 255, 255, 0) 40%),
+    radial-gradient(circle at top left, rgba(226, 232, 240, 0.72), rgba(226, 232, 240, 0) 48%);
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.heroPanel,
+.heroAside {
+  position: relative;
+  z-index: 1;
+}
+
+.heroAside {
+  backdrop-filter: blur(12px);
+}
+
+.legendList {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.legendItem {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: auto 1fr;
+  align-items: start;
+}
+
+.metricCard {
+  position: relative;
+  overflow: hidden;
+}
+
+.metricCard::after {
+  content: "";
+  position: absolute;
+  right: -2.25rem;
+  bottom: -2.75rem;
+  width: 7.5rem;
+  height: 7.5rem;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.55);
+  filter: blur(2px);
+  pointer-events: none;
+}
+
+.metricCard > * {
+  position: relative;
+  z-index: 1;
+}
+
+.boardScroller {
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+  scrollbar-width: thin;
+}
+
+.boardGrid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(18.5rem, 1fr));
+  gap: 1.25rem;
+  min-width: 98rem;
+}
+
+.columnShell {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.85), rgba(248, 250, 252, 0.95)),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(241, 245, 249, 0.8));
+}
+
+.columnShell::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: 0.35rem;
+  background: linear-gradient(90deg, var(--column-accent), color-mix(in srgb, var(--column-accent) 36%, white));
+}
+
+.columnShell[data-column="captured"] {
+  --column-accent: #0284c7;
+}
+
+.columnShell[data-column="triage"] {
+  --column-accent: #7c3aed;
+}
+
+.columnShell[data-column="waiting"] {
+  --column-accent: #d97706;
+}
+
+.columnShell[data-column="in-flight"] {
+  --column-accent: #0f766e;
+}
+
+.columnShell[data-column="ready"] {
+  --column-accent: #059669;
+}
+
+.queueCard {
+  position: relative;
+  overflow: hidden;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease;
+}
+
+.queueCard:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.1);
+}
+
+.queueCard[data-escalation="watch"] {
+  border-color: rgba(245, 158, 11, 0.38);
+  background: linear-gradient(180deg, rgba(255, 251, 235, 0.92), rgba(255, 255, 255, 0.98));
+}
+
+.queueCard[data-escalation="priority"] {
+  border-color: rgba(249, 115, 22, 0.42);
+  background: linear-gradient(180deg, rgba(255, 247, 237, 0.96), rgba(255, 255, 255, 0.98));
+}
+
+.queueCard[data-escalation="sla-risk"] {
+  border-color: rgba(225, 29, 72, 0.42);
+  background: linear-gradient(180deg, rgba(255, 241, 242, 0.96), rgba(255, 255, 255, 0.99));
+  box-shadow: 0 20px 50px rgba(225, 29, 72, 0.12);
+}
+
+.queueCard[data-blocked="true"] {
+  border-style: dashed;
+}
+
+.queueCard[data-blocked="true"]::after {
+  content: "";
+  position: absolute;
+  inset: auto -2rem -2rem auto;
+  width: 7rem;
+  height: 7rem;
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgba(251, 191, 36, 0.18) 0%, rgba(251, 191, 36, 0) 72%);
+  pointer-events: none;
+}
+
+.queueCard > * {
+  position: relative;
+  z-index: 1;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  padding: 0.42rem 0.7rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.statusPill {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(241, 245, 249, 0.95);
+  color: rgb(51 65 85);
+}
+
+.escalationSteady {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(248, 250, 252, 0.95);
+  color: rgb(71 85 105);
+}
+
+.escalationWatch {
+  border: 1px solid rgba(245, 158, 11, 0.24);
+  background: rgba(255, 251, 235, 0.96);
+  color: rgb(161 98 7);
+}
+
+.escalationPriority {
+  border: 1px solid rgba(249, 115, 22, 0.22);
+  background: rgba(255, 247, 237, 0.96);
+  color: rgb(194 65 12);
+}
+
+.escalationSlaRisk {
+  border: 1px solid rgba(225, 29, 72, 0.22);
+  background: rgba(255, 241, 242, 0.98);
+  color: rgb(190 24 93);
+}
+
+.blockedPill {
+  border: 1px solid rgba(202, 138, 4, 0.28);
+  background: rgba(254, 249, 195, 0.94);
+  color: rgb(133 77 14);
+}
+
+.tag {
+  background: rgba(255, 255, 255, 0.82);
+  backdrop-filter: blur(8px);
+}
+
+@media (max-width: 1279px) {
+  .boardGrid {
+    min-width: 92rem;
+  }
+}
+
+@media (max-width: 767px) {
+  .heroSurface::before {
+    width: 14rem;
+    height: 14rem;
+    right: -4rem;
+    bottom: -4rem;
+  }
+
+  .boardGrid {
+    min-width: 80rem;
+  }
+}
+
+@media (min-width: 1440px) {
+  .boardGrid {
+    min-width: 0;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold the `queue-board` route so the implementation can land incrementally
- reserve the page structure for summary metrics, queue columns, and escalation states
- continue the remaining issue subtasks on this draft PR in follow-up commits

Closes #89