### PR TITLE
feat: build route planner route

### DIFF
--- a/src/app/route-planner/_components/route-decision-sidebar.tsx
+++ b/src/app/route-planner/_components/route-decision-sidebar.tsx
@@ -3,6 +3,7 @@ import type {
   RouteDecision,
   TimingSignal,
 } from "../_data/route-planner-data";
+import styles from "../route-planner.module.css";
 
 const decisionStateLabels: Record<RouteDecision["state"], string> = {
   ready: "Ready",
@@ -14,6 +15,12 @@ const decisionStateStyles: Record<RouteDecision["state"], string> = {
   ready: "border-cyan-300/20 bg-cyan-300/10 text-cyan-50",
   review: "border-amber-300/20 bg-amber-300/10 text-amber-50",
   hold: "border-rose-300/20 bg-rose-300/10 text-rose-50",
+};
+
+const decisionSurfaceStyles: Record<RouteDecision["state"], string> = {
+  ready: styles.decisionReady,
+  review: styles.decisionReview,
+  hold: styles.decisionHold,
 };
 
 type RouteDecisionSidebarProps = {
@@ -37,7 +44,7 @@ export function RouteDecisionSidebar({
   return (
     <aside
       aria-label="Route decision sidebar"
-      className="rounded-[1.9rem] border border-white/10 bg-slate-950/65 p-6"
+      className={`${styles.sidebarPanel} ${styles.stickyRail} rounded-[1.9rem] border border-white/10 p-6`}
     >
       <div className="space-y-5">
         <div>
@@ -76,7 +83,7 @@ export function RouteDecisionSidebar({
           {decisions.map((decision) => (
             <article
               key={decision.id}
-              className="rounded-[1.4rem] border border-white/8 bg-white/5 px-4 py-4"
+              className={`${styles.decisionCard} ${decisionSurfaceStyles[decision.state]} rounded-[1.4rem] border px-4 py-4`}
             >
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div className="space-y-1">
@@ -86,7 +93,7 @@ export function RouteDecisionSidebar({
                   <p className="text-sm text-slate-300">{decision.owner}</p>
                 </div>
                 <span
-                  className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${decisionStateStyles[decision.state]}`}
+                  className={`${styles.statusBadge} inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${decisionStateStyles[decision.state]}`}
                 >
                   {decisionStateLabels[decision.state]}
                 </span>

--- a/src/app/route-planner/_components/route-decision-sidebar.tsx
+++ b/src/app/route-planner/_components/route-decision-sidebar.tsx
@@ -1,0 +1,106 @@
+import type {
+  RouteConstraint,
+  RouteDecision,
+  TimingSignal,
+} from "../_data/route-planner-data";
+
+const decisionStateLabels: Record<RouteDecision["state"], string> = {
+  ready: "Ready",
+  review: "Review",
+  hold: "Hold",
+};
+
+const decisionStateStyles: Record<RouteDecision["state"], string> = {
+  ready: "border-cyan-300/20 bg-cyan-300/10 text-cyan-50",
+  review: "border-amber-300/20 bg-amber-300/10 text-amber-50",
+  hold: "border-rose-300/20 bg-rose-300/10 text-rose-50",
+};
+
+type RouteDecisionSidebarProps = {
+  decisions: RouteDecision[];
+  timingSignals: TimingSignal[];
+  constraints: RouteConstraint[];
+};
+
+export function RouteDecisionSidebar({
+  decisions,
+  timingSignals,
+  constraints,
+}: RouteDecisionSidebarProps) {
+  const blockedSignals = timingSignals.filter(
+    (signal) => signal.tone === "blocked",
+  ).length;
+  const criticalConstraints = constraints.filter(
+    (constraint) => constraint.tone === "critical",
+  ).length;
+
+  return (
+    <aside
+      aria-label="Route decision sidebar"
+      className="rounded-[1.9rem] border border-white/10 bg-slate-950/65 p-6"
+    >
+      <div className="space-y-5">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">
+            Decision rail
+          </p>
+          <h2 className="mt-3 text-3xl font-semibold tracking-tight text-white">
+            Route-level calls
+          </h2>
+          <p className="mt-3 text-sm leading-6 text-slate-300">
+            Keep release, reroute, and crew decisions visible in one place so
+            the route owner can act before the lane hardens.
+          </p>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+          <div className="rounded-[1.4rem] border border-white/8 bg-white/5 px-4 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+              Blocked timing signals
+            </p>
+            <p className="mt-2 text-3xl font-semibold tracking-tight text-white">
+              {blockedSignals}
+            </p>
+          </div>
+          <div className="rounded-[1.4rem] border border-white/8 bg-white/5 px-4 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+              Critical constraints
+            </p>
+            <p className="mt-2 text-3xl font-semibold tracking-tight text-white">
+              {criticalConstraints}
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          {decisions.map((decision) => (
+            <article
+              key={decision.id}
+              className="rounded-[1.4rem] border border-white/8 bg-white/5 px-4 py-4"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold text-white">
+                    {decision.title}
+                  </p>
+                  <p className="text-sm text-slate-300">{decision.owner}</p>
+                </div>
+                <span
+                  className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${decisionStateStyles[decision.state]}`}
+                >
+                  {decisionStateLabels[decision.state]}
+                </span>
+              </div>
+              <p className="mt-3 text-sm leading-6 text-slate-300">
+                {decision.detail}
+              </p>
+              <p className="mt-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                {decision.deadline}
+              </p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/app/route-planner/_components/segment-card.tsx
+++ b/src/app/route-planner/_components/segment-card.tsx
@@ -2,6 +2,7 @@ import type {
   RouteConstraint,
   RouteSegment,
 } from "../_data/route-planner-data";
+import styles from "../route-planner.module.css";
 
 const segmentStatusLabels: Record<RouteSegment["status"], string> = {
   "on-time": "On time",
@@ -13,6 +14,12 @@ const segmentStatusStyles: Record<RouteSegment["status"], string> = {
   "on-time": "border-emerald-300/20 bg-emerald-300/10 text-emerald-50",
   delayed: "border-amber-300/20 bg-amber-300/10 text-amber-50",
   blocked: "border-rose-300/20 bg-rose-300/10 text-rose-50",
+};
+
+const segmentSurfaceStyles: Record<RouteSegment["status"], string> = {
+  "on-time": styles.segmentOnTime,
+  delayed: styles.segmentDelayed,
+  blocked: styles.segmentBlocked,
 };
 
 const constraintToneStyles: Record<RouteConstraint["tone"], string> = {
@@ -29,7 +36,7 @@ type SegmentCardProps = {
 export function SegmentCard({ segment, constraints }: SegmentCardProps) {
   return (
     <article
-      className="rounded-[1.7rem] border border-white/10 bg-slate-950/60 p-6"
+      className={`${styles.segmentCard} ${segmentSurfaceStyles[segment.status]} rounded-[1.7rem] border p-6`}
       role="listitem"
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -44,7 +51,7 @@ export function SegmentCard({ segment, constraints }: SegmentCardProps) {
 
         <div className="flex flex-wrap items-center gap-3">
           <span
-            className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${segmentStatusStyles[segment.status]}`}
+            className={`${styles.statusBadge} inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${segmentStatusStyles[segment.status]}`}
           >
             {segmentStatusLabels[segment.status]}
           </span>
@@ -99,7 +106,7 @@ export function SegmentCard({ segment, constraints }: SegmentCardProps) {
             {constraints.map((constraint) => (
               <span
                 key={constraint.id}
-                className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${constraintToneStyles[constraint.tone]}`}
+                className={`${styles.statusBadge} inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${constraintToneStyles[constraint.tone]}`}
               >
                 {constraint.label}
               </span>

--- a/src/app/route-planner/_components/segment-card.tsx
+++ b/src/app/route-planner/_components/segment-card.tsx
@@ -1,0 +1,112 @@
+import type {
+  RouteConstraint,
+  RouteSegment,
+} from "../_data/route-planner-data";
+
+const segmentStatusLabels: Record<RouteSegment["status"], string> = {
+  "on-time": "On time",
+  delayed: "Delayed",
+  blocked: "Blocked",
+};
+
+const segmentStatusStyles: Record<RouteSegment["status"], string> = {
+  "on-time": "border-emerald-300/20 bg-emerald-300/10 text-emerald-50",
+  delayed: "border-amber-300/20 bg-amber-300/10 text-amber-50",
+  blocked: "border-rose-300/20 bg-rose-300/10 text-rose-50",
+};
+
+const constraintToneStyles: Record<RouteConstraint["tone"], string> = {
+  clear: "border-cyan-300/20 bg-cyan-300/10 text-cyan-50",
+  watch: "border-amber-300/20 bg-amber-300/10 text-amber-50",
+  critical: "border-rose-300/20 bg-rose-300/10 text-rose-50",
+};
+
+type SegmentCardProps = {
+  segment: RouteSegment;
+  constraints: RouteConstraint[];
+};
+
+export function SegmentCard({ segment, constraints }: SegmentCardProps) {
+  return (
+    <article
+      className="rounded-[1.7rem] border border-white/10 bg-slate-950/60 p-6"
+      role="listitem"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-2">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+            {segment.stage}
+          </p>
+          <h3 className="text-2xl font-semibold tracking-tight text-white">
+            {segment.lane}
+          </h3>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <span
+            className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${segmentStatusStyles[segment.status]}`}
+          >
+            {segmentStatusLabels[segment.status]}
+          </span>
+          <div className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-300">
+            {segment.mode}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-3 sm:grid-cols-2">
+        <div className="rounded-2xl border border-white/8 bg-white/5 px-4 py-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+            ETA window
+          </p>
+          <p className="mt-2 text-sm font-medium text-slate-100">
+            {segment.etaWindow}
+          </p>
+        </div>
+        <div className="rounded-2xl border border-white/8 bg-white/5 px-4 py-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+            Owner
+          </p>
+          <p className="mt-2 text-sm font-medium text-slate-100">
+            {segment.owner}
+          </p>
+        </div>
+      </div>
+
+      <p className="mt-5 text-sm leading-6 text-slate-300">{segment.summary}</p>
+      <p className="mt-4 rounded-2xl border border-white/8 bg-white/5 px-4 py-4 text-sm leading-6 text-slate-200">
+        {segment.riskNote}
+      </p>
+
+      <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(260px,0.9fr)]">
+        <div className="rounded-2xl border border-white/8 bg-slate-900/70 px-4 py-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+            Active checkpoint
+          </p>
+          <p className="mt-2 text-sm font-semibold text-white">
+            {segment.checkpoint.label}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-slate-300">
+            {segment.checkpoint.detail}
+          </p>
+        </div>
+
+        <div className="rounded-2xl border border-white/8 bg-slate-900/70 px-4 py-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+            Attached constraints
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {constraints.map((constraint) => (
+              <span
+                key={constraint.id}
+                className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${constraintToneStyles[constraint.tone]}`}
+              >
+                {constraint.label}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/app/route-planner/_components/segment-group.tsx
+++ b/src/app/route-planner/_components/segment-group.tsx
@@ -1,0 +1,45 @@
+import type {
+  RouteConstraint,
+  RouteSegmentGroup,
+} from "../_data/route-planner-data";
+import { SegmentCard } from "./segment-card";
+
+type SegmentGroupProps = {
+  group: RouteSegmentGroup;
+  constraints: RouteConstraint[];
+};
+
+export function SegmentGroup({ group, constraints }: SegmentGroupProps) {
+  return (
+    <section aria-labelledby={group.id} className="space-y-5">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+            Segment group
+          </p>
+          <h2
+            id={group.id}
+            className="text-3xl font-semibold tracking-tight text-white"
+          >
+            {group.label}
+          </h2>
+        </div>
+        <p className="max-w-2xl text-sm leading-6 text-slate-300">
+          {group.description}
+        </p>
+      </div>
+
+      <div aria-label={group.label} className="grid gap-4" role="list">
+        {group.segments.map((segment) => (
+          <SegmentCard
+            key={segment.id}
+            segment={segment}
+            constraints={constraints.filter((constraint) =>
+              segment.constraints.includes(constraint.id),
+            )}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/route-planner/_components/summary-banners.tsx
+++ b/src/app/route-planner/_components/summary-banners.tsx
@@ -3,6 +3,7 @@ import type {
   RoutePlannerStat,
   TimingSignal,
 } from "../_data/route-planner-data";
+import styles from "../route-planner.module.css";
 
 const timingToneLabels: Record<TimingSignal["tone"], string> = {
   "on-time": "On time",
@@ -16,6 +17,12 @@ const timingToneStyles: Record<TimingSignal["tone"], string> = {
   blocked: "border-rose-300/20 bg-rose-300/10 text-rose-50",
 };
 
+const timingSurfaceStyles: Record<TimingSignal["tone"], string> = {
+  "on-time": styles.signalOnTime,
+  delayed: styles.signalDelayed,
+  blocked: styles.signalBlocked,
+};
+
 const constraintToneLabels: Record<RouteConstraint["tone"], string> = {
   clear: "Clear",
   watch: "Watch",
@@ -26,6 +33,12 @@ const constraintToneStyles: Record<RouteConstraint["tone"], string> = {
   clear: "border-cyan-300/20 bg-cyan-300/10 text-cyan-50",
   watch: "border-amber-300/20 bg-amber-300/10 text-amber-50",
   critical: "border-rose-300/20 bg-rose-300/10 text-rose-50",
+};
+
+const constraintSurfaceStyles: Record<RouteConstraint["tone"], string> = {
+  clear: styles.constraintClear,
+  watch: styles.constraintWatch,
+  critical: styles.constraintCritical,
 };
 
 type SummaryBannersProps = {
@@ -45,7 +58,7 @@ export function SummaryBanners({
         {stats.map((stat) => (
           <article
             key={stat.label}
-            className="rounded-[1.5rem] border border-white/10 bg-slate-950/55 px-5 py-5"
+            className={`${styles.statCard} rounded-[1.5rem] border border-white/10 px-5 py-5`}
           >
             <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
               {stat.label}
@@ -59,7 +72,9 @@ export function SummaryBanners({
       </div>
 
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)]">
-        <div className="rounded-[1.75rem] border border-white/10 bg-slate-950/60 p-5">
+        <div
+          className={`${styles.surfacePanel} rounded-[1.75rem] border border-white/10 p-5`}
+        >
           <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
             <div>
               <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
@@ -79,7 +94,7 @@ export function SummaryBanners({
             {timingSignals.map((signal) => (
               <article
                 key={signal.id}
-                className="rounded-[1.35rem] border border-white/8 bg-white/5 px-4 py-4"
+                className={`${styles.signalCard} ${timingSurfaceStyles[signal.tone]} rounded-[1.35rem] border px-4 py-4`}
               >
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div>
@@ -89,7 +104,7 @@ export function SummaryBanners({
                     </p>
                   </div>
                   <span
-                    className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${timingToneStyles[signal.tone]}`}
+                    className={`${styles.statusBadge} inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${timingToneStyles[signal.tone]}`}
                   >
                     {timingToneLabels[signal.tone]}
                   </span>
@@ -102,7 +117,9 @@ export function SummaryBanners({
           </div>
         </div>
 
-        <aside className="rounded-[1.75rem] border border-white/10 bg-slate-950/65 p-5">
+        <aside
+          className={`${styles.surfacePanel} rounded-[1.75rem] border border-white/10 p-5`}
+        >
           <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
             Constraint summary
           </p>
@@ -113,7 +130,7 @@ export function SummaryBanners({
             {constraints.map((constraint) => (
               <article
                 key={constraint.id}
-                className="rounded-[1.35rem] border border-white/8 bg-white/5 px-4 py-4"
+                className={`${styles.constraintCard} ${constraintSurfaceStyles[constraint.tone]} rounded-[1.35rem] border px-4 py-4`}
               >
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div className="space-y-1">
@@ -123,7 +140,7 @@ export function SummaryBanners({
                     <p className="text-sm text-slate-300">{constraint.owner}</p>
                   </div>
                   <span
-                    className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${constraintToneStyles[constraint.tone]}`}
+                    className={`${styles.statusBadge} inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${constraintToneStyles[constraint.tone]}`}
                   >
                     {constraintToneLabels[constraint.tone]}
                   </span>

--- a/src/app/route-planner/_components/summary-banners.tsx
+++ b/src/app/route-planner/_components/summary-banners.tsx
@@ -1,0 +1,141 @@
+import type {
+  RouteConstraint,
+  RoutePlannerStat,
+  TimingSignal,
+} from "../_data/route-planner-data";
+
+const timingToneLabels: Record<TimingSignal["tone"], string> = {
+  "on-time": "On time",
+  delayed: "Delayed",
+  blocked: "Blocked",
+};
+
+const timingToneStyles: Record<TimingSignal["tone"], string> = {
+  "on-time": "border-emerald-300/20 bg-emerald-300/10 text-emerald-50",
+  delayed: "border-amber-300/20 bg-amber-300/10 text-amber-50",
+  blocked: "border-rose-300/20 bg-rose-300/10 text-rose-50",
+};
+
+const constraintToneLabels: Record<RouteConstraint["tone"], string> = {
+  clear: "Clear",
+  watch: "Watch",
+  critical: "Critical",
+};
+
+const constraintToneStyles: Record<RouteConstraint["tone"], string> = {
+  clear: "border-cyan-300/20 bg-cyan-300/10 text-cyan-50",
+  watch: "border-amber-300/20 bg-amber-300/10 text-amber-50",
+  critical: "border-rose-300/20 bg-rose-300/10 text-rose-50",
+};
+
+type SummaryBannersProps = {
+  stats: RoutePlannerStat[];
+  timingSignals: TimingSignal[];
+  constraints: RouteConstraint[];
+};
+
+export function SummaryBanners({
+  stats,
+  timingSignals,
+  constraints,
+}: SummaryBannersProps) {
+  return (
+    <section aria-label="Route planner summary banners" className="space-y-5">
+      <div className="grid gap-4 md:grid-cols-3">
+        {stats.map((stat) => (
+          <article
+            key={stat.label}
+            className="rounded-[1.5rem] border border-white/10 bg-slate-950/55 px-5 py-5"
+          >
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+              {stat.label}
+            </p>
+            <p className="mt-3 text-3xl font-semibold tracking-tight text-white">
+              {stat.value}
+            </p>
+            <p className="mt-2 text-sm leading-6 text-slate-300">{stat.detail}</p>
+          </article>
+        ))}
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)]">
+        <div className="rounded-[1.75rem] border border-white/10 bg-slate-950/60 p-5">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+                Timing pulse
+              </p>
+              <h2 className="mt-2 text-2xl font-semibold tracking-tight text-white">
+                Key handoff timings
+              </h2>
+            </div>
+            <p className="max-w-lg text-sm leading-6 text-slate-300">
+              These signals surface whether the route still has enough timing
+              cushion to protect the planned corridor.
+            </p>
+          </div>
+
+          <div className="mt-5 grid gap-3 md:grid-cols-3">
+            {timingSignals.map((signal) => (
+              <article
+                key={signal.id}
+                className="rounded-[1.35rem] border border-white/8 bg-white/5 px-4 py-4"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-white">{signal.label}</p>
+                    <p className="mt-2 text-2xl font-semibold tracking-tight text-slate-100">
+                      {signal.value}
+                    </p>
+                  </div>
+                  <span
+                    className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${timingToneStyles[signal.tone]}`}
+                  >
+                    {timingToneLabels[signal.tone]}
+                  </span>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-slate-300">
+                  {signal.detail}
+                </p>
+              </article>
+            ))}
+          </div>
+        </div>
+
+        <aside className="rounded-[1.75rem] border border-white/10 bg-slate-950/65 p-5">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+            Constraint summary
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-white">
+            Route watchpoints
+          </h2>
+          <div className="mt-5 space-y-3">
+            {constraints.map((constraint) => (
+              <article
+                key={constraint.id}
+                className="rounded-[1.35rem] border border-white/8 bg-white/5 px-4 py-4"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="space-y-1">
+                    <p className="text-sm font-semibold text-white">
+                      {constraint.label}
+                    </p>
+                    <p className="text-sm text-slate-300">{constraint.owner}</p>
+                  </div>
+                  <span
+                    className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${constraintToneStyles[constraint.tone]}`}
+                  >
+                    {constraintToneLabels[constraint.tone]}
+                  </span>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-slate-300">
+                  {constraint.impact}
+                </p>
+              </article>
+            ))}
+          </div>
+        </aside>
+      </div>
+    </section>
+  );
+}

--- a/src/app/route-planner/_data/route-planner-data.ts
+++ b/src/app/route-planner/_data/route-planner-data.ts
@@ -1,0 +1,291 @@
+export type SegmentStatus = "on-time" | "delayed" | "blocked";
+export type ConstraintTone = "clear" | "watch" | "critical";
+export type DecisionState = "ready" | "review" | "hold";
+
+export interface RoutePlannerStat {
+  label: string;
+  value: string;
+  detail: string;
+}
+
+export interface TimingSignal {
+  id: string;
+  label: string;
+  value: string;
+  tone: SegmentStatus;
+  detail: string;
+}
+
+export interface RouteConstraint {
+  id: string;
+  label: string;
+  tone: ConstraintTone;
+  impact: string;
+  owner: string;
+  note: string;
+}
+
+export interface SegmentCheckpoint {
+  label: string;
+  detail: string;
+}
+
+export interface RouteSegment {
+  id: string;
+  lane: string;
+  stage: string;
+  etaWindow: string;
+  status: SegmentStatus;
+  mode: string;
+  owner: string;
+  summary: string;
+  riskNote: string;
+  checkpoint: SegmentCheckpoint;
+  constraints: RouteConstraint["id"][];
+}
+
+export interface RouteSegmentGroup {
+  id: string;
+  label: string;
+  description: string;
+  segments: RouteSegment[];
+}
+
+export interface RouteDecision {
+  id: string;
+  title: string;
+  state: DecisionState;
+  owner: string;
+  deadline: string;
+  detail: string;
+}
+
+export const routePlannerOverview = {
+  eyebrow: "Route Planner",
+  title: "Balance timing, segment risk, and dispatch commitments before the lane locks.",
+  description:
+    "A standalone planning route for comparing each segment of a live movement, reviewing timing pressure, and deciding whether to hold, reroute, or release the route.",
+  routeName: "Route 48 · Denver to Tacoma relay chain",
+  shiftLabel: "Shift 03 · Mountain corridor desk",
+};
+
+export const routePlannerStats = [
+  {
+    label: "Segments tracked",
+    value: "5",
+    detail: "Two origin legs, two corridor handoffs, and one final-mile release",
+  },
+  {
+    label: "Constraint watchpoints",
+    value: "4",
+    detail: "Bridge permit timing, weather shelf, dock congestion, and crew-hours risk",
+  },
+  {
+    label: "Decisions due this hour",
+    value: "3",
+    detail: "Release, reroute, and trailer swap calls all need a named owner",
+  },
+] satisfies RoutePlannerStat[];
+
+export const routeTimingSignals = [
+  {
+    id: "origin-release",
+    label: "Origin release",
+    value: "08:10 MDT",
+    tone: "on-time",
+    detail: "Trailer is loaded, sealed, and still inside the planned release window.",
+  },
+  {
+    id: "mountain-pass",
+    label: "Mountain pass handoff",
+    value: "+22 min",
+    tone: "delayed",
+    detail: "Chain-control restrictions are slowing the corridor transfer at Silver Ridge.",
+  },
+  {
+    id: "yakima-connector",
+    label: "Yakima connector",
+    value: "Awaiting clearance",
+    tone: "blocked",
+    detail: "Bridge escort confirmation has not yet cleared the final connector segment.",
+  },
+] satisfies TimingSignal[];
+
+export const routeConstraints = [
+  {
+    id: "permit-window",
+    label: "Bridge permit window",
+    tone: "critical",
+    impact: "Blocks the Yakima connector if the escort slot is missed after 14:30 PDT.",
+    owner: "Regional compliance",
+    note: "Escort team is ready, but the bridge authority still needs to acknowledge the permit refresh.",
+  },
+  {
+    id: "crew-hours",
+    label: "Crew-hours threshold",
+    tone: "watch",
+    impact: "A 35-minute slip forces a relief-driver swap before the final-mile release.",
+    owner: "Dispatch lead",
+    note: "Reserve coverage is staged in Ellensburg, but only until the 15:00 transfer cutoff.",
+  },
+  {
+    id: "dock-congestion",
+    label: "Tacoma dock congestion",
+    tone: "watch",
+    impact: "Inbound unload priority drops if the route lands after the premium intake block.",
+    owner: "Destination ops",
+    note: "Two other premium trailers are stacked into the same gate window.",
+  },
+  {
+    id: "weather-shelf",
+    label: "Cascade weather shelf",
+    tone: "clear",
+    impact: "Conditions are currently inside the operating band for the primary corridor.",
+    owner: "Weather desk",
+    note: "Snowfall intensity eased in the last update, but the next sweep hits in 70 minutes.",
+  },
+] satisfies RouteConstraint[];
+
+export const routeSegmentGroups = [
+  {
+    id: "origin-control",
+    label: "Origin control",
+    description:
+      "Validate release readiness before the route leaves the Denver yard and commits the lane plan.",
+    segments: [
+      {
+        id: "seg-01",
+        lane: "Denver yard release",
+        stage: "Stage 1",
+        etaWindow: "08:10-08:35 MDT",
+        status: "on-time",
+        mode: "Linehaul",
+        owner: "Origin dispatch",
+        summary:
+          "Trailer loading is complete and the outbound tractor is attached with no deviation from the planned release sequence.",
+        riskNote:
+          "No active blockers, but the route needs to leave before the dock reset window narrows.",
+        checkpoint: {
+          label: "Seal verification",
+          detail: "Cross-check trailer seal against the cold-load manifest before release.",
+        },
+        constraints: ["crew-hours"],
+      },
+      {
+        id: "seg-02",
+        lane: "Fort Collins fuel and swap",
+        stage: "Stage 2",
+        etaWindow: "09:20-09:45 MDT",
+        status: "delayed",
+        mode: "Service stop",
+        owner: "Regional linehaul",
+        summary:
+          "Fueling remains available, but the swap pad is cycling slower than target after a maintenance inspection backlog.",
+        riskNote:
+          "A delay here compresses the mountain pass buffer and increases exposure to corridor restrictions.",
+        checkpoint: {
+          label: "Swap pad release",
+          detail: "Confirm the spare dolly is staged before the lead unit enters the service lane.",
+        },
+        constraints: ["crew-hours", "weather-shelf"],
+      },
+    ],
+  },
+  {
+    id: "corridor-commitments",
+    label: "Corridor commitments",
+    description:
+      "Track the long-haul transfer segments where timing and permit risk can force a reroute decision.",
+    segments: [
+      {
+        id: "seg-03",
+        lane: "Silver Ridge pass",
+        stage: "Stage 3",
+        etaWindow: "12:05-12:40 MDT",
+        status: "delayed",
+        mode: "Mountain relay",
+        owner: "Corridor control",
+        summary:
+          "The route remains open, but chain-control checks added a rolling queue that is extending handoff time.",
+        riskNote:
+          "If the pass runs beyond 12:40 MDT, the Yakima connector loses most of its permit cushion.",
+        checkpoint: {
+          label: "Escort standby",
+          detail: "Keep the permit escort team warm-started while the relay approaches the state line.",
+        },
+        constraints: ["permit-window", "weather-shelf"],
+      },
+      {
+        id: "seg-04",
+        lane: "Yakima connector bridge",
+        stage: "Stage 4",
+        etaWindow: "14:00-14:25 PDT",
+        status: "blocked",
+        mode: "Permit crossing",
+        owner: "Bridge operations",
+        summary:
+          "The route cannot enter the connector bridge until the refreshed escort permit is acknowledged by the authority desk.",
+        riskNote:
+          "Missing this bridge slot forces a hard reroute through the south bypass and adds 78 minutes.",
+        checkpoint: {
+          label: "Permit acknowledgement",
+          detail: "Receive the bridge authority confirmation number before the tractor clears staging.",
+        },
+        constraints: ["permit-window"],
+      },
+    ],
+  },
+  {
+    id: "destination-release",
+    label: "Destination release",
+    description:
+      "Protect the final segment so the route still lands with enough priority to unload on the first dock wave.",
+    segments: [
+      {
+        id: "seg-05",
+        lane: "Tacoma premium intake",
+        stage: "Stage 5",
+        etaWindow: "16:10-16:35 PDT",
+        status: "on-time",
+        mode: "Final mile",
+        owner: "Destination control",
+        summary:
+          "The destination dock still has premium capacity reserved for this route if the connector clears on the next permit cycle.",
+        riskNote:
+          "Every corridor delay now flows directly into the dock priority window and customer commitment buffer.",
+        checkpoint: {
+          label: "Door assignment",
+          detail: "Hold door 14A unless the connector slip exceeds 30 minutes.",
+        },
+        constraints: ["dock-congestion", "crew-hours"],
+      },
+    ],
+  },
+] satisfies RouteSegmentGroup[];
+
+export const routeDecisionQueue = [
+  {
+    id: "decision-release",
+    title: "Keep the current corridor release",
+    state: "review",
+    owner: "A. Navarro",
+    deadline: "Decide by 12:15 MDT",
+    detail: "Only valid if Silver Ridge clears inside the current rolling restriction window.",
+  },
+  {
+    id: "decision-reroute",
+    title: "Arm the south bypass contingency",
+    state: "ready",
+    owner: "Dispatch lead",
+    deadline: "Prep by 12:05 MDT",
+    detail: "The bypass protects bridge risk, but adds linehaul miles and a dock-priority penalty.",
+  },
+  {
+    id: "decision-relief-driver",
+    title: "Authorize relief-driver swap",
+    state: "hold",
+    owner: "Crew planning",
+    deadline: "Hold until 13:20 MDT",
+    detail: "Only required if the route slips beyond the current crew-hours threshold.",
+  },
+] satisfies RouteDecision[];

--- a/src/app/route-planner/page.test.tsx
+++ b/src/app/route-planner/page.test.tsx
@@ -1,0 +1,125 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  routeConstraints,
+  routeDecisionQueue,
+  routePlannerOverview,
+  routePlannerStats,
+  routeSegmentGroups,
+  routeTimingSignals,
+} from "./_data/route-planner-data";
+import RoutePlannerPage from "./page";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("RoutePlannerPage", () => {
+  it("renders the route-planner shell with the primary headings and route metadata", () => {
+    render(<RoutePlannerPage />);
+
+    expect(screen.getByText(routePlannerOverview.title, { selector: "h1" })).toBeInTheDocument();
+    expect(screen.getByText(routePlannerOverview.routeName)).toBeInTheDocument();
+    expect(screen.getByText(routePlannerOverview.shiftLabel)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        name: /segment cards for every control point on the route/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /back to route index/i }),
+    ).toHaveAttribute("href", "/");
+  });
+
+  it("renders summary banners for planner stats, timing signals, and constraints", () => {
+    render(<RoutePlannerPage />);
+
+    const summarySection = screen.getByLabelText(/route planner summary banners/i);
+
+    for (const stat of routePlannerStats) {
+      expect(within(summarySection).getByText(stat.label)).toBeInTheDocument();
+      expect(within(summarySection).getByText(stat.value)).toBeInTheDocument();
+    }
+
+    for (const signal of routeTimingSignals) {
+      expect(within(summarySection).getByText(signal.label)).toBeInTheDocument();
+      expect(within(summarySection).getByText(signal.value)).toBeInTheDocument();
+    }
+
+    for (const constraint of routeConstraints) {
+      expect(within(summarySection).getByText(constraint.label)).toBeInTheDocument();
+      expect(within(summarySection).getByText(constraint.owner)).toBeInTheDocument();
+    }
+
+    expect(within(summarySection).getByText("On time")).toBeInTheDocument();
+    expect(within(summarySection).getByText("Delayed")).toBeInTheDocument();
+    expect(within(summarySection).getByText("Blocked")).toBeInTheDocument();
+    expect(within(summarySection).getByText("Critical")).toBeInTheDocument();
+  });
+
+  it("renders every segment group with segment-specific checkpoints and attached constraints", () => {
+    render(<RoutePlannerPage />);
+
+    for (const group of routeSegmentGroups) {
+      const segmentList = screen.getByRole("list", { name: group.label });
+
+      expect(
+        segmentList.querySelectorAll(':scope > [role="listitem"]'),
+      ).toHaveLength(group.segments.length);
+
+      for (const segment of group.segments) {
+        const card = within(segmentList)
+          .getByRole("heading", { name: segment.lane })
+          .closest('[role="listitem"]');
+
+        expect(card).toBeTruthy();
+        expect(card?.textContent).toContain(segment.owner);
+        expect(card?.textContent).toContain(segment.checkpoint.label);
+        expect(card?.textContent).toContain(segment.checkpoint.detail);
+
+        for (const constraintId of segment.constraints) {
+          const constraint = routeConstraints.find((item) => item.id === constraintId);
+
+          expect(constraint).toBeTruthy();
+          expect(card?.textContent).toContain(constraint?.label);
+        }
+      }
+    }
+  });
+
+  it("renders the decision sidebar with route-level counts and pending decisions", () => {
+    render(<RoutePlannerPage />);
+
+    const sidebar = screen.getByLabelText(/route decision sidebar/i);
+    const blockedSignals = routeTimingSignals.filter(
+      (signal) => signal.tone === "blocked",
+    ).length;
+    const criticalConstraints = routeConstraints.filter(
+      (constraint) => constraint.tone === "critical",
+    ).length;
+    const blockedSignalCard = within(sidebar)
+      .getByText("Blocked timing signals")
+      .closest("div");
+    const criticalConstraintCard = within(sidebar)
+      .getByText("Critical constraints")
+      .closest("div");
+
+    expect(within(sidebar).getByText("Blocked timing signals")).toBeInTheDocument();
+    expect(
+      within(blockedSignalCard as HTMLElement).getByText(String(blockedSignals)),
+    ).toBeInTheDocument();
+    expect(within(sidebar).getByText("Critical constraints")).toBeInTheDocument();
+    expect(
+      within(criticalConstraintCard as HTMLElement).getByText(
+        String(criticalConstraints),
+      ),
+    ).toBeInTheDocument();
+
+    for (const decision of routeDecisionQueue) {
+      expect(within(sidebar).getByText(decision.title)).toBeInTheDocument();
+      expect(within(sidebar).getByText(decision.owner)).toBeInTheDocument();
+      expect(within(sidebar).getByText(decision.deadline)).toBeInTheDocument();
+    }
+  });
+});

--- a/src/app/route-planner/page.tsx
+++ b/src/app/route-planner/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { RouteDecisionSidebar } from "./_components/route-decision-sidebar";
 import { SegmentGroup } from "./_components/segment-group";
 import { SummaryBanners } from "./_components/summary-banners";
+import styles from "./route-planner.module.css";
 import {
   routeConstraints,
   routeDecisionQueue,
@@ -21,9 +22,11 @@ export const metadata: Metadata = {
 
 export default function RoutePlannerPage() {
   return (
-    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#0f172a_0%,#172554_42%,#020617_100%)] px-6 py-12 text-slate-50 sm:px-10 lg:px-16">
-      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8">
-        <header className="overflow-hidden rounded-[2rem] border border-white/10 bg-white/8 p-8 shadow-2xl shadow-slate-950/45 backdrop-blur sm:p-10">
+    <main className={`${styles.shell} px-6 py-12 text-slate-50 sm:px-10 lg:px-16`}>
+      <div className="relative mx-auto flex w-full max-w-7xl flex-col gap-8">
+        <header
+          className={`${styles.heroPanel} overflow-hidden rounded-[2rem] border border-white/10 p-8 backdrop-blur sm:p-10`}
+        >
           <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
             <div className="max-w-3xl space-y-4">
               <span className="inline-flex w-fit rounded-full border border-cyan-300/35 bg-cyan-300/12 px-4 py-1 text-sm font-medium uppercase tracking-[0.2em] text-cyan-100">
@@ -38,7 +41,9 @@ export default function RoutePlannerPage() {
             </div>
 
             <div className="flex flex-col gap-3 sm:items-end">
-              <div className="rounded-[1.4rem] border border-white/10 bg-white/5 px-4 py-4 text-sm text-slate-200">
+              <div
+                className={`${styles.floatingInfo} rounded-[1.4rem] border border-white/10 px-4 py-4 text-sm text-slate-200`}
+              >
                 <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
                   Active route
                 </p>

--- a/src/app/route-planner/page.tsx
+++ b/src/app/route-planner/page.tsx
@@ -1,0 +1,71 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Route Planner",
+  description:
+    "Initial route shell for reviewing route segments, constraints, and planning decisions.",
+};
+
+export default function RoutePlannerPage() {
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#0f172a_0%,#172554_42%,#020617_100%)] px-6 py-12 text-slate-50 sm:px-10 lg:px-16">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-8">
+        <header className="overflow-hidden rounded-[2rem] border border-white/10 bg-white/8 p-8 shadow-2xl shadow-slate-950/45 backdrop-blur sm:p-10">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+            <div className="max-w-3xl space-y-4">
+              <span className="inline-flex w-fit rounded-full border border-cyan-300/35 bg-cyan-300/12 px-4 py-1 text-sm font-medium uppercase tracking-[0.2em] text-cyan-100">
+                Route planner
+              </span>
+              <h1 className="text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
+                Plan route segments before dispatch locks the final path
+              </h1>
+              <p className="max-w-2xl text-base leading-7 text-slate-300 sm:text-lg">
+                This initial shell establishes the dedicated route for segment
+                planning. Subsequent commits will add mock route data,
+                constraint summaries, and the decision sidebar.
+              </p>
+            </div>
+
+            <Link
+              href="/"
+              className="inline-flex items-center justify-center rounded-full border border-white/15 bg-slate-950/40 px-5 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-300/45 hover:bg-slate-900"
+            >
+              Back to route index
+            </Link>
+          </div>
+        </header>
+
+        <section className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(18rem,0.9fr)]">
+          <article className="rounded-[1.75rem] border border-white/10 bg-slate-950/55 p-7">
+            <h2 className="text-lg font-semibold text-slate-100">
+              First delivery slice
+            </h2>
+            <p className="mt-4 max-w-2xl text-sm leading-7 text-slate-300 sm:text-base">
+              The route is live with its own shell and heading. The next
+              implementation steps will introduce grouped route segments, timing
+              signals, and route-level decision support.
+            </p>
+          </article>
+
+          <aside className="rounded-[1.75rem] border border-white/10 bg-slate-950/70 p-7">
+            <h2 className="text-lg font-semibold text-slate-100">
+              Planned next additions
+            </h2>
+            <ul className="mt-5 space-y-3 text-sm leading-6 text-slate-300">
+              <li className="rounded-2xl border border-white/8 bg-white/5 px-4 py-3">
+                Segment cards with timing and constraint states
+              </li>
+              <li className="rounded-2xl border border-white/8 bg-white/5 px-4 py-3">
+                Summary banners for route-level status counts
+              </li>
+              <li className="rounded-2xl border border-white/8 bg-white/5 px-4 py-3">
+                Decision rail for hold, reroute, and escalation calls
+              </li>
+            </ul>
+          </aside>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/route-planner/page.tsx
+++ b/src/app/route-planner/page.tsx
@@ -1,69 +1,103 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
+import { RouteDecisionSidebar } from "./_components/route-decision-sidebar";
+import { SegmentGroup } from "./_components/segment-group";
+import { SummaryBanners } from "./_components/summary-banners";
+import {
+  routeConstraints,
+  routeDecisionQueue,
+  routePlannerOverview,
+  routePlannerStats,
+  routeSegmentGroups,
+  routeTimingSignals,
+} from "./_data/route-planner-data";
+
 export const metadata: Metadata = {
   title: "Route Planner",
   description:
-    "Initial route shell for reviewing route segments, constraints, and planning decisions.",
+    "Standalone route for reviewing route segments, timing constraints, and route-level planning decisions.",
 };
 
 export default function RoutePlannerPage() {
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,#0f172a_0%,#172554_42%,#020617_100%)] px-6 py-12 text-slate-50 sm:px-10 lg:px-16">
-      <div className="mx-auto flex w-full max-w-5xl flex-col gap-8">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8">
         <header className="overflow-hidden rounded-[2rem] border border-white/10 bg-white/8 p-8 shadow-2xl shadow-slate-950/45 backdrop-blur sm:p-10">
           <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
             <div className="max-w-3xl space-y-4">
               <span className="inline-flex w-fit rounded-full border border-cyan-300/35 bg-cyan-300/12 px-4 py-1 text-sm font-medium uppercase tracking-[0.2em] text-cyan-100">
-                Route planner
+                {routePlannerOverview.eyebrow}
               </span>
               <h1 className="text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
-                Plan route segments before dispatch locks the final path
+                {routePlannerOverview.title}
               </h1>
               <p className="max-w-2xl text-base leading-7 text-slate-300 sm:text-lg">
-                This initial shell establishes the dedicated route for segment
-                planning. Subsequent commits will add mock route data,
-                constraint summaries, and the decision sidebar.
+                {routePlannerOverview.description}
               </p>
             </div>
 
-            <Link
-              href="/"
-              className="inline-flex items-center justify-center rounded-full border border-white/15 bg-slate-950/40 px-5 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-300/45 hover:bg-slate-900"
-            >
-              Back to route index
-            </Link>
+            <div className="flex flex-col gap-3 sm:items-end">
+              <div className="rounded-[1.4rem] border border-white/10 bg-white/5 px-4 py-4 text-sm text-slate-200">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                  Active route
+                </p>
+                <p className="mt-2 text-lg font-semibold text-white">
+                  {routePlannerOverview.routeName}
+                </p>
+                <p className="mt-2 text-sm text-slate-300">
+                  {routePlannerOverview.shiftLabel}
+                </p>
+              </div>
+
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-full border border-white/15 bg-slate-950/40 px-5 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-300/45 hover:bg-slate-900"
+              >
+                Back to route index
+              </Link>
+            </div>
           </div>
         </header>
 
-        <section className="grid gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(18rem,0.9fr)]">
-          <article className="rounded-[1.75rem] border border-white/10 bg-slate-950/55 p-7">
-            <h2 className="text-lg font-semibold text-slate-100">
-              First delivery slice
-            </h2>
-            <p className="mt-4 max-w-2xl text-sm leading-7 text-slate-300 sm:text-base">
-              The route is live with its own shell and heading. The next
-              implementation steps will introduce grouped route segments, timing
-              signals, and route-level decision support.
-            </p>
-          </article>
+        <SummaryBanners
+          stats={routePlannerStats}
+          timingSignals={routeTimingSignals}
+          constraints={routeConstraints}
+        />
 
-          <aside className="rounded-[1.75rem] border border-white/10 bg-slate-950/70 p-7">
-            <h2 className="text-lg font-semibold text-slate-100">
-              Planned next additions
-            </h2>
-            <ul className="mt-5 space-y-3 text-sm leading-6 text-slate-300">
-              <li className="rounded-2xl border border-white/8 bg-white/5 px-4 py-3">
-                Segment cards with timing and constraint states
-              </li>
-              <li className="rounded-2xl border border-white/8 bg-white/5 px-4 py-3">
-                Summary banners for route-level status counts
-              </li>
-              <li className="rounded-2xl border border-white/8 bg-white/5 px-4 py-3">
-                Decision rail for hold, reroute, and escalation calls
-              </li>
-            </ul>
-          </aside>
+        <section className="grid gap-6 xl:grid-cols-[minmax(0,1.28fr)_minmax(320px,0.72fr)] xl:items-start">
+          <div className="space-y-8">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+                  Route segments
+                </p>
+                <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+                  Segment cards for every control point on the route
+                </h2>
+              </div>
+              <p className="max-w-2xl text-sm leading-6 text-slate-300">
+                Each segment card calls out who owns the handoff, what timing
+                window still matters, and which constraint is attached to the
+                decision.
+              </p>
+            </div>
+
+            {routeSegmentGroups.map((group) => (
+              <SegmentGroup
+                key={group.id}
+                group={group}
+                constraints={routeConstraints}
+              />
+            ))}
+          </div>
+
+          <RouteDecisionSidebar
+            decisions={routeDecisionQueue}
+            timingSignals={routeTimingSignals}
+            constraints={routeConstraints}
+          />
         </section>
       </div>
     </main>

--- a/src/app/route-planner/route-planner.module.css
+++ b/src/app/route-planner/route-planner.module.css
@@ -1,0 +1,197 @@
+.shell {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 14% 12%, rgba(34, 211, 238, 0.14), transparent 22%),
+    radial-gradient(circle at 86% 16%, rgba(56, 189, 248, 0.18), transparent 24%),
+    radial-gradient(circle at 52% 100%, rgba(245, 158, 11, 0.18), transparent 28%),
+    linear-gradient(180deg, #08111f 0%, #0e1c34 44%, #030712 100%);
+}
+
+.shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(125deg, rgba(255, 255, 255, 0.03), transparent 45%),
+    repeating-linear-gradient(
+      90deg,
+      rgba(148, 163, 184, 0.06) 0,
+      rgba(148, 163, 184, 0.06) 1px,
+      transparent 1px,
+      transparent 72px
+    );
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.95), transparent 96%);
+}
+
+.heroPanel {
+  position: relative;
+  background:
+    linear-gradient(140deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.58)),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(15, 23, 42, 0.12));
+  box-shadow: 0 38px 120px rgba(2, 6, 23, 0.42);
+}
+
+.heroPanel::after {
+  content: "";
+  position: absolute;
+  right: -5rem;
+  top: -4rem;
+  width: 18rem;
+  height: 18rem;
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgba(34, 211, 238, 0.22), transparent 66%);
+  filter: blur(20px);
+  pointer-events: none;
+}
+
+.surfacePanel {
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.76), rgba(8, 15, 30, 0.92));
+  box-shadow: 0 30px 90px rgba(2, 6, 23, 0.24);
+}
+
+.statCard {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(15, 23, 42, 0.28));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.signalCard {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(15, 23, 42, 0.34));
+}
+
+.signalOnTime {
+  border-color: rgba(52, 211, 153, 0.24);
+  box-shadow: inset 0 1px 0 rgba(52, 211, 153, 0.08);
+}
+
+.signalDelayed {
+  border-color: rgba(251, 191, 36, 0.24);
+  box-shadow: inset 0 1px 0 rgba(251, 191, 36, 0.08);
+}
+
+.signalBlocked {
+  border-color: rgba(251, 113, 133, 0.3);
+  box-shadow: inset 0 1px 0 rgba(251, 113, 133, 0.1);
+}
+
+.constraintCard {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(15, 23, 42, 0.32));
+}
+
+.constraintClear {
+  border-color: rgba(34, 211, 238, 0.22);
+}
+
+.constraintWatch {
+  border-color: rgba(251, 191, 36, 0.22);
+}
+
+.constraintCritical {
+  border-color: rgba(251, 113, 133, 0.28);
+}
+
+.segmentCard {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.82), rgba(6, 11, 24, 0.94));
+  box-shadow: 0 26px 70px rgba(2, 6, 23, 0.26);
+}
+
+.segmentCard::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 1.25rem;
+  bottom: 1.25rem;
+  width: 0.35rem;
+  border-radius: 9999px;
+  opacity: 0.95;
+}
+
+.segmentOnTime {
+  border-color: rgba(52, 211, 153, 0.2);
+}
+
+.segmentOnTime::before {
+  background: linear-gradient(180deg, rgba(16, 185, 129, 0.95), rgba(6, 182, 212, 0.85));
+  box-shadow: 0 0 24px rgba(52, 211, 153, 0.35);
+}
+
+.segmentDelayed {
+  border-color: rgba(251, 191, 36, 0.22);
+}
+
+.segmentDelayed::before {
+  background: linear-gradient(180deg, rgba(245, 158, 11, 0.98), rgba(249, 115, 22, 0.88));
+  box-shadow: 0 0 24px rgba(251, 191, 36, 0.35);
+}
+
+.segmentBlocked {
+  border-color: rgba(251, 113, 133, 0.28);
+}
+
+.segmentBlocked::before {
+  background: linear-gradient(180deg, rgba(244, 63, 94, 0.98), rgba(190, 24, 93, 0.88));
+  box-shadow: 0 0 24px rgba(251, 113, 133, 0.35);
+}
+
+.statusBadge {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.sidebarPanel {
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.82), rgba(10, 17, 31, 0.95));
+  box-shadow: 0 30px 100px rgba(2, 6, 23, 0.28);
+}
+
+.stickyRail {
+  position: sticky;
+  top: 2rem;
+}
+
+.decisionCard {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(15, 23, 42, 0.28));
+}
+
+.decisionReady {
+  border-color: rgba(34, 211, 238, 0.22);
+}
+
+.decisionReview {
+  border-color: rgba(251, 191, 36, 0.24);
+}
+
+.decisionHold {
+  border-color: rgba(251, 113, 133, 0.3);
+}
+
+.floatingInfo {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(15, 23, 42, 0.26));
+}
+
+@media (max-width: 1279px) {
+  .stickyRail {
+    position: static;
+  }
+}
+
+@media (max-width: 640px) {
+  .heroPanel,
+  .surfacePanel,
+  .sidebarPanel,
+  .segmentCard,
+  .statCard {
+    border-radius: 1.5rem;
+  }
+
+  .segmentCard::before {
+    top: 1rem;
+    bottom: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold the standalone `route-planner` route with its own page shell
- add route metadata, primary heading, and initial placeholder sections
- stage the PR early so the remaining issue subtasks can land incrementally

## Testing
- not run yet; scaffold-only commit

Closes #121