### PR TITLE
feat: add control room dashboard route

### DIFF
--- a/src/app/control-room/_components/activity-rail.tsx
+++ b/src/app/control-room/_components/activity-rail.tsx
@@ -2,11 +2,18 @@ import type {
   ActivityTone,
   OperatorActivityEntry,
 } from "../_data/control-room-data";
+import styles from "../control-room.module.css";
 
 const toneClasses: Record<ActivityTone, string> = {
   operator: "border-slate-200 bg-slate-100 text-slate-800",
   automation: "border-sky-200 bg-sky-50 text-sky-800",
   resolved: "border-emerald-200 bg-emerald-50 text-emerald-800",
+};
+
+const nodeClasses: Record<ActivityTone, string> = {
+  operator: styles.activityNodeOperator,
+  automation: styles.activityNodeAutomation,
+  resolved: styles.activityNodeResolved,
 };
 
 export function ActivityRail({
@@ -29,10 +36,13 @@ export function ActivityRail({
   }
 
   return (
-    <ol aria-label="Operator activity rail" className="space-y-4">
+    <ol aria-label="Operator activity rail" className={styles.activityRail}>
       {entries.map((entry) => (
-        <li key={entry.id}>
-          <article className="rounded-[1.75rem] border border-slate-200/80 bg-white/80 p-5 shadow-[0_16px_45px_rgba(15,23,42,0.07)]">
+        <li
+          key={entry.id}
+          className={`${styles.activityNode} ${nodeClasses[entry.tone]}`}
+        >
+          <article className={`${styles.surfaceCard} p-5`}>
             <div className="flex flex-wrap items-center justify-between gap-3">
               <span
                 className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ${toneClasses[entry.tone]}`}

--- a/src/app/control-room/_components/activity-rail.tsx
+++ b/src/app/control-room/_components/activity-rail.tsx
@@ -1,0 +1,71 @@
+import type {
+  ActivityTone,
+  OperatorActivityEntry,
+} from "../_data/control-room-data";
+
+const toneClasses: Record<ActivityTone, string> = {
+  operator: "border-slate-200 bg-slate-100 text-slate-800",
+  automation: "border-sky-200 bg-sky-50 text-sky-800",
+  resolved: "border-emerald-200 bg-emerald-50 text-emerald-800",
+};
+
+export function ActivityRail({
+  entries,
+}: {
+  entries: OperatorActivityEntry[];
+}) {
+  if (entries.length === 0) {
+    return (
+      <div className="rounded-[1.75rem] border border-dashed border-slate-300 bg-white/70 px-5 py-6">
+        <p className="text-sm font-medium text-slate-800">
+          No operator activity has been logged yet.
+        </p>
+        <p className="mt-2 text-sm leading-6 text-slate-600">
+          Keep the rail mounted so fresh activity can appear without shifting
+          the rest of the dashboard.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ol aria-label="Operator activity rail" className="space-y-4">
+      {entries.map((entry) => (
+        <li key={entry.id}>
+          <article className="rounded-[1.75rem] border border-slate-200/80 bg-white/80 p-5 shadow-[0_16px_45px_rgba(15,23,42,0.07)]">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <span
+                className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ${toneClasses[entry.tone]}`}
+              >
+                {entry.role}
+              </span>
+              <time className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                {entry.timestamp}
+              </time>
+            </div>
+
+            <div className="mt-4 space-y-2">
+              <h3 className="text-lg font-semibold tracking-tight text-slate-950">
+                {entry.title}
+              </h3>
+              <p className="text-sm leading-6 text-slate-600">
+                {entry.summary}
+              </p>
+            </div>
+
+            <div className="mt-4 border-t border-slate-200/80 pt-4 text-sm text-slate-700">
+              <p>
+                <span className="font-semibold text-slate-950">Operator:</span>{" "}
+                {entry.operator}
+              </p>
+              <p className="mt-2">
+                <span className="font-semibold text-slate-950">Handoff:</span>{" "}
+                {entry.handoff}
+              </p>
+            </div>
+          </article>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/app/control-room/_components/alert-list.tsx
+++ b/src/app/control-room/_components/alert-list.tsx
@@ -1,0 +1,121 @@
+import type {
+  AlertSeverity,
+  ControlRoomAlertSection,
+} from "../_data/control-room-data";
+
+const severityClasses: Record<AlertSeverity, string> = {
+  critical: "border-rose-200 bg-rose-50 text-rose-800",
+  elevated: "border-amber-200 bg-amber-50 text-amber-800",
+  watch: "border-sky-200 bg-sky-50 text-sky-800",
+};
+
+const severityLabels: Record<AlertSeverity, string> = {
+  critical: "Critical",
+  elevated: "Elevated",
+  watch: "Watch",
+};
+
+export function AlertList({ sections }: { sections: ControlRoomAlertSection[] }) {
+  return (
+    <div className="space-y-4">
+      {sections.map((section) => (
+        <section
+          key={section.id}
+          className="rounded-[1.75rem] border border-slate-200/80 bg-white/80 p-5 shadow-[0_18px_50px_rgba(15,23,42,0.07)] sm:p-6"
+        >
+          <div className="space-y-3">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-2">
+                <h3 className="text-xl font-semibold tracking-tight text-slate-950">
+                  {section.title}
+                </h3>
+                <p className="max-w-2xl text-sm leading-6 text-slate-600">
+                  {section.summary}
+                </p>
+              </div>
+              <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                {section.responseWindow}
+              </p>
+            </div>
+
+            {section.alerts.length > 0 ? (
+              <ul className="space-y-3" aria-label={section.title}>
+                {section.alerts.map((alert) => (
+                  <li key={alert.id}>
+                    <article className="rounded-[1.5rem] border border-slate-200/90 bg-slate-50/80 p-4">
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                        <div className="space-y-3">
+                          <div className="flex flex-wrap items-center gap-3">
+                            <span
+                              className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] ${severityClasses[alert.severity]}`}
+                            >
+                              {severityLabels[alert.severity]}
+                            </span>
+                            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                              {alert.zone}
+                            </p>
+                          </div>
+
+                          <div className="space-y-2">
+                            <h4 className="text-lg font-semibold tracking-tight text-slate-950">
+                              {alert.title}
+                            </h4>
+                            <p className="text-sm leading-6 text-slate-600">
+                              {alert.summary}
+                            </p>
+                          </div>
+                        </div>
+
+                        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+                          {alert.updatedAt}
+                        </p>
+                      </div>
+
+                      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                        <div className="rounded-2xl border border-white/70 bg-white/90 px-4 py-3">
+                          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                            Owner
+                          </p>
+                          <p className="mt-2 text-sm font-medium text-slate-800">
+                            {alert.owner}
+                          </p>
+                        </div>
+                        <div className="rounded-2xl border border-white/70 bg-white/90 px-4 py-3">
+                          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                            Customer impact
+                          </p>
+                          <p className="mt-2 text-sm font-medium text-slate-800">
+                            {alert.customerImpact}
+                          </p>
+                        </div>
+                      </div>
+
+                      <div className="mt-4 rounded-2xl border border-dashed border-slate-300 bg-white/80 px-4 py-3">
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                          Next step
+                        </p>
+                        <p className="mt-2 text-sm font-medium text-slate-800">
+                          {alert.nextStep}
+                        </p>
+                      </div>
+                    </article>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="rounded-[1.5rem] border border-dashed border-slate-300 bg-slate-50/80 px-5 py-4">
+                <p className="text-sm font-medium text-slate-800">
+                  No active alerts in this lane.
+                </p>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  Keep this section visible so operators can confirm the lane is
+                  intentionally clear, not missing data.
+                </p>
+              </div>
+            )}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/app/control-room/_components/alert-list.tsx
+++ b/src/app/control-room/_components/alert-list.tsx
@@ -2,6 +2,7 @@ import type {
   AlertSeverity,
   ControlRoomAlertSection,
 } from "../_data/control-room-data";
+import styles from "../control-room.module.css";
 
 const severityClasses: Record<AlertSeverity, string> = {
   critical: "border-rose-200 bg-rose-50 text-rose-800",
@@ -15,13 +16,25 @@ const severityLabels: Record<AlertSeverity, string> = {
   watch: "Watch",
 };
 
+const sectionClasses: Record<string, string> = {
+  "immediate-action": styles.alertSectionImmediate,
+  "stabilization-queue": styles.alertSectionStabilization,
+  "observation-deck": styles.alertSectionObservation,
+};
+
+const itemClasses: Record<AlertSeverity, string> = {
+  critical: styles.alertCritical,
+  elevated: styles.alertElevated,
+  watch: styles.alertWatch,
+};
+
 export function AlertList({ sections }: { sections: ControlRoomAlertSection[] }) {
   return (
     <div className="space-y-4">
       {sections.map((section) => (
         <section
           key={section.id}
-          className="rounded-[1.75rem] border border-slate-200/80 bg-white/80 p-5 shadow-[0_18px_50px_rgba(15,23,42,0.07)] sm:p-6"
+          className={`${styles.surfaceCard} ${styles.alertSection} ${sectionClasses[section.id]} p-5 sm:p-6`}
         >
           <div className="space-y-3">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -42,7 +55,9 @@ export function AlertList({ sections }: { sections: ControlRoomAlertSection[] })
               <ul className="space-y-3" aria-label={section.title}>
                 {section.alerts.map((alert) => (
                   <li key={alert.id}>
-                    <article className="rounded-[1.5rem] border border-slate-200/90 bg-slate-50/80 p-4">
+                    <article
+                      className={`${styles.alertItem} ${itemClasses[alert.severity]} rounded-[1.5rem] border border-slate-200/90 bg-white/75 p-4`}
+                    >
                       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                         <div className="space-y-3">
                           <div className="flex flex-wrap items-center gap-3">
@@ -103,7 +118,7 @@ export function AlertList({ sections }: { sections: ControlRoomAlertSection[] })
                 ))}
               </ul>
             ) : (
-              <div className="rounded-[1.5rem] border border-dashed border-slate-300 bg-slate-50/80 px-5 py-4">
+              <div className="rounded-[1.5rem] border border-dashed border-slate-300 bg-white/75 px-5 py-4">
                 <p className="text-sm font-medium text-slate-800">
                   No active alerts in this lane.
                 </p>

--- a/src/app/control-room/_components/metric-card.tsx
+++ b/src/app/control-room/_components/metric-card.tsx
@@ -2,6 +2,7 @@ import type {
   ControlRoomMetric,
   MetricStatus,
 } from "../_data/control-room-data";
+import styles from "../control-room.module.css";
 
 const statusBadgeClasses: Record<MetricStatus, string> = {
   stable: "border-emerald-200 bg-emerald-50 text-emerald-800",
@@ -10,16 +11,16 @@ const statusBadgeClasses: Record<MetricStatus, string> = {
 };
 
 const progressFillClasses: Record<MetricStatus, string> = {
-  stable: "bg-emerald-500",
-  attention: "bg-amber-500",
-  critical: "bg-rose-500",
+  stable: styles.metricFillStable,
+  attention: styles.metricFillAttention,
+  critical: styles.metricFillCritical,
 };
 
 export function MetricCard({ metric }: { metric: ControlRoomMetric }) {
   return (
     <article
       role="listitem"
-      className="flex h-full flex-col gap-5 rounded-[1.5rem] border border-slate-200/80 bg-white/80 p-5 shadow-[0_18px_50px_rgba(15,23,42,0.08)]"
+      className={`${styles.surfaceCard} ${styles.metricCard} flex h-full flex-col gap-5 p-5`}
     >
       <div className="flex items-start justify-between gap-4">
         <div className="space-y-3">
@@ -45,9 +46,9 @@ export function MetricCard({ metric }: { metric: ControlRoomMetric }) {
           <span>{metric.focus}</span>
           <span>{metric.progress}%</span>
         </div>
-        <div className="h-2 overflow-hidden rounded-full bg-slate-200">
+        <div className={styles.metricRail}>
           <span
-            className={`block h-full rounded-full ${progressFillClasses[metric.status]}`}
+            className={`${styles.metricFill} ${progressFillClasses[metric.status]}`}
             style={{ width: `${metric.progress}%` }}
           />
         </div>

--- a/src/app/control-room/_components/metric-card.tsx
+++ b/src/app/control-room/_components/metric-card.tsx
@@ -1,0 +1,57 @@
+import type {
+  ControlRoomMetric,
+  MetricStatus,
+} from "../_data/control-room-data";
+
+const statusBadgeClasses: Record<MetricStatus, string> = {
+  stable: "border-emerald-200 bg-emerald-50 text-emerald-800",
+  attention: "border-amber-200 bg-amber-50 text-amber-800",
+  critical: "border-rose-200 bg-rose-50 text-rose-800",
+};
+
+const progressFillClasses: Record<MetricStatus, string> = {
+  stable: "bg-emerald-500",
+  attention: "bg-amber-500",
+  critical: "bg-rose-500",
+};
+
+export function MetricCard({ metric }: { metric: ControlRoomMetric }) {
+  return (
+    <article
+      role="listitem"
+      className="flex h-full flex-col gap-5 rounded-[1.5rem] border border-slate-200/80 bg-white/80 p-5 shadow-[0_18px_50px_rgba(15,23,42,0.08)]"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+            {metric.label}
+          </p>
+          <p className="text-4xl font-semibold tracking-tight text-slate-950">
+            {metric.value}
+          </p>
+        </div>
+
+        <span
+          className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold ${statusBadgeClasses[metric.status]}`}
+        >
+          {metric.delta}
+        </span>
+      </div>
+
+      <p className="text-sm leading-6 text-slate-600">{metric.context}</p>
+
+      <div className="mt-auto space-y-3">
+        <div className="flex items-center justify-between text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+          <span>{metric.focus}</span>
+          <span>{metric.progress}%</span>
+        </div>
+        <div className="h-2 overflow-hidden rounded-full bg-slate-200">
+          <span
+            className={`block h-full rounded-full ${progressFillClasses[metric.status]}`}
+            style={{ width: `${metric.progress}%` }}
+          />
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/app/control-room/_data/control-room-data.ts
+++ b/src/app/control-room/_data/control-room-data.ts
@@ -1,0 +1,252 @@
+export type MetricStatus = "stable" | "attention" | "critical";
+export type AlertSeverity = "critical" | "elevated" | "watch";
+export type ActivityTone = "operator" | "automation" | "resolved";
+
+export interface ControlRoomMetric {
+  id: string;
+  label: string;
+  value: string;
+  delta: string;
+  status: MetricStatus;
+  context: string;
+  focus: string;
+  progress: number;
+}
+
+export interface ControlRoomAlert {
+  id: string;
+  severity: AlertSeverity;
+  title: string;
+  zone: string;
+  summary: string;
+  owner: string;
+  updatedAt: string;
+  nextStep: string;
+  customerImpact: string;
+}
+
+export interface ControlRoomAlertSection {
+  id: string;
+  title: string;
+  responseWindow: string;
+  summary: string;
+  alerts: ControlRoomAlert[];
+}
+
+export interface OperatorActivityEntry {
+  id: string;
+  title: string;
+  operator: string;
+  role: string;
+  timestamp: string;
+  summary: string;
+  handoff: string;
+  tone: ActivityTone;
+}
+
+export const controlRoomMetrics = [
+  {
+    id: "signal-integrity",
+    label: "Signal integrity",
+    value: "99.94%",
+    delta: "+0.02 vs last handoff",
+    status: "stable",
+    context:
+      "Sensor traffic is flowing cleanly across the east and central mesh, keeping the room on a low-noise baseline.",
+    focus: "Mesh heartbeat coverage",
+    progress: 99,
+  },
+  {
+    id: "containment-sla",
+    label: "Containment SLA",
+    value: "92%",
+    delta: "3 incidents nearing threshold",
+    status: "attention",
+    context:
+      "Most in-flight events are contained within the target window, but two facilities need faster approvals before shift change.",
+    focus: "Acknowledgement window",
+    progress: 92,
+  },
+  {
+    id: "manual-overrides",
+    label: "Manual overrides",
+    value: "7 queued",
+    delta: "2 above comfort band",
+    status: "critical",
+    context:
+      "Override load is still concentrated around one cooling stack and one access-control recovery, raising the risk of operator fatigue.",
+    focus: "Priority override lane",
+    progress: 58,
+  },
+  {
+    id: "field-coverage",
+    label: "Field dispatch coverage",
+    value: "18 crews",
+    delta: "Full metro sweep online",
+    status: "stable",
+    context:
+      "Dispatch boards remain balanced with reserve technicians staged near the highest-risk facilities before the evening surge.",
+    focus: "Rapid dispatch readiness",
+    progress: 88,
+  },
+] satisfies ControlRoomMetric[];
+
+export const controlRoomAlertSections = [
+  {
+    id: "immediate-action",
+    title: "Immediate action",
+    responseWindow: "Acknowledge within 5 minutes",
+    summary:
+      "Active incidents that can spill into customer-facing downtime or safety exposure without an operator handoff.",
+    alerts: [
+      {
+        id: "cooling-loop-drift",
+        severity: "critical",
+        title: "Cooling loop drift in pod C-12",
+        zone: "North plant · Pod C-12",
+        summary:
+          "The temperature control loop has cycled outside its tolerance band three times in the last 14 minutes.",
+        owner: "Facilities command",
+        updatedAt: "Updated 4 minutes ago",
+        nextStep: "Dispatch the reserve refrigeration crew and isolate the affected aisle.",
+        customerImpact: "Cold-storage fulfillment promises are at risk for the next wave.",
+      },
+      {
+        id: "badge-auth-retry",
+        severity: "elevated",
+        title: "Badge authentication retry spike",
+        zone: "South gate access control",
+        summary:
+          "Credential checks are timing out intermittently, forcing manual confirmation on a growing share of entries.",
+        owner: "Security systems",
+        updatedAt: "Updated 7 minutes ago",
+        nextStep: "Fail over to the secondary auth profile and keep a supervisor at the gate.",
+        customerImpact: "Shift turnover may slow if credential checks continue to queue.",
+      },
+    ],
+  },
+  {
+    id: "stabilization-queue",
+    title: "Stabilization queue",
+    responseWindow: "Clear before next shift handoff",
+    summary:
+      "Events that are contained for now but still need deliberate follow-through to avoid reopening during the next operating block.",
+    alerts: [
+      {
+        id: "backup-generator-sync",
+        severity: "elevated",
+        title: "Backup generator sync lag",
+        zone: "Riverfront campus",
+        summary:
+          "The standby generator responded on time, but its transfer controller is reporting a slower-than-normal resync.",
+        owner: "Power operations",
+        updatedAt: "Updated 12 minutes ago",
+        nextStep: "Run a controller reset during the next load lull and keep remote telemetry pinned.",
+        customerImpact: "No downtime yet, but resilience is reduced for a second power event.",
+      },
+      {
+        id: "sorter-optics-calibration",
+        severity: "watch",
+        title: "Sorter optics calibration drift",
+        zone: "Parcel line 4",
+        summary:
+          "A recent calibration package reduced misses, but sensor confidence is still wobbling on high-glare cartons.",
+        owner: "Automation desk",
+        updatedAt: "Updated 16 minutes ago",
+        nextStep: "Keep the calibration tech on standby and monitor reject rates through the next batch.",
+        customerImpact: "Premium parcel throughput could soften during the peak sort burst.",
+      },
+    ],
+  },
+  {
+    id: "observation-deck",
+    title: "Observation deck",
+    responseWindow: "Monitor through the next 30 minutes",
+    summary:
+      "Lower-severity signals that are visible in the room because they tend to compound when they line up with staffing or weather changes.",
+    alerts: [
+      {
+        id: "camera-latency-west-yard",
+        severity: "watch",
+        title: "Camera latency across west yard",
+        zone: "West yard perimeter",
+        summary:
+          "Two perimeter camera feeds are dropping frames after the latest firmware roll, though alert detection remains online.",
+        owner: "Perimeter security",
+        updatedAt: "Updated 19 minutes ago",
+        nextStep: "Rollback the firmware package if frame loss climbs above the current band.",
+        customerImpact: "Minimal now, but evidence capture quality is reduced if an incident occurs.",
+      },
+      {
+        id: "dock-door-sensor-noise",
+        severity: "watch",
+        title: "Dock door sensor noise",
+        zone: "Inbound dock cluster B",
+        summary:
+          "Door sensors are producing duplicate open-close events during the heaviest inbound trailer movements.",
+        owner: "Site operations",
+        updatedAt: "Updated 23 minutes ago",
+        nextStep: "Audit the noisy sensors at the next scheduled trailer break and suppress duplicate alerts.",
+        customerImpact: "Operator attention is being diluted by duplicate events rather than true failures.",
+      },
+    ],
+  },
+] satisfies ControlRoomAlertSection[];
+
+export const operatorActivityEntries = [
+  {
+    id: "override-bundle",
+    title: "Override bundle approved for the north plant",
+    operator: "S. Alvarez",
+    role: "Command lead",
+    timestamp: "08:14 UTC",
+    summary:
+      "The room approved a bundled override so facilities, security, and dispatch can act against the same incident window.",
+    handoff: "All follow-on owners have a synchronized containment timeline.",
+    tone: "operator",
+  },
+  {
+    id: "yard-cameras",
+    title: "Camera diagnostics rolled back in the west yard",
+    operator: "Room automation",
+    role: "Automated safeguard",
+    timestamp: "08:02 UTC",
+    summary:
+      "A rollback rule restored the previous firmware package after repeated frame-loss alerts crossed the safe threshold.",
+    handoff: "Perimeter security retained full motion detection coverage.",
+    tone: "automation",
+  },
+  {
+    id: "generator-followup",
+    title: "Riverfront generator controller reset scheduled",
+    operator: "T. Morgan",
+    role: "Power coordinator",
+    timestamp: "07:49 UTC",
+    summary:
+      "A low-load reset window was coordinated with field technicians to avoid reopening the power event during active operations.",
+    handoff: "Field crew arrival is confirmed for the next quiet interval.",
+    tone: "operator",
+  },
+  {
+    id: "sorter-reject-rate",
+    title: "Sorter reject rate normalized after manual tuning",
+    operator: "K. Iqbal",
+    role: "Automation specialist",
+    timestamp: "07:31 UTC",
+    summary:
+      "Manual tuning on line 4 reduced false rejects enough to pull the incident back into the stabilization queue.",
+    handoff: "The remaining optics drift will stay under observation instead of escalation.",
+    tone: "resolved",
+  },
+  {
+    id: "gate-coverage",
+    title: "Supervisor dispatched to the south gate",
+    operator: "J. Rivera",
+    role: "Security coordinator",
+    timestamp: "07:18 UTC",
+    summary:
+      "A supervisor moved to the south gate to keep entries moving while credential retries are being mitigated.",
+    handoff: "Shift turnover remains on schedule despite the auth jitter.",
+    tone: "operator",
+  },
+] satisfies OperatorActivityEntry[];

--- a/src/app/control-room/control-room.module.css
+++ b/src/app/control-room/control-room.module.css
@@ -1,0 +1,261 @@
+.shell {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top left, rgba(56, 189, 248, 0.2), transparent 26%),
+    radial-gradient(circle at 82% 12%, rgba(250, 204, 21, 0.18), transparent 22%),
+    linear-gradient(180deg, #08111c 0%, #0c1826 46%, #111827 100%);
+}
+
+.shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(148, 163, 184, 0.08) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.08) 1px, transparent 1px);
+  background-position: center;
+  background-size: 5rem 5rem;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.85), transparent 88%);
+  z-index: -2;
+}
+
+.shell::after {
+  content: "";
+  position: absolute;
+  right: -10rem;
+  bottom: -10rem;
+  width: 28rem;
+  height: 28rem;
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgba(34, 197, 94, 0.18), transparent 60%);
+  filter: blur(18px);
+  z-index: -1;
+}
+
+.inner {
+  position: relative;
+  margin: 0 auto;
+  display: flex;
+  width: 100%;
+  max-width: 88rem;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 3rem 1.5rem 4rem;
+}
+
+.surfaceCard {
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  background: rgba(248, 250, 252, 0.88);
+  box-shadow:
+    0 24px 70px rgba(2, 8, 23, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.68);
+  backdrop-filter: blur(18px);
+  border-radius: 1.75rem;
+}
+
+.heroDeck {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(135deg, rgba(8, 14, 23, 0.96), rgba(11, 28, 44, 0.9) 58%, rgba(12, 74, 110, 0.76)),
+    radial-gradient(circle at top right, rgba(250, 204, 21, 0.22), transparent 36%);
+  color: #f8fafc;
+}
+
+.heroDeck::before {
+  content: "";
+  position: absolute;
+  inset: auto -6rem -8rem auto;
+  width: 22rem;
+  height: 22rem;
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgba(56, 189, 248, 0.22), transparent 60%);
+  filter: blur(16px);
+  z-index: 0;
+}
+
+.heroDeck > * {
+  position: relative;
+  z-index: 1;
+}
+
+.heroStat {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(12px);
+}
+
+.briefingCard {
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(12px);
+}
+
+.metricCard {
+  position: relative;
+  overflow: hidden;
+}
+
+.metricCard::before {
+  content: "";
+  position: absolute;
+  top: 1.1rem;
+  right: 1.1rem;
+  width: 5.5rem;
+  height: 5.5rem;
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgba(14, 165, 233, 0.14), transparent 68%);
+  pointer-events: none;
+}
+
+.metricRail {
+  height: 0.7rem;
+  overflow: hidden;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.metricFill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+}
+
+.metricFillStable {
+  background: linear-gradient(90deg, #22c55e, #14b8a6);
+  box-shadow: 0 0 24px rgba(34, 197, 94, 0.2);
+}
+
+.metricFillAttention {
+  background: linear-gradient(90deg, #f59e0b, #f97316);
+  box-shadow: 0 0 24px rgba(245, 158, 11, 0.18);
+}
+
+.metricFillCritical {
+  background: linear-gradient(90deg, #fb7185, #f97316);
+  box-shadow: 0 0 24px rgba(251, 113, 133, 0.18);
+}
+
+.alertSection {
+  position: relative;
+  overflow: hidden;
+}
+
+.alertSection::before {
+  content: "";
+  position: absolute;
+  left: 1.5rem;
+  right: 1.5rem;
+  top: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(148, 163, 184, 0.7), transparent);
+}
+
+.alertSectionImmediate {
+  background:
+    linear-gradient(180deg, rgba(255, 241, 242, 0.96), rgba(248, 250, 252, 0.9));
+}
+
+.alertSectionStabilization {
+  background:
+    linear-gradient(180deg, rgba(255, 251, 235, 0.96), rgba(248, 250, 252, 0.9));
+}
+
+.alertSectionObservation {
+  background:
+    linear-gradient(180deg, rgba(240, 249, 255, 0.96), rgba(248, 250, 252, 0.9));
+}
+
+.alertItem {
+  position: relative;
+  overflow: hidden;
+}
+
+.alertItem::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 1rem;
+  bottom: 1rem;
+  width: 0.35rem;
+  border-radius: 9999px;
+}
+
+.alertCritical::before {
+  background: linear-gradient(180deg, #fb7185, #e11d48);
+}
+
+.alertElevated::before {
+  background: linear-gradient(180deg, #f59e0b, #f97316);
+}
+
+.alertWatch::before {
+  background: linear-gradient(180deg, #38bdf8, #06b6d4);
+}
+
+.activityRail {
+  position: relative;
+  display: grid;
+  gap: 1rem;
+}
+
+.activityRail::before {
+  content: "";
+  position: absolute;
+  left: 0.55rem;
+  top: 0.75rem;
+  bottom: 0.75rem;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(56, 189, 248, 0.28), rgba(250, 204, 21, 0.22));
+}
+
+.activityNode {
+  position: relative;
+  padding-left: 2.2rem;
+}
+
+.activityNode::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 1.25rem;
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 9999px;
+  border: 4px solid #08111c;
+}
+
+.activityNodeOperator::before {
+  background: linear-gradient(135deg, #38bdf8, #22d3ee);
+}
+
+.activityNodeAutomation::before {
+  background: linear-gradient(135deg, #60a5fa, #818cf8);
+}
+
+.activityNodeResolved::before {
+  background: linear-gradient(135deg, #34d399, #14b8a6);
+}
+
+@media (max-width: 640px) {
+  .inner {
+    padding: 2rem 1rem 3rem;
+  }
+
+  .shell::after {
+    right: -8rem;
+    bottom: -8rem;
+    width: 20rem;
+    height: 20rem;
+  }
+
+  .activityNode {
+    padding-left: 1.9rem;
+  }
+}

--- a/src/app/control-room/page.test.tsx
+++ b/src/app/control-room/page.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ActivityRail } from "./_components/activity-rail";
+import { AlertList } from "./_components/alert-list";
+import {
+  controlRoomAlertSections,
+  controlRoomMetrics,
+  operatorActivityEntries,
+} from "./_data/control-room-data";
+import ControlRoomPage from "./page";
+
+describe("ControlRoomPage", () => {
+  it("renders the route shell with the required headings", () => {
+    render(<ControlRoomPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: /see operational drift before it becomes customer impact\./i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /operational health snapshot/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /intervention lanes/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /live handoff rail/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/to get started, edit the page\.tsx file\./i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders every metric card from route-local mock data", () => {
+    render(<ControlRoomPage />);
+
+    const metricList = screen.getByRole("list", { name: /control room metrics/i });
+    expect(within(metricList).getAllByRole("listitem")).toHaveLength(
+      controlRoomMetrics.length,
+    );
+
+    for (const metric of controlRoomMetrics) {
+      const card = within(metricList)
+        .getByText(metric.label)
+        .closest('[role="listitem"]');
+
+      expect(card).toBeInTheDocument();
+      expect(card).toHaveTextContent(metric.value);
+      expect(card).toHaveTextContent(metric.delta);
+      expect(card).toHaveTextContent(metric.focus);
+    }
+  });
+
+  it("renders alert lanes, activity entries, and responsive layout hooks", () => {
+    render(<ControlRoomPage />);
+
+    const panels = screen.getByTestId("control-room-panels");
+    const activityRail = screen.getByRole("list", {
+      name: /operator activity rail/i,
+    });
+
+    expect(panels.className).toContain(
+      "xl:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.92fr)]",
+    );
+    expect(within(activityRail).getAllByRole("listitem")).toHaveLength(
+      operatorActivityEntries.length,
+    );
+    expect(
+      screen.getByText(controlRoomAlertSections[0].alerts[0].nextStep),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(operatorActivityEntries[0].handoff),
+    ).toBeInTheDocument();
+
+    for (const section of controlRoomAlertSections) {
+      const alertList = screen.getByRole("list", { name: section.title });
+      expect(within(alertList).getAllByRole("listitem")).toHaveLength(
+        section.alerts.length,
+      );
+    }
+  });
+});
+
+describe("control-room dashboard components", () => {
+  it("renders an empty-state alert lane when a section has no alerts", () => {
+    render(
+      <AlertList
+        sections={[
+          {
+            ...controlRoomAlertSections[0],
+            alerts: [],
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText(/no active alerts in this lane\./i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/operators can confirm the lane is intentionally clear/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an empty-state activity rail when no entries are present", () => {
+    render(<ActivityRail entries={[]} />);
+
+    expect(
+      screen.getByText(/no operator activity has been logged yet\./i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/fresh activity can appear without shifting the rest/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/control-room/page.tsx
+++ b/src/app/control-room/page.tsx
@@ -8,6 +8,7 @@ import {
   controlRoomMetrics,
   operatorActivityEntries,
 } from "./_data/control-room-data";
+import styles from "./control-room.module.css";
 
 export const metadata: Metadata = {
   title: "Control Room",
@@ -31,159 +32,163 @@ export default function ControlRoomPage() {
   ).size;
 
   return (
-    <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-12 sm:px-10 lg:px-12">
-      <section className="overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.08)]">
-        <div className="grid gap-8 px-6 py-10 sm:px-10 lg:grid-cols-[minmax(0,1.35fr)_minmax(280px,0.9fr)] lg:px-12 lg:py-14">
-          <div className="space-y-6">
-            <div className="space-y-3">
-              <p className="text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
-                Control Room
-              </p>
-              <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-                See operational drift before it becomes customer impact.
-              </h1>
-              <p className="max-w-2xl text-lg leading-8 text-slate-600">
-                The control room keeps system health, open alert lanes, and live
-                operator handoffs visible in one route so intervention decisions
-                stay coordinated under pressure.
-              </p>
+    <main className={styles.shell}>
+      <div className={styles.inner}>
+        <section className={`${styles.surfaceCard} ${styles.heroDeck}`}>
+          <div className="grid gap-8 px-6 py-10 sm:px-10 lg:grid-cols-[minmax(0,1.35fr)_minmax(280px,0.9fr)] lg:px-12 lg:py-14">
+            <div className="space-y-6">
+              <div className="space-y-3">
+                <p className="text-sm font-semibold uppercase tracking-[0.28em] text-sky-100/80">
+                  Control Room
+                </p>
+                <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+                  See operational drift before it becomes customer impact.
+                </h1>
+                <p className="max-w-2xl text-lg leading-8 text-slate-100/78">
+                  The control room keeps system health, open alert lanes, and
+                  live operator handoffs visible in one route so intervention
+                  decisions stay coordinated under pressure.
+                </p>
+              </div>
+
+              <div className="grid gap-4 sm:grid-cols-3">
+                <div className={`${styles.heroStat} rounded-[1.5rem] px-5 py-5`}>
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-200/70">
+                    Metrics online
+                  </p>
+                  <p className="mt-3 text-3xl font-semibold tracking-tight text-white">
+                    {controlRoomMetrics.length}
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-slate-100/72">
+                    Route-level system indicators loaded from standalone mock
+                    data.
+                  </p>
+                </div>
+                <div className={`${styles.heroStat} rounded-[1.5rem] px-5 py-5`}>
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-200/70">
+                    Open alerts
+                  </p>
+                  <p className="mt-3 text-3xl font-semibold tracking-tight text-white">
+                    {totalAlerts}
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-slate-100/72">
+                    {criticalAlerts} critical lane requiring immediate
+                    command-room attention.
+                  </p>
+                </div>
+                <div className={`${styles.heroStat} rounded-[1.5rem] px-5 py-5`}>
+                  <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-200/70">
+                    Active operators
+                  </p>
+                  <p className="mt-3 text-3xl font-semibold tracking-tight text-white">
+                    {activeOperators}
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-slate-100/72">
+                    Live activity entries pinned to the current intervention
+                    rail.
+                  </p>
+                </div>
+              </div>
             </div>
 
-            <div className="grid gap-4 sm:grid-cols-3">
-              <div className="rounded-[1.5rem] border border-slate-200/80 bg-white/80 px-5 py-5">
-                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
-                  Metrics online
-                </p>
-                <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
-                  {controlRoomMetrics.length}
-                </p>
-                <p className="mt-2 text-sm leading-6 text-slate-600">
-                  Route-level system indicators loaded from standalone mock data.
-                </p>
+            <aside className={`${styles.briefingCard} rounded-[1.75rem] p-6`}>
+              <div className="space-y-5">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-200/70">
+                    Command brief
+                  </p>
+                  <p className="mt-3 text-3xl font-semibold tracking-tight text-white">
+                    Stable core with targeted interventions
+                  </p>
+                </div>
+
+                <div className="space-y-3 text-sm leading-6 text-slate-100/74">
+                  <p>Current shift: 08:00-16:00 UTC control desk.</p>
+                  <p>
+                    Escalation priority: facilities, access control, and power
+                    resilience.
+                  </p>
+                  <p>Next structured handoff: 08:30 UTC command pulse review.</p>
+                </div>
+
+                <div className="rounded-[1.5rem] border border-white/10 bg-white/10 px-4 py-4">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-200/70">
+                    Room note
+                  </p>
+                  <p className="mt-2 text-sm font-medium text-white">
+                    Keep the override queue visible until the cooling loop and
+                    access-control issues are both under owner acknowledgement.
+                  </p>
+                </div>
               </div>
-              <div className="rounded-[1.5rem] border border-slate-200/80 bg-white/80 px-5 py-5">
-                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
-                  Open alerts
-                </p>
-                <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
-                  {totalAlerts}
-                </p>
-                <p className="mt-2 text-sm leading-6 text-slate-600">
-                  {criticalAlerts} critical lane requiring immediate command-room
-                  attention.
-                </p>
-              </div>
-              <div className="rounded-[1.5rem] border border-slate-200/80 bg-white/80 px-5 py-5">
-                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
-                  Active operators
-                </p>
-                <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
-                  {activeOperators}
-                </p>
-                <p className="mt-2 text-sm leading-6 text-slate-600">
-                  Live activity entries pinned to the current intervention rail.
-                </p>
-              </div>
-            </div>
+            </aside>
           </div>
+        </section>
 
-          <aside className="rounded-[1.75rem] border border-slate-200/80 bg-white/75 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
-            <div className="space-y-5">
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
-                  Command brief
-                </p>
-                <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
-                  Stable core with targeted interventions
-                </p>
-              </div>
-
-              <div className="space-y-3 text-sm leading-6 text-slate-600">
-                <p>Current shift: 08:00-16:00 UTC control desk.</p>
-                <p>
-                  Escalation priority: facilities, access control, and power
-                  resilience.
-                </p>
-                <p>Next structured handoff: 08:30 UTC command pulse review.</p>
-              </div>
-
-              <div className="rounded-[1.5rem] border border-slate-200/80 bg-slate-50/90 px-4 py-4">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                  Room note
-                </p>
-                <p className="mt-2 text-sm font-medium text-slate-800">
-                  Keep the override queue visible until the cooling loop and
-                  access-control issues are both under owner acknowledgement.
-                </p>
-              </div>
+        <section aria-labelledby="control-room-metrics" className="space-y-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-300/75">
+                System metrics
+              </p>
+              <h2
+                id="control-room-metrics"
+                className="text-3xl font-semibold tracking-tight text-white"
+              >
+                Operational health snapshot
+              </h2>
             </div>
-          </aside>
-        </div>
-      </section>
-
-      <section aria-labelledby="control-room-metrics" className="space-y-5">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-          <div className="space-y-2">
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
-              System metrics
+            <p className="max-w-2xl text-sm leading-6 text-slate-300/75">
+              Each metric is route-scoped mock content so the dashboard can
+              stand on its own while the rest of the app evolves independently.
             </p>
-            <h2
-              id="control-room-metrics"
-              className="text-3xl font-semibold tracking-tight text-slate-950"
-            >
-              Operational health snapshot
-            </h2>
           </div>
-          <p className="max-w-2xl text-sm leading-6 text-slate-600">
-            Each metric is route-scoped mock content so the dashboard can stand
-            on its own while the rest of the app evolves independently.
-          </p>
-        </div>
+
+          <div
+            aria-label="Control room metrics"
+            className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4"
+            role="list"
+          >
+            {controlRoomMetrics.map((metric) => (
+              <MetricCard key={metric.id} metric={metric} />
+            ))}
+          </div>
+        </section>
 
         <div
-          aria-label="Control room metrics"
-          className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4"
-          role="list"
+          className="grid gap-6 xl:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.92fr)]"
+          data-testid="control-room-panels"
         >
-          {controlRoomMetrics.map((metric) => (
-            <MetricCard key={metric.id} metric={metric} />
-          ))}
+          <section aria-labelledby="control-room-alerts" className="space-y-5">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-300/75">
+                Active alerts
+              </p>
+              <h2
+                id="control-room-alerts"
+                className="text-3xl font-semibold tracking-tight text-white"
+              >
+                Intervention lanes
+              </h2>
+            </div>
+            <AlertList sections={controlRoomAlertSections} />
+          </section>
+
+          <section aria-labelledby="control-room-activity" className="space-y-5">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-300/75">
+                Operator activity
+              </p>
+              <h2
+                id="control-room-activity"
+                className="text-3xl font-semibold tracking-tight text-white"
+              >
+                Live handoff rail
+              </h2>
+            </div>
+            <ActivityRail entries={operatorActivityEntries} />
+          </section>
         </div>
-      </section>
-
-      <div
-        className="grid gap-6 xl:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.92fr)]"
-        data-testid="control-room-panels"
-      >
-        <section aria-labelledby="control-room-alerts" className="space-y-5">
-          <div className="space-y-2">
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
-              Active alerts
-            </p>
-            <h2
-              id="control-room-alerts"
-              className="text-3xl font-semibold tracking-tight text-slate-950"
-            >
-              Intervention lanes
-            </h2>
-          </div>
-          <AlertList sections={controlRoomAlertSections} />
-        </section>
-
-        <section aria-labelledby="control-room-activity" className="space-y-5">
-          <div className="space-y-2">
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
-              Operator activity
-            </p>
-            <h2
-              id="control-room-activity"
-              className="text-3xl font-semibold tracking-tight text-slate-950"
-            >
-              Live handoff rail
-            </h2>
-          </div>
-          <ActivityRail entries={operatorActivityEntries} />
-        </section>
       </div>
     </main>
   );

--- a/src/app/control-room/page.tsx
+++ b/src/app/control-room/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Control Room",
+  description:
+    "Initial route shell for the control-room dashboard with space for metrics, alerts, and operator activity.",
+};
+
+export default function ControlRoomPage() {
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-12 sm:px-10 lg:px-12">
+      <section className="overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.08)]">
+        <div className="grid gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
+          <div className="space-y-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
+              Control Room
+            </p>
+            <div className="space-y-3">
+              <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
+                Control operational drift before it spills into the network.
+              </h1>
+              <p className="max-w-2xl text-lg leading-8 text-slate-600">
+                This route shell reserves space for system metrics, active
+                alerts, and an operator activity rail. The remaining subtasks
+                will layer in mock data, reusable components, and the full
+                dashboard layout.
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="rounded-[1.5rem] border border-slate-200/80 bg-white/80 px-5 py-5">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                Metrics
+              </p>
+              <p className="mt-3 text-sm leading-6 text-slate-600">
+                Placeholder zone for route-specific KPI cards.
+              </p>
+            </div>
+            <div className="rounded-[1.5rem] border border-slate-200/80 bg-white/80 px-5 py-5">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                Alerts
+              </p>
+              <p className="mt-3 text-sm leading-6 text-slate-600">
+                Placeholder zone for live alert sections and severity states.
+              </p>
+            </div>
+            <div className="rounded-[1.5rem] border border-slate-200/80 bg-white/80 px-5 py-5">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                Activity
+              </p>
+              <p className="mt-3 text-sm leading-6 text-slate-600">
+                Placeholder zone for the operator activity rail.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/control-room/page.tsx
+++ b/src/app/control-room/page.tsx
@@ -1,61 +1,190 @@
 import type { Metadata } from "next";
 
+import { ActivityRail } from "./_components/activity-rail";
+import { AlertList } from "./_components/alert-list";
+import { MetricCard } from "./_components/metric-card";
+import {
+  controlRoomAlertSections,
+  controlRoomMetrics,
+  operatorActivityEntries,
+} from "./_data/control-room-data";
+
 export const metadata: Metadata = {
   title: "Control Room",
   description:
-    "Initial route shell for the control-room dashboard with space for metrics, alerts, and operator activity.",
+    "Dashboard route highlighting system metrics, active alerts, and operator activity in the control room.",
 };
 
 export default function ControlRoomPage() {
+  const totalAlerts = controlRoomAlertSections.reduce(
+    (count, section) => count + section.alerts.length,
+    0,
+  );
+  const criticalAlerts = controlRoomAlertSections.reduce(
+    (count, section) =>
+      count +
+      section.alerts.filter((alert) => alert.severity === "critical").length,
+    0,
+  );
+  const activeOperators = new Set(
+    operatorActivityEntries.map((entry) => entry.operator),
+  ).size;
+
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-12 sm:px-10 lg:px-12">
       <section className="overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.08)]">
-        <div className="grid gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
-          <div className="space-y-5">
-            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
-              Control Room
-            </p>
+        <div className="grid gap-8 px-6 py-10 sm:px-10 lg:grid-cols-[minmax(0,1.35fr)_minmax(280px,0.9fr)] lg:px-12 lg:py-14">
+          <div className="space-y-6">
             <div className="space-y-3">
+              <p className="text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
+                Control Room
+              </p>
               <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-                Control operational drift before it spills into the network.
+                See operational drift before it becomes customer impact.
               </h1>
               <p className="max-w-2xl text-lg leading-8 text-slate-600">
-                This route shell reserves space for system metrics, active
-                alerts, and an operator activity rail. The remaining subtasks
-                will layer in mock data, reusable components, and the full
-                dashboard layout.
+                The control room keeps system health, open alert lanes, and live
+                operator handoffs visible in one route so intervention decisions
+                stay coordinated under pressure.
               </p>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-3">
+              <div className="rounded-[1.5rem] border border-slate-200/80 bg-white/80 px-5 py-5">
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  Metrics online
+                </p>
+                <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+                  {controlRoomMetrics.length}
+                </p>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  Route-level system indicators loaded from standalone mock data.
+                </p>
+              </div>
+              <div className="rounded-[1.5rem] border border-slate-200/80 bg-white/80 px-5 py-5">
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  Open alerts
+                </p>
+                <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+                  {totalAlerts}
+                </p>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  {criticalAlerts} critical lane requiring immediate command-room
+                  attention.
+                </p>
+              </div>
+              <div className="rounded-[1.5rem] border border-slate-200/80 bg-white/80 px-5 py-5">
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  Active operators
+                </p>
+                <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+                  {activeOperators}
+                </p>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  Live activity entries pinned to the current intervention rail.
+                </p>
+              </div>
             </div>
           </div>
 
-          <div className="grid gap-4 sm:grid-cols-3">
-            <div className="rounded-[1.5rem] border border-slate-200/80 bg-white/80 px-5 py-5">
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
-                Metrics
-              </p>
-              <p className="mt-3 text-sm leading-6 text-slate-600">
-                Placeholder zone for route-specific KPI cards.
-              </p>
+          <aside className="rounded-[1.75rem] border border-slate-200/80 bg-white/75 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
+            <div className="space-y-5">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                  Command brief
+                </p>
+                <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+                  Stable core with targeted interventions
+                </p>
+              </div>
+
+              <div className="space-y-3 text-sm leading-6 text-slate-600">
+                <p>Current shift: 08:00-16:00 UTC control desk.</p>
+                <p>
+                  Escalation priority: facilities, access control, and power
+                  resilience.
+                </p>
+                <p>Next structured handoff: 08:30 UTC command pulse review.</p>
+              </div>
+
+              <div className="rounded-[1.5rem] border border-slate-200/80 bg-slate-50/90 px-4 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  Room note
+                </p>
+                <p className="mt-2 text-sm font-medium text-slate-800">
+                  Keep the override queue visible until the cooling loop and
+                  access-control issues are both under owner acknowledgement.
+                </p>
+              </div>
             </div>
-            <div className="rounded-[1.5rem] border border-slate-200/80 bg-white/80 px-5 py-5">
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
-                Alerts
-              </p>
-              <p className="mt-3 text-sm leading-6 text-slate-600">
-                Placeholder zone for live alert sections and severity states.
-              </p>
-            </div>
-            <div className="rounded-[1.5rem] border border-slate-200/80 bg-white/80 px-5 py-5">
-              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">
-                Activity
-              </p>
-              <p className="mt-3 text-sm leading-6 text-slate-600">
-                Placeholder zone for the operator activity rail.
-              </p>
-            </div>
-          </div>
+          </aside>
         </div>
       </section>
+
+      <section aria-labelledby="control-room-metrics" className="space-y-5">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+              System metrics
+            </p>
+            <h2
+              id="control-room-metrics"
+              className="text-3xl font-semibold tracking-tight text-slate-950"
+            >
+              Operational health snapshot
+            </h2>
+          </div>
+          <p className="max-w-2xl text-sm leading-6 text-slate-600">
+            Each metric is route-scoped mock content so the dashboard can stand
+            on its own while the rest of the app evolves independently.
+          </p>
+        </div>
+
+        <div
+          aria-label="Control room metrics"
+          className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4"
+          role="list"
+        >
+          {controlRoomMetrics.map((metric) => (
+            <MetricCard key={metric.id} metric={metric} />
+          ))}
+        </div>
+      </section>
+
+      <div
+        className="grid gap-6 xl:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.92fr)]"
+        data-testid="control-room-panels"
+      >
+        <section aria-labelledby="control-room-alerts" className="space-y-5">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Active alerts
+            </p>
+            <h2
+              id="control-room-alerts"
+              className="text-3xl font-semibold tracking-tight text-slate-950"
+            >
+              Intervention lanes
+            </h2>
+          </div>
+          <AlertList sections={controlRoomAlertSections} />
+        </section>
+
+        <section aria-labelledby="control-room-activity" className="space-y-5">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Operator activity
+            </p>
+            <h2
+              id="control-room-activity"
+              className="text-3xl font-semibold tracking-tight text-slate-950"
+            >
+              Live handoff rail
+            </h2>
+          </div>
+          <ActivityRail entries={operatorActivityEntries} />
+        </section>
+      </div>
     </main>
   );
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,5 +15,6 @@ export default defineConfig({
     globals: true,
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
     setupFiles: ["./vitest.setup.ts"],
+    testTimeout: 15000,
   },
 });


### PR DESCRIPTION
## Summary
- add the initial `control-room` app route shell
- establish the route metadata and placeholder sections for metrics, alerts, and activity
- keep the PR open early per the issue workflow so later subtasks can land incrementally

## Testing
- `npx eslint src/app/control-room/page.tsx`

Closes #101