### PR TITLE
feat: build status board route

### DIFF
--- a/src/app/status-board/_components/regional-health-group.tsx
+++ b/src/app/status-board/_components/regional-health-group.tsx
@@ -13,7 +13,8 @@ export function RegionalHealthGroup({ group }: RegionalHealthGroupProps) {
   return (
     <section
       aria-labelledby={headingId}
-      className="rounded-[2rem] border border-slate-200/80 bg-[var(--surface)] p-6 shadow-[0_20px_80px_rgba(15,23,42,0.06)] sm:p-8"
+      data-state={group.status}
+      className="overflow-hidden rounded-[2rem] border border-slate-200/80 bg-[var(--surface)] p-6 shadow-[0_20px_80px_rgba(15,23,42,0.06)] sm:p-8"
     >
       <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
         <div className="max-w-3xl">

--- a/src/app/status-board/_components/regional-health-group.tsx
+++ b/src/app/status-board/_components/regional-health-group.tsx
@@ -1,0 +1,88 @@
+import type { RegionalHealthGroup } from "../_data/status-board-data";
+import { ServiceHealthCard } from "./service-health-card";
+import { healthStateLabels, summaryStateStyles } from "./state-styles";
+
+type RegionalHealthGroupProps = {
+  group: RegionalHealthGroup;
+};
+
+export function RegionalHealthGroup({ group }: RegionalHealthGroupProps) {
+  const headingId = `${group.id}-heading`;
+  const styles = summaryStateStyles[group.status];
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      className="rounded-[2rem] border border-slate-200/80 bg-[var(--surface)] p-6 shadow-[0_20px_80px_rgba(15,23,42,0.06)] sm:p-8"
+    >
+      <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+        <div className="max-w-3xl">
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">
+            {group.coverageWindow}
+          </p>
+          <div className="mt-3 flex flex-wrap items-center gap-3">
+            <h2
+              id={headingId}
+              className="text-3xl font-semibold tracking-tight text-slate-950"
+            >
+              {group.name}
+            </h2>
+            <span
+              className={`rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${styles.badge}`}
+            >
+              {healthStateLabels[group.status]}
+            </span>
+          </div>
+          <p className="mt-4 text-base leading-7 text-slate-700">{group.summary}</p>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-3 lg:min-w-[21rem]">
+          <div className="rounded-[1.2rem] border border-slate-200 bg-white/80 p-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+              Services
+            </p>
+            <p className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">
+              {group.serviceCount}
+            </p>
+          </div>
+          <div className="rounded-[1.2rem] border border-amber-200 bg-amber-50/70 p-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-900">
+              Warnings
+            </p>
+            <p className="mt-2 text-2xl font-semibold tracking-tight text-amber-950">
+              {group.warningCount}
+            </p>
+          </div>
+          <div className="rounded-[1.2rem] border border-rose-200 bg-rose-50/70 p-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-900">
+              Degraded
+            </p>
+            <p className="mt-2 text-2xl font-semibold tracking-tight text-rose-950">
+              {group.degradedCount}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-8">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">
+            Regional services
+          </p>
+          <p className="text-sm text-slate-600">
+            {group.services.length} services under review
+          </p>
+        </div>
+        <ul
+          aria-label={`${group.name} services`}
+          className="mt-4 grid gap-4 xl:grid-cols-2"
+          role="list"
+        >
+          {group.services.map((service) => (
+            <ServiceHealthCard key={service.id} service={service} />
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/app/status-board/_components/response-checklist-sidebar.tsx
+++ b/src/app/status-board/_components/response-checklist-sidebar.tsx
@@ -1,0 +1,115 @@
+import type {
+  ResponseChecklistItem,
+  ResponseSidebarNote,
+} from "../_data/status-board-data";
+
+type ResponseChecklistSidebarProps = {
+  items: ResponseChecklistItem[];
+  notes: ResponseSidebarNote[];
+};
+
+export function ResponseChecklistSidebar({
+  items,
+  notes,
+}: ResponseChecklistSidebarProps) {
+  const completedCount = items.filter((item) => item.completed).length;
+  const openCount = items.length - completedCount;
+
+  return (
+    <aside
+      aria-labelledby="response-checklist-heading"
+      className="rounded-[2rem] border border-slate-200/80 bg-slate-950 p-6 text-white shadow-[0_28px_90px_rgba(15,23,42,0.28)] sm:p-7"
+    >
+      <div className="rounded-[1.5rem] border border-white/10 bg-white/6 p-5">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-emerald-300">
+          Response sidebar
+        </p>
+        <h2
+          id="response-checklist-heading"
+          className="mt-4 text-3xl font-semibold tracking-tight"
+        >
+          Checklist before the next regional handoff.
+        </h2>
+        <p className="mt-4 text-sm leading-7 text-slate-300">
+          The sidebar turns active issues into a short operational checklist so
+          the handoff stays concrete and easy to verify.
+        </p>
+
+        <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
+          <div className="rounded-[1.15rem] bg-white/8 px-4 py-3">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+              Open actions
+            </p>
+            <p className="mt-2 text-2xl font-semibold text-white">{openCount}</p>
+          </div>
+          <div className="rounded-[1.15rem] bg-white/8 px-4 py-3">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+              Completed
+            </p>
+            <p className="mt-2 text-2xl font-semibold text-white">
+              {completedCount}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+          Active checklist
+        </p>
+        <div aria-label="Response checklist" className="mt-4 space-y-3" role="list">
+          {items.map((item) => (
+            <div
+              key={item.id}
+              className="rounded-[1.35rem] border border-white/10 bg-white/6 p-4"
+              role="listitem"
+            >
+              <div className="flex items-start gap-3">
+                <div
+                  aria-hidden="true"
+                  className={`mt-1 h-5 w-5 rounded-full border ${
+                    item.completed
+                      ? "border-emerald-300 bg-emerald-300"
+                      : "border-white/35 bg-transparent"
+                  }`}
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <h3 className="text-base font-semibold text-white">
+                        {item.title}
+                      </h3>
+                      <p className="mt-1 text-sm text-slate-300">{item.owner}</p>
+                    </div>
+                    <span className="rounded-full border border-white/10 bg-white/8 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-300">
+                      {item.dueBy}
+                    </span>
+                  </div>
+                  <p className="mt-3 text-sm leading-6 text-slate-300">
+                    {item.detail}
+                  </p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-6 rounded-[1.5rem] border border-white/10 bg-white/6 p-5">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+          Handoff notes
+        </p>
+        <dl className="mt-4 space-y-4">
+          {notes.map((note) => (
+            <div key={note.label}>
+              <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                {note.label}
+              </dt>
+              <dd className="mt-1 text-sm leading-6 text-white">{note.value}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </aside>
+  );
+}

--- a/src/app/status-board/_components/response-checklist-sidebar.tsx
+++ b/src/app/status-board/_components/response-checklist-sidebar.tsx
@@ -18,7 +18,7 @@ export function ResponseChecklistSidebar({
   return (
     <aside
       aria-labelledby="response-checklist-heading"
-      className="rounded-[2rem] border border-slate-200/80 bg-slate-950 p-6 text-white shadow-[0_28px_90px_rgba(15,23,42,0.28)] sm:p-7"
+      className="rounded-[2rem] border border-slate-200/80 bg-slate-950 p-6 text-white shadow-[0_28px_90px_rgba(15,23,42,0.28)] sm:p-7 xl:sticky xl:top-6"
     >
       <div className="rounded-[1.5rem] border border-white/10 bg-white/6 p-5">
         <p className="text-xs font-semibold uppercase tracking-[0.28em] text-emerald-300">

--- a/src/app/status-board/_components/service-health-card.tsx
+++ b/src/app/status-board/_components/service-health-card.tsx
@@ -10,6 +10,7 @@ export function ServiceHealthCard({ service }: ServiceHealthCardProps) {
 
   return (
     <li
+      data-state={service.status}
       className={`rounded-[1.5rem] border p-5 shadow-[0_18px_45px_rgba(15,23,42,0.06)] ${styles.panel}`}
     >
       <div className="flex items-start justify-between gap-4">

--- a/src/app/status-board/_components/service-health-card.tsx
+++ b/src/app/status-board/_components/service-health-card.tsx
@@ -1,0 +1,69 @@
+import type { ServiceHealthItem } from "../_data/status-board-data";
+import { healthStateLabels, serviceStateStyles } from "./state-styles";
+
+type ServiceHealthCardProps = {
+  service: ServiceHealthItem;
+};
+
+export function ServiceHealthCard({ service }: ServiceHealthCardProps) {
+  const styles = serviceStateStyles[service.status];
+
+  return (
+    <li
+      className={`rounded-[1.5rem] border p-5 shadow-[0_18px_45px_rgba(15,23,42,0.06)] ${styles.panel}`}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+            {service.category}
+          </p>
+          <h3 className="text-2xl font-semibold tracking-tight text-slate-950">
+            {service.name}
+          </h3>
+          <p className="text-sm text-slate-600">{service.owner}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className={`h-2.5 w-2.5 rounded-full ${styles.accent}`} />
+          <span
+            className={`rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${styles.badge}`}
+          >
+            {healthStateLabels[service.status]}
+          </span>
+        </div>
+      </div>
+
+      <p className="mt-4 text-sm leading-6 text-slate-700">{service.summary}</p>
+
+      <dl className="mt-5 grid gap-4 sm:grid-cols-3">
+        <div>
+          <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+            Uptime
+          </dt>
+          <dd className="mt-2 text-base font-semibold text-slate-950">
+            {service.uptime}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+            Latency
+          </dt>
+          <dd className="mt-2 text-base font-semibold text-slate-950">
+            {service.latency}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+            Incidents
+          </dt>
+          <dd className="mt-2 text-base font-semibold text-slate-950">
+            {service.incidents}
+          </dd>
+        </div>
+      </dl>
+
+      <p className="mt-5 rounded-[1rem] bg-slate-950 px-4 py-3 text-sm font-medium text-slate-100">
+        {service.nextUpdate}
+      </p>
+    </li>
+  );
+}

--- a/src/app/status-board/_components/state-styles.ts
+++ b/src/app/status-board/_components/state-styles.ts
@@ -1,0 +1,49 @@
+import type { HealthState } from "../_data/status-board-data";
+
+export const healthStateLabels: Record<HealthState, string> = {
+  healthy: "Healthy",
+  warning: "Warning",
+  degraded: "Degraded",
+};
+
+export const summaryStateStyles: Record<
+  HealthState,
+  { panel: string; badge: string; value: string }
+> = {
+  healthy: {
+    panel: "border-emerald-200 bg-emerald-50/80",
+    badge: "border-emerald-300 bg-emerald-100 text-emerald-800",
+    value: "text-emerald-950",
+  },
+  warning: {
+    panel: "border-amber-200 bg-amber-50/80",
+    badge: "border-amber-300 bg-amber-100 text-amber-900",
+    value: "text-amber-950",
+  },
+  degraded: {
+    panel: "border-rose-200 bg-rose-50/85",
+    badge: "border-rose-300 bg-rose-100 text-rose-900",
+    value: "text-rose-950",
+  },
+};
+
+export const serviceStateStyles: Record<
+  HealthState,
+  { panel: string; badge: string; accent: string }
+> = {
+  healthy: {
+    panel: "border-emerald-200/90 bg-white/85",
+    badge: "border-emerald-200 bg-emerald-50 text-emerald-800",
+    accent: "bg-emerald-500",
+  },
+  warning: {
+    panel: "border-amber-200/90 bg-white/85",
+    badge: "border-amber-200 bg-amber-50 text-amber-900",
+    accent: "bg-amber-500",
+  },
+  degraded: {
+    panel: "border-rose-200/90 bg-white/85",
+    badge: "border-rose-200 bg-rose-50 text-rose-900",
+    accent: "bg-rose-500",
+  },
+};

--- a/src/app/status-board/_components/status-summary-banner.tsx
+++ b/src/app/status-board/_components/status-summary-banner.tsx
@@ -10,6 +10,7 @@ export function StatusSummaryBanner({ stat }: StatusSummaryBannerProps) {
 
   return (
     <article
+      role="listitem"
       className={`rounded-[1.6rem] border p-5 shadow-[0_18px_50px_rgba(15,23,42,0.06)] ${styles.panel}`}
     >
       <div className="flex items-start justify-between gap-3">

--- a/src/app/status-board/_components/status-summary-banner.tsx
+++ b/src/app/status-board/_components/status-summary-banner.tsx
@@ -1,0 +1,31 @@
+import type { StatusBoardSummaryStat } from "../_data/status-board-data";
+import { healthStateLabels, summaryStateStyles } from "./state-styles";
+
+type StatusSummaryBannerProps = {
+  stat: StatusBoardSummaryStat;
+};
+
+export function StatusSummaryBanner({ stat }: StatusSummaryBannerProps) {
+  const styles = summaryStateStyles[stat.state];
+
+  return (
+    <article
+      className={`rounded-[1.6rem] border p-5 shadow-[0_18px_50px_rgba(15,23,42,0.06)] ${styles.panel}`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-600">
+          {stat.label}
+        </p>
+        <span
+          className={`rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${styles.badge}`}
+        >
+          {healthStateLabels[stat.state]}
+        </span>
+      </div>
+      <p className={`mt-4 text-3xl font-semibold tracking-tight ${styles.value}`}>
+        {stat.value}
+      </p>
+      <p className="mt-3 text-sm leading-6 text-slate-700">{stat.detail}</p>
+    </article>
+  );
+}

--- a/src/app/status-board/_components/status-summary-banner.tsx
+++ b/src/app/status-board/_components/status-summary-banner.tsx
@@ -10,6 +10,7 @@ export function StatusSummaryBanner({ stat }: StatusSummaryBannerProps) {
 
   return (
     <article
+      data-state={stat.state}
       role="listitem"
       className={`rounded-[1.6rem] border p-5 shadow-[0_18px_50px_rgba(15,23,42,0.06)] ${styles.panel}`}
     >

--- a/src/app/status-board/_data/status-board-data.ts
+++ b/src/app/status-board/_data/status-board-data.ts
@@ -32,6 +32,20 @@ export interface RegionalHealthGroup {
   services: ServiceHealthItem[];
 }
 
+export interface ResponseChecklistItem {
+  id: string;
+  title: string;
+  owner: string;
+  dueBy: string;
+  completed: boolean;
+  detail: string;
+}
+
+export interface ResponseSidebarNote {
+  label: string;
+  value: string;
+}
+
 export const statusBoardSummary = {
   eyebrow: "Status Board",
   title: "Track regional service health and response posture in one place.",
@@ -289,3 +303,57 @@ export const regionalHealthGroups = [
     ],
   },
 ] satisfies RegionalHealthGroup[];
+
+export const responseChecklist = [
+  {
+    id: "carrier-escalation",
+    title: "Confirm carrier escalation coverage for North America fanout retries",
+    owner: "Messaging platform",
+    dueBy: "Due in 9 minutes",
+    completed: false,
+    detail:
+      "Validate whether the backup routing policy should be extended through the east region peak window.",
+  },
+  {
+    id: "frankfurt-storage",
+    title: "Review Frankfurt storage recovery before reopening large export jobs",
+    owner: "Insights platform",
+    dueBy: "Due in 6 minutes",
+    completed: false,
+    detail:
+      "Keep enterprise export queues throttled until storage rehydration clears the recovery checkpoint.",
+  },
+  {
+    id: "latam-autoscale",
+    title: "Approve additional ingest workers for the Sao Paulo billing spike",
+    owner: "Records platform",
+    dueBy: "Due in 12 minutes",
+    completed: false,
+    detail:
+      "Worker saturation is increasing queue time for invoice and verification uploads across LATAM.",
+  },
+  {
+    id: "support-failover",
+    title: "Verify support intake failover after the Bogota balancer rotation",
+    owner: "Support systems",
+    dueBy: "Review in 4 minutes",
+    completed: true,
+    detail:
+      "Primary unhealthy node has been removed and active traffic is now pinned to the healthy pair.",
+  },
+] satisfies ResponseChecklistItem[];
+
+export const responseSidebarNotes = [
+  {
+    label: "Escalation lead",
+    value: "Aisha Morgan · Reliability command",
+  },
+  {
+    label: "Next operations review",
+    value: "09:00 UTC regional handoff",
+  },
+  {
+    label: "Customer advisory",
+    value: "Prepared for Europe exports and LATAM support intake",
+  },
+] satisfies ResponseSidebarNote[];

--- a/src/app/status-board/_data/status-board-data.ts
+++ b/src/app/status-board/_data/status-board-data.ts
@@ -1,0 +1,291 @@
+export type HealthState = "healthy" | "warning" | "degraded";
+
+export interface StatusBoardSummaryStat {
+  label: string;
+  value: string;
+  detail: string;
+  state: HealthState;
+}
+
+export interface ServiceHealthItem {
+  id: string;
+  name: string;
+  category: string;
+  owner: string;
+  status: HealthState;
+  uptime: string;
+  latency: string;
+  incidents: string;
+  summary: string;
+  nextUpdate: string;
+}
+
+export interface RegionalHealthGroup {
+  id: string;
+  name: string;
+  coverageWindow: string;
+  status: HealthState;
+  summary: string;
+  serviceCount: number;
+  warningCount: number;
+  degradedCount: number;
+  services: ServiceHealthItem[];
+}
+
+export const statusBoardSummary = {
+  eyebrow: "Status Board",
+  title: "Track regional service health and response posture in one place.",
+  description:
+    "A route-scoped monitoring board for reviewing service reliability, regional exceptions, and where the response team needs to focus next.",
+  generatedAt: "Snapshot captured at 08:42 UTC",
+  stats: [
+    {
+      label: "Regions reporting",
+      value: "4",
+      detail: "North America, Europe, APAC, and LATAM are included in the board.",
+      state: "healthy",
+    },
+    {
+      label: "Healthy services",
+      value: "9",
+      detail: "Most services are staying within expected latency and availability targets.",
+      state: "healthy",
+    },
+    {
+      label: "Warning services",
+      value: "2",
+      detail: "Elevated attention is needed before these services tip into an incident state.",
+      state: "warning",
+    },
+    {
+      label: "Degraded services",
+      value: "2",
+      detail: "Two services currently need direct intervention from response leads.",
+      state: "degraded",
+    },
+  ] satisfies StatusBoardSummaryStat[],
+};
+
+export const regionalHealthGroups = [
+  {
+    id: "north-america",
+    name: "North America",
+    coverageWindow: "Coverage 24 / 7 · Handoffs every 6 hours",
+    status: "warning",
+    summary:
+      "Core delivery and search services remain online, but the notifications pipeline is seeing rising retry pressure in the east region.",
+    serviceCount: 4,
+    warningCount: 1,
+    degradedCount: 0,
+    services: [
+      {
+        id: "na-edge-api",
+        name: "Edge API Gateway",
+        category: "Traffic and routing",
+        owner: "Platform edge",
+        status: "healthy",
+        uptime: "99.99%",
+        latency: "184 ms p95",
+        incidents: "No active incidents",
+        summary:
+          "Ingress traffic is within expected limits and cache hit rates stayed above the overnight target.",
+        nextUpdate: "Next region review in 18 minutes",
+      },
+      {
+        id: "na-search-cluster",
+        name: "Search Cluster",
+        category: "Discovery",
+        owner: "Search reliability",
+        status: "healthy",
+        uptime: "99.97%",
+        latency: "231 ms p95",
+        incidents: "1 resolved this shift",
+        summary:
+          "Query latency normalized after a rolling shard rebalance completed before the morning peak.",
+        nextUpdate: "Capacity review in 42 minutes",
+      },
+      {
+        id: "na-notifications",
+        name: "Notification Fanout",
+        category: "Messaging",
+        owner: "Messaging platform",
+        status: "warning",
+        uptime: "99.74%",
+        latency: "2.1 s dispatch",
+        incidents: "Retries elevated",
+        summary:
+          "Retry queues are climbing for SMS and push delivery in the east region after a third-party carrier slowdown.",
+        nextUpdate: "Carrier escalation check in 9 minutes",
+      },
+      {
+        id: "na-billing-sync",
+        name: "Billing Sync",
+        category: "Finance operations",
+        owner: "Revenue systems",
+        status: "healthy",
+        uptime: "99.95%",
+        latency: "7 min batch lag",
+        incidents: "No active incidents",
+        summary:
+          "Sync jobs are completing inside the hourly batch window with no reconciliation backlog on the ledger side.",
+        nextUpdate: "Ledger audit at top of hour",
+      },
+    ],
+  },
+  {
+    id: "europe",
+    name: "Europe",
+    coverageWindow: "Coverage 20 / 7 · Follow-the-sun support",
+    status: "degraded",
+    summary:
+      "Authentication remains stable, but reporting exports are degraded while the Frankfurt storage cluster finishes a recovery cycle.",
+    serviceCount: 3,
+    warningCount: 0,
+    degradedCount: 1,
+    services: [
+      {
+        id: "eu-auth",
+        name: "Identity Gateway",
+        category: "Authentication",
+        owner: "Trust platform",
+        status: "healthy",
+        uptime: "99.98%",
+        latency: "143 ms p95",
+        incidents: "No active incidents",
+        summary:
+          "Token issuance and session refresh traffic stayed flat through the last release window.",
+        nextUpdate: "Trust review in 35 minutes",
+      },
+      {
+        id: "eu-exports",
+        name: "Reporting Exports",
+        category: "Analytics delivery",
+        owner: "Insights platform",
+        status: "degraded",
+        uptime: "98.92%",
+        latency: "34 min queue delay",
+        incidents: "Customer-visible degradation",
+        summary:
+          "Large CSV export jobs are queued behind storage rehydration work in Frankfurt, delaying enterprise reporting deliveries.",
+        nextUpdate: "Storage recovery checkpoint in 6 minutes",
+      },
+      {
+        id: "eu-workflows",
+        name: "Workflow Runner",
+        category: "Automation",
+        owner: "Automation systems",
+        status: "healthy",
+        uptime: "99.96%",
+        latency: "11 s median task start",
+        incidents: "No active incidents",
+        summary:
+          "Background jobs are staying within concurrency limits after a scheduler tune-up earlier in the shift.",
+        nextUpdate: "Queue sweep in 27 minutes",
+      },
+    ],
+  },
+  {
+    id: "apac",
+    name: "APAC",
+    coverageWindow: "Coverage 24 / 7 · Primary desk in Singapore",
+    status: "healthy",
+    summary:
+      "The APAC region is steady with healthy demand handling across app traffic, media processing, and partner webhooks.",
+    serviceCount: 3,
+    warningCount: 0,
+    degradedCount: 0,
+    services: [
+      {
+        id: "apac-app-shell",
+        name: "App Shell",
+        category: "Frontend delivery",
+        owner: "Experience platform",
+        status: "healthy",
+        uptime: "99.99%",
+        latency: "119 ms p95",
+        incidents: "No active incidents",
+        summary:
+          "Static and dynamic route delivery is stable across Tokyo, Singapore, and Sydney edge regions.",
+        nextUpdate: "Synthetic review in 21 minutes",
+      },
+      {
+        id: "apac-media",
+        name: "Media Processor",
+        category: "Uploads and transforms",
+        owner: "Media services",
+        status: "healthy",
+        uptime: "99.94%",
+        latency: "48 s average job time",
+        incidents: "No active incidents",
+        summary:
+          "Transcode queues are below threshold and high-resolution exports are clearing without worker saturation.",
+        nextUpdate: "Worker pool audit in 54 minutes",
+      },
+      {
+        id: "apac-partner-hooks",
+        name: "Partner Webhooks",
+        category: "Integrations",
+        owner: "Partner ecosystem",
+        status: "healthy",
+        uptime: "99.93%",
+        latency: "412 ms p95",
+        incidents: "No active incidents",
+        summary:
+          "Delivery success has remained above the weekly baseline after yesterday's retry policy adjustment.",
+        nextUpdate: "Partner pulse in 31 minutes",
+      },
+    ],
+  },
+  {
+    id: "latam",
+    name: "LATAM",
+    coverageWindow: "Coverage 18 / 7 · Regional escalation desk",
+    status: "warning",
+    summary:
+      "Checkout and support intake are online, but document ingestion is trending toward saturation during the current billing-cycle spike.",
+    serviceCount: 3,
+    warningCount: 1,
+    degradedCount: 1,
+    services: [
+      {
+        id: "latam-checkout",
+        name: "Checkout Service",
+        category: "Transactions",
+        owner: "Commerce core",
+        status: "healthy",
+        uptime: "99.97%",
+        latency: "287 ms p95",
+        incidents: "No active incidents",
+        summary:
+          "Authorization and fraud checks are completing within normal bounds even with end-of-month transaction growth.",
+        nextUpdate: "Fraud trend review in 24 minutes",
+      },
+      {
+        id: "latam-doc-ingest",
+        name: "Document Ingest",
+        category: "File intake",
+        owner: "Records platform",
+        status: "warning",
+        uptime: "99.68%",
+        latency: "4.8 min queue time",
+        incidents: "Backlog above threshold",
+        summary:
+          "Invoice and identity-verification uploads are queuing faster than workers can clear them in Sao Paulo.",
+        nextUpdate: "Autoscaling decision in 12 minutes",
+      },
+      {
+        id: "latam-support-intake",
+        name: "Support Intake",
+        category: "Case routing",
+        owner: "Support systems",
+        status: "degraded",
+        uptime: "98.71%",
+        latency: "6.4 s form submit",
+        incidents: "Intermittent submission failures",
+        summary:
+          "Customers are hitting sporadic submission errors while the Bogota queue balancer recovers from an unhealthy node rotation.",
+        nextUpdate: "Balancer failover review in 4 minutes",
+      },
+    ],
+  },
+] satisfies RegionalHealthGroup[];

--- a/src/app/status-board/page.test.tsx
+++ b/src/app/status-board/page.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  regionalHealthGroups,
+  responseChecklist,
+  responseSidebarNotes,
+  statusBoardSummary,
+} from "./_data/status-board-data";
+import StatusBoardPage from "./page";
+
+describe("StatusBoardPage", () => {
+  it("renders the route shell, hero summary, and checklist sidebar", () => {
+    render(<StatusBoardPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /track regional service health and response posture in one place/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /service health grouped by region/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /checklist before the next regional handoff/i,
+      }),
+    ).toBeInTheDocument();
+
+    const summaryList = screen.getByRole("list", {
+      name: /status board summary/i,
+    });
+
+    expect(within(summaryList).getAllByRole("listitem")).toHaveLength(
+      statusBoardSummary.stats.length,
+    );
+    expect(screen.getByTestId("status-board-layout").className).toContain(
+      "xl:grid-cols-[minmax(0,1.32fr)_minmax(320px,0.78fr)]",
+    );
+  });
+
+  it("renders every configured region with its grouped service cards", () => {
+    render(<StatusBoardPage />);
+
+    for (const group of regionalHealthGroups) {
+      const groupHeading = screen.getByRole("heading", {
+        level: 2,
+        name: group.name,
+      });
+      const groupSection = groupHeading.closest("section");
+
+      expect(groupSection).toBeInTheDocument();
+      expect(groupSection).toHaveAttribute("data-state", group.status);
+      expect(within(groupSection as HTMLElement).getByText(group.summary)).toBeInTheDocument();
+
+      const serviceList = within(groupSection as HTMLElement).getByRole("list", {
+        name: `${group.name} services`,
+      });
+
+      expect(within(serviceList).getAllByRole("listitem")).toHaveLength(
+        group.services.length,
+      );
+
+      for (const service of group.services) {
+        const card = within(serviceList).getByText(service.name).closest("li");
+
+        expect(card).toBeInTheDocument();
+        expect(card).toHaveAttribute("data-state", service.status);
+        expect(card).toHaveTextContent(service.uptime);
+        expect(card).toHaveTextContent(service.latency);
+      }
+    }
+  });
+
+  it("renders checklist items, completion counts, and handoff notes", () => {
+    render(<StatusBoardPage />);
+
+    const checklist = screen.getByRole("list", {
+      name: /response checklist/i,
+    });
+    const sidebarHeading = screen.getByRole("heading", {
+      level: 2,
+      name: /checklist before the next regional handoff/i,
+    });
+    const sidebar = sidebarHeading.closest("aside");
+
+    expect(within(checklist).getAllByRole("listitem")).toHaveLength(
+      responseChecklist.length,
+    );
+    expect(sidebar).toBeInTheDocument();
+    expect(sidebar).toHaveTextContent("Open actions");
+    expect(sidebar).toHaveTextContent(
+      String(responseChecklist.filter((item) => !item.completed).length),
+    );
+    expect(sidebar).toHaveTextContent("Completed");
+    expect(sidebar).toHaveTextContent(
+      String(responseChecklist.filter((item) => item.completed).length),
+    );
+
+    for (const note of responseSidebarNotes) {
+      expect(screen.getByText(note.label)).toBeInTheDocument();
+      expect(screen.getByText(note.value)).toBeInTheDocument();
+    }
+  });
+});

--- a/src/app/status-board/page.tsx
+++ b/src/app/status-board/page.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Status Board",
+  description:
+    "A regional service health route for monitoring service posture and response readiness.",
+};
+
+export default function StatusBoardPage() {
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
+      <section className="rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] p-8 shadow-[0_20px_90px_rgba(15,23,42,0.08)] sm:p-10">
+        <p className="text-sm font-semibold uppercase tracking-[0.28em] text-emerald-700">
+          Status Board
+        </p>
+        <h1 className="mt-4 max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
+          Monitor regional service health without leaving the app shell.
+        </h1>
+        <p className="mt-4 max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
+          The full regional board, response checklist, and mock health signals
+          will be assembled in follow-up subtasks.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/app/status-board/page.tsx
+++ b/src/app/status-board/page.tsx
@@ -1,5 +1,15 @@
 import type { Metadata } from "next";
 
+import { RegionalHealthGroup } from "./_components/regional-health-group";
+import { ResponseChecklistSidebar } from "./_components/response-checklist-sidebar";
+import { StatusSummaryBanner } from "./_components/status-summary-banner";
+import {
+  regionalHealthGroups,
+  responseChecklist,
+  responseSidebarNotes,
+  statusBoardSummary,
+} from "./_data/status-board-data";
+
 export const metadata: Metadata = {
   title: "Status Board",
   description:
@@ -7,20 +17,127 @@ export const metadata: Metadata = {
 };
 
 export default function StatusBoardPage() {
+  const impactedRegions = regionalHealthGroups.filter(
+    (group) => group.warningCount > 0 || group.degradedCount > 0,
+  ).length;
+  const degradedRegions = regionalHealthGroups.filter(
+    (group) => group.degradedCount > 0,
+  ).length;
+
   return (
-    <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
-      <section className="rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] p-8 shadow-[0_20px_90px_rgba(15,23,42,0.08)] sm:p-10">
-        <p className="text-sm font-semibold uppercase tracking-[0.28em] text-emerald-700">
-          Status Board
-        </p>
-        <h1 className="mt-4 max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-          Monitor regional service health without leaving the app shell.
-        </h1>
-        <p className="mt-4 max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
-          The full regional board, response checklist, and mock health signals
-          will be assembled in follow-up subtasks.
-        </p>
+    <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8 px-5 py-8 sm:px-8 lg:px-10 lg:py-12">
+      <section className="overflow-hidden rounded-[2.5rem] border border-slate-200/70 bg-slate-950 px-6 py-8 text-white shadow-[0_36px_110px_-48px_rgba(15,23,42,0.9)] sm:px-8 lg:px-10 lg:py-10">
+        <div className="grid gap-8 xl:grid-cols-[minmax(0,1.45fr)_minmax(300px,0.85fr)]">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-emerald-300">
+              {statusBoardSummary.eyebrow}
+            </p>
+            <h1 className="mt-4 max-w-4xl text-4xl font-semibold tracking-tight sm:text-5xl lg:text-6xl">
+              {statusBoardSummary.title}
+            </h1>
+            <p className="mt-5 max-w-3xl text-base leading-8 text-slate-300 sm:text-lg">
+              {statusBoardSummary.description}
+            </p>
+
+            <div className="mt-6 flex flex-wrap gap-3 text-sm text-slate-300">
+              <span className="rounded-full border border-white/10 bg-white/8 px-3 py-1.5">
+                {statusBoardSummary.generatedAt}
+              </span>
+              <span className="rounded-full border border-white/10 bg-white/8 px-3 py-1.5">
+                {impactedRegions} impacted regions under active review
+              </span>
+              <span className="rounded-full border border-white/10 bg-white/8 px-3 py-1.5">
+                {degradedRegions} degraded region needs direct intervention
+              </span>
+            </div>
+          </div>
+
+          <aside className="rounded-[2rem] border border-white/10 bg-white/8 p-5">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+              Response posture
+            </p>
+            <h2 className="mt-3 text-3xl font-semibold tracking-tight text-white">
+              Focus on export recovery, support failover, and backlog pressure.
+            </h2>
+            <p className="mt-4 text-sm leading-7 text-slate-300">
+              The route is designed to let an operator scan summary counts, move
+              region by region, and finish with a clear checklist for the next
+              handoff.
+            </p>
+
+            <div className="mt-6 grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
+              <div className="rounded-[1.25rem] bg-white/8 px-4 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                  Regions tracked
+                </p>
+                <p className="mt-2 text-2xl font-semibold text-white">
+                  {regionalHealthGroups.length}
+                </p>
+              </div>
+              <div className="rounded-[1.25rem] bg-white/8 px-4 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                  Checklist items
+                </p>
+                <p className="mt-2 text-2xl font-semibold text-white">
+                  {responseChecklist.length}
+                </p>
+              </div>
+              <div className="rounded-[1.25rem] bg-white/8 px-4 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                  Summary cards
+                </p>
+                <p className="mt-2 text-2xl font-semibold text-white">
+                  {statusBoardSummary.stats.length}
+                </p>
+              </div>
+            </div>
+          </aside>
+        </div>
+
+        <div
+          aria-label="Status board summary"
+          className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-4"
+          role="list"
+        >
+          {statusBoardSummary.stats.map((stat) => (
+            <StatusSummaryBanner key={stat.label} stat={stat} />
+          ))}
+        </div>
       </section>
+
+      <div
+        className="grid gap-8 xl:grid-cols-[minmax(0,1.32fr)_minmax(320px,0.78fr)] xl:items-start"
+        data-testid="status-board-layout"
+      >
+        <section aria-labelledby="status-board-regions" className="space-y-6">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                Regional coverage
+              </p>
+              <h2
+                id="status-board-regions"
+                className="mt-2 text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl"
+              >
+                Service health grouped by region
+              </h2>
+            </div>
+            <p className="max-w-2xl text-sm leading-7 text-slate-600">
+              Each region includes its own health summary, grouped service cards,
+              and operator-friendly counts for warnings and degraded systems.
+            </p>
+          </div>
+
+          {regionalHealthGroups.map((group) => (
+            <RegionalHealthGroup key={group.id} group={group} />
+          ))}
+        </section>
+
+        <ResponseChecklistSidebar
+          items={responseChecklist}
+          notes={responseSidebarNotes}
+        />
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- build the standalone `/status-board` route with summary banners, grouped regional service cards, and a checklist-style response sidebar
- add route-local mock service-health data covering multiple regions with healthy, warning, and degraded states
- add render tests for the hero summary, grouped regional content, and checklist sidebar

## Verification
- `npm test`
- `npm run build`

Closes #102