### PR TITLE
feat: build scenario board route

### DIFF
--- a/src/app/scenario-board/_components/decision-prompt-list.tsx
+++ b/src/app/scenario-board/_components/decision-prompt-list.tsx
@@ -1,0 +1,98 @@
+import type { ScenarioDecisionPrompt } from "../_data/scenario-board-data";
+
+type DecisionPromptListProps = {
+  prompts: ScenarioDecisionPrompt[];
+  notes: string[];
+};
+
+export function DecisionPromptList({
+  prompts,
+  notes,
+}: DecisionPromptListProps) {
+  return (
+    <aside
+      aria-labelledby="decision-prompts-heading"
+      className="rounded-[1.9rem] border border-slate-200 bg-white p-6 shadow-[0_18px_60px_rgba(15,23,42,0.08)] sm:p-7"
+    >
+      <div className="space-y-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-500">
+          Decision prompts
+        </p>
+        <h2
+          id="decision-prompts-heading"
+          className="text-3xl font-semibold tracking-tight text-slate-950"
+        >
+          Questions to settle before execution starts
+        </h2>
+        <p className="text-sm leading-7 text-slate-600">
+          These prompts frame the next planning review around owner, timing, and
+          explicit trade-offs instead of open-ended debate.
+        </p>
+      </div>
+
+      <div aria-label="Decision prompts" className="mt-6 grid gap-4" role="list">
+        {prompts.map((prompt) => (
+          <article
+            key={prompt.id}
+            className="rounded-[1.45rem] border border-slate-200 bg-slate-50 px-5 py-5"
+            role="listitem"
+          >
+            <div className="flex flex-wrap items-center gap-3">
+              <p className="rounded-full bg-slate-950 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-white">
+                {prompt.owner}
+              </p>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                {prompt.reviewWindow}
+              </p>
+            </div>
+
+            <h3 className="mt-4 text-xl font-semibold tracking-tight text-slate-950">
+              {prompt.title}
+            </h3>
+            <p className="mt-3 text-sm leading-7 text-slate-700">
+              {prompt.question}
+            </p>
+            <p className="mt-3 text-sm leading-6 text-slate-600">
+              {prompt.framing}
+            </p>
+
+            <ul className="mt-5 grid gap-3" role="list">
+              {prompt.options.map((option) => (
+                <li
+                  key={option.label}
+                  className="rounded-[1.1rem] border border-slate-200 bg-white px-4 py-4"
+                >
+                  <p className="text-sm font-semibold text-slate-950">
+                    {option.label}
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-slate-700">
+                    {option.impact}
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-slate-600">
+                    {option.risk}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+
+      <div className="mt-6 rounded-[1.45rem] border border-slate-200 bg-slate-50 px-5 py-5">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+          Board notes
+        </p>
+        <ul aria-label="Board notes" className="mt-4 grid gap-3" role="list">
+          {notes.map((note) => (
+            <li
+              key={note}
+              className="rounded-[1rem] border border-slate-200 bg-white px-4 py-4 text-sm leading-6 text-slate-700"
+            >
+              {note}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </aside>
+  );
+}

--- a/src/app/scenario-board/_components/outcome-matrix.tsx
+++ b/src/app/scenario-board/_components/outcome-matrix.tsx
@@ -1,0 +1,126 @@
+import type {
+  ScenarioBoardScenario,
+  ScenarioOutcomeTone,
+  ScenarioOutcomeMatrixRow,
+} from "../_data/scenario-board-data";
+
+const toneLabel: Record<ScenarioOutcomeTone, string> = {
+  strong: "Low risk",
+  balanced: "Moderate risk",
+  fragile: "High risk",
+};
+
+type OutcomeMatrixProps = {
+  scenarios: ScenarioBoardScenario[];
+  title: string;
+  description: string;
+  footer: string;
+  rows: ScenarioOutcomeMatrixRow[];
+};
+
+export function OutcomeMatrix({
+  scenarios,
+  title,
+  description,
+  footer,
+  rows,
+}: OutcomeMatrixProps) {
+  return (
+    <section
+      aria-labelledby="outcome-matrix-heading"
+      className="rounded-[2rem] border border-slate-200 bg-white p-6 shadow-[0_18px_60px_rgba(15,23,42,0.08)] sm:p-8"
+    >
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-500">
+            Outcome matrix
+          </p>
+          <h2
+            id="outcome-matrix-heading"
+            className="text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl"
+          >
+            Compare likely outcomes before you commit
+          </h2>
+        </div>
+        <p className="max-w-3xl text-sm leading-7 text-slate-600">
+          {description}
+        </p>
+      </div>
+
+      <div className="mt-6 overflow-x-auto">
+        <table aria-label={title} className="min-w-[64rem] border-separate border-spacing-y-4">
+          <caption className="sr-only">{title}</caption>
+          <thead>
+            <tr>
+              <th
+                className="rounded-[1.35rem] bg-slate-100 px-5 py-5 text-left align-bottom"
+                scope="col"
+              >
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                  Decision factor
+                </p>
+                <p className="mt-3 text-lg font-semibold text-slate-950">
+                  What changes if the board picks this lane?
+                </p>
+              </th>
+              {scenarios.map((scenario) => (
+                <th key={scenario.id} className="px-4 text-left align-bottom" scope="col">
+                  <div className="rounded-[1.35rem] border border-slate-200 bg-slate-50 px-5 py-5">
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                      {scenario.label}
+                    </p>
+                    <p className="mt-2 text-lg font-semibold text-slate-950">
+                      {scenario.title}
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-slate-600">
+                      {scenario.signal}
+                    </p>
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.id}>
+                <th
+                  className="rounded-[1.35rem] bg-slate-100 px-5 py-5 text-left align-top"
+                  scope="row"
+                >
+                  <p className="text-sm font-semibold text-slate-950">{row.criterion}</p>
+                  <p className="mt-2 text-sm leading-6 text-slate-600">
+                    {row.whyItMatters}
+                  </p>
+                </th>
+
+                {scenarios.map((scenario) => {
+                  const outcome = row.outcomes[scenario.id];
+
+                  return (
+                    <td key={`${row.id}-${scenario.id}`} className="px-4 align-top">
+                      <div className="rounded-[1.35rem] border border-slate-200 bg-slate-50 px-5 py-5">
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+                          {toneLabel[outcome.tone]}
+                        </p>
+                        <p className="mt-2 text-base font-semibold text-slate-950">
+                          {outcome.label}
+                        </p>
+                        <p className="mt-2 text-sm leading-6 text-slate-700">
+                          {outcome.detail}
+                        </p>
+                      </div>
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-5 rounded-[1.35rem] border border-slate-200 bg-slate-50 px-5 py-4">
+        <p className="text-sm leading-7 text-slate-600">{footer}</p>
+      </div>
+    </section>
+  );
+}

--- a/src/app/scenario-board/_components/scenario-card.tsx
+++ b/src/app/scenario-board/_components/scenario-card.tsx
@@ -1,0 +1,114 @@
+import type { ScenarioBoardScenario } from "../_data/scenario-board-data";
+
+const toneLabel = {
+  recommended: "Low-risk lane",
+  watch: "Moderate-risk lane",
+  fallback: "High-risk lane",
+} as const;
+
+type ScenarioCardProps = {
+  scenario: ScenarioBoardScenario;
+};
+
+export function ScenarioCard({ scenario }: ScenarioCardProps) {
+  return (
+    <article
+      className="rounded-[1.75rem] border border-slate-200 bg-white px-6 py-6 shadow-[0_18px_60px_rgba(15,23,42,0.08)]"
+      role="listitem"
+    >
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div className="max-w-3xl space-y-4">
+          <div className="flex flex-wrap items-center gap-3">
+            <p className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-700">
+              {scenario.label}
+            </p>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              {toneLabel[scenario.tone]}
+            </p>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              {scenario.window}
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            <h3 className="text-2xl font-semibold tracking-tight text-slate-950">
+              {scenario.title}
+            </h3>
+            <p className="text-sm leading-7 text-slate-600 sm:text-base">
+              {scenario.summary}
+            </p>
+            <p className="text-sm leading-7 text-slate-700">{scenario.objective}</p>
+          </div>
+        </div>
+
+        <div className="grid gap-3 rounded-[1.4rem] border border-slate-200 bg-slate-50 px-4 py-4 sm:grid-cols-2 lg:min-w-[18rem] lg:grid-cols-1">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+              Lead
+            </p>
+            <p className="mt-2 text-sm font-medium text-slate-900">{scenario.lead}</p>
+          </div>
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+              Support
+            </p>
+            <p className="mt-2 text-sm font-medium text-slate-900">
+              {scenario.support}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-6 grid gap-5 xl:grid-cols-[minmax(0,1fr)_minmax(260px,0.92fr)]">
+        <div className="rounded-[1.35rem] border border-slate-200 bg-slate-50 px-5 py-5">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Pressure point
+          </p>
+          <p className="mt-3 text-sm leading-7 text-slate-700">
+            {scenario.pressurePoint}
+          </p>
+          <p className="mt-4 text-sm leading-7 text-slate-700">{scenario.signal}</p>
+        </div>
+
+        <div aria-label={`${scenario.title} measures`} className="grid gap-3 sm:grid-cols-3 xl:grid-cols-1" role="list">
+          {scenario.measures.map((measure) => (
+            <div
+              key={measure.label}
+              className="rounded-[1.2rem] border border-slate-200 bg-slate-50 px-4 py-4"
+              role="listitem"
+            >
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                {measure.label}
+              </p>
+              <p className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">
+                {measure.value}
+              </p>
+              <p className="mt-2 text-sm leading-6 text-slate-600">
+                {measure.detail}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-6 space-y-3">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+          Critical checkpoints
+        </p>
+        <ul className="grid gap-3" role="list">
+          {scenario.checkpoints.map((checkpoint, index) => (
+            <li
+              key={checkpoint}
+              className="flex items-start gap-3 rounded-[1.2rem] border border-slate-200 bg-slate-50 px-4 py-4 text-sm leading-6 text-slate-700"
+            >
+              <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-slate-950 text-sm font-semibold text-white">
+                {index + 1}
+              </span>
+              <span>{checkpoint}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </article>
+  );
+}

--- a/src/app/scenario-board/_data/scenario-board-data.ts
+++ b/src/app/scenario-board/_data/scenario-board-data.ts
@@ -1,0 +1,438 @@
+export type ScenarioBoardScenarioId =
+  | "hybrid-buffer"
+  | "airbridge-burst"
+  | "sealift-stretch";
+
+export type ScenarioCardTone = "recommended" | "watch" | "fallback";
+
+export type ScenarioOutcomeTone = "strong" | "balanced" | "fragile";
+
+export type ScenarioBoardScenario = {
+  id: ScenarioBoardScenarioId;
+  label: string;
+  title: string;
+  summary: string;
+  objective: string;
+  window: string;
+  lead: string;
+  support: string;
+  pressurePoint: string;
+  signal: string;
+  tone: ScenarioCardTone;
+  measures: Array<{
+    label: string;
+    value: string;
+    detail: string;
+  }>;
+  checkpoints: string[];
+};
+
+export type ScenarioDecisionPrompt = {
+  id: string;
+  title: string;
+  question: string;
+  framing: string;
+  owner: string;
+  reviewWindow: string;
+  options: Array<{
+    label: string;
+    impact: string;
+    risk: string;
+  }>;
+};
+
+export type ScenarioOutcomeMatrixRow = {
+  id: string;
+  criterion: string;
+  whyItMatters: string;
+  outcomes: Record<
+    ScenarioBoardScenarioId,
+    {
+      label: string;
+      detail: string;
+      tone: ScenarioOutcomeTone;
+    }
+  >;
+};
+
+export const scenarioBoardSummary = {
+  eyebrow: "Scenario Board",
+  title: "Pressure-test the next move before the window closes.",
+  description:
+    "This planning surface keeps scenario options, decision prompts, and outcome comparisons in one route so operators can decide with trade-offs visible instead of scattered across notes.",
+  stats: [
+    {
+      label: "Scenario lanes",
+      value: "3",
+      detail: "Each lane frames a distinct posture for timing, spend, and resilience.",
+    },
+    {
+      label: "Decision prompts",
+      value: "3",
+      detail: "Prompts are tuned for the next planning review rather than post-facto analysis.",
+    },
+    {
+      label: "Outcome checks",
+      value: "5",
+      detail: "The comparison matrix surfaces where every option helps or hurts the operating plan.",
+    },
+  ],
+  boardNotes: [
+    "Treat the matrix as a planning aid, not an approval memo. It exists to sharpen the discussion.",
+    "When the demand signal changes, update the outcome row detail before rewriting the whole card set.",
+    "Use the recommended lane as the baseline and keep one faster and one cheaper fallback on the page.",
+  ],
+};
+
+export const scenarioBoardScenarios: ScenarioBoardScenario[] = [
+  {
+    id: "hybrid-buffer",
+    label: "Recommended",
+    title: "Hybrid Buffer Route",
+    summary:
+      "Split the release across a near-term air tranche and a scheduled ground buffer so the team protects speed without burning the full expedite budget.",
+    objective:
+      "Preserve service confidence while keeping enough slack in the system to absorb a second wave of requests tomorrow.",
+    window: "Activate within 18 hours",
+    lead: "Regional operations lead",
+    support: "Carrier desk + inventory planner",
+    pressurePoint:
+      "Needs supplier release confirmation before the late pickup cutoff to keep both tranches aligned.",
+    signal:
+      "Strongest balance of activation speed, margin protection, and fallback coverage if demand changes mid-cycle.",
+    tone: "recommended",
+    measures: [
+      {
+        label: "ETA confidence",
+        value: "88%",
+        detail: "Uses two delivery rails with a shared handoff plan.",
+      },
+      {
+        label: "Budget posture",
+        value: "+8%",
+        detail: "Higher than baseline, but below full expedite spend.",
+      },
+      {
+        label: "Fallback depth",
+        value: "High",
+        detail: "Ground tranche can absorb late order changes with minimal rework.",
+      },
+    ],
+    checkpoints: [
+      "Lock the split quantity before supplier dock release at 18:00 local.",
+      "Reserve one dedicated handoff window for the air tranche to avoid dock queue bleed.",
+      "Publish a customer-facing contingency note before the planning review closes.",
+    ],
+  },
+  {
+    id: "airbridge-burst",
+    label: "Fastest path",
+    title: "Airbridge Burst",
+    summary:
+      "Push the full release through priority air capacity to maximize speed and compress the recovery window into a single operating cycle.",
+    objective:
+      "Reduce customer wait time immediately when service-level risk outweighs the cost of concentrated expedite spend.",
+    window: "Activate within 6 hours",
+    lead: "Expedite coordinator",
+    support: "Finance partner + customer success lead",
+    pressurePoint:
+      "Carrier capacity and surcharge approvals both need same-shift signoff before the booking can be held.",
+    signal:
+      "Best if the next 24 hours are the only concern, but it creates the thinnest margin for downstream disruption.",
+    tone: "watch",
+    measures: [
+      {
+        label: "ETA confidence",
+        value: "94%",
+        detail: "Fastest path if booking remains intact end to end.",
+      },
+      {
+        label: "Budget posture",
+        value: "+24%",
+        detail: "Highest spend concentration of the three options.",
+      },
+      {
+        label: "Fallback depth",
+        value: "Low",
+        detail: "Replanning gets harder once the shipment is committed to air.",
+      },
+    ],
+    checkpoints: [
+      "Confirm finance coverage for the surcharge delta before tendering the booking.",
+      "Secure customer agreement on the premium path before switching all volume to air.",
+      "Hold one backup carrier contact in reserve in case the first booking slips.",
+    ],
+  },
+  {
+    id: "sealift-stretch",
+    label: "Cost guardrail",
+    title: "Sealift Stretch",
+    summary:
+      "Delay the release into a consolidated lower-cost lane and rely on buffer stock messaging to protect spend during a volatile demand cycle.",
+    objective:
+      "Keep budget pressure contained while retaining enough communication coverage to avoid surprise escalations.",
+    window: "Activate within 36 hours",
+    lead: "Network planner",
+    support: "Procurement + account operations",
+    pressurePoint:
+      "Only works if customers accept a longer promise window and the regional buffer stays available.",
+    signal:
+      "Cheapest option, but it leaves the board with the most exposure if demand keeps accelerating through the week.",
+    tone: "fallback",
+    measures: [
+      {
+        label: "ETA confidence",
+        value: "73%",
+        detail: "More vulnerable to cutoffs and downstream congestion.",
+      },
+      {
+        label: "Budget posture",
+        value: "-4%",
+        detail: "Only lane that improves spend against baseline.",
+      },
+      {
+        label: "Fallback depth",
+        value: "Medium",
+        detail: "Can pivot later, but only with service promises already softened.",
+      },
+    ],
+    checkpoints: [
+      "Validate regional buffer inventory before messaging any revised promise date.",
+      "Issue a customer briefing that explains the slower lane and the recovery trigger.",
+      "Set a hard reevaluation point after the next demand forecast refresh.",
+    ],
+  },
+];
+
+export const scenarioDecisionPrompts: ScenarioDecisionPrompt[] = [
+  {
+    id: "demand-spike",
+    title: "If demand spikes again tomorrow, what breaks first?",
+    question:
+      "Choose whether the next planning review is protecting customer wait time, holding margin, or preserving the easiest recovery path.",
+    framing:
+      "This prompt exists to force a declared priority before the team starts arguing over tactics in the room.",
+    owner: "Ops director",
+    reviewWindow: "Review at 09:30 planning standup",
+    options: [
+      {
+        label: "Protect customer wait time",
+        impact:
+          "Pushes the board toward Airbridge Burst or a larger hybrid air tranche.",
+        risk: "Raises cost exposure quickly and shortens the fallback path.",
+      },
+      {
+        label: "Protect margin",
+        impact:
+          "Keeps Sealift Stretch in scope and limits premium capacity usage.",
+        risk: "Service confidence softens if the forecast proves too conservative.",
+      },
+      {
+        label: "Protect recovery options",
+        impact:
+          "Favors the Hybrid Buffer Route because it preserves multiple next moves.",
+        risk: "May feel slower than a full expedite response in the first 12 hours.",
+      },
+    ],
+  },
+  {
+    id: "supplier-alignment",
+    title: "Which dependency deserves escalation before execution?",
+    question:
+      "Escalate the dependency that can collapse more than one scenario lane if it slips, even if it is not the loudest issue yet.",
+    framing:
+      "The goal is to spend scarce leadership attention on the dependency with the broadest blast radius.",
+    owner: "Program manager",
+    reviewWindow: "Reconfirm before supplier cutoff",
+    options: [
+      {
+        label: "Supplier release timing",
+        impact:
+          "Unlocks the Hybrid Buffer Route and stabilizes every downstream handoff.",
+        risk: "If missed, both speed and fallback quality degrade at the same time.",
+      },
+      {
+        label: "Carrier capacity hold",
+        impact:
+          "Protects Airbridge Burst if speed becomes the only objective that matters.",
+        risk: "Capacity can be expensive to hold without certainty on final volume.",
+      },
+      {
+        label: "Customer promise reset",
+        impact:
+          "Makes Sealift Stretch safer by reducing surprise escalations after the shift.",
+        risk: "Once the promise moves, reversing course creates trust friction.",
+      },
+    ],
+  },
+  {
+    id: "recovery-trigger",
+    title: "What signal should trigger a scenario change mid-cycle?",
+    question:
+      "Define a visible threshold now so the team is not improvising a scenario switch when the route is already under stress.",
+    framing:
+      "A clean trigger protects the operator from late subjective debates and keeps the handoff language crisp.",
+    owner: "Planning lead",
+    reviewWindow: "Publish with the scenario decision",
+    options: [
+      {
+        label: "Forecast variance over 12%",
+        impact:
+          "Moves the board toward more air exposure if incoming volume outruns the hybrid buffer.",
+        risk: "A noisy forecast could create churn if the threshold is too sensitive.",
+      },
+      {
+        label: "Customer escalation volume",
+        impact:
+          "Changes the decision when service pain becomes visible faster than the operational metrics.",
+        risk: "Escalations can lag the true disruption signal by several hours.",
+      },
+      {
+        label: "Supplier release miss",
+        impact:
+          "Forces an immediate fallback because the hybrid plan depends on synchronized release timing.",
+        risk: "Requires tight monitoring around the cutoff or the trigger arrives too late.",
+      },
+    ],
+  },
+];
+
+export const scenarioOutcomeMatrix = {
+  title: "Scenario outcome matrix",
+  description:
+    "Compare the likely operating outcome for each scenario before selecting the lane that will anchor the plan.",
+  footer:
+    "On smaller screens the matrix scrolls horizontally so the criteria stay readable without collapsing the cell detail.",
+  rows: [
+    {
+      id: "activation-speed",
+      criterion: "Activation speed",
+      whyItMatters:
+        "Shows how quickly the team can turn the plan into a live shipment without waiting for a second review.",
+      outcomes: {
+        "hybrid-buffer": {
+          label: "Rapid but controlled",
+          detail:
+            "Needs one coordinated supplier release, then both tranches can move in the same shift.",
+          tone: "strong",
+        },
+        "airbridge-burst": {
+          label: "Immediate",
+          detail:
+            "Fastest start if premium capacity and approvals are already lined up.",
+          tone: "strong",
+        },
+        "sealift-stretch": {
+          label: "Delayed",
+          detail:
+            "Consolidation improves spend but adds at least one more decision cycle before go-live.",
+          tone: "fragile",
+        },
+      },
+    },
+    {
+      id: "budget-exposure",
+      criterion: "Budget exposure",
+      whyItMatters:
+        "Clarifies whether the lane concentrates premium cost now or preserves room for future disruption.",
+      outcomes: {
+        "hybrid-buffer": {
+          label: "Managed increase",
+          detail:
+            "Spend rises, but only part of the volume carries premium treatment.",
+          tone: "balanced",
+        },
+        "airbridge-burst": {
+          label: "Highest concentration",
+          detail:
+            "Full expedite spend lands in a single cycle with minimal opportunity to dilute the cost.",
+          tone: "fragile",
+        },
+        "sealift-stretch": {
+          label: "Best guardrail",
+          detail:
+            "Protects the budget baseline and keeps surcharge risk low.",
+          tone: "strong",
+        },
+      },
+    },
+    {
+      id: "service-confidence",
+      criterion: "Service confidence",
+      whyItMatters:
+        "Maps how credible the promise looks to the customer once the decision is communicated.",
+      outcomes: {
+        "hybrid-buffer": {
+          label: "Credible with backup",
+          detail:
+            "Gives customers a fast partial recovery and a clear fallback if volume shifts again.",
+          tone: "strong",
+        },
+        "airbridge-burst": {
+          label: "Strong near-term confidence",
+          detail:
+            "Looks best immediately, but confidence drops sharply if a single booking slips.",
+          tone: "balanced",
+        },
+        "sealift-stretch": {
+          label: "Conditional confidence",
+          detail:
+            "Works only if the revised promise is communicated early and accepted without resistance.",
+          tone: "fragile",
+        },
+      },
+    },
+    {
+      id: "operational-strain",
+      criterion: "Operational strain",
+      whyItMatters:
+        "Highlights whether the lane is likely to overload planners, suppliers, or customer-facing teams during execution.",
+      outcomes: {
+        "hybrid-buffer": {
+          label: "Shared strain",
+          detail:
+            "More coordination upfront, but the workload is distributed across teams and time windows.",
+          tone: "balanced",
+        },
+        "airbridge-burst": {
+          label: "Intense spike",
+          detail:
+            "Creates the sharpest same-day coordination load and leaves little room for recovery mistakes.",
+          tone: "fragile",
+        },
+        "sealift-stretch": {
+          label: "Lower immediate load",
+          detail:
+            "Simpler to execute on day one, but monitoring needs stay elevated longer.",
+          tone: "balanced",
+        },
+      },
+    },
+    {
+      id: "recovery-path",
+      criterion: "Recovery path",
+      whyItMatters:
+        "Shows how easy it is to change course after launch if conditions deteriorate or improve.",
+      outcomes: {
+        "hybrid-buffer": {
+          label: "Best optionality",
+          detail:
+            "Ground buffer and partial air coverage leave the cleanest path for a mid-cycle adjustment.",
+          tone: "strong",
+        },
+        "airbridge-burst": {
+          label: "Thin fallback",
+          detail:
+            "Once the full booking is committed, the route has fewer graceful ways to recover.",
+          tone: "fragile",
+        },
+        "sealift-stretch": {
+          label: "Recoverable with messaging",
+          detail:
+            "The board can still pivot later, but only after resetting the promise a second time.",
+          tone: "balanced",
+        },
+      },
+    },
+  ] satisfies ScenarioOutcomeMatrixRow[],
+};

--- a/src/app/scenario-board/page.tsx
+++ b/src/app/scenario-board/page.tsx
@@ -1,39 +1,145 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
+import { DecisionPromptList } from "./_components/decision-prompt-list";
+import { OutcomeMatrix } from "./_components/outcome-matrix";
+import { ScenarioCard } from "./_components/scenario-card";
+import {
+  scenarioBoardScenarios,
+  scenarioBoardSummary,
+  scenarioDecisionPrompts,
+  scenarioOutcomeMatrix,
+} from "./_data/scenario-board-data";
+
 export const metadata: Metadata = {
   title: "Scenario Board",
-  description: "Minimal planning route scaffold for the scenario board surface.",
+  description:
+    "Planning route for comparing scenario cards, decision prompts, and outcome matrix trade-offs.",
 };
 
 export default function ScenarioBoardPage() {
+  const totalCheckpoints = scenarioBoardScenarios.reduce(
+    (sum, scenario) => sum + scenario.checkpoints.length,
+    0,
+  );
+
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-5xl flex-col gap-8 px-6 py-12 sm:px-10 lg:px-12">
-      <section className="rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] px-6 py-10 shadow-[0_20px_90px_rgba(15,23,42,0.08)] sm:px-10">
-        <div className="flex flex-col gap-6">
-          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-teal-700">
-            Scenario Board
-          </p>
-          <div className="space-y-4">
-            <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-              Scenario board route scaffold.
-            </h1>
-            <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
-              This minimal shell establishes the dedicated route for the
-              planning board before the scenario data, prompts, and outcome
-              matrix are layered in.
-            </p>
+    <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-12">
+      <section className="rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] px-6 py-8 shadow-[0_20px_90px_rgba(15,23,42,0.08)] sm:px-10 sm:py-10">
+        <div className="grid gap-8 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+          <div className="space-y-6">
+            <div className="space-y-4">
+              <p className="text-sm font-semibold uppercase tracking-[0.28em] text-teal-700">
+                {scenarioBoardSummary.eyebrow}
+              </p>
+              <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl lg:text-6xl">
+                {scenarioBoardSummary.title}
+              </h1>
+              <p className="max-w-3xl text-base leading-8 text-slate-600 sm:text-lg">
+                {scenarioBoardSummary.description}
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <a
+                href="#scenario-cards"
+                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
+              >
+                Review scenarios
+              </a>
+              <a
+                href="#outcome-matrix"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+              >
+                Open outcome matrix
+              </a>
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+              >
+                Back to route index
+              </Link>
+            </div>
           </div>
-          <div>
-            <Link
-              href="/"
-              className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
-            >
-              Back to route index
-            </Link>
+
+          <div className="rounded-[1.75rem] border border-slate-200 bg-white px-6 py-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Planning pulse
+            </p>
+            <div className="mt-5 grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
+              {scenarioBoardSummary.stats.map((stat) => (
+                <div
+                  key={stat.label}
+                  className="rounded-[1.25rem] border border-slate-200 bg-slate-50 px-4 py-4"
+                >
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                    {stat.label}
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">
+                    {stat.value}
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-slate-600">
+                    {stat.detail}
+                  </p>
+                </div>
+              ))}
+            </div>
+            <div className="mt-5 rounded-[1.25rem] border border-slate-200 bg-slate-50 px-4 py-4">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                Current board coverage
+              </p>
+              <p className="mt-2 text-sm leading-6 text-slate-700">
+                The route currently tracks {totalCheckpoints} checkpoints across
+                the scenario set so the planning review can compare more than a
+                one-line recommendation.
+              </p>
+            </div>
           </div>
         </div>
       </section>
+
+      <section
+        className="grid gap-6 xl:grid-cols-[minmax(0,1.08fr)_minmax(320px,0.92fr)]"
+        data-testid="scenario-board-panels"
+      >
+        <div id="scenario-cards" className="space-y-5">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-500">
+                Scenario cards
+              </p>
+              <h2 className="text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                Weigh trade-offs across the board
+              </h2>
+            </div>
+            <p className="max-w-3xl text-sm leading-7 text-slate-600">
+              Each card captures the scenario summary, owners, checkpoints, and
+              trade-offs that matter before the planning team commits.
+            </p>
+          </div>
+
+          <div aria-label="Scenario options" className="grid gap-5" role="list">
+            {scenarioBoardScenarios.map((scenario) => (
+              <ScenarioCard key={scenario.id} scenario={scenario} />
+            ))}
+          </div>
+        </div>
+
+        <DecisionPromptList
+          notes={scenarioBoardSummary.boardNotes}
+          prompts={scenarioDecisionPrompts}
+        />
+      </section>
+
+      <div id="outcome-matrix">
+        <OutcomeMatrix
+          description={scenarioOutcomeMatrix.description}
+          footer={scenarioOutcomeMatrix.footer}
+          rows={scenarioOutcomeMatrix.rows}
+          scenarios={scenarioBoardScenarios}
+          title={scenarioOutcomeMatrix.title}
+        />
+      </div>
     </main>
   );
 }

--- a/src/app/scenario-board/page.tsx
+++ b/src/app/scenario-board/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Scenario Board",
+  description: "Minimal planning route scaffold for the scenario board surface.",
+};
+
+export default function ScenarioBoardPage() {
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-5xl flex-col gap-8 px-6 py-12 sm:px-10 lg:px-12">
+      <section className="rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] px-6 py-10 shadow-[0_20px_90px_rgba(15,23,42,0.08)] sm:px-10">
+        <div className="flex flex-col gap-6">
+          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-teal-700">
+            Scenario Board
+          </p>
+          <div className="space-y-4">
+            <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
+              Scenario board route scaffold.
+            </h1>
+            <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
+              This minimal shell establishes the dedicated route for the
+              planning board before the scenario data, prompts, and outcome
+              matrix are layered in.
+            </p>
+          </div>
+          <div>
+            <Link
+              href="/"
+              className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
+            >
+              Back to route index
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- scaffold the `scenario-board` route with a minimal page shell and heading
- establish the dedicated entry point for the planning surface

## Testing
- `npm run lint -- src/app/scenario-board/page.tsx`

Closes #127