### PR TITLE
chore: update landing page headline for conflict drill

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,7 +23,7 @@ export default function Home() {
             </p>
             <div className="space-y-4">
               <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-                Browse sealed archive snapshots without leaving the app shell.
+                Controlled conflict drill A landing page headline.
               </h1>
               <p className="max-w-2xl text-lg leading-8 text-slate-600">
                 The new archive browser route focuses on quick inspection:


### PR DESCRIPTION
## Summary
- replace the homepage h1 text in src/app/page.tsx with the controlled conflict drill A headline
- leave the rest of the page unchanged
- intentionally edit the same lines as another disposable drill session for the conflict exercise

## Testing
- npm run lint
- npm test