### PR TITLE
feat: add archive vault route

### DIFF
--- a/src/app/archive-vault/_components/archive-vault-detail-panel.tsx
+++ b/src/app/archive-vault/_components/archive-vault-detail-panel.tsx
@@ -1,0 +1,102 @@
+import { ArchiveVaultMetadataBadge } from "./archive-vault-metadata-badge";
+import type { ArchiveVaultSnapshot } from "../_data/archive-vault-data";
+
+type ArchiveVaultDetailPanelProps = {
+  snapshot: ArchiveVaultSnapshot;
+  requestedSnapshotId?: string;
+  selectionFound?: boolean;
+};
+
+export function ArchiveVaultDetailPanel({
+  snapshot,
+  requestedSnapshotId,
+  selectionFound = true,
+}: ArchiveVaultDetailPanelProps) {
+  return (
+    <aside
+      aria-label="Archive vault detail panel"
+      className="rounded-[1.75rem] border border-[var(--line)] bg-[var(--surface)] p-6 shadow-[0_18px_70px_rgba(15,23,42,0.06)] sm:p-7"
+    >
+      <div className="space-y-4">
+        <div className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+            Detail summary
+          </p>
+          <h2 className="text-3xl font-semibold tracking-tight text-slate-950">
+            {snapshot.title}
+          </h2>
+          <p className="text-sm leading-7 text-slate-600 sm:text-base">
+            {snapshot.detailSummary.overview}
+          </p>
+        </div>
+
+        {!selectionFound && requestedSnapshotId ? (
+          <p
+            role="status"
+            className="rounded-2xl border border-amber-300/45 bg-amber-100/60 px-4 py-3 text-sm leading-6 text-amber-950"
+          >
+            Snapshot <span className="font-semibold">{requestedSnapshotId}</span>{" "}
+            was not found. Showing the current vault baseline instead.
+          </p>
+        ) : null}
+
+        <ul className="flex flex-wrap gap-2">
+          {snapshot.metadataBadges.map((badge) => (
+            <ArchiveVaultMetadataBadge
+              key={`${snapshot.id}-${badge.label}-detail`}
+              badge={badge}
+            />
+          ))}
+        </ul>
+      </div>
+
+      <div className="mt-6 grid gap-4 sm:grid-cols-2">
+        <article className="rounded-[1.35rem] border border-slate-200 bg-white/70 p-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Archive label
+          </p>
+          <p className="mt-2 text-lg font-semibold text-slate-950">
+            {snapshot.label}
+          </p>
+          <p className="mt-2 text-sm leading-6 text-slate-600">
+            Sealed {snapshot.archivedLabel}
+          </p>
+        </article>
+
+        <article className="rounded-[1.35rem] border border-slate-200 bg-white/70 p-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Comparison readiness
+          </p>
+          <p className="mt-2 text-sm leading-6 text-slate-700">
+            {snapshot.detailSummary.comparisonReadiness}
+          </p>
+        </article>
+      </div>
+
+      <section className="mt-6 rounded-[1.5rem] border border-slate-200 bg-white/75 p-5">
+        <h3 className="text-lg font-semibold text-slate-950">
+          {snapshot.detailSummary.heading}
+        </h3>
+        <p className="mt-3 text-sm leading-7 text-slate-600">
+          {snapshot.detailSummary.reviewWindow}
+        </p>
+
+        <dl className="mt-5 grid gap-3">
+          {snapshot.detailSummary.rows.map((row) => (
+            <div
+              key={`${snapshot.id}-${row.label}`}
+              className="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-4"
+            >
+              <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                {row.label}
+              </dt>
+              <dd className="mt-2 text-sm leading-6 text-slate-700">
+                {row.value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+    </aside>
+  );
+}

--- a/src/app/archive-vault/_components/archive-vault-detail-panel.tsx
+++ b/src/app/archive-vault/_components/archive-vault-detail-panel.tsx
@@ -1,4 +1,5 @@
 import { ArchiveVaultMetadataBadge } from "./archive-vault-metadata-badge";
+import styles from "../archive-vault.module.css";
 import type { ArchiveVaultSnapshot } from "../_data/archive-vault-data";
 
 type ArchiveVaultDetailPanelProps = {
@@ -13,34 +14,25 @@ export function ArchiveVaultDetailPanel({
   selectionFound = true,
 }: ArchiveVaultDetailPanelProps) {
   return (
-    <aside
-      aria-label="Archive vault detail panel"
-      className="rounded-[1.75rem] border border-[var(--line)] bg-[var(--surface)] p-6 shadow-[0_18px_70px_rgba(15,23,42,0.06)] sm:p-7"
-    >
-      <div className="space-y-4">
-        <div className="space-y-3">
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
-            Detail summary
-          </p>
-          <h2 className="text-3xl font-semibold tracking-tight text-slate-950">
-            {snapshot.title}
-          </h2>
-          <p className="text-sm leading-7 text-slate-600 sm:text-base">
-            {snapshot.detailSummary.overview}
-          </p>
+    <aside className={styles.detailColumn}>
+      <section
+        aria-label="Archive vault detail panel"
+        className={styles.detailPanel}
+      >
+        <div className={styles.detailHeader}>
+          <p className={styles.eyebrow}>Detail summary</p>
+          <h2 className={styles.detailTitle}>{snapshot.title}</h2>
+          <p className={styles.detailText}>{snapshot.detailSummary.overview}</p>
         </div>
 
         {!selectionFound && requestedSnapshotId ? (
-          <p
-            role="status"
-            className="rounded-2xl border border-amber-300/45 bg-amber-100/60 px-4 py-3 text-sm leading-6 text-amber-950"
-          >
+          <p role="status" className={styles.detailNotice}>
             Snapshot <span className="font-semibold">{requestedSnapshotId}</span>{" "}
             was not found. Showing the current vault baseline instead.
           </p>
         ) : null}
 
-        <ul className="flex flex-wrap gap-2">
+        <ul className={styles.metadataList}>
           {snapshot.metadataBadges.map((badge) => (
             <ArchiveVaultMetadataBadge
               key={`${snapshot.id}-${badge.label}-detail`}
@@ -48,54 +40,58 @@ export function ArchiveVaultDetailPanel({
             />
           ))}
         </ul>
-      </div>
 
-      <div className="mt-6 grid gap-4 sm:grid-cols-2">
-        <article className="rounded-[1.35rem] border border-slate-200 bg-white/70 p-4">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
-            Archive label
-          </p>
-          <p className="mt-2 text-lg font-semibold text-slate-950">
-            {snapshot.label}
-          </p>
-          <p className="mt-2 text-sm leading-6 text-slate-600">
-            Sealed {snapshot.archivedLabel}
-          </p>
-        </article>
+        <div className={styles.detailMetaGrid}>
+          <article className={styles.detailMetaCard}>
+            <p className={styles.detailMetaLabel}>Archive label</p>
+            <p className={styles.detailMetaValue}>{snapshot.label}</p>
+            <p className={styles.detailFeatureText}>
+              Sealed {snapshot.archivedLabel}
+            </p>
+          </article>
 
-        <article className="rounded-[1.35rem] border border-slate-200 bg-white/70 p-4">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
-            Comparison readiness
-          </p>
-          <p className="mt-2 text-sm leading-6 text-slate-700">
-            {snapshot.detailSummary.comparisonReadiness}
-          </p>
-        </article>
-      </div>
+          <article className={styles.detailMetaCard}>
+            <p className={styles.detailMetaLabel}>Comparison readiness</p>
+            <p className={styles.detailFeatureText}>
+              {snapshot.detailSummary.comparisonReadiness}
+            </p>
+          </article>
 
-      <section className="mt-6 rounded-[1.5rem] border border-slate-200 bg-white/75 p-5">
-        <h3 className="text-lg font-semibold text-slate-950">
-          {snapshot.detailSummary.heading}
-        </h3>
-        <p className="mt-3 text-sm leading-7 text-slate-600">
-          {snapshot.detailSummary.reviewWindow}
-        </p>
+          <article className={styles.detailMetaCard}>
+            <p className={styles.detailMetaLabel}>Source</p>
+            <p className={styles.detailMetaValue}>{snapshot.source}</p>
+            <p className={styles.detailFeatureText}>{snapshot.vaultZone}</p>
+          </article>
 
-        <dl className="mt-5 grid gap-3">
-          {snapshot.detailSummary.rows.map((row) => (
-            <div
-              key={`${snapshot.id}-${row.label}`}
-              className="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-4"
-            >
-              <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                {row.label}
-              </dt>
-              <dd className="mt-2 text-sm leading-6 text-slate-700">
-                {row.value}
-              </dd>
-            </div>
-          ))}
-        </dl>
+          <article className={styles.detailMetaCard}>
+            <p className={styles.detailMetaLabel}>Status</p>
+            <p className={styles.detailMetaValue}>{snapshot.status}</p>
+            <p className={styles.detailFeatureText}>
+              {snapshot.detailSummary.reviewWindow}
+            </p>
+          </article>
+        </div>
+
+        <section className={styles.detailSection}>
+          <h3 className={styles.detailSectionTitle}>
+            {snapshot.detailSummary.heading}
+          </h3>
+          <p className={styles.detailSectionText}>
+            {snapshot.detailSummary.reviewWindow}
+          </p>
+
+          <dl className={styles.detailRows}>
+            {snapshot.detailSummary.rows.map((row) => (
+              <div
+                key={`${snapshot.id}-${row.label}`}
+                className={styles.detailRow}
+              >
+                <dt className={styles.detailRowLabel}>{row.label}</dt>
+                <dd className={styles.detailRowValue}>{row.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
       </section>
     </aside>
   );

--- a/src/app/archive-vault/_components/archive-vault-metadata-badge.tsx
+++ b/src/app/archive-vault/_components/archive-vault-metadata-badge.tsx
@@ -1,0 +1,26 @@
+import type { ArchiveVaultMetadataBadge as ArchiveVaultMetadataBadgeValue } from "../_data/archive-vault-data";
+
+const toneClasses = {
+  accent: "border-sky-300/35 bg-sky-300/12 text-sky-950",
+  caution: "border-amber-300/40 bg-amber-200/35 text-amber-950",
+  steady: "border-emerald-300/40 bg-emerald-200/35 text-emerald-950",
+};
+
+type ArchiveVaultMetadataBadgeProps = {
+  badge: ArchiveVaultMetadataBadgeValue;
+};
+
+export function ArchiveVaultMetadataBadge({
+  badge,
+}: ArchiveVaultMetadataBadgeProps) {
+  const tone = badge.tone ?? "accent";
+
+  return (
+    <li
+      className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold tracking-[0.18em] uppercase ${toneClasses[tone]}`}
+    >
+      <span className="opacity-70">{badge.label}</span>
+      <span>{badge.value}</span>
+    </li>
+  );
+}

--- a/src/app/archive-vault/_components/archive-vault-metadata-badge.tsx
+++ b/src/app/archive-vault/_components/archive-vault-metadata-badge.tsx
@@ -1,9 +1,10 @@
 import type { ArchiveVaultMetadataBadge as ArchiveVaultMetadataBadgeValue } from "../_data/archive-vault-data";
+import styles from "../archive-vault.module.css";
 
 const toneClasses = {
-  accent: "border-sky-300/35 bg-sky-300/12 text-sky-950",
-  caution: "border-amber-300/40 bg-amber-200/35 text-amber-950",
-  steady: "border-emerald-300/40 bg-emerald-200/35 text-emerald-950",
+  accent: styles.metadataAccent,
+  caution: styles.metadataCaution,
+  steady: styles.metadataSteady,
 };
 
 type ArchiveVaultMetadataBadgeProps = {
@@ -17,9 +18,9 @@ export function ArchiveVaultMetadataBadge({
 
   return (
     <li
-      className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold tracking-[0.18em] uppercase ${toneClasses[tone]}`}
+      className={`${styles.metadataBadge} ${toneClasses[tone]}`}
     >
-      <span className="opacity-70">{badge.label}</span>
+      <span className={styles.metadataBadgeLabel}>{badge.label}</span>
       <span>{badge.value}</span>
     </li>
   );

--- a/src/app/archive-vault/_components/archive-vault-snapshot-group.tsx
+++ b/src/app/archive-vault/_components/archive-vault-snapshot-group.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { ArchiveVaultMetadataBadge } from "./archive-vault-metadata-badge";
+import styles from "../archive-vault.module.css";
 import type { ArchiveVaultSnapshotGroup } from "../_data/archive-vault-data";
 
 type ArchiveVaultSnapshotGroupProps = {
@@ -15,26 +16,22 @@ export function ArchiveVaultSnapshotGroup({
   return (
     <section
       aria-labelledby={`${group.id}-title`}
-      className="space-y-4 rounded-[1.75rem] border border-[var(--line)] bg-[var(--surface)] p-6 shadow-[0_18px_70px_rgba(15,23,42,0.06)]"
+      className={styles.groupSection}
     >
-      <div className="space-y-3">
-        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
-          {group.eyebrow}
-        </p>
+      <div className={styles.groupHeader}>
+        <p className={styles.eyebrow}>{group.eyebrow}</p>
         <h2
           id={`${group.id}-title`}
-          className="text-3xl font-semibold tracking-tight text-slate-950"
+          className={styles.groupTitle}
         >
           {group.title}
         </h2>
-        <p className="max-w-3xl text-sm leading-7 text-slate-600 sm:text-base">
-          {group.description}
-        </p>
+        <p className={styles.groupDescription}>{group.description}</p>
       </div>
 
       <div
         aria-label={`${group.title} snapshots`}
-        className="grid gap-4"
+        className={styles.snapshotStack}
         role="list"
       >
         {group.snapshots.map((snapshot) => {
@@ -44,31 +41,31 @@ export function ArchiveVaultSnapshotGroup({
             <article
               key={snapshot.id}
               aria-labelledby={`${snapshot.id}-title`}
-              className={`rounded-[1.5rem] border p-5 transition ${
+              className={`${styles.snapshotCard} ${
                 isSelected
-                  ? "border-slate-950 bg-slate-950 text-slate-50 shadow-[0_20px_65px_rgba(15,23,42,0.18)]"
-                  : "border-slate-200 bg-white/75 text-slate-950"
+                  ? styles.snapshotCardSelected
+                  : ""
               }`}
               role="listitem"
             >
-              <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                <div className="space-y-3">
+              <div className={styles.snapshotTop}>
+                <div className={styles.snapshotHeading}>
                   <p
-                    className={`text-[11px] font-semibold uppercase tracking-[0.22em] ${
-                      isSelected ? "text-amber-200" : "text-slate-500"
+                    className={`${styles.snapshotLabel} ${
+                      isSelected ? styles.snapshotLabelSelected : ""
                     }`}
                   >
                     {snapshot.label}
                   </p>
                   <h3
                     id={`${snapshot.id}-title`}
-                    className="text-2xl font-semibold tracking-tight"
+                    className={styles.snapshotTitle}
                   >
                     {snapshot.title}
                   </h3>
                   <p
-                    className={`max-w-2xl text-sm leading-7 ${
-                      isSelected ? "text-slate-200" : "text-slate-600"
+                    className={`${styles.snapshotSummary} ${
+                      isSelected ? styles.snapshotSummarySelected : ""
                     }`}
                   >
                     {snapshot.summary}
@@ -78,57 +75,65 @@ export function ArchiveVaultSnapshotGroup({
                 <Link
                   href={`/archive-vault?snapshot=${snapshot.id}`}
                   aria-current={isSelected ? "page" : undefined}
-                  className={`inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition ${
-                    isSelected
-                      ? "bg-amber-200 text-slate-950 hover:bg-amber-100"
-                      : "border border-slate-300 text-slate-700 hover:border-slate-950 hover:text-slate-950"
+                  className={`${styles.snapshotAction} ${
+                    isSelected ? styles.snapshotActionSelected : ""
                   }`}
                 >
                   {isSelected ? "Viewing snapshot" : "Open snapshot"}
                 </Link>
               </div>
 
-              <div className="mt-5 grid gap-4 md:grid-cols-3">
-                <div>
+              <div className={styles.snapshotFacts}>
+                <div
+                  className={`${styles.factCard} ${
+                    isSelected ? styles.factCardSelected : ""
+                  }`}
+                >
+                  <p className={styles.factLabel}>Archive seal</p>
                   <p
-                    className={`text-[11px] font-semibold uppercase tracking-[0.2em] ${
-                      isSelected ? "text-slate-400" : "text-slate-500"
+                    className={`${styles.factValue} ${
+                      isSelected ? styles.factValueSelected : ""
                     }`}
                   >
-                    Archive seal
+                    {snapshot.archivedLabel}
                   </p>
-                  <p className="mt-2 text-sm leading-6">{snapshot.archivedLabel}</p>
                 </div>
-                <div>
+                <div
+                  className={`${styles.factCard} ${
+                    isSelected ? styles.factCardSelected : ""
+                  }`}
+                >
+                  <p className={styles.factLabel}>Source</p>
                   <p
-                    className={`text-[11px] font-semibold uppercase tracking-[0.2em] ${
-                      isSelected ? "text-slate-400" : "text-slate-500"
+                    className={`${styles.factValue} ${
+                      isSelected ? styles.factValueSelected : ""
                     }`}
                   >
-                    Source
+                    {snapshot.source}
                   </p>
-                  <p className="mt-2 text-sm leading-6">{snapshot.source}</p>
                 </div>
-                <div>
+                <div
+                  className={`${styles.factCard} ${
+                    isSelected ? styles.factCardSelected : ""
+                  }`}
+                >
+                  <p className={styles.factLabel}>Vault zone</p>
                   <p
-                    className={`text-[11px] font-semibold uppercase tracking-[0.2em] ${
-                      isSelected ? "text-slate-400" : "text-slate-500"
+                    className={`${styles.factValue} ${
+                      isSelected ? styles.factValueSelected : ""
                     }`}
                   >
-                    Vault zone
+                    {snapshot.vaultZone}
                   </p>
-                  <p className="mt-2 text-sm leading-6">{snapshot.vaultZone}</p>
                 </div>
               </div>
 
-              <div className="mt-5 flex flex-wrap gap-2">
+              <div className={styles.snapshotTags}>
                 {snapshot.tags.map((tag) => (
                   <span
                     key={`${snapshot.id}-${tag}`}
-                    className={`rounded-full px-3 py-1 text-xs font-semibold tracking-[0.18em] uppercase ${
-                      isSelected
-                        ? "bg-white/10 text-slate-100"
-                        : "bg-slate-100 text-slate-600"
+                    className={`${styles.snapshotTag} ${
+                      isSelected ? styles.snapshotTagSelected : ""
                     }`}
                   >
                     {tag}
@@ -136,7 +141,7 @@ export function ArchiveVaultSnapshotGroup({
                 ))}
               </div>
 
-              <div className="mt-5 flex flex-wrap gap-2">
+              <div className={styles.metadataList}>
                 {snapshot.metadataBadges.map((badge) => (
                   <ArchiveVaultMetadataBadge
                     key={`${snapshot.id}-${badge.label}`}
@@ -146,20 +151,18 @@ export function ArchiveVaultSnapshotGroup({
               </div>
 
               <div
-                className={`mt-5 rounded-[1.2rem] border px-4 py-4 ${
-                  isSelected
-                    ? "border-white/10 bg-white/10"
-                    : "border-slate-200 bg-slate-50/85"
+                className={`${styles.statusCard} ${
+                  isSelected ? styles.statusCardSelected : ""
                 }`}
               >
+                <p className={styles.statusLabel}>Status</p>
                 <p
-                  className={`text-[11px] font-semibold uppercase tracking-[0.2em] ${
-                    isSelected ? "text-slate-400" : "text-slate-500"
+                  className={`${styles.statusValue} ${
+                    isSelected ? styles.statusValueSelected : ""
                   }`}
                 >
-                  Status
+                  {snapshot.status}
                 </p>
-                <p className="mt-2 text-sm font-medium">{snapshot.status}</p>
               </div>
             </article>
           );

--- a/src/app/archive-vault/_components/archive-vault-snapshot-group.tsx
+++ b/src/app/archive-vault/_components/archive-vault-snapshot-group.tsx
@@ -1,0 +1,170 @@
+import Link from "next/link";
+
+import { ArchiveVaultMetadataBadge } from "./archive-vault-metadata-badge";
+import type { ArchiveVaultSnapshotGroup } from "../_data/archive-vault-data";
+
+type ArchiveVaultSnapshotGroupProps = {
+  group: ArchiveVaultSnapshotGroup;
+  selectedSnapshotId: string;
+};
+
+export function ArchiveVaultSnapshotGroup({
+  group,
+  selectedSnapshotId,
+}: ArchiveVaultSnapshotGroupProps) {
+  return (
+    <section
+      aria-labelledby={`${group.id}-title`}
+      className="space-y-4 rounded-[1.75rem] border border-[var(--line)] bg-[var(--surface)] p-6 shadow-[0_18px_70px_rgba(15,23,42,0.06)]"
+    >
+      <div className="space-y-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+          {group.eyebrow}
+        </p>
+        <h2
+          id={`${group.id}-title`}
+          className="text-3xl font-semibold tracking-tight text-slate-950"
+        >
+          {group.title}
+        </h2>
+        <p className="max-w-3xl text-sm leading-7 text-slate-600 sm:text-base">
+          {group.description}
+        </p>
+      </div>
+
+      <div
+        aria-label={`${group.title} snapshots`}
+        className="grid gap-4"
+        role="list"
+      >
+        {group.snapshots.map((snapshot) => {
+          const isSelected = snapshot.id === selectedSnapshotId;
+
+          return (
+            <article
+              key={snapshot.id}
+              aria-labelledby={`${snapshot.id}-title`}
+              className={`rounded-[1.5rem] border p-5 transition ${
+                isSelected
+                  ? "border-slate-950 bg-slate-950 text-slate-50 shadow-[0_20px_65px_rgba(15,23,42,0.18)]"
+                  : "border-slate-200 bg-white/75 text-slate-950"
+              }`}
+              role="listitem"
+            >
+              <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div className="space-y-3">
+                  <p
+                    className={`text-[11px] font-semibold uppercase tracking-[0.22em] ${
+                      isSelected ? "text-amber-200" : "text-slate-500"
+                    }`}
+                  >
+                    {snapshot.label}
+                  </p>
+                  <h3
+                    id={`${snapshot.id}-title`}
+                    className="text-2xl font-semibold tracking-tight"
+                  >
+                    {snapshot.title}
+                  </h3>
+                  <p
+                    className={`max-w-2xl text-sm leading-7 ${
+                      isSelected ? "text-slate-200" : "text-slate-600"
+                    }`}
+                  >
+                    {snapshot.summary}
+                  </p>
+                </div>
+
+                <Link
+                  href={`/archive-vault?snapshot=${snapshot.id}`}
+                  aria-current={isSelected ? "page" : undefined}
+                  className={`inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition ${
+                    isSelected
+                      ? "bg-amber-200 text-slate-950 hover:bg-amber-100"
+                      : "border border-slate-300 text-slate-700 hover:border-slate-950 hover:text-slate-950"
+                  }`}
+                >
+                  {isSelected ? "Viewing snapshot" : "Open snapshot"}
+                </Link>
+              </div>
+
+              <div className="mt-5 grid gap-4 md:grid-cols-3">
+                <div>
+                  <p
+                    className={`text-[11px] font-semibold uppercase tracking-[0.2em] ${
+                      isSelected ? "text-slate-400" : "text-slate-500"
+                    }`}
+                  >
+                    Archive seal
+                  </p>
+                  <p className="mt-2 text-sm leading-6">{snapshot.archivedLabel}</p>
+                </div>
+                <div>
+                  <p
+                    className={`text-[11px] font-semibold uppercase tracking-[0.2em] ${
+                      isSelected ? "text-slate-400" : "text-slate-500"
+                    }`}
+                  >
+                    Source
+                  </p>
+                  <p className="mt-2 text-sm leading-6">{snapshot.source}</p>
+                </div>
+                <div>
+                  <p
+                    className={`text-[11px] font-semibold uppercase tracking-[0.2em] ${
+                      isSelected ? "text-slate-400" : "text-slate-500"
+                    }`}
+                  >
+                    Vault zone
+                  </p>
+                  <p className="mt-2 text-sm leading-6">{snapshot.vaultZone}</p>
+                </div>
+              </div>
+
+              <div className="mt-5 flex flex-wrap gap-2">
+                {snapshot.tags.map((tag) => (
+                  <span
+                    key={`${snapshot.id}-${tag}`}
+                    className={`rounded-full px-3 py-1 text-xs font-semibold tracking-[0.18em] uppercase ${
+                      isSelected
+                        ? "bg-white/10 text-slate-100"
+                        : "bg-slate-100 text-slate-600"
+                    }`}
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+
+              <div className="mt-5 flex flex-wrap gap-2">
+                {snapshot.metadataBadges.map((badge) => (
+                  <ArchiveVaultMetadataBadge
+                    key={`${snapshot.id}-${badge.label}`}
+                    badge={badge}
+                  />
+                ))}
+              </div>
+
+              <div
+                className={`mt-5 rounded-[1.2rem] border px-4 py-4 ${
+                  isSelected
+                    ? "border-white/10 bg-white/10"
+                    : "border-slate-200 bg-slate-50/85"
+                }`}
+              >
+                <p
+                  className={`text-[11px] font-semibold uppercase tracking-[0.2em] ${
+                    isSelected ? "text-slate-400" : "text-slate-500"
+                  }`}
+                >
+                  Status
+                </p>
+                <p className="mt-2 text-sm font-medium">{snapshot.status}</p>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/app/archive-vault/_data/archive-vault-data.ts
+++ b/src/app/archive-vault/_data/archive-vault-data.ts
@@ -1,0 +1,335 @@
+export type ArchiveVaultBadgeTone = "accent" | "caution" | "steady";
+
+export type ArchiveVaultMetadataBadge = {
+  label: string;
+  value: string;
+  tone?: ArchiveVaultBadgeTone;
+};
+
+export type ArchiveVaultDetailRow = {
+  label: string;
+  value: string;
+};
+
+export type ArchiveVaultDetailSummary = {
+  heading: string;
+  overview: string;
+  comparisonReadiness: string;
+  reviewWindow: string;
+  rows: ArchiveVaultDetailRow[];
+};
+
+export type ArchiveVaultSnapshot = {
+  id: string;
+  label: string;
+  title: string;
+  archivedAt: string;
+  archivedLabel: string;
+  status: string;
+  source: string;
+  vaultZone: string;
+  summary: string;
+  tags: string[];
+  metadataBadges: ArchiveVaultMetadataBadge[];
+  detailSummary: ArchiveVaultDetailSummary;
+};
+
+export type ArchiveVaultSnapshotGroup = {
+  id: string;
+  eyebrow: string;
+  title: string;
+  description: string;
+  snapshots: ArchiveVaultSnapshot[];
+};
+
+export const archiveVaultSnapshotGroups: ArchiveVaultSnapshotGroup[] = [
+  {
+    id: "audit-holds",
+    eyebrow: "Audit holds",
+    title: "Preserved compliance archives",
+    description:
+      "Long-lived archive packages kept comparison-ready for external review windows and replay drills.",
+    snapshots: [
+      {
+        id: "harbor-customs-ledger",
+        label: "Snapshot 09",
+        title: "Harbor customs ledger",
+        archivedAt: "2026-04-19T05:40:00Z",
+        archivedLabel: "April 19, 2026 at 05:40 UTC",
+        status: "Sealed for legal review",
+        source: "Glass Harbor Customs Desk",
+        vaultZone: "North Atlantic cold tier",
+        summary:
+          "Quarter-close customs entries, release memos, and dock annotations bundled into a review-safe archive ledger.",
+        tags: ["customs", "audit", "sealed-ledger"],
+        metadataBadges: [
+          {
+            label: "Retention",
+            value: "12-year legal hold",
+            tone: "caution",
+          },
+          {
+            label: "Integrity",
+            value: "Merkle seal verified",
+            tone: "steady",
+          },
+          {
+            label: "Mirror",
+            value: "2 geo-locked copies",
+            tone: "accent",
+          },
+        ],
+        detailSummary: {
+          heading: "Use as the baseline for customs dispute playback",
+          overview:
+            "The ledger keeps release signatures and correction notes in a single sealed package so reviewers can compare each amendment against the archived original.",
+          comparisonReadiness:
+            "Every correction batch is indexed by berth and release cycle, which keeps side-by-side comparisons deterministic during audit replay.",
+          reviewWindow: "Primary review window: within 9 minutes of hydrate request",
+          rows: [
+            { label: "Primary focus", value: "Release memos versus correction notes" },
+            { label: "Baseline slice", value: "Q1 berth 3 through berth 11 ledgers" },
+            { label: "Review owner", value: "Port compliance and legal liaison" },
+          ],
+        },
+      },
+      {
+        id: "relay-incident-docket",
+        label: "Snapshot 08",
+        title: "Relay incident docket",
+        archivedAt: "2026-04-11T14:15:00Z",
+        archivedLabel: "April 11, 2026 at 14:15 UTC",
+        status: "Audit replay approved",
+        source: "Inland Relay Oversight",
+        vaultZone: "Frankfurt compliance mirror",
+        summary:
+          "Escalation notes, route overrides, and witness summaries preserved for internal incident board comparisons.",
+        tags: ["incident", "oversight", "comparison-ready"],
+        metadataBadges: [
+          {
+            label: "Retention",
+            value: "8-year oversight baseline",
+            tone: "caution",
+          },
+          {
+            label: "Integrity",
+            value: "Digest chain complete",
+            tone: "steady",
+          },
+          {
+            label: "Access",
+            value: "Board review only",
+            tone: "accent",
+          },
+        ],
+        detailSummary: {
+          heading: "Use as the operator handoff comparison set",
+          overview:
+            "The archive pairs every route override with the operator shift handoff that triggered it, making replay and accountability checks easier to compare.",
+          comparisonReadiness:
+            "Docket entries are grouped by escalation lane, so discrepancy review can scan the original route change and every follow-up note together.",
+          reviewWindow: "Primary review window: within 14 minutes of hydrate request",
+          rows: [
+            { label: "Primary focus", value: "Overrides versus shift handoff notes" },
+            { label: "Baseline slice", value: "Signal lanes 2A, 3C, and 4B" },
+            { label: "Review owner", value: "Incident board recorder" },
+          ],
+        },
+      },
+    ],
+  },
+  {
+    id: "operational-recovery",
+    eyebrow: "Operational recovery",
+    title: "Restorable command archives",
+    description:
+      "Archive sets optimized for fast targeted restores when operations teams need evidence, transcripts, or dispatch context.",
+    snapshots: [
+      {
+        id: "evacuation-audio-trace",
+        label: "Snapshot 07",
+        title: "Evacuation audio trace",
+        archivedAt: "2026-03-28T16:05:00Z",
+        archivedLabel: "March 28, 2026 at 16:05 UTC",
+        status: "Ready for supervised playback",
+        source: "Northwind Transit Command",
+        vaultZone: "Zurich warm mirror",
+        summary:
+          "Command-room audio, route change transcripts, and operator acknowledgements kept together for playback-led review.",
+        tags: ["audio", "dispatch", "playback"],
+        metadataBadges: [
+          {
+            label: "Retention",
+            value: "6-year operations baseline",
+            tone: "caution",
+          },
+          {
+            label: "Integrity",
+            value: "Waveform parity verified",
+            tone: "steady",
+          },
+          {
+            label: "Restore",
+            value: "Single-route hydrate",
+            tone: "accent",
+          },
+        ],
+        detailSummary: {
+          heading: "Use as the playback source for route escalation drills",
+          overview:
+            "Audio blocks are aligned with transcript excerpts and route overrides so drill leads can compare the spoken command with the resulting network action.",
+          comparisonReadiness:
+            "Every dispatch event carries a transcript pointer and operator acknowledgement window, which keeps route-by-route playback aligned without manual stitching.",
+          reviewWindow: "Primary review window: within 6 minutes of hydrate request",
+          rows: [
+            { label: "Primary focus", value: "Operator audio versus transcript slices" },
+            { label: "Baseline slice", value: "Routes N4, E2, and bypass lane C" },
+            { label: "Review owner", value: "Transit exercise coordinator" },
+          ],
+        },
+      },
+      {
+        id: "storm-shelter-occupancy-rollup",
+        label: "Snapshot 06",
+        title: "Storm shelter occupancy rollup",
+        archivedAt: "2026-03-04T08:25:00Z",
+        archivedLabel: "March 04, 2026 at 08:25 UTC",
+        status: "Indexed for spot recovery",
+        source: "Civic Response Hub",
+        vaultZone: "Oslo warm standby",
+        summary:
+          "Shelter census logs, supply checklists, and reassignment notes preserved for targeted restore during weather events.",
+        tags: ["shelter", "response", "spot-restore"],
+        metadataBadges: [
+          {
+            label: "Retention",
+            value: "5-year response baseline",
+            tone: "caution",
+          },
+          {
+            label: "Integrity",
+            value: "Replica quorum satisfied",
+            tone: "steady",
+          },
+          {
+            label: "Restore",
+            value: "Zone-scoped recovery",
+            tone: "accent",
+          },
+        ],
+        detailSummary: {
+          heading: "Use as the occupancy comparison anchor across zones",
+          overview:
+            "The rollup links census snapshots with supply deltas, which lets operators compare occupancy swings against the inventory decisions made at the same moment.",
+          comparisonReadiness:
+            "Every zone is versioned independently so the panel can compare a single shelter corridor without loading the full event package.",
+          reviewWindow: "Primary review window: within 11 minutes of hydrate request",
+          rows: [
+            { label: "Primary focus", value: "Occupancy swings versus supply reassignments" },
+            { label: "Baseline slice", value: "Zones North, River, and East Annex" },
+            { label: "Review owner", value: "Weather response desk" },
+          ],
+        },
+      },
+    ],
+  },
+  {
+    id: "research-baselines",
+    eyebrow: "Research baselines",
+    title: "Comparative study archives",
+    description:
+      "Evidence packages preserved for slow-moving comparative review, trend analysis, and replay of intervention points.",
+    snapshots: [
+      {
+        id: "orchard-sensor-baseline",
+        label: "Snapshot 05",
+        title: "Orchard sensor baseline",
+        archivedAt: "2026-02-17T10:30:00Z",
+        archivedLabel: "February 17, 2026 at 10:30 UTC",
+        status: "Research review ready",
+        source: "Solstice Orchard Lab",
+        vaultZone: "Low-latency mirror tier",
+        summary:
+          "Telemetry packets, irrigation overrides, and notebook excerpts archived for seasonal comparison work.",
+        tags: ["telemetry", "agriculture", "seasonal-study"],
+        metadataBadges: [
+          {
+            label: "Retention",
+            value: "5-year research baseline",
+            tone: "caution",
+          },
+          {
+            label: "Integrity",
+            value: "Parity pass complete",
+            tone: "steady",
+          },
+          {
+            label: "Compare",
+            value: "Harvest-cycle aligned",
+            tone: "accent",
+          },
+        ],
+        detailSummary: {
+          heading: "Use as the baseline for intervention point analysis",
+          overview:
+            "The archive joins sensor drift, manual overrides, and notebook commentary so researchers can compare automation decisions with field intervention in one package.",
+          comparisonReadiness:
+            "Telemetry is indexed by irrigation zone and harvest cycle, which makes seasonal side-by-side comparisons consistent even when packet rates differ.",
+          reviewWindow: "Primary review window: within 4 hours of full replay request",
+          rows: [
+            { label: "Primary focus", value: "Sensor drift versus manual overrides" },
+            { label: "Baseline slice", value: "Harvest cycles 2 through 5" },
+            { label: "Review owner", value: "Yield anomaly review team" },
+          ],
+        },
+      },
+      {
+        id: "reef-survey-image-stack",
+        label: "Snapshot 04",
+        title: "Reef survey image stack",
+        archivedAt: "2026-01-26T12:55:00Z",
+        archivedLabel: "January 26, 2026 at 12:55 UTC",
+        status: "Curated for comparative review",
+        source: "Pelagic Survey Cooperative",
+        vaultZone: "Lisbon cold reference tier",
+        summary:
+          "Image captures, annotation overlays, and diver notes preserved as a single comparison set for habitat review.",
+        tags: ["imagery", "survey", "annotation"],
+        metadataBadges: [
+          {
+            label: "Retention",
+            value: "10-year habitat baseline",
+            tone: "caution",
+          },
+          {
+            label: "Integrity",
+            value: "Frame hash register signed",
+            tone: "steady",
+          },
+          {
+            label: "Compare",
+            value: "Survey-grid normalized",
+            tone: "accent",
+          },
+        ],
+        detailSummary: {
+          heading: "Use as the visual anchor for reef condition comparisons",
+          overview:
+            "Image frames remain aligned with annotation overlays and diver notes, which keeps habitat comparisons grounded in the exact survey pass that produced them.",
+          comparisonReadiness:
+            "Each frame bundle is normalized to the same survey grid, so the detail panel can compare condition changes without reprojecting the image stack.",
+          reviewWindow: "Primary review window: within 18 minutes of focused hydrate request",
+          rows: [
+            { label: "Primary focus", value: "Image deltas versus annotation overlays" },
+            { label: "Baseline slice", value: "Grid sectors C4 through E7" },
+            { label: "Review owner", value: "Habitat condition analyst" },
+          ],
+        },
+      },
+    ],
+  },
+];
+
+export const archiveVaultSnapshots = archiveVaultSnapshotGroups.flatMap(
+  (group) => group.snapshots,
+);

--- a/src/app/archive-vault/_lib/archive-vault.ts
+++ b/src/app/archive-vault/_lib/archive-vault.ts
@@ -1,0 +1,47 @@
+import {
+  archiveVaultSnapshotGroups,
+  archiveVaultSnapshots,
+  type ArchiveVaultSnapshot,
+  type ArchiveVaultSnapshotGroup,
+} from "../_data/archive-vault-data";
+
+export type ArchiveVaultSelection = {
+  snapshotGroups: ArchiveVaultSnapshotGroup[];
+  selectedSnapshot: ArchiveVaultSnapshot;
+  requestedSnapshotId?: string;
+  selectionFound: boolean;
+};
+
+function normalizeSnapshotId(snapshotId?: string) {
+  return snapshotId?.trim().toLowerCase();
+}
+
+export function readRequestedSnapshotId(
+  value: string | string[] | undefined,
+) {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
+}
+
+export function resolveArchiveVaultSelection(
+  snapshotId?: string,
+): ArchiveVaultSelection {
+  const requestedSnapshotId = normalizeSnapshotId(snapshotId);
+  const selectedSnapshot =
+    archiveVaultSnapshots.find((snapshot) => snapshot.id === requestedSnapshotId) ??
+    archiveVaultSnapshots[0];
+
+  return {
+    snapshotGroups: archiveVaultSnapshotGroups,
+    selectedSnapshot,
+    requestedSnapshotId,
+    selectionFound: requestedSnapshotId
+      ? archiveVaultSnapshots.some(
+          (snapshot) => snapshot.id === requestedSnapshotId,
+        )
+      : true,
+  };
+}

--- a/src/app/archive-vault/archive-vault.module.css
+++ b/src/app/archive-vault/archive-vault.module.css
@@ -1,0 +1,566 @@
+.vaultPage {
+  --vault-paper: rgba(255, 251, 243, 0.9);
+  --vault-paper-strong: #fffaf0;
+  --vault-line: rgba(148, 163, 184, 0.28);
+  --vault-line-strong: rgba(71, 85, 105, 0.2);
+  --vault-ink: #111827;
+  --vault-ink-soft: rgba(31, 41, 55, 0.76);
+  --vault-accent: #9a5b16;
+  --vault-accent-soft: rgba(154, 91, 22, 0.12);
+  --vault-cyan: #155e75;
+  --vault-teal: #0f766e;
+  --vault-night: #111827;
+  width: min(100%, 88rem);
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 2rem;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 2.75rem;
+  color: var(--vault-ink);
+}
+
+.heroPanel {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--vault-line);
+  border-radius: 2rem;
+  background:
+    radial-gradient(circle at top right, rgba(14, 165, 233, 0.14), transparent 28%),
+    radial-gradient(circle at bottom left, rgba(217, 119, 6, 0.16), transparent 34%),
+    linear-gradient(145deg, rgba(255, 251, 243, 0.96), rgba(248, 244, 235, 0.92));
+  box-shadow: 0 24px 90px rgba(15, 23, 42, 0.08);
+}
+
+.heroPanel::before {
+  content: "";
+  position: absolute;
+  inset: auto -6rem -8rem auto;
+  width: 18rem;
+  height: 18rem;
+  border-radius: 999px;
+  background: rgba(13, 148, 136, 0.08);
+  filter: blur(14px);
+}
+
+.heroGrid {
+  position: relative;
+  display: grid;
+  gap: 2rem;
+  padding: 1.5rem;
+}
+
+.heroCopy {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.eyebrow {
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--vault-accent);
+}
+
+.heroTitle {
+  max-width: 58rem;
+  font-size: clamp(2.5rem, 5vw, 4.45rem);
+  line-height: 0.98;
+  letter-spacing: -0.05em;
+  text-wrap: balance;
+}
+
+.heroText {
+  max-width: 48rem;
+  font-size: 1rem;
+  line-height: 1.9;
+  color: var(--vault-ink-soft);
+}
+
+.heroActions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.actionGhost,
+.actionPrimary,
+.snapshotAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.85rem 1.15rem;
+  font-size: 0.95rem;
+  font-weight: 700;
+  transition:
+    transform 160ms ease,
+    background-color 160ms ease,
+    color 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.actionGhost:hover,
+.actionPrimary:hover,
+.snapshotAction:hover {
+  transform: translateY(-1px);
+}
+
+.actionGhost {
+  border: 1px solid rgba(71, 85, 105, 0.2);
+  background: rgba(255, 255, 255, 0.58);
+  color: var(--vault-ink);
+}
+
+.actionGhost:hover {
+  border-color: rgba(15, 23, 42, 0.44);
+}
+
+.actionPrimary {
+  background: linear-gradient(135deg, #0f172a, #1f2937);
+  color: #fff7ed;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.14);
+}
+
+.actionPrimary:hover {
+  box-shadow: 0 18px 34px rgba(15, 23, 42, 0.18);
+}
+
+.overviewCard {
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 1.7rem;
+  background: rgba(255, 255, 255, 0.74);
+  padding: 1.4rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(14px);
+}
+
+.overviewTitle {
+  margin-top: 0.7rem;
+  font-size: 1.85rem;
+  line-height: 1.08;
+  letter-spacing: -0.04em;
+}
+
+.overviewGrid {
+  display: grid;
+  gap: 0.9rem;
+  margin-top: 1.3rem;
+}
+
+.overviewItem {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1.25rem;
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.94), rgba(241, 245, 249, 0.84));
+  padding: 1rem;
+}
+
+.overviewLabel,
+.factLabel,
+.statusLabel,
+.detailMetaLabel,
+.detailRowLabel {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(71, 85, 105, 0.86);
+}
+
+.overviewValue {
+  margin-top: 0.35rem;
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.02;
+  letter-spacing: -0.05em;
+}
+
+.overviewDetail {
+  margin-top: 0.5rem;
+  font-size: 0.93rem;
+  line-height: 1.65;
+  color: rgba(51, 65, 85, 0.84);
+}
+
+.contentGrid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.browserColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.browserIntro,
+.groupSection,
+.detailPanel {
+  border: 1px solid var(--vault-line);
+  border-radius: 1.8rem;
+  background: var(--vault-paper);
+  box-shadow: 0 18px 70px rgba(15, 23, 42, 0.06);
+}
+
+.browserIntro {
+  padding: 1.4rem;
+}
+
+.browserIntroHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.browserIntroTitle,
+.groupTitle,
+.detailTitle {
+  font-size: 2rem;
+  line-height: 1.04;
+  letter-spacing: -0.04em;
+}
+
+.browserIntroText,
+.groupDescription,
+.snapshotSummary,
+.detailText,
+.detailFeatureText,
+.detailSectionText,
+.detailRowValue {
+  font-size: 0.98rem;
+  line-height: 1.82;
+  color: rgba(51, 65, 85, 0.86);
+}
+
+.groupSection {
+  padding: 1.45rem;
+}
+
+.groupHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.snapshotStack {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.2rem;
+}
+
+.snapshotCard {
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  border-radius: 1.65rem;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(248, 250, 252, 0.92));
+  padding: 1.25rem;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.05);
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease,
+    border-color 160ms ease,
+    background 160ms ease;
+}
+
+.snapshotCard:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 56px rgba(15, 23, 42, 0.08);
+}
+
+.snapshotCardSelected {
+  border-color: rgba(245, 158, 11, 0.34);
+  background:
+    radial-gradient(circle at top right, rgba(245, 158, 11, 0.18), transparent 32%),
+    linear-gradient(145deg, rgba(15, 23, 42, 0.98), rgba(17, 24, 39, 0.98));
+  box-shadow: 0 24px 66px rgba(15, 23, 42, 0.16);
+  color: #f8fafc;
+}
+
+.snapshotTop {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.snapshotHeading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.snapshotLabel {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(71, 85, 105, 0.84);
+}
+
+.snapshotLabelSelected {
+  color: rgba(253, 230, 138, 0.86);
+}
+
+.snapshotTitle {
+  font-size: 1.7rem;
+  line-height: 1.06;
+  letter-spacing: -0.035em;
+}
+
+.snapshotSummarySelected,
+.factValueSelected,
+.statusValueSelected {
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.snapshotAction {
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(255, 255, 255, 0.82);
+  color: var(--vault-ink);
+}
+
+.snapshotActionSelected {
+  border-color: rgba(253, 230, 138, 0.16);
+  background: #fde68a;
+  color: #111827;
+}
+
+.snapshotFacts {
+  display: grid;
+  gap: 0.8rem;
+  margin-top: 1rem;
+}
+
+.factCard,
+.statusCard,
+.detailMetaCard,
+.detailSection,
+.detailRow {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1.2rem;
+  background: rgba(248, 250, 252, 0.82);
+}
+
+.factCard {
+  padding: 0.95rem;
+}
+
+.factCardSelected,
+.statusCardSelected {
+  border-color: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.factValue,
+.statusValue,
+.detailMetaValue {
+  margin-top: 0.35rem;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.snapshotTags,
+.metadataList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 1rem;
+}
+
+.snapshotTag {
+  border-radius: 999px;
+  background: rgba(226, 232, 240, 0.66);
+  padding: 0.55rem 0.85rem;
+  font-size: 0.73rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(51, 65, 85, 0.88);
+}
+
+.snapshotTagSelected {
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(241, 245, 249, 0.95);
+}
+
+.metadataBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.55rem 0.85rem;
+  font-size: 0.73rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.metadataBadgeLabel {
+  opacity: 0.7;
+}
+
+.metadataAccent {
+  border-color: rgba(14, 165, 233, 0.28);
+  background: rgba(14, 165, 233, 0.12);
+  color: #0f172a;
+}
+
+.metadataCaution {
+  border-color: rgba(245, 158, 11, 0.32);
+  background: rgba(245, 158, 11, 0.16);
+  color: #78350f;
+}
+
+.metadataSteady {
+  border-color: rgba(16, 185, 129, 0.32);
+  background: rgba(16, 185, 129, 0.16);
+  color: #134e4a;
+}
+
+.statusCard {
+  margin-top: 1rem;
+  padding: 1rem;
+}
+
+.detailColumn {
+  display: flex;
+  flex-direction: column;
+}
+
+.detailPanel {
+  padding: 1.4rem;
+}
+
+.detailHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.detailNotice {
+  margin-top: 0.2rem;
+  border: 1px solid rgba(245, 158, 11, 0.36);
+  border-radius: 1rem;
+  background: rgba(254, 243, 199, 0.72);
+  padding: 0.9rem 1rem;
+  font-size: 0.94rem;
+  line-height: 1.6;
+  color: #78350f;
+}
+
+.detailMetaGrid {
+  display: grid;
+  gap: 0.9rem;
+  margin-top: 1.25rem;
+}
+
+.detailMetaCard {
+  padding: 1rem;
+}
+
+.detailFeatureText {
+  margin-top: 0.35rem;
+}
+
+.detailSection {
+  margin-top: 1.2rem;
+  padding: 1.15rem;
+}
+
+.detailSectionTitle {
+  font-size: 1.05rem;
+  font-weight: 700;
+  line-height: 1.3;
+  color: var(--vault-night);
+}
+
+.detailSectionText {
+  margin-top: 0.55rem;
+}
+
+.detailRows {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.detailRow {
+  padding: 0.9rem 1rem;
+}
+
+@media (min-width: 640px) {
+  .vaultPage {
+    padding-inline: 2rem;
+  }
+
+  .heroGrid {
+    padding: 2rem;
+  }
+
+  .heroActions {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .browserIntro,
+  .groupSection,
+  .detailPanel {
+    padding: 1.6rem;
+  }
+
+  .detailMetaGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 768px) {
+  .overviewGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .snapshotFacts {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .detailRows {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .heroGrid {
+    grid-template-columns: minmax(0, 1.25fr) minmax(280px, 0.75fr);
+    align-items: end;
+  }
+
+  .browserIntroHeader {
+    flex-direction: row;
+    align-items: end;
+    justify-content: space-between;
+  }
+
+  .browserIntroText {
+    max-width: 34rem;
+  }
+
+  .snapshotTop {
+    flex-direction: row;
+    align-items: start;
+    justify-content: space-between;
+  }
+}
+
+@media (min-width: 1280px) {
+  .contentGrid {
+    grid-template-columns: minmax(0, 1.12fr) minmax(320px, 0.88fr);
+    align-items: start;
+  }
+
+  .detailPanel {
+    position: sticky;
+    top: 1.5rem;
+  }
+}

--- a/src/app/archive-vault/page.test.tsx
+++ b/src/app/archive-vault/page.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  archiveVaultSnapshotGroups,
+  archiveVaultSnapshots,
+} from "./_data/archive-vault-data";
+import ArchiveVaultPage from "./page";
+
+async function renderArchiveVaultPage(
+  snapshot?: string | string[] | undefined,
+) {
+  return render(
+    await ArchiveVaultPage({
+      searchParams: Promise.resolve({ snapshot }),
+    }),
+  );
+}
+
+describe("ArchiveVaultPage", () => {
+  it("renders the route hero and every configured snapshot group", async () => {
+    await renderArchiveVaultPage();
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /browse sealed snapshots with visible labels, metadata badges, and a comparison-ready detail panel/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /archive coverage at a glance/i,
+      }),
+    ).toBeInTheDocument();
+
+    for (const group of archiveVaultSnapshotGroups) {
+      expect(
+        screen.getByRole("heading", {
+          level: 2,
+          name: group.title,
+        }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("renders multiple snapshot entries with labels, tags, and metadata badges", async () => {
+    await renderArchiveVaultPage();
+
+    const auditHoldList = screen.getByRole("list", {
+      name: /preserved compliance archives snapshots/i,
+    });
+    expect(within(auditHoldList).getAllByRole("listitem", { name: /.+/ })).toHaveLength(
+      archiveVaultSnapshotGroups[0].snapshots.length,
+    );
+
+    expect(screen.getAllByText("Snapshot 09").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("sealed-ledger").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Retention").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("12-year legal hold").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Merkle seal verified").length).toBeGreaterThan(0);
+  });
+
+  it("renders the selected snapshot detail panel from the query string", async () => {
+    await renderArchiveVaultPage("reef-survey-image-stack");
+
+    const detailPanel = screen.getByLabelText(/archive vault detail panel/i);
+
+    expect(
+      within(detailPanel).getByRole("heading", {
+        level: 2,
+        name: "Reef survey image stack",
+      }),
+    ).toBeInTheDocument();
+    expect(detailPanel).toHaveTextContent("Habitat condition analyst");
+    expect(detailPanel).toHaveTextContent(
+      "Use as the visual anchor for reef condition comparisons",
+    );
+    expect(
+      screen.getByRole("link", {
+        name: /viewing snapshot/i,
+      }),
+    ).toHaveAttribute("href", "/archive-vault?snapshot=reef-survey-image-stack");
+  });
+
+  it("falls back to the default snapshot when the requested id is missing", async () => {
+    await renderArchiveVaultPage("missing-entry");
+
+    const detailPanel = screen.getByLabelText(/archive vault detail panel/i);
+    expect(screen.getByRole("status")).toHaveTextContent("missing-entry");
+    expect(detailPanel).toHaveTextContent(archiveVaultSnapshots[0].title);
+    expect(detailPanel).toHaveTextContent(
+      "Use as the baseline for customs dispute playback",
+    );
+  });
+});

--- a/src/app/archive-vault/page.tsx
+++ b/src/app/archive-vault/page.tsx
@@ -1,0 +1,67 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Archive Vault",
+  description:
+    "Initial route shell for browsing archive vault snapshots and detail views.",
+};
+
+export default function ArchiveVaultPage() {
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-7xl flex-1 flex-col gap-8 px-6 py-12 sm:px-10 lg:px-14">
+      <header className="overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] p-8 shadow-[0_20px_90px_rgba(15,23,42,0.08)] sm:p-10">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+          <div className="max-w-3xl space-y-4">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-amber-700">
+              Archive Vault
+            </p>
+            <h1 className="text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
+              Snapshot browser shell for preserved archive packages.
+            </h1>
+            <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
+              This route will expand into grouped archive snapshots, metadata
+              badges, and a comparison-ready detail panel.
+            </p>
+          </div>
+
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center rounded-full border border-slate-300 px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+          >
+            Back to route index
+          </Link>
+        </div>
+      </header>
+
+      <section className="grid gap-6 xl:grid-cols-[minmax(0,1.05fr)_minmax(320px,0.95fr)]">
+        <article className="rounded-[1.75rem] border border-[var(--line)] bg-[var(--surface)] p-6 shadow-[0_18px_70px_rgba(15,23,42,0.06)]">
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">
+            Snapshot browser
+          </p>
+          <h2 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+            Grouped archive entries will render here
+          </h2>
+          <p className="mt-3 max-w-2xl text-sm leading-7 text-slate-600">
+            Subtask 1 establishes the route shell and the two-column layout that
+            later subtasks will fill with archive data, tags, badges, and
+            detail content.
+          </p>
+        </article>
+
+        <aside className="rounded-[1.75rem] border border-[var(--line)] bg-[var(--surface)] p-6 shadow-[0_18px_70px_rgba(15,23,42,0.06)]">
+          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">
+            Detail panel
+          </p>
+          <h2 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+            Comparison-ready summary placeholder
+          </h2>
+          <p className="mt-3 text-sm leading-7 text-slate-600">
+            Later subtasks will populate this area with metadata labels,
+            preservation notes, and snapshot comparison context.
+          </p>
+        </aside>
+      </section>
+    </main>
+  );
+}

--- a/src/app/archive-vault/page.tsx
+++ b/src/app/archive-vault/page.tsx
@@ -1,66 +1,169 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
+import { ArchiveVaultDetailPanel } from "./_components/archive-vault-detail-panel";
+import { ArchiveVaultSnapshotGroup } from "./_components/archive-vault-snapshot-group";
+import {
+  archiveVaultSnapshotGroups,
+  archiveVaultSnapshots,
+} from "./_data/archive-vault-data";
+import {
+  readRequestedSnapshotId,
+  resolveArchiveVaultSelection,
+} from "./_lib/archive-vault";
+
+type ArchiveVaultPageProps = {
+  searchParams: Promise<{
+    snapshot?: string | string[] | undefined;
+  }>;
+};
+
+const numberFormatter = new Intl.NumberFormat("en-US");
+
 export const metadata: Metadata = {
   title: "Archive Vault",
   description:
-    "Initial route shell for browsing archive vault snapshots and detail views.",
+    "Browse grouped archive snapshots, metadata badges, and a comparison-ready detail summary.",
 };
 
-export default function ArchiveVaultPage() {
+function buildOverview() {
+  const allTags = new Set(
+    archiveVaultSnapshots.flatMap((snapshot) => snapshot.tags),
+  );
+
+  return [
+    {
+      label: "Snapshot groups",
+      value: numberFormatter.format(archiveVaultSnapshotGroups.length),
+      detail: "Independent archive lanes staged for audit, recovery, and research review.",
+    },
+    {
+      label: "Snapshots",
+      value: numberFormatter.format(archiveVaultSnapshots.length),
+      detail: "Every archive package carries labels, timestamps, tags, and comparison notes.",
+    },
+    {
+      label: "Tag themes",
+      value: numberFormatter.format(allTags.size),
+      detail: "Cross-cutting labels stay visible so the vault can be scanned quickly.",
+    },
+  ];
+}
+
+export default async function ArchiveVaultPage({
+  searchParams,
+}: ArchiveVaultPageProps) {
+  const requestedSnapshotId = readRequestedSnapshotId(
+    (await searchParams).snapshot,
+  );
+  const selection = resolveArchiveVaultSelection(requestedSnapshotId);
+  const overview = buildOverview();
+
   return (
     <main className="mx-auto flex min-h-screen w-full max-w-7xl flex-1 flex-col gap-8 px-6 py-12 sm:px-10 lg:px-14">
       <header className="overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] p-8 shadow-[0_20px_90px_rgba(15,23,42,0.08)] sm:p-10">
-        <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
-          <div className="max-w-3xl space-y-4">
-            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-amber-700">
-              Archive Vault
-            </p>
-            <h1 className="text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-              Snapshot browser shell for preserved archive packages.
-            </h1>
-            <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
-              This route will expand into grouped archive snapshots, metadata
-              badges, and a comparison-ready detail panel.
-            </p>
+        <div className="grid gap-8 xl:grid-cols-[minmax(0,1.25fr)_minmax(280px,0.75fr)] xl:items-end">
+          <div className="space-y-5">
+            <div className="space-y-4">
+              <p className="text-sm font-semibold uppercase tracking-[0.28em] text-amber-700">
+                Archive Vault
+              </p>
+              <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
+                Browse sealed snapshots with visible labels, metadata badges,
+                and a comparison-ready detail panel.
+              </h1>
+              <p className="max-w-3xl text-base leading-7 text-slate-600 sm:text-lg">
+                The vault keeps audit packages, operational restores, and
+                research baselines on one route, while preserving a dedicated
+                detail surface for deep review of the active snapshot.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+              >
+                Back to route index
+              </Link>
+              <Link
+                href={`/archive-vault?snapshot=${selection.selectedSnapshot.id}`}
+                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-5 py-3 text-sm font-semibold text-amber-50 transition hover:bg-slate-800"
+              >
+                Keep current snapshot in view
+              </Link>
+            </div>
           </div>
 
-          <Link
-            href="/"
-            className="inline-flex items-center justify-center rounded-full border border-slate-300 px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+          <section
+            aria-labelledby="archive-vault-overview-title"
+            className="rounded-[1.6rem] border border-slate-200 bg-white/70 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)]"
           >
-            Back to route index
-          </Link>
+            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">
+              Route overview
+            </p>
+            <h2
+              id="archive-vault-overview-title"
+              className="mt-3 text-2xl font-semibold tracking-tight text-slate-950"
+            >
+              Archive coverage at a glance
+            </h2>
+            <div className="mt-5 grid gap-4">
+              {overview.map((item) => (
+                <article
+                  key={item.label}
+                  className="rounded-[1.35rem] border border-slate-200 bg-slate-50/80 p-4"
+                >
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                    {item.label}
+                  </p>
+                  <p className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">
+                    {item.value}
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-slate-600">
+                    {item.detail}
+                  </p>
+                </article>
+              ))}
+            </div>
+          </section>
         </div>
       </header>
 
-      <section className="grid gap-6 xl:grid-cols-[minmax(0,1.05fr)_minmax(320px,0.95fr)]">
-        <article className="rounded-[1.75rem] border border-[var(--line)] bg-[var(--surface)] p-6 shadow-[0_18px_70px_rgba(15,23,42,0.06)]">
-          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Snapshot browser
-          </p>
-          <h2 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
-            Grouped archive entries will render here
-          </h2>
-          <p className="mt-3 max-w-2xl text-sm leading-7 text-slate-600">
-            Subtask 1 establishes the route shell and the two-column layout that
-            later subtasks will fill with archive data, tags, badges, and
-            detail content.
-          </p>
-        </article>
+      <section className="grid gap-6 xl:grid-cols-[minmax(0,1.12fr)_minmax(320px,0.88fr)] xl:items-start">
+        <div className="space-y-6">
+          <section className="rounded-[1.75rem] border border-[var(--line)] bg-[var(--surface)] p-6 shadow-[0_18px_70px_rgba(15,23,42,0.06)]">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+              <div className="space-y-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                  Snapshot browser
+                </p>
+                <h2 className="text-3xl font-semibold tracking-tight text-slate-950">
+                  Multiple archive lanes, one active detail summary
+                </h2>
+              </div>
+              <p className="max-w-2xl text-sm leading-7 text-slate-600">
+                Each group keeps its own archive purpose, while the shared
+                detail panel stays ready for comparisons, replay, and restore
+                planning from the selected snapshot.
+              </p>
+            </div>
+          </section>
 
-        <aside className="rounded-[1.75rem] border border-[var(--line)] bg-[var(--surface)] p-6 shadow-[0_18px_70px_rgba(15,23,42,0.06)]">
-          <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">
-            Detail panel
-          </p>
-          <h2 className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
-            Comparison-ready summary placeholder
-          </h2>
-          <p className="mt-3 text-sm leading-7 text-slate-600">
-            Later subtasks will populate this area with metadata labels,
-            preservation notes, and snapshot comparison context.
-          </p>
-        </aside>
+          {selection.snapshotGroups.map((group) => (
+            <ArchiveVaultSnapshotGroup
+              key={group.id}
+              group={group}
+              selectedSnapshotId={selection.selectedSnapshot.id}
+            />
+          ))}
+        </div>
+
+        <ArchiveVaultDetailPanel
+          snapshot={selection.selectedSnapshot}
+          requestedSnapshotId={selection.requestedSnapshotId}
+          selectionFound={selection.selectionFound}
+        />
       </section>
     </main>
   );

--- a/src/app/archive-vault/page.tsx
+++ b/src/app/archive-vault/page.tsx
@@ -11,6 +11,7 @@ import {
   readRequestedSnapshotId,
   resolveArchiveVaultSelection,
 } from "./_lib/archive-vault";
+import styles from "./archive-vault.module.css";
 
 type ArchiveVaultPageProps = {
   searchParams: Promise<{
@@ -60,35 +61,33 @@ export default async function ArchiveVaultPage({
   const overview = buildOverview();
 
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-7xl flex-1 flex-col gap-8 px-6 py-12 sm:px-10 lg:px-14">
-      <header className="overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] p-8 shadow-[0_20px_90px_rgba(15,23,42,0.08)] sm:p-10">
-        <div className="grid gap-8 xl:grid-cols-[minmax(0,1.25fr)_minmax(280px,0.75fr)] xl:items-end">
-          <div className="space-y-5">
+    <main className={styles.vaultPage}>
+      <header className={styles.heroPanel}>
+        <div className={styles.heroGrid}>
+          <div className={styles.heroCopy}>
             <div className="space-y-4">
-              <p className="text-sm font-semibold uppercase tracking-[0.28em] text-amber-700">
-                Archive Vault
-              </p>
-              <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
+              <p className={styles.eyebrow}>Archive Vault</p>
+              <h1 className={styles.heroTitle}>
                 Browse sealed snapshots with visible labels, metadata badges,
                 and a comparison-ready detail panel.
               </h1>
-              <p className="max-w-3xl text-base leading-7 text-slate-600 sm:text-lg">
+              <p className={styles.heroText}>
                 The vault keeps audit packages, operational restores, and
                 research baselines on one route, while preserving a dedicated
                 detail surface for deep review of the active snapshot.
               </p>
             </div>
 
-            <div className="flex flex-col gap-4 sm:flex-row">
+            <div className={styles.heroActions}>
               <Link
                 href="/"
-                className="inline-flex items-center justify-center rounded-full border border-slate-300 px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+                className={styles.actionGhost}
               >
                 Back to route index
               </Link>
               <Link
                 href={`/archive-vault?snapshot=${selection.selectedSnapshot.id}`}
-                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-5 py-3 text-sm font-semibold text-amber-50 transition hover:bg-slate-800"
+                className={styles.actionPrimary}
               >
                 Keep current snapshot in view
               </Link>
@@ -97,32 +96,24 @@ export default async function ArchiveVaultPage({
 
           <section
             aria-labelledby="archive-vault-overview-title"
-            className="rounded-[1.6rem] border border-slate-200 bg-white/70 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.85)]"
+            className={styles.overviewCard}
           >
-            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-slate-500">
-              Route overview
-            </p>
+            <p className={styles.eyebrow}>Route overview</p>
             <h2
               id="archive-vault-overview-title"
-              className="mt-3 text-2xl font-semibold tracking-tight text-slate-950"
+              className={styles.overviewTitle}
             >
               Archive coverage at a glance
             </h2>
-            <div className="mt-5 grid gap-4">
+            <div className={styles.overviewGrid}>
               {overview.map((item) => (
                 <article
                   key={item.label}
-                  className="rounded-[1.35rem] border border-slate-200 bg-slate-50/80 p-4"
+                  className={styles.overviewItem}
                 >
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                    {item.label}
-                  </p>
-                  <p className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">
-                    {item.value}
-                  </p>
-                  <p className="mt-2 text-sm leading-6 text-slate-600">
-                    {item.detail}
-                  </p>
+                  <p className={styles.overviewLabel}>{item.label}</p>
+                  <p className={styles.overviewValue}>{item.value}</p>
+                  <p className={styles.overviewDetail}>{item.detail}</p>
                 </article>
               ))}
             </div>
@@ -130,19 +121,17 @@ export default async function ArchiveVaultPage({
         </div>
       </header>
 
-      <section className="grid gap-6 xl:grid-cols-[minmax(0,1.12fr)_minmax(320px,0.88fr)] xl:items-start">
-        <div className="space-y-6">
-          <section className="rounded-[1.75rem] border border-[var(--line)] bg-[var(--surface)] p-6 shadow-[0_18px_70px_rgba(15,23,42,0.06)]">
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+      <section className={styles.contentGrid}>
+        <div className={styles.browserColumn}>
+          <section className={styles.browserIntro}>
+            <div className={styles.browserIntroHeader}>
               <div className="space-y-3">
-                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
-                  Snapshot browser
-                </p>
-                <h2 className="text-3xl font-semibold tracking-tight text-slate-950">
+                <p className={styles.eyebrow}>Snapshot browser</p>
+                <h2 className={styles.browserIntroTitle}>
                   Multiple archive lanes, one active detail summary
                 </h2>
               </div>
-              <p className="max-w-2xl text-sm leading-7 text-slate-600">
+              <p className={styles.browserIntroText}>
                 Each group keeps its own archive purpose, while the shared
                 detail panel stays ready for comparisons, replay, and restore
                 planning from the selected snapshot.


### PR DESCRIPTION
## Summary
- add the `archive-vault` route with grouped snapshot browsing and query-driven detail selection
- add dedicated mock archive data, metadata badges, and a comparison-ready detail panel
- add responsive route styling plus tests for default, targeted, and fallback render states

## Testing
- `npm test -- src/app/archive-vault/page.test.tsx`
- `npx eslint src/app/archive-vault/page.tsx src/app/archive-vault/page.test.tsx src/app/archive-vault/_components/archive-vault-detail-panel.tsx src/app/archive-vault/_components/archive-vault-snapshot-group.tsx src/app/archive-vault/_components/archive-vault-metadata-badge.tsx src/app/archive-vault/_lib/archive-vault.ts src/app/archive-vault/_data/archive-vault-data.ts`
- `npm test` *(fails in unrelated existing tests: `src/app/asset-inventory/page.test.tsx` and `src/app/field-guide/page.test.tsx` time out)*

Closes #145