### PR TITLE
feat: polish command log route

### DIFF
--- a/src/app/command-log/_components/command-event-detail.tsx
+++ b/src/app/command-log/_components/command-event-detail.tsx
@@ -1,4 +1,19 @@
 import type { CommandLogEvent } from "../_lib/command-log-data";
+import styles from "../command-log.module.css";
+
+const severityClasses = {
+  Critical: styles.severityCritical,
+  High: styles.severityHigh,
+  Moderate: styles.severityModerate,
+  Low: styles.severityLow,
+};
+
+const statusClasses = {
+  Completed: styles.statusCompleted,
+  Watching: styles.statusWatching,
+  "Needs follow-up": styles.statusNeedsFollowUp,
+  Blocked: styles.statusBlocked,
+};
 
 type CommandEventDetailProps = {
   event: CommandLogEvent;
@@ -15,7 +30,7 @@ export function CommandEventDetail({
     <aside className="xl:sticky xl:top-8 xl:self-start">
       <section
         aria-label="Event detail"
-        className="rounded-[2rem] border border-white/10 bg-slate-950 p-5 text-slate-100 shadow-[0_24px_90px_rgba(15,23,42,0.18)] sm:p-6"
+        className={`${styles.detailPanel} rounded-[2rem] border border-white/10 bg-slate-950 p-5 text-slate-100 shadow-[0_24px_90px_rgba(15,23,42,0.18)] sm:p-6`}
       >
         <div className="space-y-5">
           <div className="space-y-3">
@@ -45,21 +60,29 @@ export function CommandEventDetail({
             </p>
           ) : null}
 
-          <div className="rounded-[1.5rem] border border-white/10 bg-white/6 p-4">
+          <div
+            className={`${styles.detailSection} rounded-[1.5rem] border border-white/10 bg-white/6 p-4`}
+          >
             <div className="flex flex-wrap gap-2">
-              <span className="inline-flex rounded-full border border-rose-300/30 bg-rose-500/12 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-rose-100">
+              <span
+                className={`${styles.badge} ${severityClasses[event.severity]} inline-flex rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em]`}
+              >
                 {event.severity}
               </span>
               <span className="inline-flex rounded-full border border-white/10 bg-white/8 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-slate-100">
                 {event.category}
               </span>
-              <span className="inline-flex rounded-full border border-cyan-300/30 bg-cyan-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-100">
+              <span
+                className={`${styles.badge} ${statusClasses[event.status]} inline-flex rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em]`}
+              >
                 {event.status}
               </span>
             </div>
 
             <dl className="mt-4 grid gap-3 sm:grid-cols-2">
-              <div className="rounded-[1rem] border border-white/10 bg-slate-900/80 p-4">
+              <div
+                className={`${styles.detailInnerCard} rounded-[1rem] border border-white/10 bg-slate-900/80 p-4`}
+              >
                 <dt className="text-xs uppercase tracking-[0.18em] text-slate-400">
                   Timestamp
                 </dt>
@@ -67,7 +90,9 @@ export function CommandEventDetail({
                   {event.occurredLabel}
                 </dd>
               </div>
-              <div className="rounded-[1rem] border border-white/10 bg-slate-900/80 p-4">
+              <div
+                className={`${styles.detailInnerCard} rounded-[1rem] border border-white/10 bg-slate-900/80 p-4`}
+              >
                 <dt className="text-xs uppercase tracking-[0.18em] text-slate-400">
                   Team
                 </dt>
@@ -75,7 +100,9 @@ export function CommandEventDetail({
                   {event.team}
                 </dd>
               </div>
-              <div className="rounded-[1rem] border border-white/10 bg-slate-900/80 p-4">
+              <div
+                className={`${styles.detailInnerCard} rounded-[1rem] border border-white/10 bg-slate-900/80 p-4`}
+              >
                 <dt className="text-xs uppercase tracking-[0.18em] text-slate-400">
                   Actor
                 </dt>
@@ -83,7 +110,9 @@ export function CommandEventDetail({
                   {event.actor}
                 </dd>
               </div>
-              <div className="rounded-[1rem] border border-white/10 bg-slate-900/80 p-4">
+              <div
+                className={`${styles.detailInnerCard} rounded-[1rem] border border-white/10 bg-slate-900/80 p-4`}
+              >
                 <dt className="text-xs uppercase tracking-[0.18em] text-slate-400">
                   Environment
                 </dt>
@@ -94,12 +123,16 @@ export function CommandEventDetail({
             </dl>
           </div>
 
-          <section className="rounded-[1.5rem] border border-white/10 bg-white/6 p-4">
+          <section
+            className={`${styles.detailSection} rounded-[1.5rem] border border-white/10 bg-white/6 p-4`}
+          >
             <h3 className="text-xl font-semibold text-white">Command context</h3>
             <p className="mt-3 text-sm leading-6 text-slate-300">
               {event.summary}
             </p>
-            <div className="mt-4 rounded-[1rem] border border-white/10 bg-slate-900/80 p-4">
+            <div
+              className={`${styles.detailInnerCard} mt-4 rounded-[1rem] border border-white/10 bg-slate-900/80 p-4`}
+            >
               <p className="text-xs uppercase tracking-[0.18em] text-slate-400">
                 Executed command
               </p>
@@ -109,13 +142,15 @@ export function CommandEventDetail({
             </div>
           </section>
 
-          <section className="rounded-[1.5rem] border border-white/10 bg-white/6 p-4">
+          <section
+            className={`${styles.detailSection} rounded-[1.5rem] border border-white/10 bg-white/6 p-4`}
+          >
             <h3 className="text-xl font-semibold text-white">Related services</h3>
             <div className="mt-4 flex flex-wrap gap-2">
               {event.relatedServices.map((service) => (
                 <span
                   key={`${event.id}-${service}`}
-                  className="inline-flex rounded-full border border-white/10 bg-slate-900/80 px-3 py-1 text-sm font-medium text-slate-100"
+                  className={`${styles.servicePill} inline-flex rounded-full border px-3 py-1 text-sm font-medium text-slate-100`}
                 >
                   {service}
                 </span>
@@ -123,13 +158,15 @@ export function CommandEventDetail({
             </div>
           </section>
 
-          <section className="rounded-[1.5rem] border border-white/10 bg-white/6 p-4">
+          <section
+            className={`${styles.detailSection} rounded-[1.5rem] border border-white/10 bg-white/6 p-4`}
+          >
             <h3 className="text-xl font-semibold text-white">Operator notes</h3>
-            <ul className="mt-4 space-y-3">
+            <ul className={`${styles.notesList} mt-4 space-y-3`}>
               {event.notes.map((note) => (
                 <li
                   key={`${event.id}-${note}`}
-                  className="rounded-[1rem] border border-white/10 bg-slate-900/80 px-4 py-3 text-sm leading-6 text-slate-200"
+                  className={`${styles.noteCard} rounded-[1rem] border border-white/10 bg-slate-900/80 px-4 py-3 text-sm leading-6 text-slate-200`}
                 >
                   {note}
                 </li>
@@ -137,7 +174,9 @@ export function CommandEventDetail({
             </ul>
           </section>
 
-          <section className="rounded-[1.5rem] border border-white/10 bg-white/6 p-4">
+          <section
+            className={`${styles.detailSection} rounded-[1.5rem] border border-white/10 bg-white/6 p-4`}
+          >
             <h3 className="text-xl font-semibold text-white">Next action</h3>
             <p className="mt-3 text-sm leading-6 text-slate-200">
               {event.nextAction}

--- a/src/app/command-log/_components/command-event-list.tsx
+++ b/src/app/command-log/_components/command-event-list.tsx
@@ -3,14 +3,16 @@ import Link from "next/link";
 import type {
   CommandEventCategory,
   CommandEventSeverity,
+  CommandEventStatus,
   CommandLogEvent,
 } from "../_lib/command-log-data";
+import styles from "../command-log.module.css";
 
 const severityClasses: Record<CommandEventSeverity, string> = {
-  Critical: "border-rose-300/50 bg-rose-500/12 text-rose-100",
-  High: "border-amber-300/50 bg-amber-500/12 text-amber-100",
-  Moderate: "border-sky-300/50 bg-sky-500/12 text-sky-100",
-  Low: "border-emerald-300/50 bg-emerald-500/12 text-emerald-100",
+  Critical: styles.severityCritical,
+  High: styles.severityHigh,
+  Moderate: styles.severityModerate,
+  Low: styles.severityLow,
 };
 
 const categoryClasses: Record<CommandEventCategory, string> = {
@@ -20,6 +22,13 @@ const categoryClasses: Record<CommandEventCategory, string> = {
   Escalation: "bg-rose-500/12 text-rose-100",
   Automation: "bg-emerald-500/12 text-emerald-100",
   Handoff: "bg-amber-500/12 text-amber-100",
+};
+
+const statusClasses: Record<CommandEventStatus, string> = {
+  Completed: styles.statusCompleted,
+  Watching: styles.statusWatching,
+  "Needs follow-up": styles.statusNeedsFollowUp,
+  Blocked: styles.statusBlocked,
 };
 
 type CommandEventListProps = {
@@ -34,7 +43,7 @@ export function CommandEventList({
   return (
     <section
       aria-labelledby="command-event-list-title"
-      className="rounded-[2rem] border border-white/10 bg-slate-950/88 p-5 shadow-[0_24px_90px_rgba(15,23,42,0.2)] sm:p-6"
+      className={`${styles.eventSection} rounded-[2rem] border border-white/10 bg-slate-950/88 p-5 shadow-[0_24px_90px_rgba(15,23,42,0.2)] sm:p-6`}
     >
       <div className="space-y-3">
         <p className="text-sm font-semibold uppercase tracking-[0.24em] text-cyan-200/75">
@@ -54,17 +63,19 @@ export function CommandEventList({
         </div>
       </div>
 
-      <ol aria-label="Chronological events" className="mt-6 space-y-4">
+      <ol aria-label="Chronological events" className={`${styles.feedList} space-y-4`}>
         {events.map((event) => {
           const isSelected = event.id === selectedEventId;
 
           return (
-            <li key={event.id}>
+            <li key={event.id} className={styles.feedItem}>
               <Link
                 aria-current={isSelected ? "page" : undefined}
                 aria-label={`${isSelected ? "Viewing detail for" : "View detail for"} ${event.title}`}
                 href={`/command-log?event=${event.id}`}
-                className={`block rounded-[1.6rem] border p-5 transition hover:-translate-y-0.5 hover:border-cyan-300/40 hover:bg-slate-900/90 ${
+                className={`${styles.eventCard} ${
+                  isSelected ? styles.eventCardSelected : ""
+                } block rounded-[1.6rem] border p-5 transition hover:-translate-y-0.5 hover:border-cyan-300/40 hover:bg-slate-900/90 ${
                   isSelected
                     ? "border-cyan-300/45 bg-slate-900 text-white shadow-[0_18px_60px_rgba(8,145,178,0.18)]"
                     : "border-white/10 bg-slate-900/65 text-slate-100"
@@ -74,7 +85,7 @@ export function CommandEventList({
                   <div className="flex flex-wrap items-center justify-between gap-3">
                     <div className="flex flex-wrap gap-2">
                       <span
-                        className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] ${severityClasses[event.severity]}`}
+                        className={`${styles.badge} inline-flex rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] ${severityClasses[event.severity]}`}
                       >
                         {event.severity}
                       </span>
@@ -83,7 +94,9 @@ export function CommandEventList({
                       >
                         {event.category}
                       </span>
-                      <span className="inline-flex rounded-full border border-white/10 bg-white/6 px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-slate-200">
+                      <span
+                        className={`${styles.badge} ${statusClasses[event.status]} inline-flex rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em]`}
+                      >
                         {event.status}
                       </span>
                     </div>
@@ -125,7 +138,7 @@ export function CommandEventList({
                     {event.tags.map((tag) => (
                       <span
                         key={`${event.id}-${tag}`}
-                        className="inline-flex rounded-full border border-white/10 bg-white/6 px-3 py-1 text-xs font-medium text-slate-200"
+                        className={`${styles.tagPill} inline-flex rounded-full border px-3 py-1 text-xs font-medium`}
                       >
                         #{tag}
                       </span>

--- a/src/app/command-log/_components/command-log-shell.tsx
+++ b/src/app/command-log/_components/command-log-shell.tsx
@@ -2,6 +2,7 @@ import { CommandEventDetail } from "./command-event-detail";
 import { CommandEventList } from "./command-event-list";
 import { CommandTagSummary } from "./command-tag-summary";
 import type { CommandLogView } from "../_lib/command-log";
+import styles from "../command-log.module.css";
 
 type CommandLogShellProps = {
   view: CommandLogView;
@@ -9,8 +10,12 @@ type CommandLogShellProps = {
 
 export function CommandLogShell({ view }: CommandLogShellProps) {
   return (
-    <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8 px-6 py-8 sm:px-10 lg:px-12">
-      <section className="overflow-hidden rounded-[2rem] border border-slate-200/80 bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.08)]">
+    <main
+      className={`${styles.pageShell} mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8 px-6 py-8 sm:px-10 lg:px-12`}
+    >
+      <section
+        className={`${styles.heroPanel} overflow-hidden rounded-[2rem] border border-slate-200/80 bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.08)]`}
+      >
         <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1.15fr)_minmax(280px,0.85fr)] lg:px-12 lg:py-10">
           <div className="space-y-5">
             <p className="text-sm font-semibold uppercase tracking-[0.28em] text-amber-700">
@@ -30,7 +35,9 @@ export function CommandLogShell({ view }: CommandLogShellProps) {
             </div>
           </div>
 
-          <div className="rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-5">
+          <div
+            className={`${styles.summaryPanel} rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-5`}
+          >
             <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
               Shift snapshot
             </p>
@@ -38,7 +45,7 @@ export function CommandLogShell({ view }: CommandLogShellProps) {
               {view.summaryMetrics.map((metric) => (
                 <div
                   key={metric.label}
-                  className="rounded-[1.2rem] border border-slate-200 bg-white/80 p-4"
+                  className={`${styles.summaryMetricCard} rounded-[1.2rem] border border-slate-200 bg-white/80 p-4`}
                 >
                   <p className="text-xs uppercase tracking-[0.18em] text-slate-500">
                     {metric.label}
@@ -62,7 +69,7 @@ export function CommandLogShell({ view }: CommandLogShellProps) {
       />
 
       <div
-        className="grid gap-8 xl:grid-cols-[minmax(0,1.1fr)_minmax(360px,0.9fr)]"
+        className={`${styles.panels} grid gap-8 xl:grid-cols-[minmax(0,1.1fr)_minmax(360px,0.9fr)]`}
         data-testid="command-log-panels"
       >
         <CommandEventList

--- a/src/app/command-log/_components/command-tag-summary.tsx
+++ b/src/app/command-log/_components/command-tag-summary.tsx
@@ -1,4 +1,5 @@
 import type { CommandTagSummaryItem } from "../_lib/command-log";
+import styles from "../command-log.module.css";
 
 type CommandTagSummaryProps = {
   groups: CommandTagSummaryItem[];
@@ -12,7 +13,7 @@ export function CommandTagSummary({
   return (
     <section
       aria-labelledby="command-tag-summary-title"
-      className="rounded-[2rem] border border-slate-200/70 bg-[var(--surface)] p-5 shadow-[0_18px_65px_rgba(15,23,42,0.08)] sm:p-6"
+      className={`${styles.tagSection} rounded-[2rem] border border-slate-200/70 bg-[var(--surface)] p-5 shadow-[0_18px_65px_rgba(15,23,42,0.08)] sm:p-6`}
     >
       <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div className="space-y-2">
@@ -36,7 +37,7 @@ export function CommandTagSummary({
         {groups.map((group) => (
           <article
             key={group.tag}
-            className="rounded-[1.5rem] border border-slate-200 bg-white/78 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]"
+            className={`${styles.tagCard} rounded-[1.5rem] border border-slate-200 bg-white/78 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]`}
           >
             <div className="flex items-start justify-between gap-3">
               <div>

--- a/src/app/command-log/command-log.module.css
+++ b/src/app/command-log/command-log.module.css
@@ -1,0 +1,278 @@
+.pageShell {
+  position: relative;
+  isolation: isolate;
+}
+
+.pageShell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: 2rem;
+  background:
+    radial-gradient(circle at top right, rgba(251, 191, 36, 0.18), transparent 30%),
+    radial-gradient(circle at top left, rgba(14, 165, 233, 0.12), transparent 24%);
+  opacity: 0.95;
+}
+
+.heroPanel {
+  position: relative;
+  overflow: hidden;
+}
+
+.heroPanel::after {
+  content: "";
+  position: absolute;
+  inset: auto -6rem -8rem auto;
+  width: 18rem;
+  height: 18rem;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(251, 191, 36, 0.22), transparent 70%);
+  pointer-events: none;
+}
+
+.summaryPanel {
+  border-color: rgba(148, 163, 184, 0.22);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(248, 250, 252, 0.78)),
+    rgba(255, 250, 242, 0.84);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.8),
+    0 12px 36px rgba(15, 23, 42, 0.08);
+}
+
+.summaryMetricCard {
+  border-color: rgba(148, 163, 184, 0.24);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 252, 0.82));
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.06);
+}
+
+.tagSection {
+  background:
+    linear-gradient(180deg, rgba(255, 251, 240, 0.9), rgba(255, 255, 255, 0.72));
+}
+
+.tagCard {
+  position: relative;
+  overflow: hidden;
+  border-color: rgba(148, 163, 184, 0.22);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.95), rgba(248, 250, 252, 0.85));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.85),
+    0 14px 30px rgba(15, 23, 42, 0.05);
+}
+
+.tagCard::after {
+  content: "";
+  position: absolute;
+  inset: auto -3rem -3rem auto;
+  width: 8rem;
+  height: 8rem;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(14, 165, 233, 0.08), transparent 72%);
+  pointer-events: none;
+}
+
+.panels {
+  align-items: start;
+}
+
+.eventSection {
+  position: relative;
+  overflow: hidden;
+}
+
+.eventSection::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.08), transparent 30%),
+    radial-gradient(circle at top right, rgba(14, 165, 233, 0.08), transparent 26%);
+  pointer-events: none;
+}
+
+.feedList {
+  position: relative;
+  margin-top: 1.5rem;
+}
+
+.feedList::before {
+  content: "";
+  position: absolute;
+  left: 1rem;
+  top: 0.5rem;
+  bottom: 0.5rem;
+  width: 1px;
+  background: linear-gradient(
+    180deg,
+    rgba(34, 211, 238, 0.28),
+    rgba(148, 163, 184, 0.18)
+  );
+}
+
+.feedItem {
+  position: relative;
+  padding-left: 2.35rem;
+}
+
+.feedItem::before {
+  content: "";
+  position: absolute;
+  left: 0.75rem;
+  top: 1.5rem;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  border: 2px solid rgba(34, 211, 238, 0.55);
+  background: #f8fafc;
+  box-shadow: 0 0 0 6px rgba(15, 23, 42, 0.65);
+}
+
+.eventCard {
+  position: relative;
+  border-color: rgba(255, 255, 255, 0.09);
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.84), rgba(15, 23, 42, 0.72));
+  box-shadow: 0 16px 34px rgba(2, 6, 23, 0.18);
+}
+
+.eventCard:hover {
+  box-shadow: 0 22px 48px rgba(2, 6, 23, 0.28);
+}
+
+.eventCardSelected {
+  border-color: rgba(103, 232, 249, 0.36);
+  background:
+    linear-gradient(180deg, rgba(8, 47, 73, 0.86), rgba(15, 23, 42, 0.92));
+  box-shadow: 0 20px 48px rgba(8, 145, 178, 0.2);
+}
+
+.badge {
+  border: 1px solid transparent;
+}
+
+.severityCritical {
+  border-color: rgba(251, 113, 133, 0.38);
+  background: rgba(244, 63, 94, 0.14);
+  color: #ffe4e6;
+}
+
+.severityHigh {
+  border-color: rgba(251, 191, 36, 0.38);
+  background: rgba(245, 158, 11, 0.14);
+  color: #fef3c7;
+}
+
+.severityModerate {
+  border-color: rgba(56, 189, 248, 0.38);
+  background: rgba(14, 165, 233, 0.14);
+  color: #e0f2fe;
+}
+
+.severityLow {
+  border-color: rgba(52, 211, 153, 0.38);
+  background: rgba(16, 185, 129, 0.14);
+  color: #d1fae5;
+}
+
+.statusCompleted {
+  border-color: rgba(74, 222, 128, 0.22);
+  background: rgba(22, 163, 74, 0.12);
+  color: #dcfce7;
+}
+
+.statusWatching {
+  border-color: rgba(56, 189, 248, 0.24);
+  background: rgba(2, 132, 199, 0.14);
+  color: #dbeafe;
+}
+
+.statusNeedsFollowUp {
+  border-color: rgba(251, 191, 36, 0.24);
+  background: rgba(217, 119, 6, 0.14);
+  color: #fef3c7;
+}
+
+.statusBlocked {
+  border-color: rgba(251, 113, 133, 0.24);
+  background: rgba(225, 29, 72, 0.14);
+  color: #ffe4e6;
+}
+
+.tagPill {
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.07);
+  color: #e2e8f0;
+}
+
+.detailPanel {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(2, 6, 23, 0.96), rgba(15, 23, 42, 0.94));
+}
+
+.detailPanel::before {
+  content: "";
+  position: absolute;
+  inset: -2rem auto auto -4rem;
+  width: 10rem;
+  height: 10rem;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(14, 165, 233, 0.16), transparent 72%);
+  pointer-events: none;
+}
+
+.detailSection {
+  border-color: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.detailInnerCard {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(15, 23, 42, 0.8);
+}
+
+.servicePill {
+  border-color: rgba(255, 255, 255, 0.12);
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.88), rgba(15, 23, 42, 0.74));
+}
+
+.notesList {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.noteCard {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(15, 23, 42, 0.78);
+}
+
+@media (min-width: 768px) {
+  .feedList {
+    margin-top: 1.75rem;
+  }
+
+  .eventCard {
+    padding: 1.4rem;
+  }
+}
+
+@media (min-width: 1280px) {
+  .pageShell {
+    gap: 2rem;
+  }
+
+  .feedList {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .eventCard {
+    min-height: 18rem;
+  }
+}

--- a/src/app/command-log/page.test.tsx
+++ b/src/app/command-log/page.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CommandLogShell } from "./_components/command-log-shell";
+import { resolveCommandLogView } from "./_lib/command-log";
+import { commandLogEvents } from "./_lib/command-log-data";
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+describe("CommandLogShell", () => {
+  it("renders the route shell with the full chronological list and default detail", () => {
+    const view = resolveCommandLogView();
+
+    render(<CommandLogShell view={view} />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /chronological command events, grouped signals, and one focused detail panel\./i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: new RegExp(`repeated patterns across ${commandLogEvents.length} events`, "i"),
+      }),
+    ).toBeInTheDocument();
+
+    const eventList = screen.getByRole("list", {
+      name: /chronological events/i,
+    });
+    const detail = screen.getByRole("region", { name: /event detail/i });
+
+    expect(within(eventList).getAllByRole("listitem")).toHaveLength(
+      commandLogEvents.length,
+    );
+    expect(
+      within(detail).getByRole("heading", { name: commandLogEvents[0].title }),
+    ).toBeInTheDocument();
+    expect(
+      within(detail).getByText(commandLogEvents[0].nextAction),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the requested event detail and marks the selected entry link", () => {
+    const chosenEvent = commandLogEvents[4];
+    const view = resolveCommandLogView(chosenEvent.id);
+
+    render(<CommandLogShell view={view} />);
+
+    const detail = screen.getByRole("region", { name: /event detail/i });
+    const activeLink = screen.getByRole("link", {
+      name: new RegExp(
+        `viewing detail for ${escapeRegExp(chosenEvent.title)}`,
+        "i",
+      ),
+    });
+
+    expect(
+      within(detail).getByRole("heading", { name: chosenEvent.title }),
+    ).toBeInTheDocument();
+    expect(within(detail).getByText(chosenEvent.command)).toBeInTheDocument();
+    expect(activeLink).toHaveAttribute("href", `/command-log?event=${chosenEvent.id}`);
+    expect(activeLink).toHaveAttribute("aria-current", "page");
+  });
+
+  it("falls back to the latest event and exposes recurring tag groups for an unknown id", () => {
+    const view = resolveCommandLogView("missing-event");
+    const queueDepthGroup = view.tagSummary.find((group) => group.tag === "queue-depth");
+
+    render(<CommandLogShell view={view} />);
+
+    expect(queueDepthGroup).toMatchObject({
+      tag: "queue-depth",
+      eventCount: 3,
+    });
+    expect(screen.getByRole("status")).toHaveTextContent(
+      /missing-event.*not found/i,
+    );
+    expect(screen.getAllByText("#queue-depth").length).toBeGreaterThan(0);
+    expect(screen.getByText(/3 events/i)).toBeInTheDocument();
+
+    const detail = screen.getByRole("region", { name: /event detail/i });
+
+    expect(
+      within(detail).getByRole("heading", { name: commandLogEvents[0].title }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add route-specific visual polish for the command log feed, tag summary, and detail panel
- improve severity, status, and tag treatment for denser event review
- add render tests for default selection, query-driven detail, fallback behavior, and recurring tag groups

## Context
- Follow-up to merged PR #109, which landed before these last two commits were pushed.
- Refs #106

## Testing
- npm run lint
- npm run test