### PR TITLE
feat: add crew roster route

### DIFF
--- a/src/app/crew-roster/_components/crew-team-card.tsx
+++ b/src/app/crew-roster/_components/crew-team-card.tsx
@@ -3,6 +3,7 @@ import {
   type CrewTeam,
   type CrewCoverageTone,
 } from "../_data/crew-roster-data";
+import styles from "../crew-roster.module.css";
 
 const toneClasses = {
   stable: "border-slate-200 bg-white",
@@ -29,7 +30,7 @@ export function CrewTeamCard({ team }: { team: CrewTeam }) {
   return (
     <article
       aria-labelledby={`${team.id}-title`}
-      className={`rounded-[1.6rem] border p-5 shadow-[0_20px_50px_rgba(15,23,42,0.06)] ${toneClasses[tone]}`}
+      className={`rounded-[1.6rem] border p-5 shadow-[0_20px_50px_rgba(15,23,42,0.06)] ${styles.teamCard} ${toneClasses[tone]}`}
       data-tone={tone}
     >
       <div className="flex flex-wrap items-start justify-between gap-4">
@@ -55,7 +56,9 @@ export function CrewTeamCard({ team }: { team: CrewTeam }) {
           </div>
         </div>
 
-        <div className="rounded-[1.15rem] border border-slate-200 bg-white/80 px-4 py-3 text-right shadow-[inset_0_1px_0_rgba(255,255,255,0.7)]">
+        <div
+          className={`rounded-[1.15rem] border border-slate-200 bg-white/80 px-4 py-3 text-right shadow-[inset_0_1px_0_rgba(255,255,255,0.7)] ${styles.teamStatCard}`}
+        >
           <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
             Staffing
           </p>
@@ -70,7 +73,9 @@ export function CrewTeamCard({ team }: { team: CrewTeam }) {
 
       <p className="mt-4 text-sm leading-7 text-slate-700">{team.objective}</p>
 
-      <div className="mt-5 rounded-[1.35rem] border border-dashed border-slate-200 bg-white/75 px-4 py-4">
+      <div
+        className={`mt-5 rounded-[1.35rem] border border-dashed border-slate-200 bg-white/75 px-4 py-4 ${styles.staffingNote}`}
+      >
         <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
           Staffing note
         </p>
@@ -81,7 +86,7 @@ export function CrewTeamCard({ team }: { team: CrewTeam }) {
         {team.roleSlots.map((slot) => (
           <div
             key={slot.id}
-            className="rounded-[1.25rem] border border-slate-200 bg-white/85 px-4 py-4"
+            className={`rounded-[1.25rem] border border-slate-200 bg-white/85 px-4 py-4 ${styles.roleSlot}`}
           >
             <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
               {slot.title}

--- a/src/app/crew-roster/_components/crew-team-card.tsx
+++ b/src/app/crew-roster/_components/crew-team-card.tsx
@@ -1,0 +1,109 @@
+import {
+  getTeamStaffingTotals,
+  type CrewTeam,
+  type CrewCoverageTone,
+} from "../_data/crew-roster-data";
+
+const toneClasses = {
+  stable: "border-slate-200 bg-white",
+  watch: "border-amber-200 bg-amber-50/40",
+  thin: "border-rose-200 bg-rose-50/50",
+} satisfies Record<CrewCoverageTone, string>;
+
+function getTeamTone(gap: number): CrewCoverageTone {
+  if (gap <= 0) {
+    return "stable";
+  }
+
+  if (gap === 1) {
+    return "watch";
+  }
+
+  return "thin";
+}
+
+export function CrewTeamCard({ team }: { team: CrewTeam }) {
+  const totals = getTeamStaffingTotals(team);
+  const tone = getTeamTone(totals.gap);
+
+  return (
+    <article
+      aria-labelledby={`${team.id}-title`}
+      className={`rounded-[1.6rem] border p-5 shadow-[0_20px_50px_rgba(15,23,42,0.06)] ${toneClasses[tone]}`}
+      data-tone={tone}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full bg-slate-950 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-white">
+              {team.callsign}
+            </span>
+            <span className="rounded-full border border-slate-200 bg-white/80 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-600">
+              {team.zone}
+            </span>
+          </div>
+          <div>
+            <h3
+              id={`${team.id}-title`}
+              className="text-2xl font-semibold tracking-tight text-slate-950"
+            >
+              {team.name}
+            </h3>
+            <p className="mt-1 text-sm font-medium text-slate-500">
+              Lead: {team.lead}
+            </p>
+          </div>
+        </div>
+
+        <div className="rounded-[1.15rem] border border-slate-200 bg-white/80 px-4 py-3 text-right shadow-[inset_0_1px_0_rgba(255,255,255,0.7)]">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Staffing
+          </p>
+          <p className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">
+            {totals.staffed}/{totals.target}
+          </p>
+          <p className="mt-1 text-xs font-medium text-slate-500">
+            {totals.coveragePercent}% filled
+          </p>
+        </div>
+      </div>
+
+      <p className="mt-4 text-sm leading-7 text-slate-700">{team.objective}</p>
+
+      <div className="mt-5 rounded-[1.35rem] border border-dashed border-slate-200 bg-white/75 px-4 py-4">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+          Staffing note
+        </p>
+        <p className="mt-2 text-sm leading-6 text-slate-700">{team.staffingNote}</p>
+      </div>
+
+      <dl className="mt-5 grid gap-3 sm:grid-cols-3">
+        {team.roleSlots.map((slot) => (
+          <div
+            key={slot.id}
+            className="rounded-[1.25rem] border border-slate-200 bg-white/85 px-4 py-4"
+          >
+            <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+              {slot.title}
+            </dt>
+            <dd className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">
+              {slot.staffed}/{slot.target}
+            </dd>
+            <p className="mt-2 text-sm leading-6 text-slate-600">{slot.note}</p>
+          </div>
+        ))}
+      </dl>
+
+      <ul aria-label={`${team.name} tags`} className="mt-5 flex flex-wrap gap-2">
+        {team.tags.map((tag) => (
+          <li
+            key={tag}
+            className="rounded-full border border-slate-200 bg-white/75 px-3 py-1 text-xs font-medium text-slate-600"
+          >
+            {tag}
+          </li>
+        ))}
+      </ul>
+    </article>
+  );
+}

--- a/src/app/crew-roster/_components/duty-rotation-panel.tsx
+++ b/src/app/crew-roster/_components/duty-rotation-panel.tsx
@@ -2,6 +2,7 @@ import type {
   DutyRotationEntry,
   DutyRotationPriority,
 } from "../_data/crew-roster-data";
+import styles from "../crew-roster.module.css";
 
 const priorityClasses = {
   Primary: "border-sky-200 bg-sky-50 text-sky-950",
@@ -19,7 +20,7 @@ export function DutyRotationPanel({
   return (
     <section
       aria-labelledby="duty-rotation-title"
-      className="rounded-[2rem] border border-slate-200 bg-slate-950 p-6 text-white shadow-[0_30px_90px_rgba(15,23,42,0.2)] sm:p-7"
+      className={`rounded-[2rem] border border-slate-200 bg-slate-950 p-6 text-white shadow-[0_30px_90px_rgba(15,23,42,0.2)] sm:p-7 ${styles.rotationShell}`}
     >
       <div className="flex flex-col gap-6 lg:grid lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
         <div className="space-y-4">
@@ -46,7 +47,9 @@ export function DutyRotationPanel({
           </div>
 
           {spotlight ? (
-            <article className="rounded-[1.6rem] border border-white/10 bg-white/8 p-5">
+            <article
+              className={`rounded-[1.6rem] border border-white/10 bg-white/8 p-5 ${styles.rotationSpotlight}`}
+            >
               <div className="flex flex-wrap items-center gap-3">
                 <span
                   className={`rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${priorityClasses[spotlight.priority]}`}
@@ -78,7 +81,7 @@ export function DutyRotationPanel({
           {entries.map((entry) => (
             <article
               key={entry.id}
-              className="rounded-[1.35rem] border border-white/10 bg-white/6 px-4 py-4"
+              className={`rounded-[1.35rem] border border-white/10 bg-white/6 px-4 py-4 ${styles.rotationItem}`}
             >
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>

--- a/src/app/crew-roster/_components/duty-rotation-panel.tsx
+++ b/src/app/crew-roster/_components/duty-rotation-panel.tsx
@@ -1,0 +1,109 @@
+import type {
+  DutyRotationEntry,
+  DutyRotationPriority,
+} from "../_data/crew-roster-data";
+
+const priorityClasses = {
+  Primary: "border-sky-200 bg-sky-50 text-sky-950",
+  Support: "border-amber-200 bg-amber-50 text-amber-950",
+  Reserve: "border-violet-200 bg-violet-50 text-violet-950",
+} satisfies Record<DutyRotationPriority, string>;
+
+export function DutyRotationPanel({
+  entries,
+}: {
+  entries: DutyRotationEntry[];
+}) {
+  const spotlight = entries[0];
+
+  return (
+    <section
+      aria-labelledby="duty-rotation-title"
+      className="rounded-[2rem] border border-slate-200 bg-slate-950 p-6 text-white shadow-[0_30px_90px_rgba(15,23,42,0.2)] sm:p-7"
+    >
+      <div className="flex flex-col gap-6 lg:grid lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+        <div className="space-y-4">
+          <div className="flex flex-wrap items-center gap-3">
+            <p className="rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-sky-200">
+              Duty rotation
+            </p>
+            <p className="rounded-full border border-white/12 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-white/70">
+              Highlighted handoff
+            </p>
+          </div>
+
+          <div>
+            <h2
+              id="duty-rotation-title"
+              className="text-3xl font-semibold tracking-tight"
+            >
+              Keep the next command window visible before the handoff starts.
+            </h2>
+            <p className="mt-3 max-w-2xl text-sm leading-7 text-white/72">
+              The rotation panel calls out who owns the next watch segment, where
+              they are posted, and which backup roles stay warm if coverage shifts.
+            </p>
+          </div>
+
+          {spotlight ? (
+            <article className="rounded-[1.6rem] border border-white/10 bg-white/8 p-5">
+              <div className="flex flex-wrap items-center gap-3">
+                <span
+                  className={`rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${priorityClasses[spotlight.priority]}`}
+                >
+                  {spotlight.priority}
+                </span>
+                <span className="text-sm font-medium text-white/72">
+                  {spotlight.window}
+                </span>
+              </div>
+
+              <h3 className="mt-4 text-2xl font-semibold tracking-tight">
+                {spotlight.assignment}
+              </h3>
+              <p className="mt-2 text-lg text-white/86">
+                {spotlight.crew} · {spotlight.role}
+              </p>
+              <p className="mt-4 text-sm leading-7 text-white/72">
+                {spotlight.detail}
+              </p>
+              <p className="mt-4 text-xs font-semibold uppercase tracking-[0.2em] text-white/50">
+                {spotlight.location}
+              </p>
+            </article>
+          ) : null}
+        </div>
+
+        <div className="space-y-3">
+          {entries.map((entry) => (
+            <article
+              key={entry.id}
+              className="rounded-[1.35rem] border border-white/10 bg-white/6 px-4 py-4"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/50">
+                    {entry.window}
+                  </p>
+                  <h3 className="mt-2 text-lg font-semibold tracking-tight">
+                    {entry.assignment}
+                  </h3>
+                </div>
+                <span
+                  className={`rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${priorityClasses[entry.priority]}`}
+                >
+                  {entry.priority}
+                </span>
+              </div>
+
+              <p className="mt-3 text-sm font-medium text-white/80">
+                {entry.crew} · {entry.role}
+              </p>
+              <p className="mt-3 text-sm leading-6 text-white/70">{entry.detail}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/crew-roster/_components/shift-group-section.tsx
+++ b/src/app/crew-roster/_components/shift-group-section.tsx
@@ -1,4 +1,5 @@
 import type { CrewRosterView } from "../_data/crew-roster-data";
+import styles from "../crew-roster.module.css";
 import { CrewTeamCard } from "./crew-team-card";
 
 type ShiftGroupSectionProps = {
@@ -9,7 +10,8 @@ export function ShiftGroupSection({ shiftGroup }: ShiftGroupSectionProps) {
   return (
     <section
       aria-labelledby={`${shiftGroup.id}-title`}
-      className="rounded-[2rem] border border-slate-200 bg-white/90 p-6 shadow-[0_24px_60px_rgba(15,23,42,0.06)] sm:p-7"
+      className={`rounded-[2rem] border border-slate-200 bg-white/90 p-6 shadow-[0_24px_60px_rgba(15,23,42,0.06)] sm:p-7 ${styles.shiftSection}`}
+      data-shift={shiftGroup.id}
     >
       <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
         <div className="space-y-3">
@@ -36,7 +38,9 @@ export function ShiftGroupSection({ shiftGroup }: ShiftGroupSectionProps) {
         </div>
 
         <div className="grid gap-3 sm:grid-cols-2 lg:min-w-[22rem]">
-          <div className="rounded-[1.25rem] border border-slate-200 bg-slate-50 px-4 py-4">
+          <div
+            className={`rounded-[1.25rem] border border-slate-200 bg-slate-50 px-4 py-4 ${styles.shiftMetricCard}`}
+          >
             <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
               Shift staffing
             </p>
@@ -48,7 +52,9 @@ export function ShiftGroupSection({ shiftGroup }: ShiftGroupSectionProps) {
             </p>
           </div>
 
-          <div className="rounded-[1.25rem] border border-slate-200 bg-slate-50 px-4 py-4">
+          <div
+            className={`rounded-[1.25rem] border border-slate-200 bg-slate-50 px-4 py-4 ${styles.shiftMetricCard}`}
+          >
             <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
               Handoff lead
             </p>

--- a/src/app/crew-roster/_components/shift-group-section.tsx
+++ b/src/app/crew-roster/_components/shift-group-section.tsx
@@ -1,0 +1,70 @@
+import type { CrewRosterView } from "../_data/crew-roster-data";
+import { CrewTeamCard } from "./crew-team-card";
+
+type ShiftGroupSectionProps = {
+  shiftGroup: CrewRosterView["shiftGroups"][number];
+};
+
+export function ShiftGroupSection({ shiftGroup }: ShiftGroupSectionProps) {
+  return (
+    <section
+      aria-labelledby={`${shiftGroup.id}-title`}
+      className="rounded-[2rem] border border-slate-200 bg-white/90 p-6 shadow-[0_24px_60px_rgba(15,23,42,0.06)] sm:p-7"
+    >
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full bg-slate-950 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-white">
+              {shiftGroup.name}
+            </span>
+            <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-600">
+              {shiftGroup.window}
+            </span>
+          </div>
+
+          <div>
+            <h2
+              id={`${shiftGroup.id}-title`}
+              className="text-3xl font-semibold tracking-tight text-slate-950"
+            >
+              {shiftGroup.name} coverage
+            </h2>
+            <p className="mt-2 max-w-3xl text-sm leading-7 text-slate-600">
+              {shiftGroup.summary}
+            </p>
+          </div>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 lg:min-w-[22rem]">
+          <div className="rounded-[1.25rem] border border-slate-200 bg-slate-50 px-4 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+              Shift staffing
+            </p>
+            <p className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">
+              {shiftGroup.totals.staffed}/{shiftGroup.totals.target}
+            </p>
+            <p className="mt-1 text-sm text-slate-600">
+              {shiftGroup.totals.coveragePercent}% staffed
+            </p>
+          </div>
+
+          <div className="rounded-[1.25rem] border border-slate-200 bg-slate-50 px-4 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+              Handoff lead
+            </p>
+            <p className="mt-2 text-lg font-semibold tracking-tight text-slate-950">
+              {shiftGroup.handoffLead}
+            </p>
+            <p className="mt-1 text-sm text-slate-600">{shiftGroup.coverage}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-6 grid gap-4 xl:grid-cols-2">
+        {shiftGroup.teams.map((team) => (
+          <CrewTeamCard key={team.id} team={team} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/crew-roster/_components/staffing-summary-card.tsx
+++ b/src/app/crew-roster/_components/staffing-summary-card.tsx
@@ -1,4 +1,5 @@
 import type { StaffingSummary } from "../_data/crew-roster-data";
+import styles from "../crew-roster.module.css";
 
 const toneClasses = {
   stable: "border-emerald-200 bg-emerald-50/80 text-emerald-950",
@@ -10,7 +11,7 @@ export function StaffingSummaryCard({ summary }: { summary: StaffingSummary }) {
   return (
     <article
       role="listitem"
-      className={`flex h-full flex-col gap-4 rounded-[1.5rem] border p-5 shadow-[0_18px_40px_rgba(15,23,42,0.06)] ${toneClasses[summary.tone]}`}
+      className={`flex h-full flex-col gap-4 rounded-[1.5rem] border p-5 shadow-[0_18px_40px_rgba(15,23,42,0.06)] ${styles.summaryCard} ${toneClasses[summary.tone]}`}
     >
       <div className="space-y-2">
         <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-current/65">

--- a/src/app/crew-roster/_components/staffing-summary-card.tsx
+++ b/src/app/crew-roster/_components/staffing-summary-card.tsx
@@ -1,0 +1,25 @@
+import type { StaffingSummary } from "../_data/crew-roster-data";
+
+const toneClasses = {
+  stable: "border-emerald-200 bg-emerald-50/80 text-emerald-950",
+  watch: "border-amber-200 bg-amber-50/80 text-amber-950",
+  thin: "border-rose-200 bg-rose-50/80 text-rose-950",
+} satisfies Record<StaffingSummary["tone"], string>;
+
+export function StaffingSummaryCard({ summary }: { summary: StaffingSummary }) {
+  return (
+    <article
+      role="listitem"
+      className={`flex h-full flex-col gap-4 rounded-[1.5rem] border p-5 shadow-[0_18px_40px_rgba(15,23,42,0.06)] ${toneClasses[summary.tone]}`}
+    >
+      <div className="space-y-2">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-current/65">
+          {summary.label}
+        </p>
+        <p className="text-4xl font-semibold tracking-tight">{summary.value}</p>
+      </div>
+
+      <p className="text-sm leading-6 text-current/75">{summary.detail}</p>
+    </article>
+  );
+}

--- a/src/app/crew-roster/_data/crew-roster-data.ts
+++ b/src/app/crew-roster/_data/crew-roster-data.ts
@@ -1,0 +1,491 @@
+export type CrewCoverageTone = "stable" | "watch" | "thin";
+export type DutyRotationPriority = "Primary" | "Support" | "Reserve";
+
+export interface CrewRosterSummary {
+  eyebrow: string;
+  title: string;
+  description: string;
+  handoffWindow: string;
+}
+
+export interface CrewRoleSlot {
+  id: string;
+  title: string;
+  staffed: number;
+  target: number;
+  note: string;
+}
+
+export interface CrewTeam {
+  id: string;
+  name: string;
+  callsign: string;
+  lead: string;
+  zone: string;
+  objective: string;
+  staffingNote: string;
+  tags: string[];
+  roleSlots: CrewRoleSlot[];
+}
+
+export interface ShiftGroup {
+  id: string;
+  name: string;
+  window: string;
+  coverage: string;
+  handoffLead: string;
+  summary: string;
+  teams: CrewTeam[];
+}
+
+export interface StaffingTotals {
+  staffed: number;
+  target: number;
+  gap: number;
+  coveragePercent: number;
+}
+
+export interface StaffingSummary {
+  id: string;
+  label: string;
+  value: string;
+  detail: string;
+  tone: CrewCoverageTone;
+}
+
+export interface DutyRotationEntry {
+  id: string;
+  window: string;
+  assignment: string;
+  crew: string;
+  role: string;
+  location: string;
+  detail: string;
+  priority: DutyRotationPriority;
+}
+
+export interface CrewRosterView {
+  summary: CrewRosterSummary;
+  shiftGroups: Array<
+    ShiftGroup & {
+      totals: StaffingTotals;
+    }
+  >;
+  staffingSummaries: StaffingSummary[];
+  dutyRotation: DutyRotationEntry[];
+  totals: StaffingTotals & {
+    teamCount: number;
+    shiftCount: number;
+  };
+}
+
+export const crewRosterSummary: CrewRosterSummary = {
+  eyebrow: "Crew Roster",
+  title: "Keep every shift staffed, visible, and ready for the next handoff.",
+  description:
+    "Track who is on shift, where coverage is thin, and which duty rotation takes the next command window without relying on any backend feed.",
+  handoffWindow: "Next command handoff · 22:00 local",
+};
+
+export const shiftGroups: ShiftGroup[] = [
+  {
+    id: "day-shift",
+    name: "Day Shift",
+    window: "06:00-14:00",
+    coverage: "Launch deck, calibration lane, and outbound staging",
+    handoffLead: "Captain Mara Chen",
+    summary:
+      "Front-loads launch prep and outbound readiness so field crews start with a clean handoff packet.",
+    teams: [
+      {
+        id: "launch-deck",
+        name: "Launch Deck",
+        callsign: "Atlas One",
+        lead: "Mara Chen",
+        zone: "North launch apron",
+        objective:
+          "Run the first departure block, own deck safety, and keep runway prep synchronized with the signal desk.",
+        staffingNote:
+          "Short one dock liaison until the swing crew overlaps at 13:30.",
+        tags: ["Departure prep", "Safety window", "Outbound sync"],
+        roleSlots: [
+          {
+            id: "launch-lead",
+            title: "Shift lead",
+            staffed: 1,
+            target: 1,
+            note: "Owns the departure brief and clears the final push.",
+          },
+          {
+            id: "mission-specialist",
+            title: "Mission specialist",
+            staffed: 3,
+            target: 3,
+            note: "Coordinates sortie timing and launch-lane sequencing.",
+          },
+          {
+            id: "safety-runner",
+            title: "Safety runner",
+            staffed: 1,
+            target: 1,
+            note: "Covers pad checks and last-minute clearance calls.",
+          },
+          {
+            id: "dock-liaison",
+            title: "Dock liaison",
+            staffed: 1,
+            target: 2,
+            note: "One opening remains on the outbound transfer handoff.",
+          },
+        ],
+      },
+      {
+        id: "payload-prep",
+        name: "Payload Prep",
+        callsign: "Helix Two",
+        lead: "Priya Natarajan",
+        zone: "Calibration hangar",
+        objective:
+          "Clear the morning manifest, verify calibrations, and package exceptions before the noon cutoff.",
+        staffingNote:
+          "Fully staffed with one cross-trained verifier floating between calibration and quality checks.",
+        tags: ["Calibration", "Manifest review", "QA handoff"],
+        roleSlots: [
+          {
+            id: "calibration-tech",
+            title: "Calibration tech",
+            staffed: 2,
+            target: 2,
+            note: "Covers morning device prep and recovery sweeps.",
+          },
+          {
+            id: "systems-verifier",
+            title: "Systems verifier",
+            staffed: 2,
+            target: 2,
+            note: "Signs off on payload integrity before release.",
+          },
+          {
+            id: "prep-runner",
+            title: "Prep runner",
+            staffed: 1,
+            target: 1,
+            note: "Moves flagged kits between intake, QA, and outbound.",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "swing-shift",
+    name: "Swing Shift",
+    window: "14:00-22:00",
+    coverage: "Recovery control, relay watch, and evening escalation lanes",
+    handoffLead: "Commander Ezra Kwambai",
+    summary:
+      "Bridges launch follow-through with recovery work, keeping signals clean while escalations move through the evening desk.",
+    teams: [
+      {
+        id: "recovery-control",
+        name: "Recovery Control",
+        callsign: "Beacon Six",
+        lead: "Ezra Kwambai",
+        zone: "South recovery bay",
+        objective:
+          "Coordinate returns, stage recovery crews, and make sure repaired assets are routed to the right hold lane.",
+        staffingNote:
+          "Stable coverage with full lead and marshal staffing for the evening recovery window.",
+        tags: ["Recovery", "Routing", "Bay control"],
+        roleSlots: [
+          {
+            id: "recovery-lead",
+            title: "Recovery lead",
+            staffed: 1,
+            target: 1,
+            note: "Sets sequencing for inbound and post-flight checks.",
+          },
+          {
+            id: "bay-marshal",
+            title: "Bay marshal",
+            staffed: 2,
+            target: 2,
+            note: "Owns traffic control inside the recovery lane.",
+          },
+          {
+            id: "handoff-runner",
+            title: "Handoff runner",
+            staffed: 1,
+            target: 1,
+            note: "Moves repair tags and return packets to logistics.",
+          },
+        ],
+      },
+      {
+        id: "signal-watch",
+        name: "Signal Watch",
+        callsign: "Relay Nine",
+        lead: "Noor Al-Hassan",
+        zone: "Comms mezzanine",
+        objective:
+          "Monitor relay health, protect the evening command window, and escalate any drift before the night shift takes over.",
+        staffingNote:
+          "Needs one more observer to cover simultaneous relay drift and incident paging during the overlap hour.",
+        tags: ["Relay health", "Escalations", "Overlap coverage"],
+        roleSlots: [
+          {
+            id: "watch-lead",
+            title: "Watch lead",
+            staffed: 1,
+            target: 1,
+            note: "Calls severity and owns the evening status brief.",
+          },
+          {
+            id: "signal-observer",
+            title: "Signal observer",
+            staffed: 2,
+            target: 3,
+            note: "One seat is open for the overlap between 18:00 and 20:00.",
+          },
+          {
+            id: "incident-pager",
+            title: "Incident pager",
+            staffed: 1,
+            target: 1,
+            note: "Handles outbound paging and records rotation notes.",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "overnight-shift",
+    name: "Overnight Shift",
+    window: "22:00-06:00",
+    coverage: "Incident watch, reserve logistics, and overnight support",
+    handoffLead: "Lead Omar Rahman",
+    summary:
+      "Protects overnight stability, keeps reserve supply lanes warm, and hands day shift a clean picture of any incidents that stayed open.",
+    teams: [
+      {
+        id: "incident-watch",
+        name: "Incident Watch",
+        callsign: "Nightglass",
+        lead: "Omar Rahman",
+        zone: "Command mezzanine",
+        objective:
+          "Track overnight incidents, keep the escalation chain warm, and turn loose signals into a precise morning handoff.",
+        staffingNote:
+          "Fully staffed with a dedicated recorder for any multi-hour incident or change watch.",
+        tags: ["Night command", "Escalation", "Morning handoff"],
+        roleSlots: [
+          {
+            id: "incident-lead",
+            title: "Incident lead",
+            staffed: 1,
+            target: 1,
+            note: "Runs command posture through the overnight watch.",
+          },
+          {
+            id: "watch-analyst",
+            title: "Watch analyst",
+            staffed: 2,
+            target: 2,
+            note: "Keeps signal review and impact notes current.",
+          },
+          {
+            id: "rotation-recorder",
+            title: "Rotation recorder",
+            staffed: 1,
+            target: 1,
+            note: "Captures timeline notes for the day-shift briefing.",
+          },
+        ],
+      },
+      {
+        id: "logistics-reserve",
+        name: "Logistics Reserve",
+        callsign: "Harbor Three",
+        lead: "Tessa Morgan",
+        zone: "Reserve staging floor",
+        objective:
+          "Stage replacement kits, cover late-arrival swap requests, and keep reserve inventory ready for the dawn handoff.",
+        staffingNote:
+          "One reserve operator gap remains after a same-day reassignment to the day shift.",
+        tags: ["Reserve inventory", "Swap requests", "Dawn prep"],
+        roleSlots: [
+          {
+            id: "reserve-coordinator",
+            title: "Reserve coordinator",
+            staffed: 1,
+            target: 1,
+            note: "Owns reserve queue priority and release timing.",
+          },
+          {
+            id: "reserve-operator",
+            title: "Reserve operator",
+            staffed: 2,
+            target: 3,
+            note: "Overnight reserve handling is short one operator.",
+          },
+          {
+            id: "staging-runner",
+            title: "Staging runner",
+            staffed: 1,
+            target: 1,
+            note: "Moves urgent kits from reserve staging to the dock.",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export const dutyRotation: DutyRotationEntry[] = [
+  {
+    id: "rotation-2200",
+    window: "22:00-00:00",
+    assignment: "Command desk",
+    crew: "Omar Rahman",
+    role: "Overnight incident lead",
+    location: "Command mezzanine",
+    detail:
+      "Takes primary command during the overnight transition and owns any carryover escalations from swing shift.",
+    priority: "Primary",
+  },
+  {
+    id: "rotation-0000",
+    window: "00:00-02:00",
+    assignment: "Reserve lane",
+    crew: "Tessa Morgan",
+    role: "Reserve coordinator",
+    location: "Reserve staging floor",
+    detail:
+      "Covers late swap requests and approves any overnight reserve releases tied to active incidents.",
+    priority: "Support",
+  },
+  {
+    id: "rotation-0200",
+    window: "02:00-04:00",
+    assignment: "Signal escalation desk",
+    crew: "Noor Al-Hassan",
+    role: "Relay escalation support",
+    location: "Comms mezzanine",
+    detail:
+      "Holds remote escalation coverage for relay or paging drift that needs specialist review before dawn.",
+    priority: "Reserve",
+  },
+  {
+    id: "rotation-0400",
+    window: "04:00-06:00",
+    assignment: "Dawn handoff prep",
+    crew: "Priya Natarajan",
+    role: "Day-shift readiness lead",
+    location: "Calibration hangar",
+    detail:
+      "Stages the day-shift brief so outbound crews inherit open issues, reserve posture, and staffing gaps in one pass.",
+    priority: "Primary",
+  },
+];
+
+function getCoverageTone(gap: number): CrewCoverageTone {
+  if (gap <= 0) {
+    return "stable";
+  }
+
+  if (gap === 1) {
+    return "watch";
+  }
+
+  return "thin";
+}
+
+export function getTeamStaffingTotals(team: CrewTeam): StaffingTotals {
+  const staffed = team.roleSlots.reduce((total, slot) => total + slot.staffed, 0);
+  const target = team.roleSlots.reduce((total, slot) => total + slot.target, 0);
+  const gap = Math.max(target - staffed, 0);
+
+  return {
+    staffed,
+    target,
+    gap,
+    coveragePercent: Math.round((staffed / target) * 100),
+  };
+}
+
+export function getShiftStaffingTotals(shiftGroup: ShiftGroup): StaffingTotals {
+  const teamTotals = shiftGroup.teams.map(getTeamStaffingTotals);
+  const staffed = teamTotals.reduce((total, team) => total + team.staffed, 0);
+  const target = teamTotals.reduce((total, team) => total + team.target, 0);
+  const gap = Math.max(target - staffed, 0);
+
+  return {
+    staffed,
+    target,
+    gap,
+    coveragePercent: Math.round((staffed / target) * 100),
+  };
+}
+
+export function getCrewRosterView(): CrewRosterView {
+  const shiftGroupsWithTotals = shiftGroups.map((shiftGroup) => ({
+    ...shiftGroup,
+    totals: getShiftStaffingTotals(shiftGroup),
+  }));
+
+  const staffed = shiftGroupsWithTotals.reduce(
+    (total, shiftGroup) => total + shiftGroup.totals.staffed,
+    0,
+  );
+  const target = shiftGroupsWithTotals.reduce(
+    (total, shiftGroup) => total + shiftGroup.totals.target,
+    0,
+  );
+  const gap = Math.max(target - staffed, 0);
+
+  return {
+    summary: crewRosterSummary,
+    shiftGroups: shiftGroupsWithTotals,
+    staffingSummaries: [
+      {
+        id: "staffed-seats",
+        label: "Staffed seats",
+        value: `${staffed} / ${target}`,
+        detail: `Coverage holds at ${Math.round((staffed / target) * 100)}% across ${shiftGroupsWithTotals.length} shifts.`,
+        tone: getCoverageTone(gap),
+      },
+      {
+        id: "open-roles",
+        label: "Open roles",
+        value: `${gap}`,
+        detail: "Current gaps sit in dock liaison, signal observer, and reserve operator coverage.",
+        tone: getCoverageTone(gap),
+      },
+      {
+        id: "teams-on-roster",
+        label: "Teams on roster",
+        value: `${shiftGroupsWithTotals.reduce((total, shiftGroup) => total + shiftGroup.teams.length, 0)}`,
+        detail: "Each shift group carries two active crews with route-specific role coverage.",
+        tone: "stable",
+      },
+      {
+        id: "next-rotation",
+        label: "Next rotation",
+        value: dutyRotation[0]?.window ?? "TBD",
+        detail: `${dutyRotation[0]?.crew} takes ${dutyRotation[0]?.assignment.toLowerCase() ?? "duty coverage"} first.`,
+        tone: "watch",
+      },
+    ],
+    dutyRotation,
+    totals: {
+      staffed,
+      target,
+      gap,
+      coveragePercent: Math.round((staffed / target) * 100),
+      teamCount: shiftGroupsWithTotals.reduce(
+        (total, shiftGroup) => total + shiftGroup.teams.length,
+        0,
+      ),
+      shiftCount: shiftGroupsWithTotals.length,
+    },
+  };
+}

--- a/src/app/crew-roster/crew-roster.module.css
+++ b/src/app/crew-roster/crew-roster.module.css
@@ -1,0 +1,221 @@
+.heroSurface {
+  position: relative;
+  isolation: isolate;
+  background:
+    radial-gradient(circle at top left, rgba(247, 178, 103, 0.2), transparent 28%),
+    radial-gradient(circle at bottom right, rgba(56, 189, 248, 0.16), transparent 32%),
+    linear-gradient(135deg, #0f172a 0%, #111827 48%, #172554 100%);
+}
+
+.heroSurface::before {
+  content: "";
+  position: absolute;
+  inset: auto auto -7rem -5rem;
+  width: 20rem;
+  height: 20rem;
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgba(247, 178, 103, 0.18), transparent 70%);
+  pointer-events: none;
+}
+
+.heroSurface::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(115deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0) 38%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0));
+  pointer-events: none;
+}
+
+.heroPanel,
+.heroStatsGrid,
+.heroStatCard {
+  position: relative;
+  z-index: 1;
+}
+
+.heroStatsGrid {
+  align-content: start;
+}
+
+.heroStatCard {
+  backdrop-filter: blur(14px);
+}
+
+.summaryCard {
+  position: relative;
+  overflow: hidden;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.summaryCard:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 50px rgba(15, 23, 42, 0.1);
+}
+
+.summaryCard::after {
+  content: "";
+  position: absolute;
+  right: -2rem;
+  bottom: -2rem;
+  width: 8rem;
+  height: 8rem;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.32);
+  filter: blur(4px);
+  pointer-events: none;
+}
+
+.summaryCard > * {
+  position: relative;
+  z-index: 1;
+}
+
+.shiftSection {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 252, 0.94)),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(241, 245, 249, 0.84));
+}
+
+.shiftSection::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: 0.35rem;
+  background:
+    linear-gradient(
+      90deg,
+      var(--shift-accent),
+      color-mix(in srgb, var(--shift-accent) 40%, white)
+    );
+}
+
+.shiftSection[data-shift="day-shift"] {
+  --shift-accent: #f59e0b;
+}
+
+.shiftSection[data-shift="swing-shift"] {
+  --shift-accent: #0ea5e9;
+}
+
+.shiftSection[data-shift="overnight-shift"] {
+  --shift-accent: #8b5cf6;
+}
+
+.shiftMetricCard {
+  backdrop-filter: blur(10px);
+}
+
+.teamCard {
+  position: relative;
+  overflow: hidden;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease;
+}
+
+.teamCard:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.08);
+}
+
+.teamCard[data-tone="stable"] {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(248, 250, 252, 0.94));
+}
+
+.teamCard[data-tone="watch"] {
+  border-color: rgba(245, 158, 11, 0.25);
+  background:
+    linear-gradient(180deg, rgba(255, 251, 235, 0.95), rgba(255, 255, 255, 0.98));
+}
+
+.teamCard[data-tone="thin"] {
+  border-color: rgba(244, 63, 94, 0.24);
+  background:
+    linear-gradient(180deg, rgba(255, 241, 242, 0.95), rgba(255, 255, 255, 0.99));
+}
+
+.teamCard::after {
+  content: "";
+  position: absolute;
+  inset: auto -2rem -2.5rem auto;
+  width: 8rem;
+  height: 8rem;
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgba(15, 23, 42, 0.07), transparent 72%);
+  pointer-events: none;
+}
+
+.teamCard > * {
+  position: relative;
+  z-index: 1;
+}
+
+.teamStatCard,
+.roleSlot,
+.staffingNote {
+  backdrop-filter: blur(8px);
+}
+
+.rotationShell {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at top right, rgba(56, 189, 248, 0.16), transparent 24%),
+    radial-gradient(circle at bottom left, rgba(247, 178, 103, 0.14), transparent 24%),
+    linear-gradient(135deg, #0f172a 0%, #1e293b 48%, #111827 100%);
+}
+
+.rotationShell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(115deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0) 42%);
+  pointer-events: none;
+}
+
+.rotationShell > * {
+  position: relative;
+  z-index: 1;
+}
+
+.rotationSpotlight,
+.rotationItem {
+  transition:
+    transform 180ms ease,
+    background-color 180ms ease,
+    border-color 180ms ease;
+}
+
+.rotationItem:hover {
+  transform: translateY(-1px);
+  border-color: rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.09);
+}
+
+@media (max-width: 1279px) {
+  .heroStatsGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 767px) {
+  .heroSurface::before {
+    width: 14rem;
+    height: 14rem;
+    left: -3rem;
+    bottom: -4rem;
+  }
+
+  .heroStatsGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/src/app/crew-roster/page.test.tsx
+++ b/src/app/crew-roster/page.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import CrewRosterPage from "./page";
+import { getCrewRosterView } from "./_data/crew-roster-data";
+
+describe("CrewRosterPage", () => {
+  it("renders the crew roster route shell and not the home page content", () => {
+    render(<CrewRosterPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /keep every shift staffed, visible, and ready for the next handoff/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /coverage totals and watchpoints/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /grouped teams with staffing detail/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /keep the next command window visible before the handoff starts/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/controlled conflict drill b landing page headline/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders all staffing summary cards from the mock roster view", () => {
+    const view = getCrewRosterView();
+
+    render(<CrewRosterPage />);
+
+    const summaryList = screen.getByRole("list", {
+      name: /crew roster staffing summaries/i,
+    });
+
+    expect(within(summaryList).getAllByRole("listitem")).toHaveLength(
+      view.staffingSummaries.length,
+    );
+
+    for (const summary of view.staffingSummaries) {
+      const summaryCard = within(summaryList)
+        .getByText(summary.label)
+        .closest('[role="listitem"]');
+
+      expect(summaryCard).toBeInTheDocument();
+      expect(summaryCard).toHaveTextContent(summary.value);
+      expect(summaryCard).toHaveTextContent(summary.detail);
+    }
+  });
+
+  it("renders each shift group with its teams, staffing totals, and role details", () => {
+    const view = getCrewRosterView();
+
+    render(<CrewRosterPage />);
+
+    for (const shiftGroup of view.shiftGroups) {
+      const shiftRegion = screen.getByRole("region", {
+        name: `${shiftGroup.name} coverage`,
+      });
+
+      expect(within(shiftRegion).getByText(shiftGroup.handoffLead)).toBeInTheDocument();
+      expect(
+        within(shiftRegion).getByText(
+          `${shiftGroup.totals.staffed}/${shiftGroup.totals.target}`,
+        ),
+      ).toBeInTheDocument();
+
+      for (const team of shiftGroup.teams) {
+        expect(
+          within(shiftRegion).getByRole("heading", {
+            level: 3,
+            name: team.name,
+          }),
+        ).toBeInTheDocument();
+        expect(within(shiftRegion).getByText(team.callsign)).toBeInTheDocument();
+        expect(within(shiftRegion).getByText(team.staffingNote)).toBeInTheDocument();
+
+        for (const slot of team.roleSlots) {
+          const slotCard = within(shiftRegion).getByText(slot.title).closest("div");
+
+          expect(slotCard).toBeInTheDocument();
+          expect(slotCard).toHaveTextContent(`${slot.staffed}/${slot.target}`);
+        }
+      }
+    }
+  });
+
+  it("renders the highlighted duty rotation panel and each scheduled rotation entry", () => {
+    const view = getCrewRosterView();
+
+    render(<CrewRosterPage />);
+
+    const rotationRegion = screen.getByRole("region", {
+      name: /keep the next command window visible before the handoff starts/i,
+    });
+    const spotlight = view.dutyRotation[0];
+
+    expect(within(rotationRegion).getByText(spotlight.location)).toBeInTheDocument();
+    expect(within(rotationRegion).getAllByText(spotlight.assignment).length).toBeGreaterThan(0);
+    expect(
+      within(rotationRegion).getAllByText(new RegExp(spotlight.crew, "i")).length,
+    ).toBeGreaterThan(0);
+
+    for (const entry of view.dutyRotation) {
+      expect(within(rotationRegion).getAllByText(entry.window).length).toBeGreaterThan(0);
+      expect(within(rotationRegion).getAllByText(entry.assignment).length).toBeGreaterThan(0);
+      expect(
+        within(rotationRegion).getAllByText(new RegExp(entry.crew, "i")).length,
+      ).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/app/crew-roster/page.tsx
+++ b/src/app/crew-roster/page.tsx
@@ -4,6 +4,7 @@ import { CrewRosterView, getCrewRosterView } from "./_data/crew-roster-data";
 import { DutyRotationPanel } from "./_components/duty-rotation-panel";
 import { ShiftGroupSection } from "./_components/shift-group-section";
 import { StaffingSummaryCard } from "./_components/staffing-summary-card";
+import styles from "./crew-roster.module.css";
 
 export const metadata: Metadata = {
   title: "Crew Roster",
@@ -13,8 +14,10 @@ export const metadata: Metadata = {
 
 function HeroStats({ view }: { view: CrewRosterView }) {
   return (
-    <div className="grid gap-4 sm:grid-cols-3 xl:grid-cols-1">
-      <div className="rounded-[1.5rem] border border-white/10 bg-white/8 p-5">
+    <div className={`grid gap-4 sm:grid-cols-3 xl:grid-cols-1 ${styles.heroStatsGrid}`}>
+      <div
+        className={`rounded-[1.5rem] border border-white/10 bg-white/8 p-5 ${styles.heroStatCard}`}
+      >
         <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/50">
           Staffed seats
         </p>
@@ -27,7 +30,9 @@ function HeroStats({ view }: { view: CrewRosterView }) {
         </p>
       </div>
 
-      <div className="rounded-[1.5rem] border border-white/10 bg-white/8 p-5">
+      <div
+        className={`rounded-[1.5rem] border border-white/10 bg-white/8 p-5 ${styles.heroStatCard}`}
+      >
         <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/50">
           Shift groups
         </p>
@@ -40,7 +45,9 @@ function HeroStats({ view }: { view: CrewRosterView }) {
         </p>
       </div>
 
-      <div className="rounded-[1.5rem] border border-white/10 bg-white/8 p-5">
+      <div
+        className={`rounded-[1.5rem] border border-white/10 bg-white/8 p-5 ${styles.heroStatCard}`}
+      >
         <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/50">
           Open roles
         </p>
@@ -60,9 +67,11 @@ export default function CrewRosterPage() {
 
   return (
     <main className="mx-auto flex w-full max-w-[96rem] flex-1 flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
-      <section className="overflow-hidden rounded-[2.3rem] border border-slate-200 bg-slate-950 text-white shadow-[0_36px_120px_rgba(15,23,42,0.2)]">
+      <section
+        className={`overflow-hidden rounded-[2.3rem] border border-slate-200 bg-slate-950 text-white shadow-[0_36px_120px_rgba(15,23,42,0.2)] ${styles.heroSurface}`}
+      >
         <div className="grid gap-8 px-6 py-8 sm:px-8 sm:py-10 lg:grid-cols-[minmax(0,1.35fr)_minmax(20rem,0.85fr)] lg:px-10 lg:py-12">
-          <div className="space-y-6">
+          <div className={`space-y-6 ${styles.heroPanel}`}>
             <div className="flex flex-wrap items-center gap-3">
               <p className="rounded-full bg-[#f7b267] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-950">
                 {view.summary.eyebrow}
@@ -96,7 +105,9 @@ export default function CrewRosterPage() {
               </a>
             </div>
 
-            <div className="rounded-[1.5rem] border border-white/10 bg-white/6 px-5 py-4">
+            <div
+              className={`rounded-[1.5rem] border border-white/10 bg-white/6 px-5 py-4 ${styles.heroStatCard}`}
+            >
               <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/50">
                 Handoff window
               </p>

--- a/src/app/crew-roster/page.tsx
+++ b/src/app/crew-roster/page.tsx
@@ -1,94 +1,172 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-
-const deliveryMilestones = [
-  "Grouped shift sections for day, swing, and overnight teams",
-  "Staffing summaries that call out roster coverage and open roles",
-  "Duty rotation spotlight for the next handoff window",
-];
+import { CrewRosterView, getCrewRosterView } from "./_data/crew-roster-data";
+import { DutyRotationPanel } from "./_components/duty-rotation-panel";
+import { ShiftGroupSection } from "./_components/shift-group-section";
+import { StaffingSummaryCard } from "./_components/staffing-summary-card";
 
 export const metadata: Metadata = {
   title: "Crew Roster",
   description:
-    "Initial crew roster route shell for grouped teams, staffing summaries, and duty rotation coverage.",
+    "Crew roster route with grouped shifts, staffing summaries, and a highlighted duty rotation panel.",
 };
 
-export default function CrewRosterPage() {
+function HeroStats({ view }: { view: CrewRosterView }) {
   return (
-    <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-12 sm:px-10 lg:px-12">
-      <section className="overflow-hidden rounded-[2rem] border border-slate-200 bg-[linear-gradient(135deg,#fff7ed_0%,#ffffff_46%,#eff6ff_100%)] shadow-[0_24px_90px_rgba(15,23,42,0.08)]">
-        <div className="grid gap-8 px-6 py-10 sm:px-10 lg:grid-cols-[minmax(0,1.2fr)_minmax(18rem,0.8fr)] lg:px-12 lg:py-14">
+    <div className="grid gap-4 sm:grid-cols-3 xl:grid-cols-1">
+      <div className="rounded-[1.5rem] border border-white/10 bg-white/8 p-5">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/50">
+          Staffed seats
+        </p>
+        <p className="mt-3 text-4xl font-semibold tracking-tight">
+          {view.totals.staffed}/{view.totals.target}
+        </p>
+        <p className="mt-2 text-sm leading-6 text-white/72">
+          {view.totals.coveragePercent}% of planned coverage is filled across the
+          full roster.
+        </p>
+      </div>
+
+      <div className="rounded-[1.5rem] border border-white/10 bg-white/8 p-5">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/50">
+          Shift groups
+        </p>
+        <p className="mt-3 text-4xl font-semibold tracking-tight">
+          {view.totals.shiftCount}
+        </p>
+        <p className="mt-2 text-sm leading-6 text-white/72">
+          {view.totals.teamCount} active teams are distributed across day, swing,
+          and overnight coverage.
+        </p>
+      </div>
+
+      <div className="rounded-[1.5rem] border border-white/10 bg-white/8 p-5">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/50">
+          Open roles
+        </p>
+        <p className="mt-3 text-4xl font-semibold tracking-tight">
+          {view.totals.gap}
+        </p>
+        <p className="mt-2 text-sm leading-6 text-white/72">
+          Current gaps stay visible before the next handoff window starts.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function CrewRosterPage() {
+  const view = getCrewRosterView();
+
+  return (
+    <main className="mx-auto flex w-full max-w-[96rem] flex-1 flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
+      <section className="overflow-hidden rounded-[2.3rem] border border-slate-200 bg-slate-950 text-white shadow-[0_36px_120px_rgba(15,23,42,0.2)]">
+        <div className="grid gap-8 px-6 py-8 sm:px-8 sm:py-10 lg:grid-cols-[minmax(0,1.35fr)_minmax(20rem,0.85fr)] lg:px-10 lg:py-12">
           <div className="space-y-6">
             <div className="flex flex-wrap items-center gap-3">
-              <p className="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-amber-800">
-                Crew Roster
+              <p className="rounded-full bg-[#f7b267] px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-950">
+                {view.summary.eyebrow}
               </p>
-              <p className="rounded-full bg-white px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.18)]">
-                Initial route shell
+              <p className="rounded-full border border-white/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-white/70">
+                Grouped shift coverage
               </p>
             </div>
 
             <div className="space-y-4">
-              <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-                Stage grouped crew coverage, staffing summaries, and the next duty rotation.
+              <h1 className="max-w-4xl text-4xl font-semibold tracking-tight sm:text-5xl lg:text-6xl">
+                {view.summary.title}
               </h1>
-              <p className="max-w-3xl text-lg leading-8 text-slate-600">
-                This first pass establishes the dedicated route shell for the
-                upcoming crew roster experience. The next subtasks will fill it
-                with route-specific mock data, grouped team cards, and a richer
-                staffing presentation.
+              <p className="max-w-3xl text-base leading-8 text-white/72 sm:text-lg">
+                {view.summary.description}
               </p>
             </div>
 
             <div className="flex flex-col gap-4 sm:flex-row">
               <Link
                 href="/"
-                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
+                className="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-950 transition hover:bg-slate-100"
               >
                 Back to overview
               </Link>
               <a
-                href="https://github.com/iamasx/api-test/issues/120"
-                className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
-                target="_blank"
-                rel="noreferrer"
+                href="#crew-shifts"
+                className="inline-flex items-center justify-center rounded-full border border-white/16 px-6 py-3 text-sm font-semibold text-white transition hover:bg-white/8"
               >
-                Review issue scope
+                Browse shift groups
               </a>
+            </div>
+
+            <div className="rounded-[1.5rem] border border-white/10 bg-white/6 px-5 py-4">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/50">
+                Handoff window
+              </p>
+              <p className="mt-2 text-xl font-semibold tracking-tight">
+                {view.summary.handoffWindow}
+              </p>
             </div>
           </div>
 
-          <aside className="rounded-[1.75rem] border border-slate-200/80 bg-white/80 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.9)]">
-            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
-              Planned milestones
-            </p>
-            <ul className="mt-5 space-y-4">
-              {deliveryMilestones.map((milestone) => (
-                <li
-                  key={milestone}
-                  className="rounded-2xl border border-slate-200 bg-white px-4 py-4 text-sm leading-6 text-slate-600"
-                >
-                  {milestone}
-                </li>
-              ))}
-            </ul>
-          </aside>
+          <HeroStats view={view} />
         </div>
       </section>
 
-      <section className="rounded-[2rem] border border-dashed border-slate-300 bg-slate-50/80 px-6 py-8 sm:px-8">
-        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
-          Coming next
-        </p>
-        <h2 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
-          Shift groups, staffing panels, and rotation details land in the next commits.
-        </h2>
-        <p className="mt-4 max-w-3xl text-base leading-7 text-slate-600">
-          This placeholder section keeps the route structure in place while the
-          mock crew data model and presentation components are added
-          incrementally.
-        </p>
+      <section aria-labelledby="staffing-summary" className="space-y-5">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Staffing summary
+            </p>
+            <h2
+              id="staffing-summary"
+              className="text-3xl font-semibold tracking-tight text-slate-950"
+            >
+              Coverage totals and watchpoints
+            </h2>
+          </div>
+          <p className="max-w-3xl text-sm leading-7 text-slate-600">
+            Staffing totals are derived from route-local role slots so each
+            summary card stays aligned with the grouped team coverage below.
+          </p>
+        </div>
+
+        <div
+          aria-label="Crew roster staffing summaries"
+          className="grid gap-4 md:grid-cols-2 xl:grid-cols-4"
+          role="list"
+        >
+          {view.staffingSummaries.map((summary) => (
+            <StaffingSummaryCard key={summary.id} summary={summary} />
+          ))}
+        </div>
       </section>
+
+      <section id="crew-shifts" aria-labelledby="crew-shifts-title" className="space-y-5">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Teams by shift
+            </p>
+            <h2
+              id="crew-shifts-title"
+              className="text-3xl font-semibold tracking-tight text-slate-950"
+            >
+              Grouped teams with staffing detail
+            </h2>
+          </div>
+          <p className="max-w-3xl text-sm leading-7 text-slate-600">
+            Every shift section keeps its coverage window, handoff lead, and team
+            role slots in view so staffing gaps stand out before transitions.
+          </p>
+        </div>
+
+        <div className="space-y-6">
+          {view.shiftGroups.map((shiftGroup) => (
+            <ShiftGroupSection key={shiftGroup.id} shiftGroup={shiftGroup} />
+          ))}
+        </div>
+      </section>
+
+      <DutyRotationPanel entries={view.dutyRotation} />
     </main>
   );
 }

--- a/src/app/crew-roster/page.tsx
+++ b/src/app/crew-roster/page.tsx
@@ -1,0 +1,94 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+const deliveryMilestones = [
+  "Grouped shift sections for day, swing, and overnight teams",
+  "Staffing summaries that call out roster coverage and open roles",
+  "Duty rotation spotlight for the next handoff window",
+];
+
+export const metadata: Metadata = {
+  title: "Crew Roster",
+  description:
+    "Initial crew roster route shell for grouped teams, staffing summaries, and duty rotation coverage.",
+};
+
+export default function CrewRosterPage() {
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-12 sm:px-10 lg:px-12">
+      <section className="overflow-hidden rounded-[2rem] border border-slate-200 bg-[linear-gradient(135deg,#fff7ed_0%,#ffffff_46%,#eff6ff_100%)] shadow-[0_24px_90px_rgba(15,23,42,0.08)]">
+        <div className="grid gap-8 px-6 py-10 sm:px-10 lg:grid-cols-[minmax(0,1.2fr)_minmax(18rem,0.8fr)] lg:px-12 lg:py-14">
+          <div className="space-y-6">
+            <div className="flex flex-wrap items-center gap-3">
+              <p className="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.24em] text-amber-800">
+                Crew Roster
+              </p>
+              <p className="rounded-full bg-white px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.18)]">
+                Initial route shell
+              </p>
+            </div>
+
+            <div className="space-y-4">
+              <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
+                Stage grouped crew coverage, staffing summaries, and the next duty rotation.
+              </h1>
+              <p className="max-w-3xl text-lg leading-8 text-slate-600">
+                This first pass establishes the dedicated route shell for the
+                upcoming crew roster experience. The next subtasks will fill it
+                with route-specific mock data, grouped team cards, and a richer
+                staffing presentation.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
+              >
+                Back to overview
+              </Link>
+              <a
+                href="https://github.com/iamasx/api-test/issues/120"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Review issue scope
+              </a>
+            </div>
+          </div>
+
+          <aside className="rounded-[1.75rem] border border-slate-200/80 bg-white/80 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.9)]">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Planned milestones
+            </p>
+            <ul className="mt-5 space-y-4">
+              {deliveryMilestones.map((milestone) => (
+                <li
+                  key={milestone}
+                  className="rounded-2xl border border-slate-200 bg-white px-4 py-4 text-sm leading-6 text-slate-600"
+                >
+                  {milestone}
+                </li>
+              ))}
+            </ul>
+          </aside>
+        </div>
+      </section>
+
+      <section className="rounded-[2rem] border border-dashed border-slate-300 bg-slate-50/80 px-6 py-8 sm:px-8">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+          Coming next
+        </p>
+        <h2 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+          Shift groups, staffing panels, and rotation details land in the next commits.
+        </h2>
+        <p className="mt-4 max-w-3xl text-base leading-7 text-slate-600">
+          This placeholder section keeps the route structure in place while the
+          mock crew data model and presentation components are added
+          incrementally.
+        </p>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated `crew-roster` app route with grouped day, swing, and overnight sections
- define route-local mock data for teams, staffing totals, and duty rotation coverage
- build reusable roster summary, shift grouping, team card, and duty rotation components with responsive styling
- add route tests that cover the main render states and representative content

## Testing
- npm run lint -- src/app/crew-roster
- npm test -- src/app/crew-roster/page.test.tsx
- npm test -- src/app/team-directory/page.test.tsx
- npm test -- --maxWorkers=1

Closes #120