### PR TITLE
[Test] Add Queue Monitor route with backlog columns

### DIFF
--- a/src/app/queue-monitor/_components/escalation-detail.tsx
+++ b/src/app/queue-monitor/_components/escalation-detail.tsx
@@ -1,0 +1,120 @@
+import type { QueueMonitorCardView } from "./queue-card";
+
+export function EscalationDetail({ view }: { view: QueueMonitorCardView }) {
+  const { item, queue, owner, escalation, column } = view;
+
+  return (
+    <aside
+      aria-labelledby="queue-monitor-escalation-heading"
+      className="rounded-[1.9rem] border border-slate-200 bg-slate-950 p-6 text-white shadow-[0_26px_80px_rgba(15,23,42,0.22)] sm:p-7"
+    >
+      <div className="space-y-6">
+        <div className="space-y-3">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.26em] text-sky-200/82">
+            Escalation detail
+          </p>
+          <h2
+            id="queue-monitor-escalation-heading"
+            className="text-3xl font-semibold tracking-tight"
+          >
+            {item.title}
+          </h2>
+          <p className="text-sm leading-7 text-white/76">{item.summary}</p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="rounded-full bg-white/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-white/78">
+            {item.id}
+          </span>
+          <span className="rounded-full bg-rose-500/16 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-rose-200">
+            {escalation.label}
+          </span>
+          {item.blocked ? (
+            <span className="rounded-full bg-amber-400/18 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-amber-100">
+              Blocked
+            </span>
+          ) : null}
+        </div>
+
+        <dl className="grid gap-3 sm:grid-cols-2">
+          <div className="rounded-[1.3rem] bg-white/8 px-4 py-4">
+            <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/56">
+              Current column
+            </dt>
+            <dd className="mt-2 text-lg font-semibold">{column.title}</dd>
+            <p className="mt-2 text-sm leading-6 text-white/72">{column.description}</p>
+          </div>
+
+          <div className="rounded-[1.3rem] bg-white/8 px-4 py-4">
+            <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/56">
+              Owner
+            </dt>
+            <dd className="mt-2 text-lg font-semibold">{owner.name}</dd>
+            <p className="mt-2 text-sm leading-6 text-white/72">
+              {owner.role}, {owner.team}
+            </p>
+          </div>
+
+          <div className="rounded-[1.3rem] bg-white/8 px-4 py-4">
+            <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/56">
+              Response expectation
+            </dt>
+            <dd className="mt-2 text-sm leading-6 text-white/82">
+              {escalation.responseExpectation}
+            </dd>
+            <p className="mt-2 text-sm leading-6 text-white/66">
+              {escalation.attentionNote}
+            </p>
+          </div>
+
+          <div className="rounded-[1.3rem] bg-white/8 px-4 py-4">
+            <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/56">
+              Queue focus
+            </dt>
+            <dd className="mt-2 text-lg font-semibold">{queue.name}</dd>
+            <p className="mt-2 text-sm leading-6 text-white/72">{queue.focus}</p>
+          </div>
+        </dl>
+
+        <div className="rounded-[1.3rem] border border-white/12 bg-white/6 px-4 py-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/56">
+            Due window
+          </p>
+          <p className="mt-2 text-lg font-semibold">{item.dueWindow}</p>
+          <p className="mt-2 text-sm leading-6 text-white/76">{item.lastUpdate}</p>
+        </div>
+
+        <div className="rounded-[1.3rem] border border-white/12 bg-white/6 px-4 py-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/56">
+            Recovery path
+          </p>
+          <p className="mt-2 text-sm leading-7 text-white/82">{item.nextAction}</p>
+          <p className="mt-3 text-sm leading-7 text-white/72">
+            {item.escalationDetail}
+          </p>
+          {item.blocker ? (
+            <p className="mt-3 rounded-2xl bg-white/8 px-3 py-3 text-sm leading-7 text-amber-100">
+              {item.blocker}
+            </p>
+          ) : null}
+        </div>
+
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/56">
+            Focus points
+          </p>
+          <ul className="mt-3 space-y-3">
+            {item.focusPoints.map((point) => (
+              <li
+                key={point}
+                className="rounded-[1.2rem] border border-white/10 bg-white/6 px-4 py-3 text-sm leading-7 text-white/78"
+              >
+                {point}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/app/queue-monitor/_components/escalation-detail.tsx
+++ b/src/app/queue-monitor/_components/escalation-detail.tsx
@@ -1,4 +1,5 @@
 import type { QueueMonitorCardView } from "./queue-card";
+import styles from "../queue-monitor.module.css";
 
 export function EscalationDetail({ view }: { view: QueueMonitorCardView }) {
   const { item, queue, owner, escalation, column } = view;
@@ -6,9 +7,9 @@ export function EscalationDetail({ view }: { view: QueueMonitorCardView }) {
   return (
     <aside
       aria-labelledby="queue-monitor-escalation-heading"
-      className="rounded-[1.9rem] border border-slate-200 bg-slate-950 p-6 text-white shadow-[0_26px_80px_rgba(15,23,42,0.22)] sm:p-7"
+      className={`rounded-[1.9rem] border border-slate-200 bg-slate-950 p-6 text-white shadow-[0_26px_80px_rgba(15,23,42,0.22)] sm:p-7 ${styles.detailPanel}`}
     >
-      <div className="space-y-6">
+      <div className={`space-y-6 ${styles.detailPanelContent}`}>
         <div className="space-y-3">
           <p className="text-[11px] font-semibold uppercase tracking-[0.26em] text-sky-200/82">
             Escalation detail

--- a/src/app/queue-monitor/_components/queue-card.tsx
+++ b/src/app/queue-monitor/_components/queue-card.tsx
@@ -5,6 +5,7 @@ import type {
   QueueMonitorOwner,
   QueueMonitorQueue,
 } from "../_data/queue-monitor-data";
+import styles from "../queue-monitor.module.css";
 
 export type QueueMonitorCardView = {
   item: QueueMonitorItem;
@@ -32,11 +33,13 @@ function getEscalationClasses(level: QueueMonitorEscalationMarker["id"]) {
 
 export function QueueCard({ view }: { view: QueueMonitorCardView }) {
   const { item, queue, owner, escalation } = view;
+  const isPending =
+    item.columnId === "new-intake" || item.columnId === "ready-to-assign";
 
   return (
     <article
       aria-labelledby={`${item.id}-title`}
-      className={`rounded-[1.5rem] border p-4 shadow-[0_18px_40px_rgba(15,23,42,0.05)] ${
+      className={`rounded-[1.5rem] border p-4 shadow-[0_18px_40px_rgba(15,23,42,0.05)] ${styles.queueCard} ${
         item.blocked
           ? "border-amber-300 bg-amber-50/60"
           : escalation.id === "sla-risk"
@@ -45,6 +48,7 @@ export function QueueCard({ view }: { view: QueueMonitorCardView }) {
       }`}
       data-blocked={item.blocked}
       data-escalation={escalation.id}
+      data-pending={isPending}
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="space-y-2">
@@ -171,7 +175,7 @@ export function QueueCard({ view }: { view: QueueMonitorCardView }) {
         {item.tags.map((tag) => (
           <li
             key={tag}
-            className="rounded-full border border-slate-200 bg-white/90 px-3 py-1 text-xs font-medium text-slate-600"
+            className={`rounded-full border border-slate-200 bg-white/90 px-3 py-1 text-xs font-medium text-slate-600 ${styles.tag}`}
           >
             {tag}
           </li>

--- a/src/app/queue-monitor/_components/queue-card.tsx
+++ b/src/app/queue-monitor/_components/queue-card.tsx
@@ -1,0 +1,182 @@
+import type {
+  QueueMonitorColumnDefinition,
+  QueueMonitorEscalationMarker,
+  QueueMonitorItem,
+  QueueMonitorOwner,
+  QueueMonitorQueue,
+} from "../_data/queue-monitor-data";
+
+export type QueueMonitorCardView = {
+  item: QueueMonitorItem;
+  queue: QueueMonitorQueue;
+  owner: QueueMonitorOwner;
+  escalation: QueueMonitorEscalationMarker;
+  column: QueueMonitorColumnDefinition;
+};
+
+function getEscalationClasses(level: QueueMonitorEscalationMarker["id"]) {
+  if (level === "sla-risk") {
+    return "border-rose-200 bg-rose-50 text-rose-700";
+  }
+
+  if (level === "priority") {
+    return "border-orange-200 bg-orange-50 text-orange-700";
+  }
+
+  if (level === "watch") {
+    return "border-amber-200 bg-amber-50 text-amber-700";
+  }
+
+  return "border-slate-200 bg-slate-100 text-slate-600";
+}
+
+export function QueueCard({ view }: { view: QueueMonitorCardView }) {
+  const { item, queue, owner, escalation } = view;
+
+  return (
+    <article
+      aria-labelledby={`${item.id}-title`}
+      className={`rounded-[1.5rem] border p-4 shadow-[0_18px_40px_rgba(15,23,42,0.05)] ${
+        item.blocked
+          ? "border-amber-300 bg-amber-50/60"
+          : escalation.id === "sla-risk"
+            ? "border-rose-200 bg-rose-50/55"
+            : "border-slate-200 bg-white/92"
+      }`}
+      data-blocked={item.blocked}
+      data-escalation={escalation.id}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full bg-slate-950 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-white">
+              {item.id}
+            </span>
+            <span className="rounded-full border border-slate-200 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-600">
+              {queue.name}
+            </span>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-full border border-slate-200 bg-slate-100 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-600">
+              {item.statusLabel}
+            </span>
+            <span
+              className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${getEscalationClasses(
+                escalation.id,
+              )}`}
+            >
+              {escalation.label}
+            </span>
+            {item.blocked ? (
+              <span className="rounded-full border border-amber-300 bg-amber-100 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-800">
+                Blocked
+              </span>
+            ) : null}
+          </div>
+
+          <div className="space-y-1">
+            <h3
+              id={`${item.id}-title`}
+              className="text-lg font-semibold tracking-tight text-slate-950"
+            >
+              {item.title}
+            </h3>
+            <p className="text-sm text-slate-600">{item.account}</p>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-slate-200 bg-white/90 px-3 py-3 text-right">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Age
+          </p>
+          <p className="mt-1 text-2xl font-semibold tracking-tight text-slate-950">
+            {item.ageHours}h
+          </p>
+        </div>
+      </div>
+
+      <dl className="mt-4 grid gap-3 text-sm text-slate-700 sm:grid-cols-2">
+        <div className="rounded-2xl bg-white/75 px-3 py-3 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.16)]">
+          <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Owner
+          </dt>
+          <dd className="mt-2">
+            <span className="font-medium text-slate-950">{owner.name}</span>
+            <span className="block text-slate-500">
+              {owner.role}, {owner.team}
+            </span>
+          </dd>
+        </div>
+
+        <div className="rounded-2xl bg-white/75 px-3 py-3 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.16)]">
+          <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Due window
+          </dt>
+          <dd className="mt-2 font-medium text-slate-900">{item.dueWindow}</dd>
+        </div>
+
+        <div className="rounded-2xl bg-white/75 px-3 py-3 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.16)]">
+          <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Backlog position
+          </dt>
+          <dd className="mt-2 font-medium text-slate-900">{item.backlogPosition}</dd>
+        </div>
+
+        <div className="rounded-2xl bg-white/75 px-3 py-3 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.16)]">
+          <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Queue focus
+          </dt>
+          <dd className="mt-2 text-slate-700">{queue.focus}</dd>
+        </div>
+      </dl>
+
+      <div className="mt-4 space-y-3 rounded-[1.2rem] border border-dashed border-slate-200 px-4 py-4">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Last update
+          </p>
+          <p className="mt-2 text-sm leading-6 text-slate-700">{item.lastUpdate}</p>
+        </div>
+
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Next action
+          </p>
+          <p className="mt-2 text-sm leading-6 text-slate-700">{item.nextAction}</p>
+        </div>
+
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Escalation detail
+          </p>
+          <p className="mt-2 text-sm leading-6 text-slate-700">
+            {item.escalationDetail}
+          </p>
+        </div>
+
+        {item.blocker ? (
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+              Blocker
+            </p>
+            <p className="mt-2 text-sm leading-6 text-slate-700">{item.blocker}</p>
+          </div>
+        ) : null}
+      </div>
+
+      <p className="mt-4 text-sm leading-6 text-slate-600">{item.summary}</p>
+
+      <ul aria-label={`${item.id} tags`} className="mt-4 flex flex-wrap gap-2">
+        {item.tags.map((tag) => (
+          <li
+            key={tag}
+            className="rounded-full border border-slate-200 bg-white/90 px-3 py-1 text-xs font-medium text-slate-600"
+          >
+            {tag}
+          </li>
+        ))}
+      </ul>
+    </article>
+  );
+}

--- a/src/app/queue-monitor/_components/queue-column.tsx
+++ b/src/app/queue-monitor/_components/queue-column.tsx
@@ -1,4 +1,5 @@
 import type { QueueMonitorColumnDefinition } from "../_data/queue-monitor-data";
+import styles from "../queue-monitor.module.css";
 import { QueueCard, type QueueMonitorCardView } from "./queue-card";
 
 export function QueueColumn({
@@ -15,7 +16,7 @@ export function QueueColumn({
   return (
     <section
       aria-labelledby={headingId}
-      className="flex min-h-full flex-col rounded-[1.75rem] border border-slate-200 bg-white/78 p-5 shadow-[0_24px_60px_rgba(15,23,42,0.06)]"
+      className={`flex min-h-full flex-col rounded-[1.75rem] border border-slate-200 bg-white/78 p-5 shadow-[0_24px_60px_rgba(15,23,42,0.06)] ${styles.columnShell}`}
       data-column={column.id}
     >
       <div className="space-y-4 border-b border-slate-200 pb-4">

--- a/src/app/queue-monitor/_components/queue-column.tsx
+++ b/src/app/queue-monitor/_components/queue-column.tsx
@@ -1,0 +1,80 @@
+import type { QueueMonitorColumnDefinition } from "../_data/queue-monitor-data";
+import { QueueCard, type QueueMonitorCardView } from "./queue-card";
+
+export function QueueColumn({
+  column,
+  items,
+}: {
+  column: QueueMonitorColumnDefinition;
+  items: QueueMonitorCardView[];
+}) {
+  const headingId = `${column.id}-heading`;
+  const escalatedCount = items.filter((view) => view.escalation.id !== "steady").length;
+  const blockedCount = items.filter((view) => view.item.blocked).length;
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      className="flex min-h-full flex-col rounded-[1.75rem] border border-slate-200 bg-white/78 p-5 shadow-[0_24px_60px_rgba(15,23,42,0.06)]"
+      data-column={column.id}
+    >
+      <div className="space-y-4 border-b border-slate-200 pb-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-2">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Backlog column
+            </p>
+            <h2 id={headingId} className="text-2xl font-semibold tracking-tight text-slate-950">
+              {column.title}
+            </h2>
+          </div>
+
+          <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-right">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+              Items
+            </p>
+            <p className="mt-1 text-3xl font-semibold tracking-tight text-slate-950">
+              {items.length}
+            </p>
+          </div>
+        </div>
+
+        <p className="text-sm leading-6 text-slate-600">{column.description}</p>
+        <p className="rounded-2xl bg-slate-50 px-3 py-3 text-sm leading-6 text-slate-600">
+          {column.backlogExpectation}
+        </p>
+
+        <dl className="grid gap-3 text-sm text-slate-700 sm:grid-cols-3">
+          <div className="rounded-2xl border border-slate-200 bg-white px-3 py-3">
+            <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+              WIP limit
+            </dt>
+            <dd className="mt-2 font-medium text-slate-950">{column.wipLimit}</dd>
+          </div>
+
+          <div className="rounded-2xl border border-slate-200 bg-white px-3 py-3">
+            <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+              Escalated
+            </dt>
+            <dd className="mt-2 font-medium text-slate-950">{escalatedCount}</dd>
+          </div>
+
+          <div className="rounded-2xl border border-slate-200 bg-white px-3 py-3">
+            <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+              Blocked
+            </dt>
+            <dd className="mt-2 font-medium text-slate-950">{blockedCount}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <ul aria-label={`${column.title} items`} className="mt-4 space-y-4">
+        {items.map((view) => (
+          <li key={view.item.id}>
+            <QueueCard view={view} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/app/queue-monitor/_data/queue-monitor-data.ts
+++ b/src/app/queue-monitor/_data/queue-monitor-data.ts
@@ -1,0 +1,447 @@
+export type QueueMonitorColumnId =
+  | "new-intake"
+  | "ready-to-assign"
+  | "actively-working"
+  | "awaiting-external"
+  | "ready-to-close";
+
+export type QueueMonitorEscalationId =
+  | "steady"
+  | "watch"
+  | "priority"
+  | "sla-risk";
+
+export type QueueMonitorQueue = {
+  id: string;
+  name: string;
+  focus: string;
+  summaryWindow: string;
+};
+
+export type QueueMonitorOwner = {
+  id: string;
+  name: string;
+  role: string;
+  team: string;
+  initials: string;
+};
+
+export type QueueMonitorEscalationMarker = {
+  id: QueueMonitorEscalationId;
+  label: string;
+  summary: string;
+  responseExpectation: string;
+  attentionNote: string;
+};
+
+export type QueueMonitorColumnDefinition = {
+  id: QueueMonitorColumnId;
+  title: string;
+  description: string;
+  wipLimit: number;
+  backlogExpectation: string;
+};
+
+export type QueueMonitorItem = {
+  id: string;
+  title: string;
+  queueId: QueueMonitorQueue["id"];
+  account: string;
+  columnId: QueueMonitorColumnId;
+  ownerId: QueueMonitorOwner["id"];
+  escalationId: QueueMonitorEscalationId;
+  statusLabel: string;
+  ageHours: number;
+  blocked: boolean;
+  backlogPosition: string;
+  dueWindow: string;
+  lastUpdate: string;
+  nextAction: string;
+  escalationDetail: string;
+  blocker?: string;
+  summary: string;
+  tags: string[];
+  focusPoints: string[];
+};
+
+export const queueMonitorQueues: QueueMonitorQueue[] = [
+  {
+    id: "returns-exceptions",
+    name: "Returns Exceptions",
+    focus: "Reverse logistics tickets that need same-day classification.",
+    summaryWindow: "Watch volume before the 15:00 carrier sweep.",
+  },
+  {
+    id: "finance-recovery",
+    name: "Finance Recovery",
+    focus: "Credits, billing corrections, and payout exceptions.",
+    summaryWindow: "Keep callbacks inside the daily customer commitment window.",
+  },
+  {
+    id: "partner-holds",
+    name: "Partner Holds",
+    focus: "External blockers owned by brokers, warehouses, and delivery partners.",
+    summaryWindow: "Review every 30 minutes while partner desks are active.",
+  },
+  {
+    id: "cold-chain-control",
+    name: "Cold Chain Control",
+    focus: "Temperature-sensitive moves with tight handling windows.",
+    summaryWindow: "Escalate before reefer or dispatch holds roll overnight.",
+  },
+];
+
+export const queueMonitorOwners: QueueMonitorOwner[] = [
+  {
+    id: "amira-kim",
+    name: "Amira Kim",
+    role: "Queue lead",
+    team: "Workflow Control",
+    initials: "AK",
+  },
+  {
+    id: "jonah-reed",
+    name: "Jonah Reed",
+    role: "Escalation analyst",
+    team: "Recovery Desk",
+    initials: "JR",
+  },
+  {
+    id: "priya-nolan",
+    name: "Priya Nolan",
+    role: "Partner liaison",
+    team: "External Ops",
+    initials: "PN",
+  },
+  {
+    id: "lucas-ibarra",
+    name: "Lucas Ibarra",
+    role: "Resolution manager",
+    team: "Customer Recovery",
+    initials: "LI",
+  },
+  {
+    id: "sofia-hart",
+    name: "Sofia Hart",
+    role: "Cold-chain specialist",
+    team: "Thermal Control",
+    initials: "SH",
+  },
+];
+
+export const queueMonitorEscalationMarkers: QueueMonitorEscalationMarker[] = [
+  {
+    id: "steady",
+    label: "Steady",
+    summary: "Normal operating path with no active breach risk.",
+    responseExpectation: "Review in the next regular queue sweep.",
+    attentionNote: "Keep visible, but it does not need a focused intervention yet.",
+  },
+  {
+    id: "watch",
+    label: "Watch",
+    summary: "Needs tighter observation because aging or repeat volume is building.",
+    responseExpectation: "Recheck within the next 60 minutes.",
+    attentionNote: "A short delay is acceptable, but the route should not lose ownership.",
+  },
+  {
+    id: "priority",
+    label: "Priority",
+    summary: "Customer, cost, or throughput impact is rising and needs faster action.",
+    responseExpectation: "Escalate or update within the next planning cycle.",
+    attentionNote: "Use a named owner and visible next step until the pressure drops.",
+  },
+  {
+    id: "sla-risk",
+    label: "SLA Risk",
+    summary: "A service promise is close to breach or already unsafe without intervention.",
+    responseExpectation: "Keep on the escalation panel until a recovery path is confirmed.",
+    attentionNote: "This marker should stay pinned in the detail view until it stabilizes.",
+  },
+];
+
+export const queueMonitorColumns: QueueMonitorColumnDefinition[] = [
+  {
+    id: "new-intake",
+    title: "New Intake",
+    description: "Fresh requests waiting for the first backlog review and queue assignment.",
+    wipLimit: 4,
+    backlogExpectation: "Keep under one hour of unowned intake.",
+  },
+  {
+    id: "ready-to-assign",
+    title: "Ready To Assign",
+    description: "Scoped work that needs a named owner and an explicit next checkpoint.",
+    wipLimit: 5,
+    backlogExpectation: "Do not let assignment spill beyond the current shift.",
+  },
+  {
+    id: "actively-working",
+    title: "Actively Working",
+    description: "Owners are driving the queue item and reporting progress inside the same lane.",
+    wipLimit: 6,
+    backlogExpectation: "Keep active work below the team throughput target.",
+  },
+  {
+    id: "awaiting-external",
+    title: "Awaiting External",
+    description: "Blocked on outside approvals, documents, or partner-system recovery.",
+    wipLimit: 3,
+    backlogExpectation: "Escalate early if the partner dependency is time-sensitive.",
+  },
+  {
+    id: "ready-to-close",
+    title: "Ready To Close",
+    description: "Recovery work is done and only confirmation or final notes remain.",
+    wipLimit: 4,
+    backlogExpectation: "Close within the same business day when confirmation arrives.",
+  },
+];
+
+export const queueMonitorItems: QueueMonitorItem[] = [
+  {
+    id: "QM-301",
+    title: "Classify duplicate return authorization for Luma Market",
+    queueId: "returns-exceptions",
+    account: "Luma Market",
+    columnId: "new-intake",
+    ownerId: "amira-kim",
+    escalationId: "watch",
+    statusLabel: "Needs intake review",
+    ageHours: 2,
+    blocked: false,
+    backlogPosition: "2 of 5 in intake review",
+    dueWindow: "First action due by 10:45 local",
+    lastUpdate: "Raised from overnight duplicate scan monitor at 08:12.",
+    nextAction: "Confirm whether the second authorization should merge into the live case.",
+    escalationDetail: "The same store has raised three duplicate authorizations since yesterday.",
+    summary:
+      "Carrier labels are on hold until intake decides whether this is a repeat return or a true new request.",
+    tags: ["Returns", "Retail", "Repeat volume"],
+    focusPoints: [
+      "Check whether the prior case already consumed the restock disposition.",
+      "Avoid issuing another label while the warehouse pallet is still sealed.",
+    ],
+  },
+  {
+    id: "QM-304",
+    title: "Route cold-pack variance review for Northwind Clinics",
+    queueId: "cold-chain-control",
+    account: "Northwind Clinics",
+    columnId: "new-intake",
+    ownerId: "sofia-hart",
+    escalationId: "priority",
+    statusLabel: "Pending queue assignment",
+    ageHours: 1,
+    blocked: false,
+    backlogPosition: "1 of 3 cold-chain intake tickets",
+    dueWindow: "Assignment due before 11:00 dispatch planning",
+    lastUpdate: "Temperature logger exception arrived with the morning reefer unload.",
+    nextAction: "Assign the case to the thermal specialist before the noon outbound wave.",
+    escalationDetail: "If the review slips, the clinic replenishment may miss the protected dispatch window.",
+    summary:
+      "The shipment is stable, but the variance needs specialist ownership before the product can be released.",
+    tags: ["Cold chain", "Dispatch", "Thermal"],
+    focusPoints: [
+      "Compare logger timestamps against the dock handoff record.",
+      "Confirm whether the clinic accepted the alternate storage path.",
+    ],
+  },
+  {
+    id: "QM-287",
+    title: "Assign missed pickup credit follow-up for Harbor Electric",
+    queueId: "finance-recovery",
+    account: "Harbor Electric",
+    columnId: "ready-to-assign",
+    ownerId: "jonah-reed",
+    escalationId: "priority",
+    statusLabel: "Waiting for named owner",
+    ageHours: 6,
+    blocked: false,
+    backlogPosition: "3 of 7 in assignment queue",
+    dueWindow: "Customer callback promised before 14:00",
+    lastUpdate: "Support renewed the request after the customer asked for a same-day answer.",
+    nextAction: "Hand off to a recovery manager who can approve the credit path today.",
+    escalationDetail: "The account team has already committed to a same-day callback with a decision.",
+    summary:
+      "The queue item is fully scoped, but it needs an owner with credit approval authority before the callback window closes.",
+    tags: ["Credits", "Customer commit", "Callback"],
+    focusPoints: [
+      "Check whether the missed pickup was carrier-caused or warehouse-caused.",
+      "Confirm the credit amount already discussed with customer success.",
+    ],
+  },
+  {
+    id: "QM-292",
+    title: "Queue broker document replay for Eastline Components",
+    queueId: "partner-holds",
+    account: "Eastline Components",
+    columnId: "ready-to-assign",
+    ownerId: "priya-nolan",
+    escalationId: "watch",
+    statusLabel: "Ready for partner follow-up",
+    ageHours: 4,
+    blocked: false,
+    backlogPosition: "5 of 7 in assignment queue",
+    dueWindow: "Partner touchpoint due this hour",
+    lastUpdate: "The broker requested a clean resend after their portal timed out overnight.",
+    nextAction: "Assign to the liaison covering the broker desk before lunch coverage changes.",
+    escalationDetail: "The delay is still recoverable, but the desk handoff gets slower after noon.",
+    summary:
+      "The issue is straightforward if the replay is assigned before the broker team rotates coverage.",
+    tags: ["Broker", "Replay", "Portal"],
+    focusPoints: [
+      "Confirm the replay packet includes the amended invoice page count.",
+      "Avoid reusing the expired broker portal upload token.",
+    ],
+  },
+  {
+    id: "QM-276",
+    title: "Resolve scanner gap on Lattice Foods replenishment batch",
+    queueId: "returns-exceptions",
+    account: "Lattice Foods",
+    columnId: "actively-working",
+    ownerId: "amira-kim",
+    escalationId: "steady",
+    statusLabel: "Investigating scan history",
+    ageHours: 5,
+    blocked: false,
+    backlogPosition: "2 of 6 in active work",
+    dueWindow: "Recovery note expected by the next replenishment check",
+    lastUpdate: "Ops replayed two handheld logs and isolated the missing wave segment.",
+    nextAction: "Confirm whether the missing scans can be replayed without manual relabeling.",
+    escalationDetail: "No service breach is active because the replenishment truck is still inside tolerance.",
+    summary:
+      "The queue item is moving on schedule and should clear once the missing scan segment is replayed.",
+    tags: ["Scanning", "Replenishment", "Warehouse"],
+    focusPoints: [
+      "Check the handheld battery swap window against the missing scan timestamps.",
+      "Update the store ETA only if the replay fails.",
+    ],
+  },
+  {
+    id: "QM-281",
+    title: "Secure finance approval for Atlas Home exception credit",
+    queueId: "finance-recovery",
+    account: "Atlas Home",
+    columnId: "actively-working",
+    ownerId: "lucas-ibarra",
+    escalationId: "priority",
+    statusLabel: "Approval path in motion",
+    ageHours: 9,
+    blocked: false,
+    backlogPosition: "4 of 6 in active work",
+    dueWindow: "Decision required before the 15:00 renewal call",
+    lastUpdate: "Finance asked for proof that the warehouse carrier handoff failed twice.",
+    nextAction: "Attach the second failed pickup record and resubmit the credit request for approval.",
+    escalationDetail: "The renewal team cannot brief the customer without a final credit position.",
+    summary:
+      "Most of the work is done, but the last approval gate needs evidence before the customer-facing call.",
+    tags: ["Finance", "Renewal", "Approval"],
+    focusPoints: [
+      "Pull the warehouse gate logs for both failed pickup attempts.",
+      "Keep the account executive informed before the renewal call starts.",
+    ],
+  },
+  {
+    id: "QM-268",
+    title: "Await amended customs packet for Ember Devices",
+    queueId: "partner-holds",
+    account: "Ember Devices",
+    columnId: "awaiting-external",
+    ownerId: "priya-nolan",
+    escalationId: "watch",
+    statusLabel: "Waiting on broker resend",
+    ageHours: 11,
+    blocked: true,
+    backlogPosition: "1 of 4 external holds",
+    dueWindow: "Broker response due before detention charges start",
+    lastUpdate: "The broker acknowledged the packet error and promised a corrected upload.",
+    nextAction: "Stay on the broker queue until the amended packet appears in the portal.",
+    escalationDetail: "Charges are not active yet, but the window narrows if the resend misses the afternoon cut.",
+    blocker: "The broker portal still shows the outdated invoice packet from the first submission.",
+    summary:
+      "The queue item is externally blocked, but the broker has already confirmed they are preparing the corrected packet.",
+    tags: ["Broker", "Customs", "External hold"],
+    focusPoints: [
+      "Check that the commodity count and invoice page count match the corrected packet.",
+      "Escalate to the broker lead if nothing lands before the afternoon cut.",
+    ],
+  },
+  {
+    id: "QM-271",
+    title: "Obtain weekend dispatch waiver for Summit Bio restock",
+    queueId: "cold-chain-control",
+    account: "Summit Bio",
+    columnId: "awaiting-external",
+    ownerId: "sofia-hart",
+    escalationId: "sla-risk",
+    statusLabel: "Blocked on clinical sign-off",
+    ageHours: 17,
+    blocked: true,
+    backlogPosition: "2 of 4 external holds",
+    dueWindow: "Waiver required in 90 minutes to keep the reefer release",
+    lastUpdate: "The customer accepted the reroute plan, but clinical leadership still has not signed the weekend waiver.",
+    nextAction: "Keep the case on the escalation panel and call the clinical approver directly if legal is still silent at the top of the hour.",
+    escalationDetail: "Without the waiver, the reefer slot rolls overnight and the replenishment order misses the service commitment.",
+    blocker: "Clinical leadership has not returned the signed waiver packet to the dispatch desk.",
+    summary:
+      "This is the highest-risk queue item because the recovery path exists, but the external signature has not landed.",
+    tags: ["Cold chain", "SLA risk", "Weekend release"],
+    focusPoints: [
+      "Confirm whether legal can accept an emailed signature copy while the portal is delayed.",
+      "Prepare the fallback dispatch note in case the reefer slot is lost.",
+      "Keep the account team updated every 30 minutes until the waiver lands.",
+    ],
+  },
+  {
+    id: "QM-259",
+    title: "Close recovery note for Cedar Labs freezer alarm false positive",
+    queueId: "cold-chain-control",
+    account: "Cedar Labs",
+    columnId: "ready-to-close",
+    ownerId: "lucas-ibarra",
+    escalationId: "steady",
+    statusLabel: "Pending final note",
+    ageHours: 3,
+    blocked: false,
+    backlogPosition: "1 of 2 awaiting closure",
+    dueWindow: "Close before shift handoff",
+    lastUpdate: "The lab confirmed there was no product exposure after the alarm review.",
+    nextAction: "Send the final customer recap and archive the alarm trace with the queue record.",
+    escalationDetail: "Operational risk is cleared, so the remaining work is documentation only.",
+    summary:
+      "The queue item is functionally resolved and only needs closure notes before it leaves the board.",
+    tags: ["Closure", "Alarm review", "Documentation"],
+    focusPoints: [
+      "Attach the corrected logger screenshot to the closure note.",
+      "Confirm the lab contact received the no-exposure summary.",
+    ],
+  },
+  {
+    id: "QM-263",
+    title: "Finalize payout correction summary for Beacon Stores",
+    queueId: "finance-recovery",
+    account: "Beacon Stores",
+    columnId: "ready-to-close",
+    ownerId: "jonah-reed",
+    escalationId: "watch",
+    statusLabel: "Waiting on customer acknowledgement",
+    ageHours: 8,
+    blocked: false,
+    backlogPosition: "2 of 2 awaiting closure",
+    dueWindow: "Close today if the finance contact confirms",
+    lastUpdate: "Corrected payout figures were delivered and the customer asked for a short verification window.",
+    nextAction: "Check for acknowledgement after the next finance inbox sweep and close if approved.",
+    escalationDetail: "The account is stable, but the open loop should not roll into tomorrow without a response.",
+    summary:
+      "The financial correction is complete, and only customer acknowledgement remains before the queue item can close.",
+    tags: ["Payouts", "Customer follow-up", "Closure"],
+    focusPoints: [
+      "Confirm the corrected payout amount matches the memo already sent to the store group.",
+      "Close immediately if the customer acknowledges before handoff.",
+    ],
+  },
+];
+
+export const queueMonitorFocusedItemId = "QM-271";

--- a/src/app/queue-monitor/page.test.tsx
+++ b/src/app/queue-monitor/page.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import QueueMonitorPage from "./page";
+import {
+  queueMonitorColumns,
+  queueMonitorFocusedItemId,
+  queueMonitorItems,
+  queueMonitorQueues,
+} from "./_data/queue-monitor-data";
+
+describe("QueueMonitorPage", () => {
+  it("renders the route sections for summaries, queues, backlog columns, and escalation detail", () => {
+    render(<QueueMonitorPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /scan backlog columns, queue summaries, and the highest-risk escalation from one route/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /workflow pressure at a glance/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /queue-by-queue workload/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /backlog columns with a focused escalation lane/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/controlled conflict drill b landing page headline/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders summary metrics and queue summaries from the mock dataset", () => {
+    render(<QueueMonitorPage />);
+
+    const metricList = screen.getByRole("list", {
+      name: /queue summary metrics/i,
+    });
+    const queueSummaryList = screen.getByRole("list", {
+      name: /queue summaries/i,
+    });
+
+    expect(within(metricList).getAllByRole("listitem")).toHaveLength(4);
+    expect(within(queueSummaryList).getAllByRole("listitem")).toHaveLength(
+      queueMonitorQueues.length,
+    );
+
+    for (const queue of queueMonitorQueues) {
+      const queueCard = within(queueSummaryList)
+        .getByText(queue.name)
+        .closest('[role="listitem"]');
+
+      expect(queueCard).toBeInTheDocument();
+      expect(queueCard).toHaveTextContent(queue.focus);
+      expect(queueCard).toHaveTextContent(queue.summaryWindow);
+    }
+  });
+
+  it("renders each backlog column with the expected number of cards", () => {
+    render(<QueueMonitorPage />);
+
+    const board = screen.getByTestId("queue-monitor-columns");
+
+    for (const column of queueMonitorColumns) {
+      const expectedItems = queueMonitorItems.filter(
+        (item) => item.columnId === column.id,
+      );
+      const columnRegion = within(board).getByRole("region", {
+        name: column.title,
+      });
+      const itemList = within(columnRegion).getByRole("list", {
+        name: `${column.title} items`,
+      });
+
+      expect(within(columnRegion).getByText(column.description)).toBeInTheDocument();
+      expect(within(columnRegion).getByText(column.backlogExpectation)).toBeInTheDocument();
+      expect(within(itemList).getAllByRole("article")).toHaveLength(
+        expectedItems.length,
+      );
+    }
+  });
+
+  it("shows representative blocked and escalated content in cards and the detail panel", () => {
+    render(<QueueMonitorPage />);
+
+    const focusedItem = queueMonitorItems.find(
+      (item) => item.id === queueMonitorFocusedItemId,
+    );
+
+    expect(focusedItem).toBeDefined();
+
+    const blockedCard = screen
+      .getByRole("heading", {
+        level: 3,
+        name: /obtain weekend dispatch waiver for summit bio restock/i,
+      })
+      .closest("article");
+
+    expect(blockedCard).toBeInTheDocument();
+    expect(blockedCard).toHaveTextContent("Blocked");
+    expect(blockedCard).toHaveTextContent("SLA Risk");
+    expect(blockedCard).toHaveTextContent("Waiver required in 90 minutes");
+    expect(blockedCard).toHaveTextContent(
+      /clinical leadership has not returned the signed waiver packet/i,
+    );
+
+    const detailPanel = screen
+      .getByRole("heading", {
+        level: 2,
+        name: /obtain weekend dispatch waiver for summit bio restock/i,
+      })
+      .closest("aside");
+
+    expect(detailPanel).toBeInTheDocument();
+    expect(detailPanel).toHaveTextContent("Cold Chain Control");
+    expect(detailPanel).toHaveTextContent("SLA Risk");
+    expect(detailPanel).toHaveTextContent(
+      /keep on the escalation panel until a recovery path is confirmed/i,
+    );
+
+    for (const point of focusedItem?.focusPoints ?? []) {
+      expect(detailPanel).toHaveTextContent(point);
+    }
+  });
+});

--- a/src/app/queue-monitor/page.tsx
+++ b/src/app/queue-monitor/page.tsx
@@ -1,0 +1,116 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Queue Monitor",
+  description:
+    "Initial route shell for monitoring queue backlog columns, summaries, and escalation details.",
+};
+
+const shellSections = [
+  {
+    title: "Queue summary",
+    description:
+      "Summary tiles will surface backlog totals, aging items, and the highest-risk escalations.",
+  },
+  {
+    title: "Backlog columns",
+    description:
+      "Column sections will break the queue into operational stages with focused card content.",
+  },
+  {
+    title: "Escalation detail panel",
+    description:
+      "A dedicated panel will keep the most urgent queue item visible with owner and recovery context.",
+  },
+];
+
+export default function QueueMonitorPage() {
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-12 sm:px-10 lg:px-12">
+      <section className="overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_24px_90px_rgba(15,23,42,0.08)]">
+        <div className="grid gap-8 px-6 py-10 sm:px-10 lg:grid-cols-[minmax(0,1.2fr)_minmax(18rem,0.8fr)] lg:px-12 lg:py-14">
+          <div className="space-y-6">
+            <div className="space-y-3">
+              <p className="text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
+                Queue Monitor
+              </p>
+              <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
+                Minimal route shell for backlog monitoring and escalation follow-up.
+              </h1>
+              <p className="max-w-2xl text-lg leading-8 text-slate-600">
+                This first pass only establishes the route structure. Queue data,
+                cards, backlog columns, and detail behavior will be layered in
+                through the remaining subtasks.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
+              >
+                Back to overview
+              </Link>
+              <a
+                href="#queue-monitor-shell"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+              >
+                View scaffold
+              </a>
+            </div>
+          </div>
+
+          <aside className="rounded-[1.75rem] border border-slate-200/80 bg-white/80 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.75)]">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Subtask 1 scope
+            </p>
+            <ul className="mt-5 space-y-4">
+              <li className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 text-sm leading-6 text-slate-600">
+                Route folder and metadata are in place under `src/app/queue-monitor`.
+              </li>
+              <li className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 text-sm leading-6 text-slate-600">
+                The page already reserves dedicated sections for summaries,
+                backlog columns, and escalations.
+              </li>
+              <li className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 text-sm leading-6 text-slate-600">
+                Data, components, styling, and tests are intentionally deferred
+                to the next subtasks.
+              </li>
+            </ul>
+          </aside>
+        </div>
+      </section>
+
+      <section
+        id="queue-monitor-shell"
+        aria-labelledby="queue-monitor-shell-heading"
+        className="grid gap-5 lg:grid-cols-3"
+      >
+        {shellSections.map((section) => (
+          <article
+            key={section.title}
+            className="rounded-[1.5rem] border border-slate-200 bg-white/78 p-5 shadow-[0_18px_50px_rgba(15,23,42,0.05)]"
+          >
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Planned section
+            </p>
+            <h2
+              id={
+                section.title === "Queue summary"
+                  ? "queue-monitor-shell-heading"
+                  : undefined
+              }
+              className="mt-3 text-2xl font-semibold tracking-tight text-slate-950"
+            >
+              {section.title}
+            </h2>
+            <p className="mt-3 text-sm leading-7 text-slate-600">
+              {section.description}
+            </p>
+          </article>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/src/app/queue-monitor/page.tsx
+++ b/src/app/queue-monitor/page.tsx
@@ -12,6 +12,7 @@ import {
   queueMonitorOwners,
   queueMonitorQueues,
 } from "./_data/queue-monitor-data";
+import styles from "./queue-monitor.module.css";
 
 export const metadata: Metadata = {
   title: "Queue Monitor",
@@ -111,9 +112,11 @@ export default function QueueMonitorPage() {
 
   return (
     <main className="mx-auto flex w-full max-w-[98rem] flex-1 flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
-      <section className="overflow-hidden rounded-[2.25rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_28px_90px_rgba(15,23,42,0.08)]">
+      <section
+        className={`overflow-hidden rounded-[2.25rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_28px_90px_rgba(15,23,42,0.08)] ${styles.heroSurface}`}
+      >
         <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1.3fr)_minmax(18rem,0.85fr)] lg:px-12 lg:py-12">
-          <div className="space-y-6">
+          <div className={`space-y-6 ${styles.heroPanel}`}>
             <div className="flex flex-wrap items-center gap-3">
               <p className="rounded-full bg-sky-100 px-3 py-1 text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
                 Queue Monitor
@@ -154,7 +157,9 @@ export default function QueueMonitorPage() {
             </div>
           </div>
 
-          <aside className="rounded-[1.85rem] border border-slate-200/80 bg-slate-950 p-6 text-white shadow-[0_24px_60px_rgba(15,23,42,0.16)]">
+          <aside
+            className={`rounded-[1.85rem] border border-slate-200/80 bg-slate-950 p-6 text-white shadow-[0_24px_60px_rgba(15,23,42,0.16)] ${styles.heroAside}`}
+          >
             <div className="space-y-5">
               <div>
                 <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-sky-200/78">
@@ -226,7 +231,7 @@ export default function QueueMonitorPage() {
           {summaryMetrics.map((metric) => (
             <article
               key={metric.label}
-              className="rounded-[1.5rem] border border-slate-200 bg-white/82 p-5 shadow-[0_18px_45px_rgba(15,23,42,0.05)]"
+              className={`rounded-[1.5rem] border border-slate-200 bg-white/82 p-5 shadow-[0_18px_45px_rgba(15,23,42,0.05)] ${styles.metricCard}`}
               role="listitem"
             >
               <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
@@ -264,7 +269,8 @@ export default function QueueMonitorPage() {
           {queueSummaries.map(({ queue, itemCount, blockedCount, highestEscalation }) => (
             <article
               key={queue.id}
-              className="rounded-[1.5rem] border border-slate-200 bg-white/82 p-5 shadow-[0_18px_45px_rgba(15,23,42,0.05)]"
+              className={`rounded-[1.5rem] border border-slate-200 bg-white/82 p-5 shadow-[0_18px_45px_rgba(15,23,42,0.05)] ${styles.queueSummaryCard}`}
+              data-escalation={highestEscalation.id}
               role="listitem"
             >
               <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-500">
@@ -320,16 +326,20 @@ export default function QueueMonitorPage() {
           </p>
         </div>
 
-        <div className="grid gap-6 2xl:grid-cols-[minmax(0,1.6fr)_minmax(22rem,0.9fr)]">
-          <div id="queue-monitor-columns" className="grid gap-5 xl:grid-cols-2">
-            {columnViews.map(({ column, items }) => (
-              <QueueColumn key={column.id} column={column} items={items} />
-            ))}
+        <div className={styles.workflowGrid}>
+          <div className={styles.columnScroller}>
+            <div
+              id="queue-monitor-columns"
+              className={styles.columnGrid}
+              data-testid="queue-monitor-columns"
+            >
+              {columnViews.map(({ column, items }) => (
+                <QueueColumn key={column.id} column={column} items={items} />
+              ))}
+            </div>
           </div>
 
-          <article
-            className="self-start"
-          >
+          <article className={styles.detailRail}>
             <EscalationDetail view={focusedView} />
           </article>
         </div>

--- a/src/app/queue-monitor/page.tsx
+++ b/src/app/queue-monitor/page.tsx
@@ -1,47 +1,130 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
+import { EscalationDetail } from "./_components/escalation-detail";
+import { QueueColumn } from "./_components/queue-column";
+import type { QueueMonitorCardView } from "./_components/queue-card";
+import {
+  queueMonitorColumns,
+  queueMonitorEscalationMarkers,
+  queueMonitorFocusedItemId,
+  queueMonitorItems,
+  queueMonitorOwners,
+  queueMonitorQueues,
+} from "./_data/queue-monitor-data";
+
 export const metadata: Metadata = {
   title: "Queue Monitor",
   description:
-    "Initial route shell for monitoring queue backlog columns, summaries, and escalation details.",
+    "Queue monitoring route with backlog columns, queue summaries, and an escalation detail panel.",
 };
 
-const shellSections = [
-  {
-    title: "Queue summary",
-    description:
-      "Summary tiles will surface backlog totals, aging items, and the highest-risk escalations.",
-  },
-  {
-    title: "Backlog columns",
-    description:
-      "Column sections will break the queue into operational stages with focused card content.",
-  },
-  {
-    title: "Escalation detail panel",
-    description:
-      "A dedicated panel will keep the most urgent queue item visible with owner and recovery context.",
-  },
-];
+const escalationSeverityRank = {
+  steady: 0,
+  watch: 1,
+  priority: 2,
+  "sla-risk": 3,
+} as const;
+
+function getRequired<T extends { id: string }>(items: T[], id: string, label: string) {
+  const match = items.find((item) => item.id === id);
+
+  if (!match) {
+    throw new Error(`${label} not found for id: ${id}`);
+  }
+
+  return match;
+}
 
 export default function QueueMonitorPage() {
+  const cardViews: QueueMonitorCardView[] = queueMonitorItems.map((item) => ({
+    item,
+    queue: getRequired(queueMonitorQueues, item.queueId, "Queue"),
+    owner: getRequired(queueMonitorOwners, item.ownerId, "Queue owner"),
+    escalation: getRequired(
+      queueMonitorEscalationMarkers,
+      item.escalationId,
+      "Escalation marker",
+    ),
+    column: getRequired(queueMonitorColumns, item.columnId, "Queue column"),
+  }));
+
+  const totalItems = cardViews.length;
+  const blockedItems = cardViews.filter((view) => view.item.blocked).length;
+  const escalatedItems = cardViews.filter((view) => view.escalation.id !== "steady").length;
+  const agingItems = cardViews.filter((view) => view.item.ageHours >= 8).length;
+  const focusedView = getRequired(cardViews, queueMonitorFocusedItemId, "Focused queue item");
+  const columnViews = queueMonitorColumns.map((column) => ({
+    column,
+    items: cardViews.filter((view) => view.column.id === column.id),
+  }));
+  const queueSummaries = queueMonitorQueues.map((queue) => {
+    const items = cardViews.filter((view) => view.queue.id === queue.id);
+    const blockedCount = items.filter((view) => view.item.blocked).length;
+    const highestEscalation = items.reduce(
+      (current, view) =>
+        escalationSeverityRank[view.escalation.id] > escalationSeverityRank[current.id]
+          ? view.escalation
+          : current,
+      queueMonitorEscalationMarkers[0],
+    );
+
+    return {
+      queue,
+      itemCount: items.length,
+      blockedCount,
+      highestEscalation,
+    };
+  });
+  const summaryMetrics = [
+    {
+      label: "Open backlog",
+      value: String(totalItems),
+      detail: "All queue items currently visible across the monitor.",
+    },
+    {
+      label: "Escalated now",
+      value: String(escalatedItems),
+      detail: "Items carrying watch, priority, or SLA risk markers.",
+    },
+    {
+      label: "Blocked handoffs",
+      value: String(blockedItems),
+      detail: "Queue items waiting on a broker, approver, or partner reply.",
+    },
+    {
+      label: "Aging 8h+",
+      value: String(agingItems),
+      detail: "Cases old enough to need explicit queue attention this shift.",
+    },
+  ];
+
   return (
-    <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-12 sm:px-10 lg:px-12">
-      <section className="overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_24px_90px_rgba(15,23,42,0.08)]">
-        <div className="grid gap-8 px-6 py-10 sm:px-10 lg:grid-cols-[minmax(0,1.2fr)_minmax(18rem,0.8fr)] lg:px-12 lg:py-14">
+    <main className="mx-auto flex w-full max-w-[98rem] flex-1 flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
+      <section className="overflow-hidden rounded-[2.25rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_28px_90px_rgba(15,23,42,0.08)]">
+        <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1.3fr)_minmax(18rem,0.85fr)] lg:px-12 lg:py-12">
           <div className="space-y-6">
-            <div className="space-y-3">
-              <p className="text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
+            <div className="flex flex-wrap items-center gap-3">
+              <p className="rounded-full bg-sky-100 px-3 py-1 text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
                 Queue Monitor
               </p>
-              <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-                Minimal route shell for backlog monitoring and escalation follow-up.
+              <p className="rounded-full bg-white/85 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-slate-500 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.18)]">
+                Backlog control route
+              </p>
+            </div>
+
+            <div className="space-y-4">
+              <p className="text-sm font-semibold uppercase tracking-[0.28em] text-sky-700">
+                Shift overview
+              </p>
+              <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl lg:text-6xl">
+                Scan backlog columns, queue summaries, and the highest-risk escalation from one route.
               </h1>
-              <p className="max-w-2xl text-lg leading-8 text-slate-600">
-                This first pass only establishes the route structure. Queue data,
-                cards, backlog columns, and detail behavior will be layered in
-                through the remaining subtasks.
+              <p className="max-w-3xl text-base leading-8 text-slate-600 sm:text-lg">
+                The queue monitor keeps backlog sections, queue-level summaries,
+                and the focused escalation response in one place so an operator
+                can move from volume scan to intervention without leaving the
+                route.
               </p>
             </div>
 
@@ -53,63 +136,193 @@ export default function QueueMonitorPage() {
                 Back to overview
               </Link>
               <a
-                href="#queue-monitor-shell"
+                href="#queue-monitor-columns"
                 className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
               >
-                View scaffold
+                Jump to backlog
               </a>
             </div>
           </div>
 
-          <aside className="rounded-[1.75rem] border border-slate-200/80 bg-white/80 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.75)]">
-            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
-              Subtask 1 scope
-            </p>
-            <ul className="mt-5 space-y-4">
-              <li className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 text-sm leading-6 text-slate-600">
-                Route folder and metadata are in place under `src/app/queue-monitor`.
-              </li>
-              <li className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 text-sm leading-6 text-slate-600">
-                The page already reserves dedicated sections for summaries,
-                backlog columns, and escalations.
-              </li>
-              <li className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4 text-sm leading-6 text-slate-600">
-                Data, components, styling, and tests are intentionally deferred
-                to the next subtasks.
-              </li>
-            </ul>
+          <aside className="rounded-[1.85rem] border border-slate-200/80 bg-slate-950 p-6 text-white shadow-[0_24px_60px_rgba(15,23,42,0.16)]">
+            <div className="space-y-5">
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-sky-200/78">
+                  Queue pulse
+                </p>
+                <p className="mt-3 text-3xl font-semibold tracking-tight">
+                  {totalItems} visible items across {queueMonitorColumns.length} backlog columns
+                </p>
+              </div>
+
+              <div className="grid gap-3">
+                <div className="rounded-[1.25rem] bg-white/10 px-4 py-4">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/60">
+                    Highest-risk queue
+                  </p>
+                  <p className="mt-2 text-lg font-semibold">{focusedView.queue.name}</p>
+                  <p className="mt-2 text-sm leading-6 text-white/72">
+                    {focusedView.item.dueWindow}
+                  </p>
+                </div>
+
+                <div className="rounded-[1.25rem] bg-white/10 px-4 py-4">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/60">
+                    Primary blocker
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-white/76">
+                    {focusedView.item.blocker}
+                  </p>
+                </div>
+
+                <div className="rounded-[1.25rem] border border-white/12 bg-white/6 px-4 py-4">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/60">
+                    Response expectation
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-white/76">
+                    {focusedView.escalation.responseExpectation}
+                  </p>
+                </div>
+              </div>
+            </div>
           </aside>
         </div>
       </section>
 
-      <section
-        id="queue-monitor-shell"
-        aria-labelledby="queue-monitor-shell-heading"
-        className="grid gap-5 lg:grid-cols-3"
-      >
-        {shellSections.map((section) => (
-          <article
-            key={section.title}
-            className="rounded-[1.5rem] border border-slate-200 bg-white/78 p-5 shadow-[0_18px_50px_rgba(15,23,42,0.05)]"
-          >
+      <section aria-labelledby="queue-monitor-summary" className="space-y-5">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-2">
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
-              Planned section
+              Queue summary
             </p>
             <h2
-              id={
-                section.title === "Queue summary"
-                  ? "queue-monitor-shell-heading"
-                  : undefined
-              }
-              className="mt-3 text-2xl font-semibold tracking-tight text-slate-950"
+              id="queue-monitor-summary"
+              className="text-3xl font-semibold tracking-tight text-slate-950"
             >
-              {section.title}
+              Workflow pressure at a glance
             </h2>
-            <p className="mt-3 text-sm leading-7 text-slate-600">
-              {section.description}
+          </div>
+          <p className="max-w-3xl text-sm leading-7 text-slate-600">
+            The summary strip combines pure backlog counts with the operational
+            signals that usually drive queue rebalancing during the shift.
+          </p>
+        </div>
+
+        <div
+          aria-label="Queue summary metrics"
+          className="grid gap-4 md:grid-cols-2 xl:grid-cols-4"
+          role="list"
+        >
+          {summaryMetrics.map((metric) => (
+            <article
+              key={metric.label}
+              className="rounded-[1.5rem] border border-slate-200 bg-white/82 p-5 shadow-[0_18px_45px_rgba(15,23,42,0.05)]"
+              role="listitem"
+            >
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                {metric.label}
+              </p>
+              <p className="mt-3 text-4xl font-semibold tracking-tight text-slate-950">
+                {metric.value}
+              </p>
+              <p className="mt-3 text-sm leading-7 text-slate-600">{metric.detail}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="queue-monitor-queues" className="space-y-5">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Queue summaries
             </p>
+            <h2
+              id="queue-monitor-queues"
+              className="text-3xl font-semibold tracking-tight text-slate-950"
+            >
+              Queue-by-queue workload
+            </h2>
+          </div>
+          <p className="max-w-3xl text-sm leading-7 text-slate-600">
+            Each queue summary keeps the current focus, backlog count, and
+            highest escalation marker visible before you drop into the columns.
+          </p>
+        </div>
+
+        <div aria-label="Queue summaries" className="grid gap-4 xl:grid-cols-4" role="list">
+          {queueSummaries.map(({ queue, itemCount, blockedCount, highestEscalation }) => (
+            <article
+              key={queue.id}
+              className="rounded-[1.5rem] border border-slate-200 bg-white/82 p-5 shadow-[0_18px_45px_rgba(15,23,42,0.05)]"
+              role="listitem"
+            >
+              <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-500">
+                {queue.name}
+              </p>
+              <p className="mt-3 text-lg font-semibold tracking-tight text-slate-950">
+                {queue.focus}
+              </p>
+              <dl className="mt-4 grid gap-3 text-sm text-slate-700">
+                <div className="rounded-2xl bg-slate-50 px-3 py-3">
+                  <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                    Visible items
+                  </dt>
+                  <dd className="mt-2 font-medium text-slate-950">{itemCount}</dd>
+                </div>
+                <div className="rounded-2xl bg-slate-50 px-3 py-3">
+                  <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                    Blocked items
+                  </dt>
+                  <dd className="mt-2 font-medium text-slate-950">{blockedCount}</dd>
+                </div>
+                <div className="rounded-2xl bg-slate-50 px-3 py-3">
+                  <dt className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                    Highest escalation
+                  </dt>
+                  <dd className="mt-2 font-medium text-slate-950">
+                    {highestEscalation.label}
+                  </dd>
+                </div>
+              </dl>
+              <p className="mt-4 text-sm leading-7 text-slate-600">{queue.summaryWindow}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section aria-labelledby="queue-monitor-workflow" className="space-y-5">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Backlog workflow
+            </p>
+            <h2
+              id="queue-monitor-workflow"
+              className="text-3xl font-semibold tracking-tight text-slate-950"
+            >
+              Backlog columns with a focused escalation lane
+            </h2>
+          </div>
+          <p className="max-w-3xl text-sm leading-7 text-slate-600">
+            The column grid keeps the whole queue visible while the detail panel
+            stays pinned on the most urgent recovery path.
+          </p>
+        </div>
+
+        <div className="grid gap-6 2xl:grid-cols-[minmax(0,1.6fr)_minmax(22rem,0.9fr)]">
+          <div id="queue-monitor-columns" className="grid gap-5 xl:grid-cols-2">
+            {columnViews.map(({ column, items }) => (
+              <QueueColumn key={column.id} column={column} items={items} />
+            ))}
+          </div>
+
+          <article
+            className="self-start"
+          >
+            <EscalationDetail view={focusedView} />
           </article>
-        ))}
+        </div>
       </section>
     </main>
   );

--- a/src/app/queue-monitor/page.tsx
+++ b/src/app/queue-monitor/page.tsx
@@ -26,7 +26,11 @@ const escalationSeverityRank = {
   "sla-risk": 3,
 } as const;
 
-function getRequired<T extends { id: string }>(items: T[], id: string, label: string) {
+function getRequiredById<T extends { id: string }>(
+  items: T[],
+  id: string,
+  label: string,
+) {
   const match = items.find((item) => item.id === id);
 
   if (!match) {
@@ -39,21 +43,27 @@ function getRequired<T extends { id: string }>(items: T[], id: string, label: st
 export default function QueueMonitorPage() {
   const cardViews: QueueMonitorCardView[] = queueMonitorItems.map((item) => ({
     item,
-    queue: getRequired(queueMonitorQueues, item.queueId, "Queue"),
-    owner: getRequired(queueMonitorOwners, item.ownerId, "Queue owner"),
-    escalation: getRequired(
+    queue: getRequiredById(queueMonitorQueues, item.queueId, "Queue"),
+    owner: getRequiredById(queueMonitorOwners, item.ownerId, "Queue owner"),
+    escalation: getRequiredById(
       queueMonitorEscalationMarkers,
       item.escalationId,
       "Escalation marker",
     ),
-    column: getRequired(queueMonitorColumns, item.columnId, "Queue column"),
+    column: getRequiredById(queueMonitorColumns, item.columnId, "Queue column"),
   }));
 
   const totalItems = cardViews.length;
   const blockedItems = cardViews.filter((view) => view.item.blocked).length;
   const escalatedItems = cardViews.filter((view) => view.escalation.id !== "steady").length;
   const agingItems = cardViews.filter((view) => view.item.ageHours >= 8).length;
-  const focusedView = getRequired(cardViews, queueMonitorFocusedItemId, "Focused queue item");
+  const focusedView = cardViews.find(
+    (view) => view.item.id === queueMonitorFocusedItemId,
+  );
+
+  if (!focusedView) {
+    throw new Error(`Focused queue item not found for id: ${queueMonitorFocusedItemId}`);
+  }
   const columnViews = queueMonitorColumns.map((column) => ({
     column,
     items: cardViews.filter((view) => view.column.id === column.id),

--- a/src/app/queue-monitor/queue-monitor.module.css
+++ b/src/app/queue-monitor/queue-monitor.module.css
@@ -1,0 +1,253 @@
+.heroSurface {
+  position: relative;
+  isolation: isolate;
+}
+
+.heroSurface::before {
+  content: "";
+  position: absolute;
+  inset: auto -5rem -6rem auto;
+  width: 20rem;
+  height: 20rem;
+  border-radius: 9999px;
+  background:
+    radial-gradient(circle, rgba(56, 189, 248, 0.2) 0%, rgba(56, 189, 248, 0) 72%);
+  pointer-events: none;
+}
+
+.heroSurface::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(115deg, rgba(255, 255, 255, 0.72), rgba(255, 255, 255, 0) 42%),
+    radial-gradient(circle at top left, rgba(226, 232, 240, 0.76), rgba(226, 232, 240, 0) 48%);
+  opacity: 0.88;
+  pointer-events: none;
+}
+
+.heroPanel,
+.heroAside {
+  position: relative;
+  z-index: 1;
+}
+
+.heroAside {
+  backdrop-filter: blur(16px);
+}
+
+.metricCard,
+.queueSummaryCard,
+.columnShell,
+.queueCard,
+.detailPanel {
+  position: relative;
+  overflow: hidden;
+}
+
+.metricCard::after,
+.queueSummaryCard::after {
+  content: "";
+  position: absolute;
+  right: -2rem;
+  bottom: -2.5rem;
+  width: 7.5rem;
+  height: 7.5rem;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.5);
+  pointer-events: none;
+}
+
+.metricCard > *,
+.queueSummaryCard > *,
+.detailPanelContent {
+  position: relative;
+  z-index: 1;
+}
+
+.queueSummaryCard::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0.35rem;
+  background: var(--summary-accent, rgba(148, 163, 184, 0.8));
+}
+
+.queueSummaryCard[data-escalation="watch"] {
+  --summary-accent: #f59e0b;
+}
+
+.queueSummaryCard[data-escalation="priority"] {
+  --summary-accent: #f97316;
+}
+
+.queueSummaryCard[data-escalation="sla-risk"] {
+  --summary-accent: #e11d48;
+}
+
+.workflowGrid {
+  display: grid;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.columnScroller {
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+  scrollbar-width: thin;
+}
+
+.columnGrid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(5, minmax(19rem, 1fr));
+  min-width: 100rem;
+}
+
+.detailRail {
+  align-self: start;
+}
+
+.detailPanel {
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.96), rgba(15, 23, 42, 0.92)),
+    radial-gradient(circle at top right, rgba(56, 189, 248, 0.16), rgba(56, 189, 248, 0) 42%);
+}
+
+.detailPanel::before {
+  content: "";
+  position: absolute;
+  inset: auto -4rem -4rem auto;
+  width: 12rem;
+  height: 12rem;
+  border-radius: 9999px;
+  background:
+    radial-gradient(circle, rgba(56, 189, 248, 0.18) 0%, rgba(56, 189, 248, 0) 72%);
+  pointer-events: none;
+}
+
+.columnShell {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(248, 250, 252, 0.96)),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(241, 245, 249, 0.82));
+}
+
+.columnShell::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: 0.35rem;
+  background:
+    linear-gradient(90deg, var(--column-accent), color-mix(in srgb, var(--column-accent) 36%, white));
+}
+
+.columnShell[data-column="new-intake"] {
+  --column-accent: #0284c7;
+}
+
+.columnShell[data-column="ready-to-assign"] {
+  --column-accent: #0f766e;
+}
+
+.columnShell[data-column="actively-working"] {
+  --column-accent: #7c3aed;
+}
+
+.columnShell[data-column="awaiting-external"] {
+  --column-accent: #d97706;
+}
+
+.columnShell[data-column="ready-to-close"] {
+  --column-accent: #059669;
+}
+
+.queueCard {
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease;
+}
+
+.queueCard:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 45px rgba(15, 23, 42, 0.09);
+}
+
+.queueCard[data-pending="true"] {
+  background:
+    linear-gradient(180deg, rgba(240, 249, 255, 0.92), rgba(255, 255, 255, 0.98));
+}
+
+.queueCard[data-escalation="watch"] {
+  border-color: rgba(245, 158, 11, 0.34);
+  background:
+    linear-gradient(180deg, rgba(255, 251, 235, 0.94), rgba(255, 255, 255, 0.99));
+}
+
+.queueCard[data-escalation="priority"] {
+  border-color: rgba(249, 115, 22, 0.34);
+  background:
+    linear-gradient(180deg, rgba(255, 247, 237, 0.95), rgba(255, 255, 255, 0.99));
+}
+
+.queueCard[data-escalation="sla-risk"] {
+  border-color: rgba(225, 29, 72, 0.36);
+  background:
+    linear-gradient(180deg, rgba(255, 241, 242, 0.96), rgba(255, 255, 255, 0.99));
+  box-shadow: 0 24px 55px rgba(225, 29, 72, 0.12);
+}
+
+.queueCard[data-blocked="true"] {
+  border-style: dashed;
+}
+
+.queueCard[data-blocked="true"]::after {
+  content: "";
+  position: absolute;
+  inset: auto -2rem -2rem auto;
+  width: 7rem;
+  height: 7rem;
+  border-radius: 9999px;
+  background:
+    radial-gradient(circle, rgba(250, 204, 21, 0.2) 0%, rgba(250, 204, 21, 0) 72%);
+  pointer-events: none;
+}
+
+.queueCard > * {
+  position: relative;
+  z-index: 1;
+}
+
+.tag {
+  backdrop-filter: blur(10px);
+}
+
+@media (min-width: 1536px) {
+  .workflowGrid {
+    grid-template-columns: minmax(0, 1fr) minmax(22rem, 25rem);
+  }
+
+  .detailRail {
+    position: sticky;
+    top: 1.5rem;
+  }
+}
+
+@media (min-width: 1800px) {
+  .columnGrid {
+    min-width: 0;
+  }
+}
+
+@media (max-width: 767px) {
+  .heroSurface::before {
+    right: -4rem;
+    bottom: -4rem;
+    width: 14rem;
+    height: 14rem;
+  }
+
+  .columnGrid {
+    min-width: 86rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add the initial `queue-monitor` route shell under `src/app/queue-monitor`
- reserve sections for queue summaries, backlog columns, and escalation details
- stage the work so follow-up commits can add mock data, components, styling, and tests

## Testing
- npm run lint -- src/app/queue-monitor/page.tsx

Closes #143