### PR TITLE
feat: finalize scenario board route

### DIFF
--- a/src/app/scenario-board/_components/decision-prompt-list.tsx
+++ b/src/app/scenario-board/_components/decision-prompt-list.tsx
@@ -1,4 +1,5 @@
 import type { ScenarioDecisionPrompt } from "../_data/scenario-board-data";
+import styles from "../scenario-board.module.css";
 
 type DecisionPromptListProps = {
   prompts: ScenarioDecisionPrompt[];
@@ -12,19 +13,19 @@ export function DecisionPromptList({
   return (
     <aside
       aria-labelledby="decision-prompts-heading"
-      className="rounded-[1.9rem] border border-slate-200 bg-white p-6 shadow-[0_18px_60px_rgba(15,23,42,0.08)] sm:p-7"
+      className={`${styles.railSurface} rounded-[1.9rem] border border-white/10 p-6 text-slate-50 sm:p-7`}
     >
       <div className="space-y-3">
-        <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-500">
+        <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-300">
           Decision prompts
         </p>
         <h2
           id="decision-prompts-heading"
-          className="text-3xl font-semibold tracking-tight text-slate-950"
+          className="text-3xl font-semibold tracking-tight text-white"
         >
           Questions to settle before execution starts
         </h2>
-        <p className="text-sm leading-7 text-slate-600">
+        <p className="text-sm leading-7 text-slate-300">
           These prompts frame the next planning review around owner, timing, and
           explicit trade-offs instead of open-ended debate.
         </p>
@@ -34,25 +35,23 @@ export function DecisionPromptList({
         {prompts.map((prompt) => (
           <article
             key={prompt.id}
-            className="rounded-[1.45rem] border border-slate-200 bg-slate-50 px-5 py-5"
+            className="rounded-[1.45rem] border border-white/10 bg-slate-950/24 px-5 py-5"
             role="listitem"
           >
             <div className="flex flex-wrap items-center gap-3">
-              <p className="rounded-full bg-slate-950 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-white">
+              <p className="rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-100">
                 {prompt.owner}
               </p>
-              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
                 {prompt.reviewWindow}
               </p>
             </div>
 
-            <h3 className="mt-4 text-xl font-semibold tracking-tight text-slate-950">
+            <h3 className="mt-4 text-xl font-semibold tracking-tight text-white">
               {prompt.title}
             </h3>
-            <p className="mt-3 text-sm leading-7 text-slate-700">
-              {prompt.question}
-            </p>
-            <p className="mt-3 text-sm leading-6 text-slate-600">
+            <p className="mt-3 text-sm leading-7 text-slate-100">{prompt.question}</p>
+            <p className="mt-3 text-sm leading-6 text-slate-300">
               {prompt.framing}
             </p>
 
@@ -60,15 +59,13 @@ export function DecisionPromptList({
               {prompt.options.map((option) => (
                 <li
                   key={option.label}
-                  className="rounded-[1.1rem] border border-slate-200 bg-white px-4 py-4"
+                  className="rounded-[1.1rem] border border-white/8 bg-white/6 px-4 py-4"
                 >
-                  <p className="text-sm font-semibold text-slate-950">
-                    {option.label}
-                  </p>
-                  <p className="mt-2 text-sm leading-6 text-slate-700">
+                  <p className="text-sm font-semibold text-white">{option.label}</p>
+                  <p className="mt-2 text-sm leading-6 text-slate-200">
                     {option.impact}
                   </p>
-                  <p className="mt-2 text-sm leading-6 text-slate-600">
+                  <p className="mt-2 text-sm leading-6 text-slate-400">
                     {option.risk}
                   </p>
                 </li>
@@ -78,15 +75,15 @@ export function DecisionPromptList({
         ))}
       </div>
 
-      <div className="mt-6 rounded-[1.45rem] border border-slate-200 bg-slate-50 px-5 py-5">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+      <div className="mt-6 rounded-[1.45rem] border border-white/10 bg-white/6 px-5 py-5">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-300">
           Board notes
         </p>
         <ul aria-label="Board notes" className="mt-4 grid gap-3" role="list">
           {notes.map((note) => (
             <li
               key={note}
-              className="rounded-[1rem] border border-slate-200 bg-white px-4 py-4 text-sm leading-6 text-slate-700"
+              className="rounded-[1rem] border border-white/10 bg-slate-950/22 px-4 py-4 text-sm leading-6 text-slate-200"
             >
               {note}
             </li>

--- a/src/app/scenario-board/_components/outcome-matrix.tsx
+++ b/src/app/scenario-board/_components/outcome-matrix.tsx
@@ -3,6 +3,13 @@ import type {
   ScenarioOutcomeTone,
   ScenarioOutcomeMatrixRow,
 } from "../_data/scenario-board-data";
+import styles from "../scenario-board.module.css";
+
+const toneClasses: Record<ScenarioOutcomeTone, string> = {
+  strong: styles.cellStrong,
+  balanced: styles.cellBalanced,
+  fragile: styles.cellFragile,
+};
 
 const toneLabel: Record<ScenarioOutcomeTone, string> = {
   strong: "Low risk",
@@ -27,12 +34,13 @@ export function OutcomeMatrix({
 }: OutcomeMatrixProps) {
   return (
     <section
+      id="outcome-matrix"
       aria-labelledby="outcome-matrix-heading"
-      className="rounded-[2rem] border border-slate-200 bg-white p-6 shadow-[0_18px_60px_rgba(15,23,42,0.08)] sm:p-8"
+      className="rounded-[2rem] border border-slate-200/70 bg-[linear-gradient(180deg,rgba(255,251,235,0.98),rgba(255,255,255,0.98))] p-6 shadow-[0_30px_110px_rgba(15,23,42,0.12)] sm:p-8"
     >
       <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div className="space-y-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-500">
+          <p className="text-xs font-semibold uppercase tracking-[0.26em] text-teal-700">
             Outcome matrix
           </p>
           <h2
@@ -47,13 +55,16 @@ export function OutcomeMatrix({
         </p>
       </div>
 
-      <div className="mt-6 overflow-x-auto">
-        <table aria-label={title} className="min-w-[64rem] border-separate border-spacing-y-4">
+      <div
+        className={`${styles.matrixScroll} mt-6 overflow-x-auto`}
+        data-testid="outcome-matrix-wrap"
+      >
+        <table aria-label={title} className={styles.matrixTable}>
           <caption className="sr-only">{title}</caption>
           <thead>
             <tr>
               <th
-                className="rounded-[1.35rem] bg-slate-100 px-5 py-5 text-left align-bottom"
+                className={`${styles.stubCell} px-5 py-5 text-left align-bottom`}
                 scope="col"
               >
                 <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
@@ -64,8 +75,12 @@ export function OutcomeMatrix({
                 </p>
               </th>
               {scenarios.map((scenario) => (
-                <th key={scenario.id} className="px-4 text-left align-bottom" scope="col">
-                  <div className="rounded-[1.35rem] border border-slate-200 bg-slate-50 px-5 py-5">
+                <th
+                  key={scenario.id}
+                  className={`${styles.columnHead} px-4 text-left align-bottom`}
+                  scope="col"
+                >
+                  <div className="rounded-[1.45rem] border border-slate-200 bg-slate-50 px-5 py-5">
                     <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
                       {scenario.label}
                     </p>
@@ -84,7 +99,7 @@ export function OutcomeMatrix({
             {rows.map((row) => (
               <tr key={row.id}>
                 <th
-                  className="rounded-[1.35rem] bg-slate-100 px-5 py-5 text-left align-top"
+                  className={`${styles.stubCell} px-5 py-5 text-left align-top`}
                   scope="row"
                 >
                   <p className="text-sm font-semibold text-slate-950">{row.criterion}</p>
@@ -92,13 +107,14 @@ export function OutcomeMatrix({
                     {row.whyItMatters}
                   </p>
                 </th>
-
                 {scenarios.map((scenario) => {
                   const outcome = row.outcomes[scenario.id];
 
                   return (
                     <td key={`${row.id}-${scenario.id}`} className="px-4 align-top">
-                      <div className="rounded-[1.35rem] border border-slate-200 bg-slate-50 px-5 py-5">
+                      <div
+                        className={`${styles.matrixCell} ${toneClasses[outcome.tone]}`}
+                      >
                         <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
                           {toneLabel[outcome.tone]}
                         </p>

--- a/src/app/scenario-board/_components/scenario-card.tsx
+++ b/src/app/scenario-board/_components/scenario-card.tsx
@@ -1,9 +1,28 @@
 import type { ScenarioBoardScenario } from "../_data/scenario-board-data";
+import styles from "../scenario-board.module.css";
 
-const toneLabel = {
-  recommended: "Low-risk lane",
-  watch: "Moderate-risk lane",
-  fallback: "High-risk lane",
+const toneClasses = {
+  recommended: {
+    label: "Low-risk lane",
+    frame: "border-emerald-300/26",
+    badge: "bg-emerald-100 text-emerald-950",
+    accent: "text-emerald-200",
+    chip: "border-emerald-300/20 bg-emerald-300/10",
+  },
+  watch: {
+    label: "Moderate-risk lane",
+    frame: "border-amber-300/28",
+    badge: "bg-amber-100 text-amber-950",
+    accent: "text-amber-200",
+    chip: "border-amber-300/18 bg-amber-300/10",
+  },
+  fallback: {
+    label: "High-risk lane",
+    frame: "border-sky-300/28",
+    badge: "bg-sky-100 text-sky-950",
+    accent: "text-sky-200",
+    chip: "border-sky-300/18 bg-sky-300/10",
+  },
 } as const;
 
 type ScenarioCardProps = {
@@ -11,79 +30,94 @@ type ScenarioCardProps = {
 };
 
 export function ScenarioCard({ scenario }: ScenarioCardProps) {
+  const tone = toneClasses[scenario.tone];
+
   return (
     <article
-      className="rounded-[1.75rem] border border-slate-200 bg-white px-6 py-6 shadow-[0_18px_60px_rgba(15,23,42,0.08)]"
+      className={`${styles.cardChrome} rounded-[1.75rem] border p-6 text-slate-50 sm:p-7 ${tone.frame}`}
       role="listitem"
     >
-      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+      <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
         <div className="max-w-3xl space-y-4">
           <div className="flex flex-wrap items-center gap-3">
-            <p className="rounded-full bg-slate-100 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-700">
+            <p
+              className={`inline-flex rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.22em] ${tone.badge}`}
+            >
               {scenario.label}
             </p>
-            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-              {toneLabel[scenario.tone]}
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-300">
+              {tone.label}
             </p>
-            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-300">
               {scenario.window}
             </p>
           </div>
 
           <div className="space-y-3">
-            <h3 className="text-2xl font-semibold tracking-tight text-slate-950">
+            <h3 className="text-2xl font-semibold tracking-tight text-white sm:text-[2rem]">
               {scenario.title}
             </h3>
-            <p className="text-sm leading-7 text-slate-600 sm:text-base">
+            <p className="text-sm leading-7 text-slate-200 sm:text-base">
               {scenario.summary}
             </p>
-            <p className="text-sm leading-7 text-slate-700">{scenario.objective}</p>
+            <p className="text-sm leading-7 text-slate-100">{scenario.objective}</p>
           </div>
         </div>
 
-        <div className="grid gap-3 rounded-[1.4rem] border border-slate-200 bg-slate-50 px-4 py-4 sm:grid-cols-2 lg:min-w-[18rem] lg:grid-cols-1">
+        <div className="grid gap-3 rounded-[1.4rem] border border-white/10 bg-white/6 px-4 py-4 sm:grid-cols-2 xl:min-w-[18rem] xl:grid-cols-1">
           <div>
-            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
               Lead
             </p>
-            <p className="mt-2 text-sm font-medium text-slate-900">{scenario.lead}</p>
+            <p className="mt-2 text-sm font-medium text-white">{scenario.lead}</p>
           </div>
           <div>
-            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
               Support
             </p>
-            <p className="mt-2 text-sm font-medium text-slate-900">
-              {scenario.support}
-            </p>
+            <p className="mt-2 text-sm font-medium text-white">{scenario.support}</p>
           </div>
         </div>
       </div>
 
-      <div className="mt-6 grid gap-5 xl:grid-cols-[minmax(0,1fr)_minmax(260px,0.92fr)]">
-        <div className="rounded-[1.35rem] border border-slate-200 bg-slate-50 px-5 py-5">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
-            Pressure point
+      <div className="mt-6 grid gap-5 xl:grid-cols-[minmax(0,1.04fr)_minmax(260px,0.96fr)]">
+        <div className={`rounded-[1.45rem] border px-5 py-5 ${tone.chip}`}>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-300">
+            Decision frame
           </p>
-          <p className="mt-3 text-sm leading-7 text-slate-700">
-            {scenario.pressurePoint}
+          <p className="mt-3 text-base leading-7 text-slate-100">
+            {scenario.objective}
           </p>
-          <p className="mt-4 text-sm leading-7 text-slate-700">{scenario.signal}</p>
+          <p className={`mt-4 text-sm leading-6 ${tone.accent}`}>{scenario.signal}</p>
+
+          <div className="mt-5 rounded-[1.15rem] border border-white/10 bg-slate-950/30 px-4 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+              Pressure point
+            </p>
+            <p className="mt-2 text-sm leading-6 text-slate-200">
+              {scenario.pressurePoint}
+            </p>
+          </div>
         </div>
 
-        <div aria-label={`${scenario.title} measures`} className="grid gap-3 sm:grid-cols-3 xl:grid-cols-1" role="list">
+        <div
+          aria-label={`${scenario.title} measures`}
+          className="grid gap-3 sm:grid-cols-3 xl:grid-cols-1"
+          role="list"
+        >
           {scenario.measures.map((measure) => (
             <div
               key={measure.label}
-              className="rounded-[1.2rem] border border-slate-200 bg-slate-50 px-4 py-4"
+              className="rounded-[1.3rem] border border-white/10 bg-white/7 px-4 py-4"
               role="listitem"
             >
-              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
                 {measure.label}
               </p>
-              <p className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">
+              <p className="mt-2 text-2xl font-semibold tracking-tight text-white">
                 {measure.value}
               </p>
-              <p className="mt-2 text-sm leading-6 text-slate-600">
+              <p className="mt-2 text-sm leading-6 text-slate-300">
                 {measure.detail}
               </p>
             </div>
@@ -92,19 +126,19 @@ export function ScenarioCard({ scenario }: ScenarioCardProps) {
       </div>
 
       <div className="mt-6 space-y-3">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
           Critical checkpoints
         </p>
         <ul className="grid gap-3" role="list">
           {scenario.checkpoints.map((checkpoint, index) => (
             <li
               key={checkpoint}
-              className="flex items-start gap-3 rounded-[1.2rem] border border-slate-200 bg-slate-50 px-4 py-4 text-sm leading-6 text-slate-700"
+              className="flex items-start gap-3 rounded-[1.2rem] border border-white/10 bg-slate-950/24 px-4 py-4"
             >
-              <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-slate-950 text-sm font-semibold text-white">
+              <span className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-white/10 bg-white/10 text-sm font-semibold text-white">
                 {index + 1}
               </span>
-              <span>{checkpoint}</span>
+              <span className="text-sm leading-6 text-slate-200">{checkpoint}</span>
             </li>
           ))}
         </ul>

--- a/src/app/scenario-board/page.test.tsx
+++ b/src/app/scenario-board/page.test.tsx
@@ -1,0 +1,132 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  scenarioBoardScenarios,
+  scenarioBoardSummary,
+  scenarioDecisionPrompts,
+  scenarioOutcomeMatrix,
+} from "./_data/scenario-board-data";
+import ScenarioBoardPage from "./page";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ScenarioBoardPage", () => {
+  it("renders the scenario board shell with its main planning sections", () => {
+    render(<ScenarioBoardPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: scenarioBoardSummary.title,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /weigh trade-offs across the board/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /questions to settle before execution starts/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /compare likely outcomes before you commit/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /open outcome matrix/i }),
+    ).toHaveAttribute("href", "#outcome-matrix");
+  });
+
+  it("renders every scenario card with ownership, measures, and checkpoints", () => {
+    render(<ScenarioBoardPage />);
+
+    const scenarioList = screen.getByRole("list", { name: /scenario options/i });
+
+    expect(scenarioList.querySelectorAll(':scope > [role="listitem"]')).toHaveLength(
+      scenarioBoardScenarios.length,
+    );
+
+    for (const scenario of scenarioBoardScenarios) {
+      const card = within(scenarioList)
+        .getByRole("heading", { name: scenario.title })
+        .closest('[role="listitem"]');
+
+      expect(card).toBeTruthy();
+      expect(card).toHaveTextContent(scenario.lead);
+      expect(card).toHaveTextContent(scenario.support);
+      expect(card).toHaveTextContent(scenario.measures[0].value);
+      expect(card).toHaveTextContent(scenario.checkpoints[0]);
+    }
+  });
+
+  it("renders decision prompts with owners, review windows, and option trade-offs", () => {
+    render(<ScenarioBoardPage />);
+
+    const promptList = screen.getByRole("list", { name: /decision prompts/i });
+
+    expect(promptList.querySelectorAll(':scope > [role="listitem"]')).toHaveLength(
+      scenarioDecisionPrompts.length,
+    );
+
+    for (const prompt of scenarioDecisionPrompts) {
+      const promptCard = within(promptList)
+        .getByRole("heading", { name: prompt.title })
+        .closest('[role="listitem"]');
+
+      expect(promptCard).toBeTruthy();
+      expect(promptCard).toHaveTextContent(prompt.question);
+      expect(promptCard).toHaveTextContent(prompt.owner);
+      expect(promptCard).toHaveTextContent(prompt.reviewWindow);
+      expect(promptCard).toHaveTextContent(prompt.options[0].label);
+      expect(promptCard).toHaveTextContent(prompt.options[0].risk);
+    }
+
+    const notesList = screen.getByRole("list", { name: /board notes/i });
+    expect(within(notesList).getAllByRole("listitem")).toHaveLength(
+      scenarioBoardSummary.boardNotes.length,
+    );
+  });
+
+  it("renders the outcome matrix with every criterion and preserves responsive hooks", () => {
+    render(<ScenarioBoardPage />);
+
+    const matrix = screen.getByRole("table", {
+      name: scenarioOutcomeMatrix.title,
+    });
+    const panelLayout = screen.getByTestId("scenario-board-panels");
+    const matrixWrap = screen.getByTestId("outcome-matrix-wrap");
+
+    expect(panelLayout.className).toContain(
+      "xl:grid-cols-[minmax(0,1.08fr)_minmax(320px,0.92fr)]",
+    );
+    expect(matrixWrap.className).toContain("overflow-x-auto");
+
+    for (const scenario of scenarioBoardScenarios) {
+      expect(within(matrix).getByText(scenario.title)).toBeInTheDocument();
+    }
+
+    for (const row of scenarioOutcomeMatrix.rows) {
+      expect(within(matrix).getByText(row.criterion)).toBeInTheDocument();
+      expect(
+        within(matrix).getByText(row.outcomes["hybrid-buffer"].label),
+      ).toBeInTheDocument();
+      expect(
+        within(matrix).getByText(row.outcomes["airbridge-burst"].label),
+      ).toBeInTheDocument();
+      expect(
+        within(matrix).getByText(row.outcomes["sealift-stretch"].label),
+      ).toBeInTheDocument();
+    }
+
+    expect(screen.getByText(scenarioOutcomeMatrix.footer)).toBeInTheDocument();
+  });
+});

--- a/src/app/scenario-board/page.tsx
+++ b/src/app/scenario-board/page.tsx
@@ -10,6 +10,7 @@ import {
   scenarioDecisionPrompts,
   scenarioOutcomeMatrix,
 } from "./_data/scenario-board-data";
+import styles from "./scenario-board.module.css";
 
 export const metadata: Metadata = {
   title: "Scenario Board",
@@ -18,120 +19,145 @@ export const metadata: Metadata = {
 };
 
 export default function ScenarioBoardPage() {
+  const recommendedScenario =
+    scenarioBoardScenarios.find((scenario) => scenario.tone === "recommended") ??
+    scenarioBoardScenarios[0];
   const totalCheckpoints = scenarioBoardScenarios.reduce(
     (sum, scenario) => sum + scenario.checkpoints.length,
     0,
   );
 
   return (
-    <main className="mx-auto flex w-full max-w-7xl flex-1 flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-12">
-      <section className="rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] px-6 py-8 shadow-[0_20px_90px_rgba(15,23,42,0.08)] sm:px-10 sm:py-10">
-        <div className="grid gap-8 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
-          <div className="space-y-6">
-            <div className="space-y-4">
-              <p className="text-sm font-semibold uppercase tracking-[0.28em] text-teal-700">
-                {scenarioBoardSummary.eyebrow}
-              </p>
-              <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl lg:text-6xl">
-                {scenarioBoardSummary.title}
-              </h1>
-              <p className="max-w-3xl text-base leading-8 text-slate-600 sm:text-lg">
-                {scenarioBoardSummary.description}
-              </p>
-            </div>
+    <main
+      className={`${styles.pageShell} relative min-h-screen overflow-hidden px-6 py-12 text-slate-50 sm:px-10 lg:px-14`}
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute left-0 top-0 h-80 w-80 rounded-full bg-teal-300/10 blur-3xl"
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute bottom-0 right-0 h-96 w-96 rounded-full bg-amber-300/10 blur-3xl"
+      />
 
-            <div className="flex flex-col gap-4 sm:flex-row">
-              <a
-                href="#scenario-cards"
-                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
-              >
-                Review scenarios
-              </a>
-              <a
-                href="#outcome-matrix"
-                className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
-              >
-                Open outcome matrix
-              </a>
-              <Link
-                href="/"
-                className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
-              >
-                Back to route index
-              </Link>
-            </div>
-          </div>
+      <div className="relative mx-auto flex max-w-7xl flex-col gap-8">
+        <section
+          className={`${styles.heroSurface} overflow-hidden rounded-[2.25rem] border border-white/10 px-8 py-8 shadow-[0_34px_120px_rgba(2,6,23,0.42)] sm:px-10 sm:py-10`}
+        >
+          <div className="grid gap-8 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)]">
+            <div className="space-y-6">
+              <div className="space-y-4">
+                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-teal-200/80">
+                  {scenarioBoardSummary.eyebrow}
+                </p>
+                <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-balance text-white sm:text-5xl lg:text-6xl">
+                  {scenarioBoardSummary.title}
+                </h1>
+                <p className="max-w-3xl text-base leading-8 text-slate-200 sm:text-lg">
+                  {scenarioBoardSummary.description}
+                </p>
+              </div>
 
-          <div className="rounded-[1.75rem] border border-slate-200 bg-white px-6 py-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
-            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
-              Planning pulse
-            </p>
-            <div className="mt-5 grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
-              {scenarioBoardSummary.stats.map((stat) => (
-                <div
-                  key={stat.label}
-                  className="rounded-[1.25rem] border border-slate-200 bg-slate-50 px-4 py-4"
+              <div className="flex flex-col gap-4 sm:flex-row">
+                <a
+                  href="#scenario-cards"
+                  className="inline-flex items-center justify-center rounded-full bg-teal-300 px-6 py-3 text-sm font-semibold text-slate-950 transition hover:bg-teal-200"
                 >
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                    {stat.label}
+                  Review scenarios
+                </a>
+                <a
+                  href="#outcome-matrix"
+                  className="inline-flex items-center justify-center rounded-full border border-white/14 bg-white/6 px-6 py-3 text-sm font-semibold text-slate-50 transition hover:border-amber-300/40 hover:bg-white/10"
+                >
+                  Open outcome matrix
+                </a>
+                <Link
+                  href="/"
+                  className="inline-flex items-center justify-center rounded-full border border-white/14 bg-white/6 px-6 py-3 text-sm font-semibold text-slate-50 transition hover:border-white/30 hover:bg-white/10"
+                >
+                  Back to route index
+                </Link>
+              </div>
+            </div>
+
+            <aside className="rounded-[1.8rem] border border-white/10 bg-slate-950/28 p-6 backdrop-blur">
+              <div className="space-y-5">
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-300">
+                    Board pulse
                   </p>
-                  <p className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">
-                    {stat.value}
-                  </p>
-                  <p className="mt-2 text-sm leading-6 text-slate-600">
-                    {stat.detail}
+                  <p className="mt-3 text-3xl font-semibold tracking-tight text-white">
+                    {recommendedScenario.title} is the cleanest starting point.
                   </p>
                 </div>
+
+                <div className="grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
+                  {scenarioBoardSummary.stats.map((stat) => (
+                    <div
+                      key={stat.label}
+                      className="rounded-[1.3rem] border border-white/10 bg-white/7 px-4 py-4"
+                    >
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+                        {stat.label}
+                      </p>
+                      <p className="mt-2 text-2xl font-semibold text-white">
+                        {stat.value}
+                      </p>
+                      <p className="mt-2 text-sm leading-6 text-slate-200">
+                        {stat.detail}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+
+                <div className="rounded-[1.3rem] border border-teal-300/18 bg-teal-300/10 px-4 py-4">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-teal-100/80">
+                    Planning signal
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-slate-100">
+                    The route currently tracks {totalCheckpoints} checkpoints
+                    across all scenarios so the team can compare handoffs, not
+                    just headlines.
+                  </p>
+                </div>
+              </div>
+            </aside>
+          </div>
+        </section>
+
+        <section
+          className="grid gap-6 xl:grid-cols-[minmax(0,1.08fr)_minmax(320px,0.92fr)]"
+          data-testid="scenario-board-panels"
+        >
+          <div id="scenario-cards" className="space-y-5">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-300">
+                  Scenario cards
+                </p>
+                <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+                  Weigh trade-offs across the board
+                </h2>
+              </div>
+              <p className="max-w-3xl text-sm leading-7 text-slate-300">
+                Each card captures the scenario summary, owners, checkpoints,
+                and trade-offs that matter before the planning team commits.
+              </p>
+            </div>
+
+            <div aria-label="Scenario options" className="grid gap-5" role="list">
+              {scenarioBoardScenarios.map((scenario) => (
+                <ScenarioCard key={scenario.id} scenario={scenario} />
               ))}
             </div>
-            <div className="mt-5 rounded-[1.25rem] border border-slate-200 bg-slate-50 px-4 py-4">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                Current board coverage
-              </p>
-              <p className="mt-2 text-sm leading-6 text-slate-700">
-                The route currently tracks {totalCheckpoints} checkpoints across
-                the scenario set so the planning review can compare more than a
-                one-line recommendation.
-              </p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section
-        className="grid gap-6 xl:grid-cols-[minmax(0,1.08fr)_minmax(320px,0.92fr)]"
-        data-testid="scenario-board-panels"
-      >
-        <div id="scenario-cards" className="space-y-5">
-          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-            <div className="space-y-2">
-              <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-500">
-                Scenario cards
-              </p>
-              <h2 className="text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
-                Weigh trade-offs across the board
-              </h2>
-            </div>
-            <p className="max-w-3xl text-sm leading-7 text-slate-600">
-              Each card captures the scenario summary, owners, checkpoints, and
-              trade-offs that matter before the planning team commits.
-            </p>
           </div>
 
-          <div aria-label="Scenario options" className="grid gap-5" role="list">
-            {scenarioBoardScenarios.map((scenario) => (
-              <ScenarioCard key={scenario.id} scenario={scenario} />
-            ))}
-          </div>
-        </div>
+          <DecisionPromptList
+            notes={scenarioBoardSummary.boardNotes}
+            prompts={scenarioDecisionPrompts}
+          />
+        </section>
 
-        <DecisionPromptList
-          notes={scenarioBoardSummary.boardNotes}
-          prompts={scenarioDecisionPrompts}
-        />
-      </section>
-
-      <div id="outcome-matrix">
         <OutcomeMatrix
           description={scenarioOutcomeMatrix.description}
           footer={scenarioOutcomeMatrix.footer}

--- a/src/app/scenario-board/scenario-board.module.css
+++ b/src/app/scenario-board/scenario-board.module.css
@@ -1,0 +1,127 @@
+.pageShell {
+  background-image:
+    radial-gradient(circle at top left, rgba(20, 184, 166, 0.18), transparent 26%),
+    radial-gradient(circle at top right, rgba(251, 191, 36, 0.2), transparent 28%),
+    linear-gradient(180deg, #08131d 0%, #102132 48%, #13283d 100%);
+}
+
+.heroSurface {
+  position: relative;
+  isolation: isolate;
+}
+
+.heroSurface::before {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.12), rgba(15, 23, 42, 0.12)),
+    radial-gradient(circle at top right, rgba(45, 212, 191, 0.12), transparent 38%);
+  z-index: -1;
+}
+
+.heroSurface::after {
+  content: "";
+  position: absolute;
+  right: -5rem;
+  top: -4rem;
+  height: 14rem;
+  width: 14rem;
+  border-radius: 9999px;
+  background: rgba(250, 204, 21, 0.14);
+  filter: blur(56px);
+  z-index: -1;
+}
+
+.cardChrome {
+  background: linear-gradient(180deg, rgba(11, 20, 33, 0.92), rgba(8, 15, 26, 0.98));
+  box-shadow: 0 28px 90px rgba(2, 6, 23, 0.26);
+}
+
+.railSurface {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(15, 23, 42, 0.22)),
+    linear-gradient(180deg, rgba(8, 15, 26, 0.74), rgba(8, 15, 26, 0.9));
+  box-shadow: 0 28px 90px rgba(2, 6, 23, 0.26);
+}
+
+.matrixScroll {
+  padding-bottom: 0.5rem;
+}
+
+.matrixScroll::-webkit-scrollbar {
+  height: 0.75rem;
+}
+
+.matrixScroll::-webkit-scrollbar-track {
+  border-radius: 9999px;
+  background: rgba(226, 232, 240, 0.65);
+}
+
+.matrixScroll::-webkit-scrollbar-thumb {
+  border-radius: 9999px;
+  background: linear-gradient(90deg, rgba(15, 23, 42, 0.48), rgba(13, 148, 136, 0.58));
+}
+
+.matrixTable {
+  min-width: 66rem;
+  border-collapse: separate;
+  border-spacing: 0 1rem;
+}
+
+.stubCell {
+  position: sticky;
+  left: 0;
+  min-width: 18rem;
+  border-radius: 1.5rem;
+  background: linear-gradient(180deg, rgba(255, 251, 235, 0.98), rgba(248, 250, 252, 0.98));
+  box-shadow: 18px 0 32px rgba(248, 250, 252, 0.88);
+  z-index: 2;
+}
+
+.columnHead {
+  min-width: 16rem;
+}
+
+.matrixCell {
+  min-width: 16rem;
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  border-radius: 1.4rem;
+  padding: 1rem 1.05rem;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+}
+
+.cellStrong {
+  background: linear-gradient(180deg, rgba(236, 253, 245, 0.96), rgba(209, 250, 229, 0.94));
+}
+
+.cellBalanced {
+  background: linear-gradient(180deg, rgba(239, 246, 255, 0.96), rgba(219, 234, 254, 0.94));
+}
+
+.cellFragile {
+  background: linear-gradient(180deg, rgba(255, 241, 242, 0.98), rgba(254, 226, 226, 0.96));
+}
+
+@media (min-width: 1280px) {
+  .railSurface {
+    position: sticky;
+    top: 1.5rem;
+  }
+}
+
+@media (max-width: 767px) {
+  .matrixTable {
+    min-width: 54rem;
+  }
+
+  .stubCell {
+    min-width: 14rem;
+  }
+
+  .columnHead,
+  .matrixCell {
+    min-width: 13.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- finish the scenario-board visual treatment with responsive low-, moderate-, and high-risk states
- add render tests for scenario groups, decision prompts, and the outcome matrix
- follow up on #139, which merged before the final styling and test commits landed

## Testing
- `npx eslint src/app/scenario-board --max-warnings 0`
- `npm test`
- `npm run build`

Refs #127