### PR TITLE
[Test] Add Lab Notebook route with experiment panels

### DIFF
--- a/src/app/lab-notebook/_components/experiment-entry-card.tsx
+++ b/src/app/lab-notebook/_components/experiment-entry-card.tsx
@@ -6,7 +6,15 @@ const statusClasses: Record<ExperimentEntry["status"], string> = {
   Blocked: "border-rose-300/45 bg-rose-300/16 text-rose-950",
 };
 
-export function ExperimentEntryCard({ entry }: { entry: ExperimentEntry }) {
+export function ExperimentEntryCard({
+  entry,
+  observationCount,
+  observationHref,
+}: {
+  entry: ExperimentEntry;
+  observationCount: number;
+  observationHref?: string;
+}) {
   return (
     <article className="rounded-[1.7rem] border border-stone-900/10 bg-[rgba(255,251,247,0.94)] p-6 shadow-[0_18px_60px_rgba(68,42,22,0.08)] backdrop-blur-sm">
       <div className="flex flex-col gap-5">
@@ -98,6 +106,30 @@ export function ExperimentEntryCard({ entry }: { entry: ExperimentEntry }) {
                   </li>
                 ))}
               </ul>
+            </div>
+
+            <div className="rounded-[1.35rem] border border-stone-900/8 bg-white/70 p-4 sm:col-span-2 lg:col-span-1">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-500">
+                Linked notes
+              </p>
+              <p className="mt-2 text-sm leading-6 text-stone-600">
+                {observationCount} linked observation panel
+                {observationCount === 1 ? "" : "s"} in this notebook.
+              </p>
+
+              {observationHref ? (
+                <a
+                  aria-label={`Open linked observations for ${entry.codename}`}
+                  className="mt-3 inline-flex items-center justify-center rounded-full bg-stone-950 px-4 py-2 text-sm font-semibold text-stone-50 transition hover:bg-stone-800"
+                  href={observationHref}
+                >
+                  Open linked observations
+                </a>
+              ) : (
+                <p className="mt-3 text-sm font-medium text-stone-500">
+                  Observation notes will appear here when a panel is added.
+                </p>
+              )}
             </div>
           </div>
         </div>

--- a/src/app/lab-notebook/_components/experiment-entry-card.tsx
+++ b/src/app/lab-notebook/_components/experiment-entry-card.tsx
@@ -8,9 +8,9 @@ const statusClasses: Record<ExperimentEntry["status"], string> = {
 
 export function ExperimentEntryCard({ entry }: { entry: ExperimentEntry }) {
   return (
-    <article className="rounded-[1.7rem] border border-stone-900/10 bg-[rgba(255,251,247,0.92)] p-6 shadow-[0_18px_60px_rgba(68,42,22,0.08)]">
+    <article className="rounded-[1.7rem] border border-stone-900/10 bg-[rgba(255,251,247,0.94)] p-6 shadow-[0_18px_60px_rgba(68,42,22,0.08)] backdrop-blur-sm">
       <div className="flex flex-col gap-5">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
           <div className="space-y-3">
             <div className="flex flex-wrap items-center gap-3">
               <span className="rounded-full border border-stone-900/10 bg-stone-900/5 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-700">
@@ -33,7 +33,7 @@ export function ExperimentEntryCard({ entry }: { entry: ExperimentEntry }) {
             </div>
           </div>
 
-          <dl className="grid gap-3 rounded-[1.4rem] border border-stone-900/8 bg-stone-100/80 p-4 text-sm text-stone-700 sm:grid-cols-2 lg:min-w-[19rem] lg:grid-cols-1">
+          <dl className="grid gap-3 rounded-[1.4rem] border border-stone-900/8 bg-stone-100/80 p-4 text-sm text-stone-700 sm:grid-cols-2 xl:min-w-[19rem] xl:grid-cols-1">
             <div>
               <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-stone-500">
                 Lead
@@ -61,16 +61,20 @@ export function ExperimentEntryCard({ entry }: { entry: ExperimentEntry }) {
           </dl>
         </div>
 
-        <div className="grid gap-4 md:grid-cols-[minmax(0,1.1fr)_minmax(13rem,0.9fr)]">
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(14rem,0.8fr)]">
           <div className="rounded-[1.35rem] border border-stone-900/8 bg-stone-50/85 p-4">
             <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-500">
               Current read
             </p>
-            <p className="mt-3 text-base leading-7 text-stone-700">{entry.signal}</p>
-            <p className="mt-3 text-sm leading-6 text-stone-600">{entry.summary}</p>
+            <p className="mt-3 text-base leading-7 text-stone-700 sm:text-[1.02rem]">
+              {entry.signal}
+            </p>
+            <p className="mt-3 text-sm leading-6 text-stone-600 sm:text-[0.96rem]">
+              {entry.summary}
+            </p>
           </div>
 
-          <div className="grid gap-3">
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
             <div className="rounded-[1.35rem] border border-stone-900/8 bg-white/70 p-4">
               <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-500">
                 Risk level

--- a/src/app/lab-notebook/_components/experiment-entry-card.tsx
+++ b/src/app/lab-notebook/_components/experiment-entry-card.tsx
@@ -1,0 +1,103 @@
+import type { ExperimentEntry } from "../_data/lab-notebook-data";
+
+const statusClasses: Record<ExperimentEntry["status"], string> = {
+  Stable: "border-emerald-300/40 bg-emerald-300/14 text-emerald-950",
+  Watch: "border-amber-300/50 bg-amber-300/18 text-amber-950",
+  Blocked: "border-rose-300/45 bg-rose-300/16 text-rose-950",
+};
+
+export function ExperimentEntryCard({ entry }: { entry: ExperimentEntry }) {
+  return (
+    <article className="rounded-[1.7rem] border border-stone-900/10 bg-[rgba(255,251,247,0.92)] p-6 shadow-[0_18px_60px_rgba(68,42,22,0.08)]">
+      <div className="flex flex-col gap-5">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-3">
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="rounded-full border border-stone-900/10 bg-stone-900/5 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-700">
+                {entry.codename}
+              </span>
+              <span
+                className={`rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] ${statusClasses[entry.status]}`}
+              >
+                {entry.status}
+              </span>
+            </div>
+
+            <div className="space-y-2">
+              <h3 className="text-2xl font-semibold tracking-tight text-stone-950">
+                {entry.title}
+              </h3>
+              <p className="max-w-2xl text-sm leading-7 text-stone-600 sm:text-base">
+                {entry.objective}
+              </p>
+            </div>
+          </div>
+
+          <dl className="grid gap-3 rounded-[1.4rem] border border-stone-900/8 bg-stone-100/80 p-4 text-sm text-stone-700 sm:grid-cols-2 lg:min-w-[19rem] lg:grid-cols-1">
+            <div>
+              <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-stone-500">
+                Lead
+              </dt>
+              <dd className="mt-1 font-medium text-stone-950">{entry.lead}</dd>
+            </div>
+            <div>
+              <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-stone-500">
+                Facility
+              </dt>
+              <dd className="mt-1 font-medium text-stone-950">{entry.facility}</dd>
+            </div>
+            <div>
+              <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-stone-500">
+                Window
+              </dt>
+              <dd className="mt-1 font-medium text-stone-950">{entry.timeWindow}</dd>
+            </div>
+            <div>
+              <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-stone-500">
+                Stage
+              </dt>
+              <dd className="mt-1 font-medium text-stone-950">{entry.stage}</dd>
+            </div>
+          </dl>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-[minmax(0,1.1fr)_minmax(13rem,0.9fr)]">
+          <div className="rounded-[1.35rem] border border-stone-900/8 bg-stone-50/85 p-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-500">
+              Current read
+            </p>
+            <p className="mt-3 text-base leading-7 text-stone-700">{entry.signal}</p>
+            <p className="mt-3 text-sm leading-6 text-stone-600">{entry.summary}</p>
+          </div>
+
+          <div className="grid gap-3">
+            <div className="rounded-[1.35rem] border border-stone-900/8 bg-white/70 p-4">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-500">
+                Risk level
+              </p>
+              <p className="mt-2 text-lg font-semibold text-stone-950">
+                {entry.riskLevel}
+              </p>
+            </div>
+
+            <div className="rounded-[1.35rem] border border-stone-900/8 bg-white/70 p-4">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-stone-500">
+                Tags
+              </p>
+              <ul className="mt-3 flex flex-wrap gap-2" role="list">
+                {entry.tags.map((tag) => (
+                  <li
+                    key={tag}
+                    className="rounded-full bg-stone-900 px-3 py-1 text-xs font-medium text-stone-50"
+                  >
+                    {tag}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/app/lab-notebook/_components/observation-panel.tsx
+++ b/src/app/lab-notebook/_components/observation-panel.tsx
@@ -1,0 +1,84 @@
+import type { ObservationPanel as ObservationPanelData } from "../_data/lab-notebook-data";
+
+export function ObservationPanel({
+  panel,
+}: {
+  panel: ObservationPanelData;
+}) {
+  return (
+    <article className="rounded-[1.65rem] border border-stone-900/10 bg-[rgba(81,52,36,0.96)] p-6 text-amber-50 shadow-[0_18px_70px_rgba(43,24,13,0.28)]">
+      <div className="flex flex-col gap-5">
+        <div className="flex flex-col gap-4 border-b border-white/10 pb-5">
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="rounded-full border border-white/10 bg-white/8 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-amber-50">
+              {panel.window}
+            </span>
+            <span className="rounded-full border border-sky-200/18 bg-sky-200/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-sky-100">
+              {panel.signalGrade}
+            </span>
+          </div>
+
+          <div className="space-y-2">
+            <h3 className="text-2xl font-semibold tracking-tight text-white">
+              {panel.title}
+            </h3>
+            <p className="text-sm leading-7 text-amber-50/78 sm:text-base">
+              {panel.focus}
+            </p>
+          </div>
+
+          <div className="grid gap-3 text-sm text-amber-50/78 sm:grid-cols-2">
+            <div className="rounded-2xl border border-white/8 bg-white/6 px-4 py-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-amber-50/60">
+                Recorder
+              </p>
+              <p className="mt-2 font-medium text-white">{panel.recorder}</p>
+            </div>
+            <div className="rounded-2xl border border-white/8 bg-white/6 px-4 py-3">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-amber-50/60">
+                Linked entry
+              </p>
+              <p className="mt-2 font-medium text-white">{panel.experimentId}</p>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-amber-50/60">
+            Observation notes
+          </p>
+          <ul className="mt-4 space-y-3" role="list">
+            {panel.notes.map((note) => (
+              <li
+                key={note}
+                className="rounded-2xl border border-white/8 bg-white/6 px-4 py-4 text-sm leading-7 text-amber-50/88"
+              >
+                {note}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="grid gap-3 lg:grid-cols-2">
+          <div className="rounded-[1.35rem] border border-amber-200/16 bg-amber-200/10 p-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-amber-50/62">
+              Anomaly
+            </p>
+            <p className="mt-3 text-sm leading-7 text-amber-50/88">
+              {panel.anomaly}
+            </p>
+          </div>
+
+          <div className="rounded-[1.35rem] border border-emerald-200/16 bg-emerald-200/10 p-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-50/76">
+              Next check
+            </p>
+            <p className="mt-3 text-sm leading-7 text-amber-50/88">
+              {panel.nextCheck}
+            </p>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/app/lab-notebook/_components/observation-panel.tsx
+++ b/src/app/lab-notebook/_components/observation-panel.tsx
@@ -2,11 +2,16 @@ import type { ObservationPanel as ObservationPanelData } from "../_data/lab-note
 
 export function ObservationPanel({
   panel,
+  entryLabel,
 }: {
   panel: ObservationPanelData;
+  entryLabel: string;
 }) {
   return (
-    <article className="rounded-[1.65rem] border border-stone-900/10 bg-[rgba(81,52,36,0.96)] p-6 text-amber-50 shadow-[0_18px_70px_rgba(43,24,13,0.28)]">
+    <article
+      className="scroll-mt-8 rounded-[1.65rem] border border-stone-900/10 bg-[rgba(81,52,36,0.96)] p-6 text-amber-50 shadow-[0_18px_70px_rgba(43,24,13,0.28)]"
+      id={panel.id}
+    >
       <div className="flex h-full flex-col gap-5">
         <div className="flex flex-col gap-4 border-b border-white/10 pb-5">
           <div className="flex flex-wrap items-center gap-3">
@@ -38,7 +43,7 @@ export function ObservationPanel({
               <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-amber-50/60">
                 Linked entry
               </p>
-              <p className="mt-2 font-medium text-white">{panel.experimentId}</p>
+              <p className="mt-2 font-medium text-white">{entryLabel}</p>
             </div>
           </div>
         </div>

--- a/src/app/lab-notebook/_components/observation-panel.tsx
+++ b/src/app/lab-notebook/_components/observation-panel.tsx
@@ -7,7 +7,7 @@ export function ObservationPanel({
 }) {
   return (
     <article className="rounded-[1.65rem] border border-stone-900/10 bg-[rgba(81,52,36,0.96)] p-6 text-amber-50 shadow-[0_18px_70px_rgba(43,24,13,0.28)]">
-      <div className="flex flex-col gap-5">
+      <div className="flex h-full flex-col gap-5">
         <div className="flex flex-col gap-4 border-b border-white/10 pb-5">
           <div className="flex flex-wrap items-center gap-3">
             <span className="rounded-full border border-white/10 bg-white/8 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-amber-50">
@@ -43,39 +43,41 @@ export function ObservationPanel({
           </div>
         </div>
 
-        <div>
-          <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-amber-50/60">
-            Observation notes
-          </p>
-          <ul className="mt-4 space-y-3" role="list">
-            {panel.notes.map((note) => (
-              <li
-                key={note}
-                className="rounded-2xl border border-white/8 bg-white/6 px-4 py-4 text-sm leading-7 text-amber-50/88"
-              >
-                {note}
-              </li>
-            ))}
-          </ul>
-        </div>
-
-        <div className="grid gap-3 lg:grid-cols-2">
-          <div className="rounded-[1.35rem] border border-amber-200/16 bg-amber-200/10 p-4">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-amber-50/62">
-              Anomaly
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1.12fr)_minmax(15rem,0.88fr)] xl:items-start">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-amber-50/60">
+              Observation notes
             </p>
-            <p className="mt-3 text-sm leading-7 text-amber-50/88">
-              {panel.anomaly}
-            </p>
+            <ul className="mt-4 space-y-3" role="list">
+              {panel.notes.map((note) => (
+                <li
+                  key={note}
+                  className="rounded-2xl border border-white/8 bg-white/6 px-4 py-4 text-sm leading-7 text-amber-50/88"
+                >
+                  {note}
+                </li>
+              ))}
+            </ul>
           </div>
 
-          <div className="rounded-[1.35rem] border border-emerald-200/16 bg-emerald-200/10 p-4">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-50/76">
-              Next check
-            </p>
-            <p className="mt-3 text-sm leading-7 text-amber-50/88">
-              {panel.nextCheck}
-            </p>
+          <div className="grid gap-3 xl:sticky xl:top-6">
+            <div className="rounded-[1.35rem] border border-amber-200/16 bg-amber-200/10 p-4">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-amber-50/62">
+                Anomaly
+              </p>
+              <p className="mt-3 text-sm leading-7 text-amber-50/88">
+                {panel.anomaly}
+              </p>
+            </div>
+
+            <div className="rounded-[1.35rem] border border-emerald-200/16 bg-emerald-200/10 p-4">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-50/76">
+                Next check
+              </p>
+              <p className="mt-3 text-sm leading-7 text-amber-50/88">
+                {panel.nextCheck}
+              </p>
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/lab-notebook/_components/status-summary-card.tsx
+++ b/src/app/lab-notebook/_components/status-summary-card.tsx
@@ -1,0 +1,25 @@
+import type { NotebookSummaryMetric } from "../_data/lab-notebook-data";
+
+const toneClasses: Record<NotebookSummaryMetric["tone"], string> = {
+  stable: "border-emerald-300/35 bg-emerald-300/14 text-emerald-950",
+  watch: "border-amber-300/45 bg-amber-300/18 text-amber-950",
+  blocked: "border-rose-300/40 bg-rose-300/16 text-rose-950",
+};
+
+export function StatusSummaryCard({
+  metric,
+}: {
+  metric: NotebookSummaryMetric;
+}) {
+  return (
+    <article
+      className={`rounded-[1.55rem] border p-5 shadow-[0_14px_50px_rgba(68,42,22,0.08)] ${toneClasses[metric.tone]}`}
+    >
+      <p className="text-[11px] font-semibold uppercase tracking-[0.24em] opacity-75">
+        {metric.label}
+      </p>
+      <p className="mt-3 text-4xl font-semibold tracking-tight">{metric.value}</p>
+      <p className="mt-3 text-sm leading-7 opacity-80">{metric.detail}</p>
+    </article>
+  );
+}

--- a/src/app/lab-notebook/_components/status-summary-card.tsx
+++ b/src/app/lab-notebook/_components/status-summary-card.tsx
@@ -13,13 +13,13 @@ export function StatusSummaryCard({
 }) {
   return (
     <article
-      className={`rounded-[1.55rem] border p-5 shadow-[0_14px_50px_rgba(68,42,22,0.08)] ${toneClasses[metric.tone]}`}
+      className={`flex h-full flex-col justify-between gap-4 rounded-[1.55rem] border p-5 shadow-[0_14px_50px_rgba(68,42,22,0.08)] backdrop-blur-sm ${toneClasses[metric.tone]}`}
     >
       <p className="text-[11px] font-semibold uppercase tracking-[0.24em] opacity-75">
         {metric.label}
       </p>
-      <p className="mt-3 text-4xl font-semibold tracking-tight">{metric.value}</p>
-      <p className="mt-3 text-sm leading-7 opacity-80">{metric.detail}</p>
+      <p className="text-4xl font-semibold tracking-tight">{metric.value}</p>
+      <p className="text-sm leading-7 opacity-80">{metric.detail}</p>
     </article>
   );
 }

--- a/src/app/lab-notebook/_data/lab-notebook-data.ts
+++ b/src/app/lab-notebook/_data/lab-notebook-data.ts
@@ -1,0 +1,228 @@
+export type ExperimentStatus = "Stable" | "Watch" | "Blocked";
+
+export type SummaryTone = "stable" | "watch" | "blocked";
+
+export type NotebookSummaryMetric = {
+  id: string;
+  label: string;
+  value: string;
+  detail: string;
+  tone: SummaryTone;
+};
+
+export type ExperimentEntry = {
+  id: string;
+  codename: string;
+  title: string;
+  objective: string;
+  lead: string;
+  facility: string;
+  timeWindow: string;
+  stage: string;
+  status: ExperimentStatus;
+  riskLevel: string;
+  signal: string;
+  summary: string;
+  tags: string[];
+};
+
+export type ObservationPanel = {
+  id: string;
+  experimentId: string;
+  title: string;
+  window: string;
+  recorder: string;
+  focus: string;
+  signalGrade: string;
+  notes: string[];
+  anomaly: string;
+  nextCheck: string;
+};
+
+export const notebookSummaryMetrics: NotebookSummaryMetric[] = [
+  {
+    id: "active-runs",
+    label: "Active runs",
+    value: "04",
+    detail: "Four notebook entries are in the current validation window.",
+    tone: "stable",
+  },
+  {
+    id: "watch-items",
+    label: "Watch items",
+    value: "02",
+    detail: "Two observations need tighter sampling before sign-off.",
+    tone: "watch",
+  },
+  {
+    id: "blocked-dependencies",
+    label: "Blocked dependencies",
+    value: "01",
+    detail: "One trial is waiting on a coolant manifold replacement.",
+    tone: "blocked",
+  },
+];
+
+export const experimentEntries: ExperimentEntry[] = [
+  {
+    id: "atlas-03",
+    codename: "Atlas-03",
+    title: "Cryogenic valve rebound study",
+    objective:
+      "Measure how quickly the primary valve train settles after a staged pressure release across three thermal profiles.",
+    lead: "Dr. Imani Rhodes",
+    facility: "East Annex / Bay 2",
+    timeWindow: "06:20-09:05 IST",
+    stage: "Thermal replay",
+    status: "Stable",
+    riskLevel: "Moderate",
+    signal: "Recovery holds inside the 2.4-second rebound threshold.",
+    summary:
+      "The cold-start and mid-band profiles stayed within tolerance, with only a brief spike during the final warm pass.",
+    tags: ["Cryogenics", "Valve train", "Replay run"],
+  },
+  {
+    id: "morrow-12",
+    codename: "Morrow-12",
+    title: "Acoustic lattice interference sweep",
+    objective:
+      "Map resonance pockets around the lattice shell while the drone cradle cycles through transit vibration patterns.",
+    lead: "Keon Alvarez",
+    facility: "Hangar South / Resonance Cage",
+    timeWindow: "09:40-12:15 IST",
+    stage: "Frequency isolation",
+    status: "Watch",
+    riskLevel: "Elevated",
+    signal: "Two upper-band harmonics are drifting outside the expected isolation range.",
+    summary:
+      "The sweep captured the expected baseline at low load, but the upper third of the band introduced inconsistent damping near the north strut.",
+    tags: ["Acoustics", "Lattice shell", "Transit vibration"],
+  },
+  {
+    id: "solace-07",
+    codename: "Solace-07",
+    title: "Coolant manifold endurance rehearsal",
+    objective:
+      "Validate manifold pressure stability through a forty-minute endurance loop before the overnight automation run.",
+    lead: "Nadia Park",
+    facility: "Core Loop / Service Spine",
+    timeWindow: "13:10-14:45 IST",
+    stage: "Preflight verification",
+    status: "Blocked",
+    riskLevel: "High",
+    signal: "Rehearsal stopped after a replacement seal showed uneven compression on the tertiary feed.",
+    summary:
+      "The endurance loop cannot resume until the tertiary branch is reseated and the spare manifold arrives from central stores.",
+    tags: ["Coolant", "Endurance", "Maintenance hold"],
+  },
+  {
+    id: "verve-21",
+    codename: "Verve-21",
+    title: "Photonic marker persistence pass",
+    objective:
+      "Track marker visibility across dust-heavy chamber light shifts to confirm that the inspection rig keeps lock at range.",
+    lead: "Asha Duvall",
+    facility: "West Chamber / Optics Lane",
+    timeWindow: "15:30-17:05 IST",
+    stage: "Visibility validation",
+    status: "Stable",
+    riskLevel: "Low",
+    signal: "Marker lock stayed above the 96% persistence target across all five chamber states.",
+    summary:
+      "The optics rig held strong despite particulate spikes, and the final dusk simulation exceeded the baseline from last week.",
+    tags: ["Optics", "Marker tracking", "Dust simulation"],
+  },
+];
+
+export const observationPanels: ObservationPanel[] = [
+  {
+    id: "atlas-03-obs-1",
+    experimentId: "atlas-03",
+    title: "Warm-pass rebound log",
+    window: "08:25-08:42 IST",
+    recorder: "S. Geller",
+    focus: "Late-stage rebound timing",
+    signalGrade: "Grade A-",
+    notes: [
+      "Valve four crossed the rebound threshold only once, and the spike fell back inside tolerance within two subsequent readings.",
+      "Sensor condensation remained lower than the early morning run, which helped keep the pressure trace clean during the warm profile.",
+      "Manual spot checks matched the automated capture within 0.03 seconds.",
+    ],
+    anomaly:
+      "A brief overshoot appeared when the release cadence tightened below the standard interval.",
+    nextCheck:
+      "Repeat the warm pass with a wider cadence gap to confirm whether the overshoot is procedural rather than mechanical.",
+  },
+  {
+    id: "morrow-12-obs-1",
+    experimentId: "morrow-12",
+    title: "Upper-band resonance pocket",
+    window: "10:40-10:58 IST",
+    recorder: "L. Moreno",
+    focus: "North strut harmonic drift",
+    signalGrade: "Grade B",
+    notes: [
+      "The north strut showed a recurring bloom near 7.2 kilohertz once the cradle switched into rough-transit simulation.",
+      "The shell dampers caught the first two peaks, but the third and fourth passes rang longer than forecast.",
+      "The interference map narrowed the drift zone to a single brace cluster instead of the full panel seam.",
+    ],
+    anomaly:
+      "Harmonic decay stretched by 14% during rough-transit mode compared with the baseline sweep.",
+    nextCheck:
+      "Pin additional contact microphones to the brace cluster and rerun the rough-transit segment at half amplitude.",
+  },
+  {
+    id: "morrow-12-obs-2",
+    experimentId: "morrow-12",
+    title: "Isolation floor comparison",
+    window: "11:20-11:44 IST",
+    recorder: "L. Moreno",
+    focus: "Floor transfer and cage response",
+    signalGrade: "Grade B+",
+    notes: [
+      "Floor transfer stayed flat until the final ladder step, which points back to the shell instead of the resonance cage.",
+      "A temporary brace tightened the low band, but it did not fully address the upper harmonic spread.",
+      "The cage response stayed within expected limits, so the current watch item remains isolated to the test article.",
+    ],
+    anomaly:
+      "The final ladder step amplified the same band even after the temporary brace was installed.",
+    nextCheck:
+      "Compare the shell scan against last cycle’s pre-transport geometry model before authorizing another full-amplitude sweep.",
+  },
+  {
+    id: "solace-07-obs-1",
+    experimentId: "solace-07",
+    title: "Seal compression failure note",
+    window: "13:52-14:06 IST",
+    recorder: "N. Park",
+    focus: "Tertiary feed compression",
+    signalGrade: "Grade C",
+    notes: [
+      "Pressure sag began on the tertiary branch eight minutes into the endurance rehearsal and widened on each loop.",
+      "Thermal imaging showed a colder edge along the replacement seal, consistent with uneven seating pressure.",
+      "The main loop held steady, which limits the block to the tertiary feed rather than the full manifold assembly.",
+    ],
+    anomaly:
+      "The replacement seal compressed unevenly after repeated thermal cycling and forced an early stop.",
+    nextCheck:
+      "Hold the run until the spare manifold arrives, then retorque the tertiary branch and repeat the first ten minutes of the endurance loop.",
+  },
+  {
+    id: "verve-21-obs-1",
+    experimentId: "verve-21",
+    title: "Dust-shift visibility notes",
+    window: "16:10-16:36 IST",
+    recorder: "A. Duvall",
+    focus: "Marker lock through low-light dust bursts",
+    signalGrade: "Grade A",
+    notes: [
+      "Marker lock dipped only once below 97%, and the recovery happened before the next camera handoff.",
+      "The chamber’s heavier dust burst reduced contrast, but the optics rig compensated without widening the scan envelope.",
+      "Operator review agreed with the automated score on all but one frame, which was later attributed to glare from a housing seam.",
+    ],
+    anomaly:
+      "A single glare-heavy frame scored below the operator average before the lock stabilized again.",
+    nextCheck:
+      "Carry the same lighting profile into the overnight automation pass to verify repeatability without manual intervention.",
+  },
+];

--- a/src/app/lab-notebook/page.test.tsx
+++ b/src/app/lab-notebook/page.test.tsx
@@ -81,6 +81,12 @@ describe("LabNotebookPage", () => {
     render(<LabNotebookPage />);
 
     const observationGrid = screen.getByTestId("lab-notebook-observation-grid");
+    const experimentSection = screen
+      .getByRole("heading", {
+        level: 2,
+        name: /active notebook entries/i,
+      })
+      .closest("section");
     const prioritySection = screen
       .getByRole("heading", { name: /priority follow-up/i })
       .closest("section");
@@ -96,6 +102,11 @@ describe("LabNotebookPage", () => {
     expect(
       within(prioritySection as HTMLElement).getByText("Solace-07"),
     ).toBeInTheDocument();
+    expect(
+      within(experimentSection as HTMLElement).getByRole("link", {
+        name: /open linked observations for morrow-12/i,
+      }),
+    ).toHaveAttribute("href", "#morrow-12-obs-1");
 
     expect(
       within(observationGrid).getByRole("heading", {
@@ -115,6 +126,14 @@ describe("LabNotebookPage", () => {
     expect(
       within(linksSection as HTMLElement).getAllByText(/1 linked observation panel\./i),
     ).toHaveLength(3);
+    expect(
+      within(linksSection as HTMLElement).getByRole("link", {
+        name: /jump to notes for atlas-03/i,
+      }),
+    ).toHaveAttribute("href", "#atlas-03-obs-1");
+    expect(
+      within(observationGrid).getByText("Atlas-03"),
+    ).toBeInTheDocument();
   });
 
   it("exposes the responsive multi-panel layout hooks", () => {

--- a/src/app/lab-notebook/page.test.tsx
+++ b/src/app/lab-notebook/page.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  experimentEntries,
+  notebookSummaryMetrics,
+  observationPanels,
+} from "./_data/lab-notebook-data";
+import LabNotebookPage from "./page";
+
+describe("LabNotebookPage", () => {
+  it("renders the notebook hero and primary section headings", () => {
+    render(<LabNotebookPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /multi-panel notebook for experiment logs, field observations, and shift summaries/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /status summaries at a glance/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /active notebook entries/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /observation panels and anomaly notes/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders every summary metric and experiment entry from mock data", () => {
+    render(<LabNotebookPage />);
+
+    const summaryList = screen.getByRole("list", {
+      name: /notebook summaries/i,
+    });
+    const experimentSection = screen
+      .getByRole("heading", {
+        level: 2,
+        name: /active notebook entries/i,
+      })
+      .closest("section");
+
+    expect(within(summaryList).getAllByRole("listitem")).toHaveLength(
+      notebookSummaryMetrics.length,
+    );
+    expect(experimentSection).toBeTruthy();
+
+    for (const metric of notebookSummaryMetrics) {
+      expect(within(summaryList).getByText(metric.label)).toBeInTheDocument();
+      expect(within(summaryList).getByText(metric.value)).toBeInTheDocument();
+    }
+
+    for (const entry of experimentEntries) {
+      expect(
+        within(experimentSection as HTMLElement).getByRole("heading", {
+          level: 3,
+          name: entry.title,
+        }),
+      ).toBeInTheDocument();
+      expect(
+        within(experimentSection as HTMLElement).getByText(entry.codename),
+      ).toBeInTheDocument();
+      expect(
+        within(experimentSection as HTMLElement).getByText(entry.lead),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("renders representative observation and follow-up content", () => {
+    render(<LabNotebookPage />);
+
+    const observationGrid = screen.getByTestId("lab-notebook-observation-grid");
+    const prioritySection = screen
+      .getByRole("heading", { name: /priority follow-up/i })
+      .closest("section");
+    const linksSection = screen
+      .getByRole("heading", { name: /notebook links/i })
+      .closest("section");
+
+    expect(prioritySection).toBeTruthy();
+    expect(linksSection).toBeTruthy();
+    expect(
+      within(prioritySection as HTMLElement).getByText("Morrow-12"),
+    ).toBeInTheDocument();
+    expect(
+      within(prioritySection as HTMLElement).getByText("Solace-07"),
+    ).toBeInTheDocument();
+
+    expect(
+      within(observationGrid).getByRole("heading", {
+        level: 3,
+        name: observationPanels[0].title,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(observationGrid).getByText(observationPanels[0].notes[0]),
+    ).toBeInTheDocument();
+    expect(
+      within(observationGrid).getByText(observationPanels[2].anomaly),
+    ).toBeInTheDocument();
+    expect(
+      within(linksSection as HTMLElement).getByText(/2 linked observation panels\./i),
+    ).toBeInTheDocument();
+    expect(
+      within(linksSection as HTMLElement).getAllByText(/1 linked observation panel\./i),
+    ).toHaveLength(3);
+  });
+
+  it("exposes the responsive multi-panel layout hooks", () => {
+    render(<LabNotebookPage />);
+
+    const summaryGrid = screen.getByTestId("lab-notebook-summary-grid");
+    const workspace = screen.getByTestId("lab-notebook-workspace");
+    const observationGrid = screen.getByTestId("lab-notebook-observation-grid");
+
+    expect(summaryGrid.className).toContain("md:grid-cols-3");
+    expect(workspace.className).toContain(
+      "xl:grid-cols-[minmax(0,1.2fr)_minmax(20rem,0.8fr)]",
+    );
+    expect(observationGrid.className).toContain("2xl:grid-cols-2");
+  });
+});

--- a/src/app/lab-notebook/page.tsx
+++ b/src/app/lab-notebook/page.tsx
@@ -1,0 +1,86 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Lab Notebook",
+  description:
+    "Notebook route shell for experiment entries, observation panels, and summary callouts.",
+};
+
+const shellSections = [
+  "Experiment entries will stack as notebook cards with owners, windows, and objectives.",
+  "Observation panels will expand field notes, anomalies, and next checks for each session.",
+  "Status summaries will call out stable signals, watch items, and blocked dependencies.",
+];
+
+export default function LabNotebookPage() {
+  return (
+    <main className="min-h-screen bg-[linear-gradient(180deg,#f6efe5_0%,#efe4d6_48%,#e7d8c7_100%)] px-6 py-12 text-stone-950 sm:px-10 lg:px-14">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
+        <header className="overflow-hidden rounded-[2rem] border border-stone-900/10 bg-[rgba(255,250,244,0.84)] p-8 shadow-[0_20px_80px_rgba(68,42,22,0.12)] backdrop-blur sm:p-10">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+            <div className="max-w-3xl space-y-4">
+              <span className="inline-flex w-fit rounded-full border border-amber-900/15 bg-amber-700/10 px-4 py-1 text-sm font-semibold uppercase tracking-[0.22em] text-amber-950">
+                Lab notebook
+              </span>
+              <h1 className="text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
+                Notebook shell for experiments, observations, and status callouts
+              </h1>
+              <p className="max-w-2xl text-base leading-7 text-stone-700 sm:text-lg">
+                This first pass establishes the dedicated route shell. Follow-up
+                subtasks will populate the notebook with experiment records,
+                observation panels, and summary signals.
+              </p>
+            </div>
+
+            <Link
+              href="/"
+              className="inline-flex items-center justify-center rounded-full border border-stone-900/12 bg-white/70 px-5 py-3 text-sm font-semibold text-stone-900 transition hover:border-stone-900/25 hover:bg-white"
+            >
+              Back to route index
+            </Link>
+          </div>
+        </header>
+
+        <section className="grid gap-6 lg:grid-cols-[minmax(0,1.15fr)_minmax(18rem,0.85fr)]">
+          <article className="rounded-[1.75rem] border border-stone-900/10 bg-white/72 p-7 shadow-[0_16px_60px_rgba(68,42,22,0.08)]">
+            <h2 className="text-lg font-semibold text-stone-950">
+              Planned notebook panels
+            </h2>
+            <ol className="mt-5 space-y-4 text-sm leading-7 text-stone-700 sm:text-base">
+              {shellSections.map((section, index) => (
+                <li
+                  key={section}
+                  className="flex gap-4 rounded-2xl border border-stone-900/8 bg-stone-50/80 px-4 py-4"
+                >
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-amber-700/10 text-sm font-semibold text-amber-950">
+                    {index + 1}
+                  </span>
+                  <span>{section}</span>
+                </li>
+              ))}
+            </ol>
+          </article>
+
+          <aside className="rounded-[1.75rem] border border-stone-900/10 bg-[rgba(77,48,31,0.92)] p-7 text-amber-50 shadow-[0_16px_60px_rgba(43,24,13,0.25)]">
+            <h2 className="text-lg font-semibold text-white">Route status</h2>
+            <dl className="mt-5 space-y-4 text-sm">
+              <div className="rounded-2xl border border-emerald-300/18 bg-emerald-300/10 p-4">
+                <dt className="font-medium text-emerald-100">Availability</dt>
+                <dd className="mt-1 leading-6 text-amber-50/90">
+                  The route is live at <code>/lab-notebook</code>.
+                </dd>
+              </div>
+              <div className="rounded-2xl border border-amber-200/18 bg-amber-200/10 p-4">
+                <dt className="font-medium text-amber-50">Next build step</dt>
+                <dd className="mt-1 leading-6 text-amber-50/90">
+                  Add mock entries, observations, and multi-panel notebook detail.
+                </dd>
+              </div>
+            </dl>
+          </aside>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/lab-notebook/page.tsx
+++ b/src/app/lab-notebook/page.tsx
@@ -30,6 +30,23 @@ export default function LabNotebookPage() {
 
     return counts;
   }, {});
+  const firstObservationIdByExperiment = observationPanels.reduce<
+    Record<string, string>
+  >((firstIds, panel) => {
+    if (!firstIds[panel.experimentId]) {
+      firstIds[panel.experimentId] = panel.id;
+    }
+
+    return firstIds;
+  }, {});
+  const entryLabelById = experimentEntries.reduce<Record<string, string>>(
+    (labels, entry) => {
+      labels[entry.id] = entry.codename;
+
+      return labels;
+    },
+    {},
+  );
 
   const priorityEntries = experimentEntries.filter(
     (entry) => entry.status !== "Stable",
@@ -182,7 +199,16 @@ export default function LabNotebookPage() {
 
             <div className="space-y-5">
               {experimentEntries.map((entry) => (
-                <ExperimentEntryCard key={entry.id} entry={entry} />
+                <ExperimentEntryCard
+                  key={entry.id}
+                  entry={entry}
+                  observationCount={observationCountByExperiment[entry.id] ?? 0}
+                  observationHref={
+                    firstObservationIdByExperiment[entry.id]
+                      ? `#${firstObservationIdByExperiment[entry.id]}`
+                      : undefined
+                  }
+                />
               ))}
             </div>
           </section>
@@ -239,15 +265,31 @@ export default function LabNotebookPage() {
                       key={entry.id}
                       className="rounded-[1.35rem] border border-stone-900/8 bg-stone-50/80 px-4 py-4"
                     >
-                      <p className="text-sm font-semibold text-stone-950">
-                        {entry.codename}
-                      </p>
-                      <p className="mt-1 text-sm leading-6 text-stone-600">
-                        {observationCountByExperiment[entry.id] ?? 0} linked
-                        observation panel
-                        {observationCountByExperiment[entry.id] === 1 ? "" : "s"}
-                        .
-                      </p>
+                      <div className="flex items-center justify-between gap-3">
+                        <div>
+                          <p className="text-sm font-semibold text-stone-950">
+                            {entry.codename}
+                          </p>
+                          <p className="mt-1 text-sm leading-6 text-stone-600">
+                            {observationCountByExperiment[entry.id] ?? 0} linked
+                            observation panel
+                            {observationCountByExperiment[entry.id] === 1
+                              ? ""
+                              : "s"}
+                            .
+                          </p>
+                        </div>
+
+                        {firstObservationIdByExperiment[entry.id] ? (
+                          <a
+                            aria-label={`Jump to notes for ${entry.codename}`}
+                            className="inline-flex shrink-0 items-center justify-center rounded-full border border-stone-900/10 bg-white px-3 py-2 text-sm font-semibold text-stone-900 transition hover:border-stone-900/25"
+                            href={`#${firstObservationIdByExperiment[entry.id]}`}
+                          >
+                            Open
+                          </a>
+                        ) : null}
+                      </div>
                     </li>
                   ))}
                 </ul>
@@ -281,7 +323,11 @@ export default function LabNotebookPage() {
             data-testid="lab-notebook-observation-grid"
           >
             {observationPanels.map((panel) => (
-              <ObservationPanel key={panel.id} panel={panel} />
+              <ObservationPanel
+                key={panel.id}
+                entryLabel={entryLabelById[panel.experimentId] ?? panel.experimentId}
+                panel={panel}
+              />
             ))}
           </div>
         </section>

--- a/src/app/lab-notebook/page.tsx
+++ b/src/app/lab-notebook/page.tsx
@@ -146,6 +146,7 @@ export default function LabNotebookPage() {
           <div
             aria-label="Notebook summaries"
             className="grid gap-4 md:grid-cols-3"
+            data-testid="lab-notebook-summary-grid"
             role="list"
           >
             {notebookSummaryMetrics.map((metric) => (
@@ -275,7 +276,10 @@ export default function LabNotebookPage() {
             </p>
           </div>
 
-          <div className="grid gap-5 2xl:grid-cols-2">
+          <div
+            className="grid gap-5 2xl:grid-cols-2"
+            data-testid="lab-notebook-observation-grid"
+          >
             {observationPanels.map((panel) => (
               <ObservationPanel key={panel.id} panel={panel} />
             ))}

--- a/src/app/lab-notebook/page.tsx
+++ b/src/app/lab-notebook/page.tsx
@@ -1,84 +1,280 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
+import { ExperimentEntryCard } from "./_components/experiment-entry-card";
+import { ObservationPanel } from "./_components/observation-panel";
+import { StatusSummaryCard } from "./_components/status-summary-card";
+import {
+  experimentEntries,
+  notebookSummaryMetrics,
+  observationPanels,
+} from "./_data/lab-notebook-data";
+
 export const metadata: Metadata = {
   title: "Lab Notebook",
   description:
     "Notebook route shell for experiment entries, observation panels, and summary callouts.",
 };
 
-const shellSections = [
-  "Experiment entries will stack as notebook cards with owners, windows, and objectives.",
-  "Observation panels will expand field notes, anomalies, and next checks for each session.",
-  "Status summaries will call out stable signals, watch items, and blocked dependencies.",
-];
+const watchListAccentClasses = {
+  Stable: "border-emerald-300/35 bg-emerald-300/14 text-emerald-950",
+  Watch: "border-amber-300/40 bg-amber-300/18 text-amber-950",
+  Blocked: "border-rose-300/40 bg-rose-300/16 text-rose-950",
+} as const;
 
 export default function LabNotebookPage() {
+  const observationCountByExperiment = observationPanels.reduce<
+    Record<string, number>
+  >((counts, panel) => {
+    counts[panel.experimentId] = (counts[panel.experimentId] ?? 0) + 1;
+
+    return counts;
+  }, {});
+
+  const priorityEntries = experimentEntries.filter(
+    (entry) => entry.status !== "Stable",
+  );
+
   return (
     <main className="min-h-screen bg-[linear-gradient(180deg,#f6efe5_0%,#efe4d6_48%,#e7d8c7_100%)] px-6 py-12 text-stone-950 sm:px-10 lg:px-14">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8">
         <header className="overflow-hidden rounded-[2rem] border border-stone-900/10 bg-[rgba(255,250,244,0.84)] p-8 shadow-[0_20px_80px_rgba(68,42,22,0.12)] backdrop-blur sm:p-10">
-          <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
-            <div className="max-w-3xl space-y-4">
-              <span className="inline-flex w-fit rounded-full border border-amber-900/15 bg-amber-700/10 px-4 py-1 text-sm font-semibold uppercase tracking-[0.22em] text-amber-950">
-                Lab notebook
-              </span>
-              <h1 className="text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
-                Notebook shell for experiments, observations, and status callouts
-              </h1>
-              <p className="max-w-2xl text-base leading-7 text-stone-700 sm:text-lg">
-                This first pass establishes the dedicated route shell. Follow-up
-                subtasks will populate the notebook with experiment records,
-                observation panels, and summary signals.
-              </p>
+          <div className="grid gap-8 xl:grid-cols-[minmax(0,1.35fr)_minmax(19rem,0.8fr)]">
+            <div className="space-y-6">
+              <div className="space-y-4">
+                <span className="inline-flex w-fit rounded-full border border-amber-900/15 bg-amber-700/10 px-4 py-1 text-sm font-semibold uppercase tracking-[0.22em] text-amber-950">
+                  Lab notebook
+                </span>
+                <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
+                  Multi-panel notebook for experiment logs, field observations, and shift summaries
+                </h1>
+                <p className="max-w-3xl text-base leading-7 text-stone-700 sm:text-lg">
+                  Review active experiment windows, compare observation notes,
+                  and keep the shift-level watch items visible in one notebook
+                  flow. Every panel on this route is driven by standalone mock
+                  data so the experience ships independently.
+                </p>
+              </div>
+
+              <div className="flex flex-col gap-4 sm:flex-row">
+                <Link
+                  href="/"
+                  className="inline-flex items-center justify-center rounded-full border border-stone-900/12 bg-white/74 px-5 py-3 text-sm font-semibold text-stone-900 transition hover:border-stone-900/25 hover:bg-white"
+                >
+                  Back to route index
+                </Link>
+                <a
+                  href="#lab-notebook-observations"
+                  className="inline-flex items-center justify-center rounded-full bg-stone-950 px-5 py-3 text-sm font-semibold text-stone-50 transition hover:bg-stone-800"
+                >
+                  Jump to observations
+                </a>
+              </div>
             </div>
 
-            <Link
-              href="/"
-              className="inline-flex items-center justify-center rounded-full border border-stone-900/12 bg-white/70 px-5 py-3 text-sm font-semibold text-stone-900 transition hover:border-stone-900/25 hover:bg-white"
-            >
-              Back to route index
-            </Link>
+            <aside className="rounded-[1.75rem] border border-stone-900/10 bg-[rgba(77,48,31,0.92)] p-6 text-amber-50 shadow-[0_16px_60px_rgba(43,24,13,0.25)]">
+              <div className="space-y-5">
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-amber-50/62">
+                    Notebook pulse
+                  </p>
+                  <p className="mt-3 text-3xl font-semibold tracking-tight text-white">
+                    Stable signal coverage with one blocked rehearsal and two watch items.
+                  </p>
+                </div>
+
+                <div className="space-y-3 text-sm leading-6 text-amber-50/82">
+                  <p>
+                    Shift handoff stays centered on the resonance sweep rerun
+                    and the coolant manifold replacement window.
+                  </p>
+                  <p>
+                    Observation packets below are ordered so investigators can
+                    move from active anomalies into clean verification passes.
+                  </p>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+                  <div className="rounded-2xl border border-white/8 bg-white/8 px-4 py-4">
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-amber-50/58">
+                      Coverage note
+                    </p>
+                    <p className="mt-2 text-sm font-medium text-white">
+                      All four experiments have at least one attached
+                      observation panel in the current notebook.
+                    </p>
+                  </div>
+                  <div className="rounded-2xl border border-white/8 bg-white/8 px-4 py-4">
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-amber-50/58">
+                      Next review
+                    </p>
+                    <p className="mt-2 text-sm font-medium text-white">
+                      Cross-team notebook review starts at 18:00 IST with
+                      operations and facilities leads.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </aside>
           </div>
         </header>
 
-        <section className="grid gap-6 lg:grid-cols-[minmax(0,1.15fr)_minmax(18rem,0.85fr)]">
-          <article className="rounded-[1.75rem] border border-stone-900/10 bg-white/72 p-7 shadow-[0_16px_60px_rgba(68,42,22,0.08)]">
-            <h2 className="text-lg font-semibold text-stone-950">
-              Planned notebook panels
-            </h2>
-            <ol className="mt-5 space-y-4 text-sm leading-7 text-stone-700 sm:text-base">
-              {shellSections.map((section, index) => (
-                <li
-                  key={section}
-                  className="flex gap-4 rounded-2xl border border-stone-900/8 bg-stone-50/80 px-4 py-4"
-                >
-                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-amber-700/10 text-sm font-semibold text-amber-950">
-                    {index + 1}
-                  </span>
-                  <span>{section}</span>
-                </li>
-              ))}
-            </ol>
-          </article>
+        <section aria-labelledby="lab-notebook-summary" className="space-y-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div className="space-y-2">
+              <span className="inline-flex w-fit rounded-full border border-amber-900/15 bg-amber-700/10 px-4 py-1 text-sm font-semibold uppercase tracking-[0.22em] text-amber-950">
+                Shift summary
+              </span>
+              <h2
+                id="lab-notebook-summary"
+                className="text-3xl font-semibold tracking-tight text-stone-950"
+              >
+                Status summaries at a glance
+              </h2>
+            </div>
+            <p className="max-w-2xl text-sm leading-6 text-stone-600">
+              The notebook keeps the active run count, watch queue, and blocked
+              dependencies visible before you drill into individual entries.
+            </p>
+          </div>
 
-          <aside className="rounded-[1.75rem] border border-stone-900/10 bg-[rgba(77,48,31,0.92)] p-7 text-amber-50 shadow-[0_16px_60px_rgba(43,24,13,0.25)]">
-            <h2 className="text-lg font-semibold text-white">Route status</h2>
-            <dl className="mt-5 space-y-4 text-sm">
-              <div className="rounded-2xl border border-emerald-300/18 bg-emerald-300/10 p-4">
-                <dt className="font-medium text-emerald-100">Availability</dt>
-                <dd className="mt-1 leading-6 text-amber-50/90">
-                  The route is live at <code>/lab-notebook</code>.
-                </dd>
+          <div
+            aria-label="Notebook summaries"
+            className="grid gap-4 md:grid-cols-3"
+            role="list"
+          >
+            {notebookSummaryMetrics.map((metric) => (
+              <div key={metric.id} role="listitem">
+                <StatusSummaryCard metric={metric} />
               </div>
-              <div className="rounded-2xl border border-amber-200/18 bg-amber-200/10 p-4">
-                <dt className="font-medium text-amber-50">Next build step</dt>
-                <dd className="mt-1 leading-6 text-amber-50/90">
-                  Add mock entries, observations, and multi-panel notebook detail.
-                </dd>
+            ))}
+          </div>
+        </section>
+
+        <div
+          className="grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(20rem,0.8fr)]"
+          data-testid="lab-notebook-workspace"
+        >
+          <section aria-labelledby="lab-notebook-experiments" className="space-y-5">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <div className="space-y-2">
+                <span className="inline-flex w-fit rounded-full border border-stone-900/12 bg-white/55 px-4 py-1 text-sm font-semibold uppercase tracking-[0.22em] text-stone-700">
+                  Experiments
+                </span>
+                <h2
+                  id="lab-notebook-experiments"
+                  className="text-3xl font-semibold tracking-tight text-stone-950"
+                >
+                  Active notebook entries
+                </h2>
               </div>
-            </dl>
+              <p className="max-w-2xl text-sm leading-6 text-stone-600">
+                Each entry captures ownership, run window, current signal, and
+                the context needed to interpret the linked observation panels.
+              </p>
+            </div>
+
+            <div className="space-y-5">
+              {experimentEntries.map((entry) => (
+                <ExperimentEntryCard key={entry.id} entry={entry} />
+              ))}
+            </div>
+          </section>
+
+          <aside className="space-y-5">
+            <section className="rounded-[1.75rem] border border-stone-900/10 bg-white/72 p-6 shadow-[0_16px_60px_rgba(68,42,22,0.08)]">
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-stone-500">
+                    Watch queue
+                  </p>
+                  <h2 className="text-2xl font-semibold tracking-tight text-stone-950">
+                    Priority follow-up
+                  </h2>
+                </div>
+
+                <ul className="space-y-3" role="list">
+                  {priorityEntries.map((entry) => (
+                    <li
+                      key={entry.id}
+                      className={`rounded-[1.35rem] border px-4 py-4 ${watchListAccentClasses[entry.status]}`}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="text-sm font-semibold">{entry.codename}</p>
+                          <p className="mt-1 text-sm leading-6 opacity-85">
+                            {entry.signal}
+                          </p>
+                        </div>
+                        <span className="rounded-full bg-white/55 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-stone-950">
+                          {entry.status}
+                        </span>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </section>
+
+            <section className="rounded-[1.75rem] border border-stone-900/10 bg-white/72 p-6 shadow-[0_16px_60px_rgba(68,42,22,0.08)]">
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-stone-500">
+                    Observation routing
+                  </p>
+                  <h2 className="text-2xl font-semibold tracking-tight text-stone-950">
+                    Notebook links
+                  </h2>
+                </div>
+
+                <ul className="space-y-3" role="list">
+                  {experimentEntries.map((entry) => (
+                    <li
+                      key={entry.id}
+                      className="rounded-[1.35rem] border border-stone-900/8 bg-stone-50/80 px-4 py-4"
+                    >
+                      <p className="text-sm font-semibold text-stone-950">
+                        {entry.codename}
+                      </p>
+                      <p className="mt-1 text-sm leading-6 text-stone-600">
+                        {observationCountByExperiment[entry.id] ?? 0} linked
+                        observation panel
+                        {observationCountByExperiment[entry.id] === 1 ? "" : "s"}
+                        .
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </section>
           </aside>
+        </div>
+
+        <section aria-labelledby="lab-notebook-observations" className="space-y-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div className="space-y-2">
+              <span className="inline-flex w-fit rounded-full border border-stone-900/12 bg-white/55 px-4 py-1 text-sm font-semibold uppercase tracking-[0.22em] text-stone-700">
+                Observations
+              </span>
+              <h2
+                id="lab-notebook-observations"
+                className="text-3xl font-semibold tracking-tight text-stone-950"
+              >
+                Observation panels and anomaly notes
+              </h2>
+            </div>
+            <p className="max-w-3xl text-sm leading-6 text-stone-600">
+              Long-form note blocks stay attached to each experiment so the
+              route reads like a working notebook instead of a disconnected
+              dashboard.
+            </p>
+          </div>
+
+          <div className="grid gap-5 xl:grid-cols-2">
+            {observationPanels.map((panel) => (
+              <ObservationPanel key={panel.id} panel={panel} />
+            ))}
+          </div>
         </section>
       </div>
     </main>

--- a/src/app/lab-notebook/page.tsx
+++ b/src/app/lab-notebook/page.tsx
@@ -36,8 +36,13 @@ export default function LabNotebookPage() {
   );
 
   return (
-    <main className="min-h-screen bg-[linear-gradient(180deg,#f6efe5_0%,#efe4d6_48%,#e7d8c7_100%)] px-6 py-12 text-stone-950 sm:px-10 lg:px-14">
-      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8">
+    <main className="relative min-h-screen overflow-hidden bg-[linear-gradient(180deg,#f6efe5_0%,#efe4d6_48%,#e7d8c7_100%)] px-6 py-12 text-stone-950 sm:px-10 lg:px-14">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-x-0 top-0 h-[28rem] bg-[radial-gradient(circle_at_top_left,rgba(245,158,11,0.16),transparent_36%),radial-gradient(circle_at_top_right,rgba(120,113,108,0.18),transparent_32%)]"
+      />
+
+      <div className="relative mx-auto flex w-full max-w-7xl flex-col gap-8">
         <header className="overflow-hidden rounded-[2rem] border border-stone-900/10 bg-[rgba(255,250,244,0.84)] p-8 shadow-[0_20px_80px_rgba(68,42,22,0.12)] backdrop-blur sm:p-10">
           <div className="grid gap-8 xl:grid-cols-[minmax(0,1.35fr)_minmax(19rem,0.8fr)]">
             <div className="space-y-6">
@@ -181,7 +186,7 @@ export default function LabNotebookPage() {
             </div>
           </section>
 
-          <aside className="space-y-5">
+          <aside className="space-y-5 xl:sticky xl:top-8 xl:self-start">
             <section className="rounded-[1.75rem] border border-stone-900/10 bg-white/72 p-6 shadow-[0_16px_60px_rgba(68,42,22,0.08)]">
               <div className="space-y-4">
                 <div className="space-y-2">
@@ -270,7 +275,7 @@ export default function LabNotebookPage() {
             </p>
           </div>
 
-          <div className="grid gap-5 xl:grid-cols-2">
+          <div className="grid gap-5 2xl:grid-cols-2">
             {observationPanels.map((panel) => (
               <ObservationPanel key={panel.id} panel={panel} />
             ))}


### PR DESCRIPTION
## Summary
- add the initial /lab-notebook route shell with route metadata
- establish the first notebook layout with planned panel placeholders and route status
- open the PR after subtask 1 so follow-up commits stay visible

## Testing
- not run yet

Closes #105