### PR TITLE
Add asset catalog route with availability details

### DIFF
--- a/src/app/asset-catalog/page.test.tsx
+++ b/src/app/asset-catalog/page.test.tsx
@@ -1,0 +1,122 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import AssetCatalogPage from "./page";
+
+describe("AssetCatalogPage", () => {
+  it("renders the route with searchable sections, category tabs, and a visible detail panel", () => {
+    render(<AssetCatalogPage />);
+
+    const categoryTabs = screen.getByLabelText(/asset catalog categories/i);
+
+    expect(
+      screen.getByRole("heading", {
+        name: /searchable asset sections with category tabs and a focused availability detail panel/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("searchbox", { name: /search assets/i }),
+    ).toBeInTheDocument();
+    expect(within(categoryTabs).getByText("All Assets")).toBeInTheDocument();
+    expect(screen.getByText("Aerial Survey", { selector: "h2" })).toBeInTheDocument();
+    expect(
+      screen.getByText("Shelter Systems", { selector: "h2" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/selected asset availability details/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows meaningful status and availability details on asset cards", () => {
+    render(<AssetCatalogPage />);
+
+    const meridianCard = screen.getByRole("button", {
+      name: /meridian survey drone/i,
+    });
+    const atlasCard = screen.getByRole("button", {
+      name: /atlas cell cart/i,
+    });
+
+    expect(meridianCard).toHaveTextContent("Available");
+    expect(meridianCard).toHaveTextContent(
+      "6 drones ready across the north apron and can launch in under 12 minutes.",
+    );
+    expect(meridianCard).toHaveTextContent("6 ready units");
+    expect(meridianCard).toHaveTextContent("Overflight Team Delta");
+
+    expect(atlasCard).toHaveTextContent("Unavailable");
+    expect(atlasCard).toHaveTextContent("0 carts ready");
+    expect(atlasCard).toHaveTextContent("Grid Recovery Unit");
+  });
+
+  it(
+    "filters the catalog by category and search while keeping the detail panel visible",
+    async () => {
+    const user = userEvent.setup();
+
+    render(<AssetCatalogPage />);
+
+      const categoryTabs = screen.getByLabelText(/asset catalog categories/i);
+      const powerTab = within(categoryTabs)
+        .getByText("Power Reserve")
+        .closest("button");
+
+      expect(powerTab).not.toBeNull();
+      await user.click(powerTab!);
+
+      expect(
+        screen.getByText("Power Reserve", { selector: "h2" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("Aerial Survey", { selector: "h2" }),
+      ).not.toBeInTheDocument();
+
+      const detailPanel = screen.getByLabelText(
+        /selected asset availability details/i,
+      );
+
+      expect(
+        within(detailPanel).getByText("Atlas Cell Cart", { selector: "h2" }),
+      ).toBeInTheDocument();
+
+      fireEvent.change(screen.getByRole("searchbox", { name: /search assets/i }), {
+        target: { value: "microgrid" },
+      });
+
+      expect(
+        await screen.findByText("Pulse Microgrid Crate", { selector: "h3" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("Atlas Cell Cart", { selector: "h3" }),
+      ).not.toBeInTheDocument();
+      expect(detailPanel).toBeInTheDocument();
+      expect(
+        await within(detailPanel).findByText("Pulse Microgrid Crate", {
+          selector: "h2",
+        }),
+      ).toBeInTheDocument();
+    },
+    10000,
+  );
+
+  it("updates the detail panel when a different asset card is selected", async () => {
+    const user = userEvent.setup();
+
+    render(<AssetCatalogPage />);
+
+    await user.click(
+      screen.getByRole("button", { name: /breakwater lift sled/i }),
+    );
+
+    const detailPanel = screen.getByLabelText(/selected asset availability details/i);
+
+    expect(
+      within(detailPanel).getByRole("heading", { name: "Breakwater Lift Sled" }),
+    ).toBeInTheDocument();
+    expect(within(detailPanel).getByText("East marina gate")).toBeInTheDocument();
+    expect(
+      within(detailPanel).getByText("Shoreline Handling Team"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/asset-catalog/page.tsx
+++ b/src/app/asset-catalog/page.tsx
@@ -1,86 +1,22 @@
 import type { Metadata } from "next";
 
+import { AssetCatalogExperience } from "@/components/asset-catalog/asset-catalog-experience";
+import {
+  assetCatalogAssets,
+  assetCatalogCategories,
+} from "@/data/asset-catalog";
+
 export const metadata: Metadata = {
   title: "Asset Catalog",
   description:
-    "Initial shell for the asset catalog route with space for searchable sections and availability detail.",
+    "Search grouped mock assets by category and review a focused availability detail panel.",
 };
-
-const placeholderCategories = [
-  "Flight Systems",
-  "Field Support",
-  "Power Reserves",
-];
-
-const placeholderChecks = [
-  "Searchable sections will land in the next subtask.",
-  "Availability detail stays pinned as the focused panel.",
-  "Mock asset and category data will drive the final layout.",
-];
 
 export default function AssetCatalogPage() {
   return (
-    <main className="min-h-screen bg-[linear-gradient(180deg,#fffaf0_0%,#f6f1e7_52%,#f8fafc_100%)] px-6 py-8 text-slate-950 sm:px-8 lg:px-10 lg:py-10">
-      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
-        <section className="overflow-hidden rounded-[2.5rem] border border-slate-200/80 bg-slate-950 px-6 py-8 text-white shadow-[0_32px_100px_-40px_rgba(15,23,42,0.85)] sm:px-8 lg:px-10">
-          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-amber-300">
-            Asset Catalog
-          </p>
-          <h1 className="mt-4 max-w-3xl text-4xl font-semibold tracking-tight sm:text-5xl">
-            Minimal route shell for searchable asset sections and availability
-            detail.
-          </h1>
-          <p className="mt-5 max-w-3xl text-base leading-8 text-slate-300 sm:text-lg">
-            This first pass establishes the dedicated route requested in issue
-            128. Search, category tabs, asset cards, and the focused detail
-            panel will be layered in through the remaining subtasks.
-          </p>
-        </section>
-
-        <section className="grid gap-6 lg:grid-cols-[minmax(0,1.4fr)_320px]">
-          <div className="rounded-[2rem] border border-slate-200/80 bg-white/90 p-6 shadow-[0_18px_60px_-40px_rgba(15,23,42,0.45)] backdrop-blur">
-            <div className="flex flex-wrap gap-3">
-              {placeholderCategories.map((category) => (
-                <span
-                  key={category}
-                  className="rounded-full border border-slate-300 bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-700"
-                >
-                  {category}
-                </span>
-              ))}
-            </div>
-
-            <div className="mt-6 rounded-[1.75rem] border border-dashed border-slate-300 bg-slate-50 p-6">
-              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
-                Catalog Workspace
-              </p>
-              <p className="mt-4 text-lg font-semibold text-slate-950">
-                Search field, grouped asset cards, and responsive states will be
-                implemented in the next subtasks.
-              </p>
-            </div>
-          </div>
-
-          <aside className="rounded-[2rem] border border-slate-200/80 bg-[linear-gradient(180deg,#162033_0%,#0f172a_100%)] p-6 text-white shadow-[0_24px_80px_-32px_rgba(15,23,42,0.85)]">
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
-              Focus Panel
-            </p>
-            <h2 className="mt-4 text-2xl font-semibold">
-              Availability detail panel placeholder
-            </h2>
-            <ul className="mt-5 space-y-3 text-sm leading-7 text-slate-300">
-              {placeholderChecks.map((item) => (
-                <li
-                  key={item}
-                  className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3"
-                >
-                  {item}
-                </li>
-              ))}
-            </ul>
-          </aside>
-        </section>
-      </div>
-    </main>
+    <AssetCatalogExperience
+      categories={assetCatalogCategories}
+      items={assetCatalogAssets}
+    />
   );
 }

--- a/src/app/asset-catalog/page.tsx
+++ b/src/app/asset-catalog/page.tsx
@@ -1,0 +1,86 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Asset Catalog",
+  description:
+    "Initial shell for the asset catalog route with space for searchable sections and availability detail.",
+};
+
+const placeholderCategories = [
+  "Flight Systems",
+  "Field Support",
+  "Power Reserves",
+];
+
+const placeholderChecks = [
+  "Searchable sections will land in the next subtask.",
+  "Availability detail stays pinned as the focused panel.",
+  "Mock asset and category data will drive the final layout.",
+];
+
+export default function AssetCatalogPage() {
+  return (
+    <main className="min-h-screen bg-[linear-gradient(180deg,#fffaf0_0%,#f6f1e7_52%,#f8fafc_100%)] px-6 py-8 text-slate-950 sm:px-8 lg:px-10 lg:py-10">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-8">
+        <section className="overflow-hidden rounded-[2.5rem] border border-slate-200/80 bg-slate-950 px-6 py-8 text-white shadow-[0_32px_100px_-40px_rgba(15,23,42,0.85)] sm:px-8 lg:px-10">
+          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-amber-300">
+            Asset Catalog
+          </p>
+          <h1 className="mt-4 max-w-3xl text-4xl font-semibold tracking-tight sm:text-5xl">
+            Minimal route shell for searchable asset sections and availability
+            detail.
+          </h1>
+          <p className="mt-5 max-w-3xl text-base leading-8 text-slate-300 sm:text-lg">
+            This first pass establishes the dedicated route requested in issue
+            128. Search, category tabs, asset cards, and the focused detail
+            panel will be layered in through the remaining subtasks.
+          </p>
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-[minmax(0,1.4fr)_320px]">
+          <div className="rounded-[2rem] border border-slate-200/80 bg-white/90 p-6 shadow-[0_18px_60px_-40px_rgba(15,23,42,0.45)] backdrop-blur">
+            <div className="flex flex-wrap gap-3">
+              {placeholderCategories.map((category) => (
+                <span
+                  key={category}
+                  className="rounded-full border border-slate-300 bg-slate-100 px-4 py-2 text-sm font-semibold text-slate-700"
+                >
+                  {category}
+                </span>
+              ))}
+            </div>
+
+            <div className="mt-6 rounded-[1.75rem] border border-dashed border-slate-300 bg-slate-50 p-6">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                Catalog Workspace
+              </p>
+              <p className="mt-4 text-lg font-semibold text-slate-950">
+                Search field, grouped asset cards, and responsive states will be
+                implemented in the next subtasks.
+              </p>
+            </div>
+          </div>
+
+          <aside className="rounded-[2rem] border border-slate-200/80 bg-[linear-gradient(180deg,#162033_0%,#0f172a_100%)] p-6 text-white shadow-[0_24px_80px_-32px_rgba(15,23,42,0.85)]">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+              Focus Panel
+            </p>
+            <h2 className="mt-4 text-2xl font-semibold">
+              Availability detail panel placeholder
+            </h2>
+            <ul className="mt-5 space-y-3 text-sm leading-7 text-slate-300">
+              {placeholderChecks.map((item) => (
+                <li
+                  key={item}
+                  className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3"
+                >
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </aside>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/components/asset-catalog/asset-card.tsx
+++ b/src/components/asset-catalog/asset-card.tsx
@@ -1,4 +1,5 @@
 import {
+  assetAvailabilityStateStyles,
   getAssetCategoryById,
   type CatalogAsset,
 } from "@/data/asset-catalog";
@@ -11,6 +12,7 @@ type AssetCardProps = {
 
 export function AssetCard({ item, selected, onSelect }: AssetCardProps) {
   const category = getAssetCategoryById(item.categoryId);
+  const stateStyle = assetAvailabilityStateStyles[item.state];
 
   return (
     <button
@@ -35,11 +37,14 @@ export function AssetCard({ item, selected, onSelect }: AssetCardProps) {
         </div>
         <span
           className={`rounded-full border px-3 py-1 text-xs font-semibold ${
-            selected
-              ? "border-white/20 bg-white/10 text-white"
-              : "border-slate-300 bg-slate-100 text-slate-700"
+            selected ? stateStyle.selectedBadge : stateStyle.badge
           }`}
         >
+          <span
+            className={`mr-2 inline-flex h-2 w-2 rounded-full ${
+              selected ? "bg-current/90" : stateStyle.dot
+            }`}
+          />
           {item.state}
         </span>
       </div>
@@ -84,6 +89,42 @@ export function AssetCard({ item, selected, onSelect }: AssetCardProps) {
           </dd>
         </div>
       </dl>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        <div
+          className={`rounded-2xl border px-4 py-3 ${
+            selected ? "border-white/10 bg-white/8" : "border-black/5 bg-black/[0.03]"
+          }`}
+        >
+          <p
+            className={`text-xs font-semibold uppercase tracking-[0.18em] ${
+              selected ? "text-slate-300" : "text-slate-500"
+            }`}
+          >
+            Readiness
+          </p>
+          <p className="mt-2 text-sm font-medium">
+            {item.availability.readyUnits} ready units • reserve floor{" "}
+            {item.availability.reserveFloor}
+          </p>
+        </div>
+        <div
+          className={`rounded-2xl border px-4 py-3 ${
+            selected ? "border-white/10 bg-white/8" : "border-black/5 bg-black/[0.03]"
+          }`}
+        >
+          <p
+            className={`text-xs font-semibold uppercase tracking-[0.18em] ${
+              selected ? "text-slate-300" : "text-slate-500"
+            }`}
+          >
+            Assigned Lead
+          </p>
+          <p className="mt-2 text-sm font-medium">
+            {item.availability.assignedLead}
+          </p>
+        </div>
+      </div>
 
       <div className="mt-4 flex flex-wrap gap-2">
         {item.tags.map((tag) => (

--- a/src/components/asset-catalog/asset-card.tsx
+++ b/src/components/asset-catalog/asset-card.tsx
@@ -1,0 +1,104 @@
+import {
+  getAssetCategoryById,
+  type CatalogAsset,
+} from "@/data/asset-catalog";
+
+type AssetCardProps = {
+  item: CatalogAsset;
+  selected: boolean;
+  onSelect: (assetId: string) => void;
+};
+
+export function AssetCard({ item, selected, onSelect }: AssetCardProps) {
+  const category = getAssetCategoryById(item.categoryId);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(item.id)}
+      className={`w-full rounded-[1.75rem] border p-5 text-left transition ${
+        selected
+          ? "border-slate-950 bg-slate-950 text-white shadow-[0_24px_60px_-32px_rgba(15,23,42,0.75)]"
+          : "border-slate-200 bg-white text-slate-950 hover:border-slate-300 hover:bg-slate-50"
+      }`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p
+            className={`text-xs font-semibold uppercase tracking-[0.2em] ${
+              selected ? "text-slate-300" : "text-slate-500"
+            }`}
+          >
+            {category?.shortLabel ?? "Catalog"} • {item.assetCode}
+          </p>
+          <h3 className="mt-2 text-lg font-semibold">{item.name}</h3>
+        </div>
+        <span
+          className={`rounded-full border px-3 py-1 text-xs font-semibold ${
+            selected
+              ? "border-white/20 bg-white/10 text-white"
+              : "border-slate-300 bg-slate-100 text-slate-700"
+          }`}
+        >
+          {item.state}
+        </span>
+      </div>
+
+      <p
+        className={`mt-3 text-sm leading-6 ${
+          selected ? "text-slate-200" : "text-slate-600"
+        }`}
+      >
+        {item.description}
+      </p>
+
+      <dl className="mt-5 grid gap-3 sm:grid-cols-2">
+        <div
+          className={`rounded-2xl border px-4 py-3 ${
+            selected ? "border-white/10 bg-white/8" : "border-black/5 bg-black/[0.03]"
+          }`}
+        >
+          <dt
+            className={`text-xs font-semibold uppercase tracking-[0.18em] ${
+              selected ? "text-slate-300" : "text-slate-500"
+            }`}
+          >
+            Availability
+          </dt>
+          <dd className="mt-2 text-sm font-medium">{item.availability.summary}</dd>
+        </div>
+        <div
+          className={`rounded-2xl border px-4 py-3 ${
+            selected ? "border-white/10 bg-white/8" : "border-black/5 bg-black/[0.03]"
+          }`}
+        >
+          <dt
+            className={`text-xs font-semibold uppercase tracking-[0.18em] ${
+              selected ? "text-slate-300" : "text-slate-500"
+            }`}
+          >
+            Release Window
+          </dt>
+          <dd className="mt-2 text-sm font-medium">
+            {item.availability.releaseWindow}
+          </dd>
+        </div>
+      </dl>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {item.tags.map((tag) => (
+          <span
+            key={tag}
+            className={`rounded-full border px-3 py-1 text-xs font-medium ${
+              selected
+                ? "border-white/12 bg-white/8 text-slate-100"
+                : "border-slate-200 bg-slate-100 text-slate-700"
+            }`}
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+    </button>
+  );
+}

--- a/src/components/asset-catalog/asset-catalog-experience.tsx
+++ b/src/components/asset-catalog/asset-catalog-experience.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useDeferredValue, useState } from "react";
+
+import {
+  getAssetCatalogSections,
+  getAssetCategoryOptions,
+  type AssetCategory,
+  type CatalogAsset,
+} from "@/data/asset-catalog";
+
+import { AssetCatalogSection } from "./asset-catalog-section";
+import { AvailabilityDetailPanel } from "./availability-detail-panel";
+import { CatalogSearchBar } from "./catalog-search-bar";
+import { CategoryTabs } from "./category-tabs";
+
+type AssetCatalogExperienceProps = {
+  categories: AssetCategory[];
+  items: CatalogAsset[];
+};
+
+export function AssetCatalogExperience({
+  categories,
+  items,
+}: AssetCatalogExperienceProps) {
+  const [activeCategoryId, setActiveCategoryId] = useState("all");
+  const [searchValue, setSearchValue] = useState("");
+  const [selectedAssetId, setSelectedAssetId] = useState(items[0]?.id ?? "");
+
+  const deferredSearchValue = useDeferredValue(searchValue);
+  const categoryOptions = getAssetCategoryOptions(items, categories);
+  const sections = getAssetCatalogSections(
+    items,
+    categories,
+    activeCategoryId,
+    deferredSearchValue,
+  );
+  const visibleItems = sections.flatMap((section) => section.items);
+  const selectedAsset =
+    visibleItems.find((item) => item.id === selectedAssetId) ??
+    items.find((item) => item.id === selectedAssetId) ??
+    visibleItems[0];
+
+  const availableAssets = items.filter((item) => item.state === "Available").length;
+  const reservedAssets = items.filter((item) => item.state === "Reserved").length;
+  const unavailableAssets = items.filter(
+    (item) => item.state === "Unavailable",
+  ).length;
+
+  function syncSelectedAsset(nextCategoryId: string, nextSearchValue: string) {
+    const nextSections = getAssetCatalogSections(
+      items,
+      categories,
+      nextCategoryId,
+      nextSearchValue,
+    );
+    const nextVisibleItems = nextSections.flatMap((section) => section.items);
+
+    if (
+      nextVisibleItems.length > 0 &&
+      !nextVisibleItems.some((item) => item.id === selectedAssetId)
+    ) {
+      setSelectedAssetId(nextVisibleItems[0]?.id ?? "");
+    }
+  }
+
+  function handleCategoryChange(categoryId: string) {
+    setActiveCategoryId(categoryId);
+    syncSelectedAsset(categoryId, searchValue);
+  }
+
+  function handleSearchChange(value: string) {
+    setSearchValue(value);
+    syncSelectedAsset(activeCategoryId, value);
+  }
+
+  if (!selectedAsset) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen bg-[linear-gradient(180deg,#fffaf0_0%,#f6f1e7_48%,#f8fafc_100%)] text-slate-950">
+      <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
+        <section className="overflow-hidden rounded-[2.5rem] border border-slate-200/80 bg-slate-950 px-6 py-8 text-white shadow-[0_32px_100px_-40px_rgba(15,23,42,0.85)] sm:px-8 lg:px-10">
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,1.6fr)_minmax(260px,0.8fr)]">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.32em] text-amber-300">
+                Asset Catalog
+              </p>
+              <h1 className="mt-4 max-w-3xl text-4xl font-semibold tracking-tight sm:text-5xl">
+                Searchable asset sections with category tabs and a focused
+                availability detail panel.
+              </h1>
+              <p className="mt-5 max-w-3xl text-base leading-8 text-slate-300 sm:text-lg">
+                This route organizes staged assets into operating lanes, keeps
+                search active across metadata-rich availability records, and
+                anchors the selected asset beside the catalog for quick review.
+              </p>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-3 lg:grid-cols-1">
+              <div className="rounded-[1.75rem] border border-white/10 bg-white/6 p-5">
+                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-400">
+                  Available
+                </p>
+                <p className="mt-3 text-3xl font-semibold">{availableAssets}</p>
+                <p className="mt-2 text-sm text-slate-300">
+                  Assets ready now
+                </p>
+              </div>
+              <div className="rounded-[1.75rem] border border-white/10 bg-white/6 p-5">
+                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-400">
+                  Reserved
+                </p>
+                <p className="mt-3 text-3xl font-semibold">{reservedAssets}</p>
+                <p className="mt-2 text-sm text-slate-300">
+                  Assigned but healthy
+                </p>
+              </div>
+              <div className="rounded-[1.75rem] border border-white/10 bg-white/6 p-5">
+                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-400">
+                  Unavailable
+                </p>
+                <p className="mt-3 text-3xl font-semibold">{unavailableAssets}</p>
+                <p className="mt-2 text-sm text-slate-300">
+                  Blocked from dispatch
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <CatalogSearchBar
+          searchValue={searchValue}
+          resultCount={visibleItems.length}
+          totalCount={items.length}
+          onSearchChange={handleSearchChange}
+        />
+
+        <CategoryTabs
+          options={categoryOptions}
+          activeCategoryId={activeCategoryId}
+          onSelect={handleCategoryChange}
+        />
+
+        <div className="grid gap-8 xl:grid-cols-[minmax(0,1.55fr)_380px]">
+          <div className="space-y-6">
+            {sections.length > 0 ? (
+              sections.map((section) => (
+                <AssetCatalogSection
+                  key={section.id}
+                  section={section}
+                  selectedAssetId={selectedAsset.id}
+                  onSelectAsset={setSelectedAssetId}
+                />
+              ))
+            ) : (
+              <section className="rounded-[2rem] border border-dashed border-slate-300 bg-white/80 p-8 text-center shadow-[0_18px_60px_-40px_rgba(15,23,42,0.35)]">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                  No Visible Assets
+                </p>
+                <h2 className="mt-3 text-2xl font-semibold text-slate-950">
+                  Adjust the search or switch categories to bring assets back
+                  into view.
+                </h2>
+                <p className="mt-4 text-sm leading-7 text-slate-600">
+                  The focused detail panel stays pinned to the last selected
+                  asset so availability context remains visible while you refine
+                  the catalog.
+                </p>
+              </section>
+            )}
+          </div>
+
+          <AvailabilityDetailPanel item={selectedAsset} />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/components/asset-catalog/asset-catalog-section.tsx
+++ b/src/components/asset-catalog/asset-catalog-section.tsx
@@ -1,0 +1,57 @@
+import type { AssetCatalogSection as AssetCatalogSectionType } from "@/data/asset-catalog";
+
+import { AssetCard } from "./asset-card";
+
+type AssetCatalogSectionProps = {
+  section: AssetCatalogSectionType;
+  selectedAssetId: string;
+  onSelectAsset: (assetId: string) => void;
+};
+
+export function AssetCatalogSection({
+  section,
+  selectedAssetId,
+  onSelectAsset,
+}: AssetCatalogSectionProps) {
+  return (
+    <section
+      aria-labelledby={`${section.id}-section-title`}
+      className="rounded-[2rem] border border-slate-200/80 bg-white/90 p-5 shadow-[0_18px_60px_-40px_rgba(15,23,42,0.45)]"
+    >
+      <div
+        className={`rounded-[1.5rem] border border-transparent bg-gradient-to-r px-5 py-5 ${section.accent}`}
+      >
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Asset Section
+            </p>
+            <h2
+              id={`${section.id}-section-title`}
+              className="mt-2 text-2xl font-semibold text-slate-950"
+            >
+              {section.name}
+            </h2>
+          </div>
+          <p className="text-sm font-medium text-slate-600">
+            {section.items.length} assets • {section.totalReadyUnits} ready units
+          </p>
+        </div>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-700">
+          {section.description}
+        </p>
+      </div>
+
+      <div className="mt-5 grid gap-4 lg:grid-cols-2">
+        {section.items.map((item) => (
+          <AssetCard
+            key={item.id}
+            item={item}
+            selected={item.id === selectedAssetId}
+            onSelect={onSelectAsset}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/asset-catalog/asset-catalog-section.tsx
+++ b/src/components/asset-catalog/asset-catalog-section.tsx
@@ -33,9 +33,11 @@ export function AssetCatalogSection({
               {section.name}
             </h2>
           </div>
-          <p className="text-sm font-medium text-slate-600">
-            {section.items.length} assets • {section.totalReadyUnits} ready units
-          </p>
+          <div className="flex flex-wrap gap-2 text-sm font-medium text-slate-600">
+            <span>{section.items.length} assets</span>
+            <span>{section.totalReadyUnits} ready units</span>
+            <span>{section.constrainedItems} constrained</span>
+          </div>
         </div>
         <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-700">
           {section.description}

--- a/src/components/asset-catalog/availability-detail-panel.tsx
+++ b/src/components/asset-catalog/availability-detail-panel.tsx
@@ -1,0 +1,123 @@
+import {
+  assetAvailabilityStateCopy,
+  getAssetCategoryById,
+  type CatalogAsset,
+} from "@/data/asset-catalog";
+
+type AvailabilityDetailPanelProps = {
+  item: CatalogAsset;
+};
+
+export function AvailabilityDetailPanel({
+  item,
+}: AvailabilityDetailPanelProps) {
+  const category = getAssetCategoryById(item.categoryId);
+
+  return (
+    <aside
+      aria-label="Selected asset availability details"
+      className="rounded-[2rem] border border-slate-200/80 bg-slate-950 p-6 text-white shadow-[0_24px_80px_-32px_rgba(15,23,42,0.85)]"
+    >
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+        Focused Asset
+      </p>
+      <div className="mt-4 flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold">{item.name}</h2>
+          <p className="mt-2 text-sm text-slate-300">
+            {category?.name ?? "Catalog"} • {item.assetCode}
+          </p>
+        </div>
+        <span className="rounded-full border border-white/15 bg-white/8 px-3 py-1 text-xs font-semibold text-white">
+          {item.state}
+        </span>
+      </div>
+
+      <p className="mt-5 text-sm leading-7 text-slate-300">{item.missionFit}</p>
+
+      <div className="mt-6 rounded-[1.5rem] border border-white/10 bg-white/6 px-4 py-4">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+          State Readout
+        </p>
+        <p className="mt-2 text-sm leading-7 text-slate-200">
+          {assetAvailabilityStateCopy[item.state]}
+        </p>
+      </div>
+
+      <dl className="mt-6 grid gap-3">
+        <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+          <dt className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+            Availability
+          </dt>
+          <dd className="mt-2 text-sm font-medium text-white">
+            {item.availability.summary}
+          </dd>
+        </div>
+        <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+          <dt className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+            Ready Units
+          </dt>
+          <dd className="mt-2 text-sm font-medium text-white">
+            {item.availability.readyUnits} ready • reserve floor{" "}
+            {item.availability.reserveFloor}
+          </dd>
+        </div>
+        <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+          <dt className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+            Release Window
+          </dt>
+          <dd className="mt-2 text-sm font-medium text-white">
+            {item.availability.releaseWindow}
+          </dd>
+        </div>
+        <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+          <dt className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+            Next Transfer
+          </dt>
+          <dd className="mt-2 text-sm font-medium text-white">
+            {item.availability.nextTransfer}
+          </dd>
+        </div>
+        <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+          <dt className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+            Staging Location
+          </dt>
+          <dd className="mt-2 text-sm font-medium text-white">
+            {item.availability.stagingLocation}
+          </dd>
+        </div>
+        <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+          <dt className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+            Assigned Lead
+          </dt>
+          <dd className="mt-2 text-sm font-medium text-white">
+            {item.availability.assignedLead}
+          </dd>
+        </div>
+        <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+          <dt className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+            Supply Lane
+          </dt>
+          <dd className="mt-2 text-sm font-medium text-white">
+            {item.availability.supplyLane}
+          </dd>
+        </div>
+        <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
+          <dt className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
+            Last Audit
+          </dt>
+          <dd className="mt-2 text-sm font-medium text-white">
+            {item.availability.lastAudit}
+          </dd>
+        </div>
+      </dl>
+
+      <div className="mt-6 rounded-[1.5rem] border border-white/10 bg-white/5 p-4">
+        <h3 className="text-sm font-semibold text-white">Constraints</h3>
+        <p className="mt-3 text-sm leading-7 text-slate-300">
+          {item.availability.constraints}
+        </p>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/asset-catalog/availability-detail-panel.tsx
+++ b/src/components/asset-catalog/availability-detail-panel.tsx
@@ -1,5 +1,6 @@
 import {
   assetAvailabilityStateCopy,
+  assetAvailabilityStateStyles,
   getAssetCategoryById,
   type CatalogAsset,
 } from "@/data/asset-catalog";
@@ -12,11 +13,12 @@ export function AvailabilityDetailPanel({
   item,
 }: AvailabilityDetailPanelProps) {
   const category = getAssetCategoryById(item.categoryId);
+  const stateStyle = assetAvailabilityStateStyles[item.state];
 
   return (
     <aside
       aria-label="Selected asset availability details"
-      className="rounded-[2rem] border border-slate-200/80 bg-slate-950 p-6 text-white shadow-[0_24px_80px_-32px_rgba(15,23,42,0.85)]"
+      className="rounded-[2rem] border border-slate-200/80 bg-slate-950 p-6 text-white shadow-[0_24px_80px_-32px_rgba(15,23,42,0.85)] xl:sticky xl:top-6"
     >
       <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
         Focused Asset
@@ -28,23 +30,26 @@ export function AvailabilityDetailPanel({
             {category?.name ?? "Catalog"} • {item.assetCode}
           </p>
         </div>
-        <span className="rounded-full border border-white/15 bg-white/8 px-3 py-1 text-xs font-semibold text-white">
+        <span
+          className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold ${stateStyle.selectedBadge}`}
+        >
+          <span className={`h-2 w-2 rounded-full ${stateStyle.dot}`} />
           {item.state}
         </span>
       </div>
 
       <p className="mt-5 text-sm leading-7 text-slate-300">{item.missionFit}</p>
 
-      <div className="mt-6 rounded-[1.5rem] border border-white/10 bg-white/6 px-4 py-4">
-        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-          State Readout
+      <div className={`mt-6 rounded-[1.5rem] border px-4 py-4 ${stateStyle.emphasis}`}>
+        <p className="text-xs font-semibold uppercase tracking-[0.18em]">
+          Availability State
         </p>
-        <p className="mt-2 text-sm leading-7 text-slate-200">
+        <p className="mt-2 text-sm leading-7">
           {assetAvailabilityStateCopy[item.state]}
         </p>
       </div>
 
-      <dl className="mt-6 grid gap-3">
+      <dl className="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
         <div className="rounded-[1.5rem] border border-white/10 bg-white/5 px-4 py-4">
           <dt className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
             Availability

--- a/src/components/asset-catalog/catalog-search-bar.tsx
+++ b/src/components/asset-catalog/catalog-search-bar.tsx
@@ -1,0 +1,52 @@
+import type { ChangeEvent } from "react";
+
+type CatalogSearchBarProps = {
+  searchValue: string;
+  resultCount: number;
+  totalCount: number;
+  onSearchChange: (value: string) => void;
+};
+
+export function CatalogSearchBar({
+  searchValue,
+  resultCount,
+  totalCount,
+  onSearchChange,
+}: CatalogSearchBarProps) {
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
+    onSearchChange(event.target.value);
+  }
+
+  return (
+    <section className="rounded-[2rem] border border-slate-200/80 bg-white/90 p-5 shadow-[0_18px_60px_-40px_rgba(15,23,42,0.45)]">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+            Search
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold text-slate-950">
+            Find assets by code, crew, staging lane, or availability notes
+          </h2>
+          <p className="mt-3 max-w-2xl text-sm leading-6 text-slate-600">
+            Search spans asset names, category context, lead assignments,
+            supply paths, and operational constraints.
+          </p>
+        </div>
+        <p className="text-sm font-medium text-slate-600">
+          {resultCount} visible of {totalCount} tracked assets
+        </p>
+      </div>
+
+      <label className="mt-5 block">
+        <span className="sr-only">Search assets</span>
+        <input
+          type="search"
+          value={searchValue}
+          onChange={handleChange}
+          placeholder="Search Meridian, dock workshop, backup hull, LiDAR..."
+          className="w-full rounded-[1.5rem] border border-slate-300 bg-slate-50 px-5 py-4 text-sm text-slate-950 outline-none transition placeholder:text-slate-400 focus:border-slate-950 focus:bg-white"
+        />
+      </label>
+    </section>
+  );
+}

--- a/src/components/asset-catalog/category-tabs.tsx
+++ b/src/components/asset-catalog/category-tabs.tsx
@@ -1,0 +1,75 @@
+import type { AssetCategoryOption } from "@/data/asset-catalog";
+
+type CategoryTabsProps = {
+  options: AssetCategoryOption[];
+  activeCategoryId: string;
+  onSelect: (categoryId: string) => void;
+};
+
+export function CategoryTabs({
+  options,
+  activeCategoryId,
+  onSelect,
+}: CategoryTabsProps) {
+  return (
+    <nav
+      aria-label="Asset catalog categories"
+      className="rounded-[2rem] border border-slate-200/80 bg-white/90 p-4 shadow-[0_18px_60px_-40px_rgba(15,23,42,0.45)]"
+    >
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+            Category Tabs
+          </p>
+          <h2 className="text-xl font-semibold text-slate-950">
+            Shift between asset groups
+          </h2>
+        </div>
+        <p className="max-w-2xl text-sm leading-6 text-slate-600">
+          Each category keeps the catalog focused around a single operating
+          lane while preserving the selected asset when possible.
+        </p>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+        {options.map((option) => {
+          const isActive = option.id === activeCategoryId;
+
+          return (
+            <button
+              key={option.id}
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => onSelect(option.id)}
+              className={`rounded-[1.5rem] border px-4 py-4 text-left transition ${
+                isActive
+                  ? "border-slate-950 bg-slate-950 text-white shadow-lg shadow-slate-950/15"
+                  : "border-slate-200 bg-slate-50/80 text-slate-900 hover:border-slate-300 hover:bg-white"
+              }`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <div className="text-sm font-semibold">{option.name}</div>
+                  <div
+                    className={`mt-1 text-xs leading-5 ${
+                      isActive ? "text-slate-300" : "text-slate-500"
+                    }`}
+                  >
+                    {option.description}
+                  </div>
+                </div>
+                <span
+                  className={`inline-flex min-w-10 justify-center rounded-full px-2.5 py-1 text-xs font-semibold ${
+                    isActive ? "bg-white/12 text-white" : "bg-slate-900 text-white"
+                  }`}
+                >
+                  {option.count}
+                </span>
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/src/data/asset-catalog.ts
+++ b/src/data/asset-catalog.ts
@@ -1,0 +1,378 @@
+export type AssetAvailabilityState = "Available" | "Reserved" | "Unavailable";
+
+export type AssetCategory = {
+  id: string;
+  name: string;
+  shortLabel: string;
+  description: string;
+  accent: string;
+};
+
+export type AssetAvailability = {
+  summary: string;
+  readyUnits: number;
+  reserveFloor: number;
+  releaseWindow: string;
+  nextTransfer: string;
+  stagingLocation: string;
+  assignedLead: string;
+  supplyLane: string;
+  lastAudit: string;
+  constraints: string;
+};
+
+export type CatalogAsset = {
+  id: string;
+  name: string;
+  assetCode: string;
+  categoryId: string;
+  state: AssetAvailabilityState;
+  description: string;
+  missionFit: string;
+  tags: string[];
+  availability: AssetAvailability;
+};
+
+export type AssetCategoryOption = {
+  id: string;
+  name: string;
+  description: string;
+  count: number;
+};
+
+export type AssetCatalogSection = AssetCategory & {
+  items: CatalogAsset[];
+  totalReadyUnits: number;
+  constrainedItems: number;
+};
+
+export const assetCatalogCategories: AssetCategory[] = [
+  {
+    id: "aerial",
+    name: "Aerial Survey",
+    shortLabel: "Aerial",
+    description:
+      "Rotary drones, beacon rigs, and mapping payloads staged for rapid overflight.",
+    accent: "from-sky-500/20 via-cyan-400/12 to-transparent",
+  },
+  {
+    id: "shelter",
+    name: "Shelter Systems",
+    shortLabel: "Shelter",
+    description:
+      "Portable shelter, climate control, and relief support assets assigned to base camps.",
+    accent: "from-orange-500/20 via-amber-400/12 to-transparent",
+  },
+  {
+    id: "power",
+    name: "Power Reserve",
+    shortLabel: "Power",
+    description:
+      "Mobile batteries, microgrid crates, and power recovery hardware held for field restores.",
+    accent: "from-emerald-500/20 via-lime-400/12 to-transparent",
+  },
+  {
+    id: "coastal",
+    name: "Coastal Logistics",
+    shortLabel: "Coastal",
+    description:
+      "Launch craft, dock tools, and lift support gear reserved for shoreline corridors.",
+    accent: "from-fuchsia-500/20 via-rose-400/12 to-transparent",
+  },
+];
+
+export const assetAvailabilityStateCopy: Record<
+  AssetAvailabilityState,
+  string
+> = {
+  Available:
+    "Asset can be assigned immediately without dropping below the catalog reserve floor.",
+  Reserved:
+    "Asset is healthy, but the current allocation is tied to an active deployment window.",
+  Unavailable:
+    "Asset is intentionally withheld from scheduling until repair, weather clearance, or replenishment closes out.",
+};
+
+export const assetCatalogAssets: CatalogAsset[] = [
+  {
+    id: "meridian-survey-drone",
+    name: "Meridian Survey Drone",
+    assetCode: "AIR-204",
+    categoryId: "aerial",
+    state: "Available",
+    description:
+      "Long-endurance quadcopter used for corridor scans, thermal sweeps, and low-altitude mapping.",
+    missionFit:
+      "Best for early daylight passes where one crew needs both thermal and visual coverage.",
+    tags: ["Thermal", "LiDAR", "8K relay"],
+    availability: {
+      summary: "6 drones ready across the north apron and can launch in under 12 minutes.",
+      readyUnits: 6,
+      reserveFloor: 2,
+      releaseWindow: "Immediate release through 22 Apr, 18:00 local",
+      nextTransfer: "One unit rotates to the canyon relay mission tonight at 21:15.",
+      stagingLocation: "North apron hangar 2",
+      assignedLead: "Overflight Team Delta",
+      supplyLane: "Rotor parts arrive from the mesa depot every morning at 06:30.",
+      lastAudit: "2026-04-19",
+      constraints: "Thermal payload four is waiting on a lens swap after the next return cycle.",
+    },
+  },
+  {
+    id: "halo-beacon-mast",
+    name: "Halo Beacon Mast",
+    assetCode: "AIR-319",
+    categoryId: "aerial",
+    state: "Reserved",
+    description:
+      "Collapsible relay mast that extends signal coverage for drone operations beyond ridge interference.",
+    missionFit:
+      "Usually paired with long-route drone launches when terrain blocks the southern repeater line.",
+    tags: ["Relay", "Portable mast", "Signal extension"],
+    availability: {
+      summary: "2 mast kits remain on hand while 1 is locked to the ridgewatch survey package.",
+      readyUnits: 2,
+      reserveFloor: 1,
+      releaseWindow: "Next free assignment opens after ridgewatch teardown on 23 Apr.",
+      nextTransfer: "Current reserved mast is due back after the 07:40 uplink test tomorrow.",
+      stagingLocation: "Antenna cage B",
+      assignedLead: "Comms Support Crew",
+      supplyLane: "Replacement guy-wire bundles are staged at relay warehouse west.",
+      lastAudit: "2026-04-18",
+      constraints: "Spare mounting feet are below target and should be replenished this week.",
+    },
+  },
+  {
+    id: "drift-shelter-pod",
+    name: "Drift Shelter Pod",
+    assetCode: "SHL-112",
+    categoryId: "shelter",
+    state: "Available",
+    description:
+      "Rapid-deploy shelter pod with climate control, cot storage, and integrated lighting.",
+    missionFit:
+      "Used when a temporary overnight footprint is needed before a full camp transfer can land.",
+    tags: ["Shelter", "HVAC", "Rapid setup"],
+    availability: {
+      summary: "4 pods are staged in the east yard with climate packs already loaded.",
+      readyUnits: 4,
+      reserveFloor: 2,
+      releaseWindow: "Open for assignment through the weekend weather cycle.",
+      nextTransfer: "No transfers planned before the Friday field briefing.",
+      stagingLocation: "East yard shelter row",
+      assignedLead: "Camp Operations",
+      supplyLane: "Canvas patch kits replenish from central stores on Tuesday and Friday.",
+      lastAudit: "2026-04-20",
+      constraints: "Pod 3 carries a cosmetic panel dent but remains certified for service.",
+    },
+  },
+  {
+    id: "ember-water-hub",
+    name: "Ember Water Hub",
+    assetCode: "SHL-241",
+    categoryId: "shelter",
+    state: "Reserved",
+    description:
+      "Filtered water and wash station module bundled with camp sanitation and refill hardware.",
+    missionFit:
+      "Best for mid-duration staging zones that need potable water service without a full utility trailer.",
+    tags: ["Water", "Sanitation", "Camp support"],
+    availability: {
+      summary: "1 hub is committed to shoreline camp Bravo while 1 standby unit remains sealed.",
+      readyUnits: 1,
+      reserveFloor: 1,
+      releaseWindow: "Standby unit can move now, reserved unit clears on 24 Apr after inspection.",
+      nextTransfer: "Bravo handoff returns to the depot after the coastal medical drill closes.",
+      stagingLocation: "Camp support lane 4",
+      assignedLead: "Relief Logistics",
+      supplyLane: "Filter packs flow through municipal supply every 48 hours.",
+      lastAudit: "2026-04-17",
+      constraints: "Any second deployment requires extra refill bladders from the warehouse annex.",
+    },
+  },
+  {
+    id: "atlas-cell-cart",
+    name: "Atlas Cell Cart",
+    assetCode: "PWR-508",
+    categoryId: "power",
+    state: "Unavailable",
+    description:
+      "Towable high-capacity battery cart for supporting clinic tents and mobile command posts.",
+    missionFit:
+      "Preferred when short deployment windows need quiet power without spinning up generators.",
+    tags: ["Battery", "Mobile power", "Clinic support"],
+    availability: {
+      summary: "0 carts ready while the primary inverter stack is under bench repair.",
+      readyUnits: 0,
+      reserveFloor: 1,
+      releaseWindow: "Repair target is 25 Apr pending inverter validation.",
+      nextTransfer: "Once repaired, the cart is tentatively booked for command post standby.",
+      stagingLocation: "Power bench south",
+      assignedLead: "Grid Recovery Unit",
+      supplyLane: "Refurbished inverter modules are due from the harbor lab tomorrow evening.",
+      lastAudit: "2026-04-20",
+      constraints: "Dispatch remains blocked until both the inverter swap and load soak complete.",
+    },
+  },
+  {
+    id: "pulse-microgrid-crate",
+    name: "Pulse Microgrid Crate",
+    assetCode: "PWR-612",
+    categoryId: "power",
+    state: "Available",
+    description:
+      "Containerized microgrid bundle with breakers, storage packs, and rapid tie-in hardware.",
+    missionFit:
+      "Used when a field site needs more than emergency backup but less than a full utility trailer.",
+    tags: ["Microgrid", "Breakers", "Field restore"],
+    availability: {
+      summary: "3 crates are charged, balanced, and ready for transport before nightfall.",
+      readyUnits: 3,
+      reserveFloor: 1,
+      releaseWindow: "Immediate release, with one crate held for overnight storm contingency.",
+      nextTransfer: "A single crate is tentatively assigned to the canyon clinic on 21 Apr.",
+      stagingLocation: "South utility spine",
+      assignedLead: "Power Staging Crew",
+      supplyLane: "Breaker cartridges and cooling loops replenish from the metro depot daily.",
+      lastAudit: "2026-04-19",
+      constraints: "Route planning must account for the low bridge on the old service road.",
+    },
+  },
+  {
+    id: "tidebridge-dock-skiff",
+    name: "Tidebridge Dock Skiff",
+    assetCode: "SEA-087",
+    categoryId: "coastal",
+    state: "Reserved",
+    description:
+      "Shallow-draft skiff used for dock-to-shore shuttle runs when the fixed pier is congested.",
+    missionFit:
+      "Best for fast personnel and crate transfers along tidal inlets where larger craft cannot berth.",
+    tags: ["Marine", "Shuttle", "Low draft"],
+    availability: {
+      summary: "1 skiff is on active harbor rotation and the backup hull remains fueled at berth.",
+      readyUnits: 1,
+      reserveFloor: 1,
+      releaseWindow: "Backup skiff can be reassigned after the 14:30 tide update.",
+      nextTransfer: "Active rotation closes after the evening med-supply shuttle.",
+      stagingLocation: "Berth C south finger",
+      assignedLead: "Harbor Transit Team",
+      supplyLane: "Fuel and spare prop kits replenish through dock services each morning.",
+      lastAudit: "2026-04-18",
+      constraints: "Crosswind restrictions apply once sustained gusts move above 28 knots.",
+    },
+  },
+  {
+    id: "breakwater-lift-sled",
+    name: "Breakwater Lift Sled",
+    assetCode: "SEA-143",
+    categoryId: "coastal",
+    state: "Available",
+    description:
+      "Low-profile lift sled for moving palletized cargo over unstable dock plates and ramps.",
+    missionFit:
+      "Usually paired with the skiff route when relief pallets need to bypass the crane queue.",
+    tags: ["Lift assist", "Dock cargo", "Pallet transfer"],
+    availability: {
+      summary: "5 sleds are staged near the east marina gate with two crews already certified.",
+      readyUnits: 5,
+      reserveFloor: 2,
+      releaseWindow: "Open all day, with no conflicting reservations on the board.",
+      nextTransfer: "No scheduled moves until the late cargo sweep at 19:10.",
+      stagingLocation: "East marina gate",
+      assignedLead: "Shoreline Handling Team",
+      supplyLane: "Replacement rollers and straps restock from dock workshop stock.",
+      lastAudit: "2026-04-20",
+      constraints: "Two sleds are rated only for medium-load pallets until bearing upgrades land.",
+    },
+  },
+];
+
+export function getAssetCategoryById(categoryId: string) {
+  return assetCatalogCategories.find((category) => category.id === categoryId);
+}
+
+export function getAssetById(assetId: string) {
+  return assetCatalogAssets.find((asset) => asset.id === assetId);
+}
+
+export function getAssetCategoryOptions(
+  items: CatalogAsset[],
+  categories: AssetCategory[],
+): AssetCategoryOption[] {
+  return [
+    {
+      id: "all",
+      name: "All Assets",
+      description: "Every staged asset and availability track in the catalog.",
+      count: items.length,
+    },
+    ...categories.map((category) => ({
+      id: category.id,
+      name: category.name,
+      description: category.description,
+      count: items.filter((item) => item.categoryId === category.id).length,
+    })),
+  ];
+}
+
+function matchesCatalogSearch(asset: CatalogAsset, normalizedQuery: string) {
+  if (!normalizedQuery) {
+    return true;
+  }
+
+  const haystack = [
+    asset.name,
+    asset.assetCode,
+    asset.description,
+    asset.missionFit,
+    asset.state,
+    asset.availability.summary,
+    asset.availability.releaseWindow,
+    asset.availability.stagingLocation,
+    asset.availability.assignedLead,
+    asset.availability.supplyLane,
+    asset.availability.constraints,
+    asset.tags.join(" "),
+  ]
+    .join(" ")
+    .toLowerCase();
+
+  return haystack.includes(normalizedQuery);
+}
+
+export function getAssetCatalogSections(
+  items: CatalogAsset[],
+  categories: AssetCategory[],
+  activeCategoryId: string,
+  searchQuery: string,
+): AssetCatalogSection[] {
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const filteredItems = items.filter((item) =>
+    matchesCatalogSearch(item, normalizedQuery),
+  );
+  const visibleCategories =
+    activeCategoryId === "all"
+      ? categories
+      : categories.filter((category) => category.id === activeCategoryId);
+
+  return visibleCategories
+    .map((category) => {
+      const sectionItems = filteredItems.filter(
+        (item) => item.categoryId === category.id,
+      );
+
+      return {
+        ...category,
+        items: sectionItems,
+        totalReadyUnits: sectionItems.reduce(
+          (sum, item) => sum + item.availability.readyUnits,
+          0,
+        ),
+        constrainedItems: sectionItems.filter(
+          (item) => item.state !== "Available",
+        ).length,
+      };
+    })
+    .filter((section) => section.items.length > 0);
+}

--- a/src/data/asset-catalog.ts
+++ b/src/data/asset-catalog.ts
@@ -93,6 +93,36 @@ export const assetAvailabilityStateCopy: Record<
     "Asset is intentionally withheld from scheduling until repair, weather clearance, or replenishment closes out.",
 };
 
+export const assetAvailabilityStateStyles: Record<
+  AssetAvailabilityState,
+  {
+    badge: string;
+    dot: string;
+    selectedBadge: string;
+    emphasis: string;
+  }
+> = {
+  Available: {
+    badge: "border-emerald-200 bg-emerald-50 text-emerald-700",
+    dot: "bg-emerald-500",
+    selectedBadge:
+      "border-emerald-400/25 bg-emerald-400/14 text-emerald-50",
+    emphasis: "border-emerald-400/25 bg-emerald-400/12 text-emerald-50",
+  },
+  Reserved: {
+    badge: "border-amber-200 bg-amber-50 text-amber-700",
+    dot: "bg-amber-500",
+    selectedBadge: "border-amber-400/25 bg-amber-400/14 text-amber-50",
+    emphasis: "border-amber-400/25 bg-amber-400/12 text-amber-50",
+  },
+  Unavailable: {
+    badge: "border-rose-200 bg-rose-50 text-rose-700",
+    dot: "bg-rose-500",
+    selectedBadge: "border-rose-400/25 bg-rose-400/14 text-rose-50",
+    emphasis: "border-rose-400/25 bg-rose-400/12 text-rose-50",
+  },
+};
+
 export const assetCatalogAssets: CatalogAsset[] = [
   {
     id: "meridian-survey-drone",


### PR DESCRIPTION
Closes #128

## Summary
- add mocked asset catalog categories, assets, and availability metadata
- build searchable category tabs, grouped asset cards, and a focused availability detail panel
- cover the route with tests for initial render, filtering, and asset selection

## Validation
- npm run lint
- npm test -- src/app/asset-catalog/page.test.tsx
- npm run build
