### PR TITLE
feat: build parcel hub route with shipment lanes

### DIFF
--- a/src/app/parcel-hub/_components/exception-detail-panel.tsx
+++ b/src/app/parcel-hub/_components/exception-detail-panel.tsx
@@ -1,0 +1,138 @@
+import type { ParcelHubExceptionView } from "../_data/parcel-hub-data";
+
+type ExceptionDetailPanelProps = {
+  exception: ParcelHubExceptionView;
+};
+
+const severityToneMap: Record<ParcelHubExceptionView["severity"], string> = {
+  Monitor: "border-sky-200 bg-sky-50 text-sky-800",
+  "Action Required": "border-amber-200 bg-amber-50 text-amber-800",
+  Critical: "border-rose-200 bg-rose-50 text-rose-800",
+};
+
+export function ExceptionDetailPanel({
+  exception,
+}: ExceptionDetailPanelProps) {
+  const titleId = `${exception.id}-title`;
+
+  return (
+    <aside
+      aria-labelledby={titleId}
+      className="rounded-[2rem] border border-slate-200 bg-slate-950 p-6 text-white shadow-[0_24px_90px_rgba(15,23,42,0.22)]"
+      role="region"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-cyan-200/80">
+            Exception detail
+          </p>
+          <h2
+            id={titleId}
+            className="mt-3 text-3xl font-semibold tracking-tight"
+          >
+            {exception.title}
+          </h2>
+        </div>
+        <span
+          className={`rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${severityToneMap[exception.severity]}`}
+        >
+          {exception.severity}
+        </span>
+      </div>
+
+      <p className="mt-4 text-sm leading-7 text-white/76">{exception.summary}</p>
+
+      <div className="mt-6 grid gap-3 sm:grid-cols-2">
+        <div className="rounded-[1.5rem] border border-white/10 bg-white/6 px-4 py-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">
+            Lane and code
+          </p>
+          <p className="mt-2 text-sm font-semibold text-white">
+            {exception.lane.name}
+          </p>
+          <p className="mt-1 text-sm text-white/66">{exception.code}</p>
+        </div>
+        <div className="rounded-[1.5rem] border border-white/10 bg-white/6 px-4 py-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">
+            Owner and update
+          </p>
+          <p className="mt-2 text-sm font-semibold text-white">
+            {exception.owner}
+          </p>
+          <p className="mt-1 text-sm text-white/66">{exception.updatedAt}</p>
+        </div>
+      </div>
+
+      <div className="mt-6 rounded-[1.5rem] border border-white/10 bg-white/6 px-4 py-4">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">
+          Customer impact
+        </p>
+        <p className="mt-2 text-sm leading-7 text-white/76">
+          {exception.customerImpact}
+        </p>
+        <p className="mt-4 text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">
+          Value at risk
+        </p>
+        <p className="mt-2 text-sm font-semibold text-white">
+          {exception.valueAtRisk}
+        </p>
+      </div>
+
+      <div className="mt-6 rounded-[1.5rem] border border-cyan-400/25 bg-[linear-gradient(135deg,rgba(34,211,238,0.18),rgba(15,23,42,0.7))] px-4 py-4">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-cyan-200/80">
+          Recommended action
+        </p>
+        <p className="mt-2 text-sm leading-7 text-white/84">
+          {exception.recommendedAction}
+        </p>
+      </div>
+
+      <div className="mt-6">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">
+          Affected parcels
+        </p>
+        <ul aria-label="Affected parcels" className="mt-4 space-y-3">
+          {exception.parcels.map((parcel) => (
+            <li key={parcel.id}>
+              <article className="rounded-[1.25rem] border border-white/10 bg-white/6 px-4 py-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <h3 className="text-lg font-semibold tracking-tight text-white">
+                      {parcel.recipient}
+                    </h3>
+                    <p className="mt-1 text-sm text-white/66">
+                      {parcel.destination}
+                    </p>
+                  </div>
+                  <span className="rounded-full border border-white/12 bg-white/8 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-white/70">
+                    {parcel.trackingCode}
+                  </span>
+                </div>
+
+                <p className="mt-3 text-sm leading-7 text-white/76">
+                  {parcel.checkpointLabel}
+                </p>
+              </article>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="mt-6">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">
+          Checkpoint notes
+        </p>
+        <ul className="mt-4 space-y-3">
+          {exception.checkpointNotes.map((note) => (
+            <li
+              key={note}
+              className="rounded-[1.25rem] border border-white/10 bg-white/6 px-4 py-4 text-sm leading-7 text-white/76"
+            >
+              {note}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </aside>
+  );
+}

--- a/src/app/parcel-hub/_components/exception-detail-panel.tsx
+++ b/src/app/parcel-hub/_components/exception-detail-panel.tsx
@@ -1,4 +1,5 @@
 import type { ParcelHubExceptionView } from "../_data/parcel-hub-data";
+import styles from "../parcel-hub.module.css";
 
 type ExceptionDetailPanelProps = {
   exception: ParcelHubExceptionView;
@@ -18,7 +19,8 @@ export function ExceptionDetailPanel({
   return (
     <aside
       aria-labelledby={titleId}
-      className="rounded-[2rem] border border-slate-200 bg-slate-950 p-6 text-white shadow-[0_24px_90px_rgba(15,23,42,0.22)]"
+      className={`rounded-[2rem] border border-slate-200 bg-slate-950 p-6 text-white shadow-[0_24px_90px_rgba(15,23,42,0.22)] ${styles.exceptionPanel}`}
+      data-severity={exception.severity}
       role="region"
     >
       <div className="flex items-start justify-between gap-4">
@@ -43,7 +45,9 @@ export function ExceptionDetailPanel({
       <p className="mt-4 text-sm leading-7 text-white/76">{exception.summary}</p>
 
       <div className="mt-6 grid gap-3 sm:grid-cols-2">
-        <div className="rounded-[1.5rem] border border-white/10 bg-white/6 px-4 py-4">
+        <div
+          className={`rounded-[1.5rem] border border-white/10 bg-white/6 px-4 py-4 ${styles.detailSection}`}
+        >
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">
             Lane and code
           </p>
@@ -52,7 +56,9 @@ export function ExceptionDetailPanel({
           </p>
           <p className="mt-1 text-sm text-white/66">{exception.code}</p>
         </div>
-        <div className="rounded-[1.5rem] border border-white/10 bg-white/6 px-4 py-4">
+        <div
+          className={`rounded-[1.5rem] border border-white/10 bg-white/6 px-4 py-4 ${styles.detailSection}`}
+        >
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">
             Owner and update
           </p>
@@ -63,7 +69,9 @@ export function ExceptionDetailPanel({
         </div>
       </div>
 
-      <div className="mt-6 rounded-[1.5rem] border border-white/10 bg-white/6 px-4 py-4">
+      <div
+        className={`mt-6 rounded-[1.5rem] border border-white/10 bg-white/6 px-4 py-4 ${styles.detailSection}`}
+      >
         <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/55">
           Customer impact
         </p>
@@ -78,7 +86,9 @@ export function ExceptionDetailPanel({
         </p>
       </div>
 
-      <div className="mt-6 rounded-[1.5rem] border border-cyan-400/25 bg-[linear-gradient(135deg,rgba(34,211,238,0.18),rgba(15,23,42,0.7))] px-4 py-4">
+      <div
+        className={`mt-6 rounded-[1.5rem] border border-cyan-400/25 bg-[linear-gradient(135deg,rgba(34,211,238,0.18),rgba(15,23,42,0.7))] px-4 py-4 ${styles.detailCallout}`}
+      >
         <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-cyan-200/80">
           Recommended action
         </p>
@@ -94,7 +104,9 @@ export function ExceptionDetailPanel({
         <ul aria-label="Affected parcels" className="mt-4 space-y-3">
           {exception.parcels.map((parcel) => (
             <li key={parcel.id}>
-              <article className="rounded-[1.25rem] border border-white/10 bg-white/6 px-4 py-4">
+              <article
+                className={`rounded-[1.25rem] border border-white/10 bg-white/6 px-4 py-4 ${styles.affectedParcelCard}`}
+              >
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div>
                     <h3 className="text-lg font-semibold tracking-tight text-white">
@@ -126,7 +138,7 @@ export function ExceptionDetailPanel({
           {exception.checkpointNotes.map((note) => (
             <li
               key={note}
-              className="rounded-[1.25rem] border border-white/10 bg-white/6 px-4 py-4 text-sm leading-7 text-white/76"
+              className={`rounded-[1.25rem] border border-white/10 bg-white/6 px-4 py-4 text-sm leading-7 text-white/76 ${styles.noteCard}`}
             >
               {note}
             </li>

--- a/src/app/parcel-hub/_components/parcel-hub-shell.tsx
+++ b/src/app/parcel-hub/_components/parcel-hub-shell.tsx
@@ -1,0 +1,184 @@
+import Link from "next/link";
+
+import type { ParcelHubView } from "../_data/parcel-hub-data";
+import { ExceptionDetailPanel } from "./exception-detail-panel";
+import { ParcelLaneSection } from "./parcel-lane-section";
+
+type ParcelHubShellProps = {
+  view: ParcelHubView;
+};
+
+export function ParcelHubShell({ view }: ParcelHubShellProps) {
+  return (
+    <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(14,165,233,0.12),transparent_24%),radial-gradient(circle_at_bottom_right,rgba(251,146,60,0.12),transparent_28%),linear-gradient(180deg,#f8fafc_0%,#eef4f7_48%,#f8fafc_100%)] text-slate-950">
+      <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
+        <section className="overflow-hidden rounded-[2.5rem] border border-slate-200/80 bg-slate-950 px-6 py-8 text-white shadow-[0_32px_110px_-42px_rgba(15,23,42,0.92)] sm:px-8 lg:px-10">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-cyan-300">
+              Parcel Hub
+            </p>
+            <Link
+              href="/"
+              className="rounded-full border border-white/12 px-4 py-2 text-sm font-medium text-white/82 transition-colors hover:bg-white/8"
+            >
+              Back to overview
+            </Link>
+          </div>
+
+          <div className="mt-6 grid gap-8 xl:grid-cols-[minmax(0,1.45fr)_minmax(280px,0.95fr)]">
+            <div>
+              <h1 className="max-w-4xl text-4xl font-semibold tracking-tight sm:text-5xl">
+                Monitor shipment lanes, parcel exceptions, and recovery moves from
+                one parcel hub route.
+              </h1>
+              <p className="mt-5 max-w-3xl text-base leading-8 text-white/72 sm:text-lg">
+                The parcel hub route keeps shipment lanes readable without a
+                backend integration: each lane groups parcel summaries by release
+                path, exception summaries show where promise risk is building, and
+                the detail panel stays focused on the highest-pressure recovery
+                action.
+              </p>
+
+              <div className="mt-6 flex flex-wrap gap-3 text-sm text-white/74">
+                <span className="rounded-full border border-white/10 bg-white/8 px-3 py-1.5">
+                  {view.totalParcelCount} tracked parcels
+                </span>
+                <span className="rounded-full border border-white/10 bg-white/8 px-3 py-1.5">
+                  {view.totalPackageCount} packages represented
+                </span>
+                <span className="rounded-full border border-white/10 bg-white/8 px-3 py-1.5">
+                  {view.exceptions.length} exception summaries open
+                </span>
+                <span className="rounded-full border border-white/10 bg-white/8 px-3 py-1.5">
+                  Highlighted owner: {view.highlightedException.owner}
+                </span>
+              </div>
+            </div>
+
+            <div
+              aria-label="Parcel hub metrics"
+              className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1"
+              role="list"
+            >
+              {view.metrics.map((metric) => (
+                <div
+                  key={metric.id}
+                  className="rounded-[1.5rem] border border-white/10 bg-white/6 p-5"
+                  role="listitem"
+                >
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-white/55">
+                    {metric.label}
+                  </p>
+                  <p className="mt-3 text-3xl font-semibold tracking-tight">
+                    {metric.value}
+                  </p>
+                  <p className="mt-2 text-sm leading-7 text-white/72">
+                    {metric.detail}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section aria-labelledby="parcel-exception-summary" className="space-y-4">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                Exception summary
+              </p>
+              <h2
+                id="parcel-exception-summary"
+                className="mt-2 text-3xl font-semibold tracking-tight text-slate-950"
+              >
+                Open recovery work
+              </h2>
+            </div>
+            <p className="max-w-3xl text-sm leading-7 text-slate-600">
+              Each summary card condenses the active issue, risk, and owner before
+              you drill into the highlighted detail panel.
+            </p>
+          </div>
+
+          <ul aria-label="Exception summaries" className="grid gap-4 lg:grid-cols-3">
+            {view.exceptions.map((exception) => (
+              <li key={exception.id}>
+                <article className="rounded-[1.75rem] border border-slate-200 bg-white/88 p-5 shadow-[0_18px_60px_rgba(15,23,42,0.07)]">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="max-w-72">
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                        {exception.code}
+                      </p>
+                      <h3 className="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
+                        {exception.title}
+                      </h3>
+                    </div>
+                    <span className="rounded-full border border-slate-200 bg-slate-100 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-600">
+                      {exception.severity}
+                    </span>
+                  </div>
+
+                  <p className="mt-4 text-sm leading-7 text-slate-700">
+                    {exception.summary}
+                  </p>
+
+                  <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                    <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                        Lane
+                      </p>
+                      <p className="mt-2 text-sm font-semibold text-slate-950">
+                        {exception.lane.name}
+                      </p>
+                    </div>
+                    <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                        Owner
+                      </p>
+                      <p className="mt-2 text-sm font-semibold text-slate-950">
+                        {exception.owner}
+                      </p>
+                    </div>
+                  </div>
+
+                  <p className="mt-4 text-sm font-medium text-slate-600">
+                    {exception.valueAtRisk}
+                  </p>
+                </article>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        <div className="grid gap-8 xl:grid-cols-[minmax(0,1.55fr)_380px]">
+          <section aria-labelledby="shipment-lanes-heading" className="space-y-6">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                  Shipment lanes
+                </p>
+                <h2
+                  id="shipment-lanes-heading"
+                  className="mt-2 text-3xl font-semibold tracking-tight text-slate-950"
+                >
+                  Lane-by-lane parcel flow
+                </h2>
+              </div>
+              <p className="max-w-3xl text-sm leading-7 text-slate-600">
+                Lane sections keep the route operationally useful by combining
+                release context, parcel cards, and exception counts in the same
+                scan path.
+              </p>
+            </div>
+
+            {view.lanes.map((lane) => (
+              <ParcelLaneSection key={lane.id} lane={lane} />
+            ))}
+          </section>
+
+          <ExceptionDetailPanel exception={view.highlightedException} />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/parcel-hub/_components/parcel-hub-shell.tsx
+++ b/src/app/parcel-hub/_components/parcel-hub-shell.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import styles from "../parcel-hub.module.css";
 import type { ParcelHubView } from "../_data/parcel-hub-data";
 import { ExceptionDetailPanel } from "./exception-detail-panel";
 import { ParcelLaneSection } from "./parcel-lane-section";
@@ -10,9 +11,13 @@ type ParcelHubShellProps = {
 
 export function ParcelHubShell({ view }: ParcelHubShellProps) {
   return (
-    <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(14,165,233,0.12),transparent_24%),radial-gradient(circle_at_bottom_right,rgba(251,146,60,0.12),transparent_28%),linear-gradient(180deg,#f8fafc_0%,#eef4f7_48%,#f8fafc_100%)] text-slate-950">
+    <div
+      className={`min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(14,165,233,0.12),transparent_24%),radial-gradient(circle_at_bottom_right,rgba(251,146,60,0.12),transparent_28%),linear-gradient(180deg,#f8fafc_0%,#eef4f7_48%,#f8fafc_100%)] text-slate-950 ${styles.pageShell}`}
+    >
       <main className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-5 py-8 sm:px-8 lg:px-10 lg:py-10">
-        <section className="overflow-hidden rounded-[2.5rem] border border-slate-200/80 bg-slate-950 px-6 py-8 text-white shadow-[0_32px_110px_-42px_rgba(15,23,42,0.92)] sm:px-8 lg:px-10">
+        <section
+          className={`overflow-hidden rounded-[2.5rem] border border-slate-200/80 bg-slate-950 px-6 py-8 text-white shadow-[0_32px_110px_-42px_rgba(15,23,42,0.92)] sm:px-8 lg:px-10 ${styles.heroPanel}`}
+        >
           <div className="flex flex-wrap items-center justify-between gap-3">
             <p className="text-xs font-semibold uppercase tracking-[0.3em] text-cyan-300">
               Parcel Hub
@@ -63,7 +68,7 @@ export function ParcelHubShell({ view }: ParcelHubShellProps) {
               {view.metrics.map((metric) => (
                 <div
                   key={metric.id}
-                  className="rounded-[1.5rem] border border-white/10 bg-white/6 p-5"
+                  className={`rounded-[1.5rem] border border-white/10 bg-white/6 p-5 ${styles.metricCard}`}
                   role="listitem"
                 >
                   <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-white/55">
@@ -103,7 +108,10 @@ export function ParcelHubShell({ view }: ParcelHubShellProps) {
           <ul aria-label="Exception summaries" className="grid gap-4 lg:grid-cols-3">
             {view.exceptions.map((exception) => (
               <li key={exception.id}>
-                <article className="rounded-[1.75rem] border border-slate-200 bg-white/88 p-5 shadow-[0_18px_60px_rgba(15,23,42,0.07)]">
+                <article
+                  className={`rounded-[1.75rem] border border-slate-200 bg-white/88 p-5 shadow-[0_18px_60px_rgba(15,23,42,0.07)] ${styles.summaryCard}`}
+                  data-severity={exception.severity}
+                >
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="max-w-72">
                       <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">

--- a/src/app/parcel-hub/_components/parcel-lane-section.tsx
+++ b/src/app/parcel-hub/_components/parcel-lane-section.tsx
@@ -1,0 +1,101 @@
+import type { ParcelHubLaneView } from "../_data/parcel-hub-data";
+import { ParcelSummaryCard } from "./parcel-summary-card";
+
+type ParcelLaneSectionProps = {
+  lane: ParcelHubLaneView;
+};
+
+const healthToneMap: Record<ParcelHubLaneView["health"], string> = {
+  Stable: "border-emerald-200 bg-emerald-50 text-emerald-800",
+  Watch: "border-amber-200 bg-amber-50 text-amber-800",
+  Exception: "border-rose-200 bg-rose-50 text-rose-800",
+};
+
+export function ParcelLaneSection({ lane }: ParcelLaneSectionProps) {
+  const headingId = `${lane.id}-heading`;
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      className="rounded-[2rem] border border-slate-200 bg-white/92 p-6 shadow-[0_20px_80px_rgba(15,23,42,0.08)]"
+      role="region"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="max-w-3xl">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={`rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${healthToneMap[lane.health]}`}
+            >
+              {lane.health}
+            </span>
+            <span className="rounded-full border border-slate-200 bg-slate-100 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-600">
+              {lane.routeLabel}
+            </span>
+          </div>
+
+          <h2
+            id={headingId}
+            className="mt-4 text-3xl font-semibold tracking-tight text-slate-950"
+          >
+            {lane.name}
+          </h2>
+          <p className="mt-3 text-sm leading-7 text-slate-700">{lane.summary}</p>
+        </div>
+
+        <div className="min-w-56 rounded-[1.5rem] border border-slate-200 bg-slate-50 px-4 py-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+            Coordinator
+          </p>
+          <p className="mt-2 text-sm font-semibold text-slate-950">
+            {lane.coordinator}
+          </p>
+          <p className="mt-2 text-sm text-slate-600">{lane.dock}</p>
+          <p className="mt-1 text-sm text-slate-600">{lane.departureWindow}</p>
+        </div>
+      </div>
+
+      <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <div className="rounded-[1.25rem] border border-slate-200 bg-slate-50 px-4 py-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+            Service mix
+          </p>
+          <p className="mt-2 text-sm font-semibold text-slate-950">
+            {lane.serviceMix}
+          </p>
+        </div>
+        <div className="rounded-[1.25rem] border border-slate-200 bg-slate-50 px-4 py-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+            Package count
+          </p>
+          <p className="mt-2 text-sm font-semibold text-slate-950">
+            {lane.packageCount} packages
+          </p>
+        </div>
+        <div className="rounded-[1.25rem] border border-slate-200 bg-slate-50 px-4 py-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+            Delayed or exception
+          </p>
+          <p className="mt-2 text-sm font-semibold text-slate-950">
+            {lane.delayedParcelCount} parcels
+          </p>
+        </div>
+        <div className="rounded-[1.25rem] border border-slate-200 bg-slate-50 px-4 py-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+            Open exceptions
+          </p>
+          <p className="mt-2 text-sm font-semibold text-slate-950">
+            {lane.exceptionCount} summaries
+          </p>
+        </div>
+      </div>
+
+      <ul aria-label={`${lane.name} parcels`} className="mt-6 space-y-4">
+        {lane.parcels.map((parcel) => (
+          <li key={parcel.id}>
+            <ParcelSummaryCard parcel={parcel} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/app/parcel-hub/_components/parcel-lane-section.tsx
+++ b/src/app/parcel-hub/_components/parcel-lane-section.tsx
@@ -1,4 +1,5 @@
 import type { ParcelHubLaneView } from "../_data/parcel-hub-data";
+import styles from "../parcel-hub.module.css";
 import { ParcelSummaryCard } from "./parcel-summary-card";
 
 type ParcelLaneSectionProps = {
@@ -17,7 +18,8 @@ export function ParcelLaneSection({ lane }: ParcelLaneSectionProps) {
   return (
     <section
       aria-labelledby={headingId}
-      className="rounded-[2rem] border border-slate-200 bg-white/92 p-6 shadow-[0_20px_80px_rgba(15,23,42,0.08)]"
+      className={`rounded-[2rem] border border-slate-200 bg-white/92 p-6 shadow-[0_20px_80px_rgba(15,23,42,0.08)] ${styles.laneSection}`}
+      data-health={lane.health}
       role="region"
     >
       <div className="flex flex-wrap items-start justify-between gap-4">
@@ -42,7 +44,9 @@ export function ParcelLaneSection({ lane }: ParcelLaneSectionProps) {
           <p className="mt-3 text-sm leading-7 text-slate-700">{lane.summary}</p>
         </div>
 
-        <div className="min-w-56 rounded-[1.5rem] border border-slate-200 bg-slate-50 px-4 py-4">
+        <div
+          className={`min-w-56 rounded-[1.5rem] border border-slate-200 bg-slate-50 px-4 py-4 ${styles.laneAsideCard}`}
+        >
           <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
             Coordinator
           </p>
@@ -86,6 +90,21 @@ export function ParcelLaneSection({ lane }: ParcelLaneSectionProps) {
           <p className="mt-2 text-sm font-semibold text-slate-950">
             {lane.exceptionCount} summaries
           </p>
+        </div>
+      </div>
+
+      <div
+        className={`mt-5 rounded-[1.5rem] border border-slate-200 px-4 py-4 ${styles.capacityPanel}`}
+      >
+        <div className="flex items-center justify-between gap-4 text-sm font-medium text-slate-600">
+          <span>Lane fill</span>
+          <span>{lane.capacityPercent}% utilized</span>
+        </div>
+        <div className={`mt-3 h-2.5 ${styles.capacityTrack}`}>
+          <div
+            className={styles.capacityBar}
+            style={{ width: `${lane.capacityPercent}%` }}
+          />
         </div>
       </div>
 

--- a/src/app/parcel-hub/_components/parcel-summary-card.tsx
+++ b/src/app/parcel-hub/_components/parcel-summary-card.tsx
@@ -1,4 +1,5 @@
 import type { ParcelHubParcel } from "../_data/parcel-hub-data";
+import styles from "../parcel-hub.module.css";
 
 type ParcelSummaryCardProps = {
   parcel: ParcelHubParcel;
@@ -17,7 +18,8 @@ export function ParcelSummaryCard({ parcel }: ParcelSummaryCardProps) {
   return (
     <article
       aria-labelledby={titleId}
-      className="rounded-[1.5rem] border border-slate-200 bg-white p-5 shadow-[0_18px_60px_rgba(15,23,42,0.08)]"
+      className={`rounded-[1.5rem] border border-slate-200 bg-white p-5 shadow-[0_18px_60px_rgba(15,23,42,0.08)] ${styles.parcelCard}`}
+      data-status={parcel.status}
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="max-w-2xl">

--- a/src/app/parcel-hub/_components/parcel-summary-card.tsx
+++ b/src/app/parcel-hub/_components/parcel-summary-card.tsx
@@ -1,0 +1,116 @@
+import type { ParcelHubParcel } from "../_data/parcel-hub-data";
+
+type ParcelSummaryCardProps = {
+  parcel: ParcelHubParcel;
+};
+
+const statusToneMap: Record<ParcelHubParcel["status"], string> = {
+  Manifested: "border-emerald-200 bg-emerald-50 text-emerald-800",
+  Queued: "border-slate-200 bg-slate-100 text-slate-700",
+  Delayed: "border-amber-200 bg-amber-50 text-amber-800",
+  Exception: "border-rose-200 bg-rose-50 text-rose-800",
+};
+
+export function ParcelSummaryCard({ parcel }: ParcelSummaryCardProps) {
+  const titleId = `${parcel.id}-title`;
+
+  return (
+    <article
+      aria-labelledby={titleId}
+      className="rounded-[1.5rem] border border-slate-200 bg-white p-5 shadow-[0_18px_60px_rgba(15,23,42,0.08)]"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="max-w-2xl">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={`rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${statusToneMap[parcel.status]}`}
+            >
+              {parcel.status}
+            </span>
+            <span className="rounded-full border border-slate-200 bg-slate-100 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-600">
+              {parcel.serviceLevel}
+            </span>
+            <span className="rounded-full border border-slate-200 bg-slate-100 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-600">
+              {parcel.trackingCode}
+            </span>
+          </div>
+
+          <h3
+            id={titleId}
+            className="mt-4 text-2xl font-semibold tracking-tight text-slate-950"
+          >
+            {parcel.recipient}
+          </h3>
+          <p className="mt-2 text-sm font-medium text-slate-500">
+            {parcel.destination}
+          </p>
+        </div>
+
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+            Parcel owner
+          </p>
+          <p className="mt-2 text-sm font-semibold text-slate-950">
+            {parcel.owner}
+          </p>
+          <p className="mt-2 text-sm text-slate-600">{parcel.checkpointLabel}</p>
+        </div>
+      </div>
+
+      <p className="mt-5 text-sm leading-7 text-slate-700">{parcel.summary}</p>
+
+      <dl className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+          <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+            Packages
+          </dt>
+          <dd className="mt-2 text-lg font-semibold text-slate-950">
+            {parcel.packageCount}
+          </dd>
+        </div>
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+          <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+            Weight
+          </dt>
+          <dd className="mt-2 text-lg font-semibold text-slate-950">
+            {parcel.weightKg} kg
+          </dd>
+        </div>
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+          <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+            Promise window
+          </dt>
+          <dd className="mt-2 text-sm font-semibold text-slate-950">
+            {parcel.promiseWindow}
+          </dd>
+        </div>
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-4">
+          <dt className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+            Exception value
+          </dt>
+          <dd className="mt-2 text-sm font-semibold text-slate-950">
+            {parcel.exceptionValue}
+          </dd>
+        </div>
+      </dl>
+
+      <div className="mt-5 rounded-[1.5rem] border border-slate-200 bg-slate-50 px-4 py-4">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+          Next action
+        </p>
+        <p className="mt-2 text-sm leading-7 text-slate-700">{parcel.nextAction}</p>
+      </div>
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        {parcel.tags.map((tag) => (
+          <span
+            key={tag}
+            className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-medium text-slate-600"
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+    </article>
+  );
+}

--- a/src/app/parcel-hub/_data/parcel-hub-data.ts
+++ b/src/app/parcel-hub/_data/parcel-hub-data.ts
@@ -1,0 +1,502 @@
+export type ParcelLaneHealth = "Stable" | "Watch" | "Exception";
+
+export type ParcelShipmentStatus =
+  | "Manifested"
+  | "Queued"
+  | "Delayed"
+  | "Exception";
+
+export type ParcelExceptionSeverity =
+  | "Monitor"
+  | "Action Required"
+  | "Critical";
+
+export type ParcelHubLane = {
+  id: string;
+  name: string;
+  routeLabel: string;
+  summary: string;
+  coordinator: string;
+  dock: string;
+  departureWindow: string;
+  serviceMix: string;
+  health: ParcelLaneHealth;
+  capacityPercent: number;
+};
+
+export type ParcelHubParcel = {
+  id: string;
+  laneId: string;
+  trackingCode: string;
+  recipient: string;
+  destination: string;
+  packageCount: number;
+  weightKg: number;
+  serviceLevel: string;
+  status: ParcelShipmentStatus;
+  owner: string;
+  summary: string;
+  checkpointLabel: string;
+  promiseWindow: string;
+  nextAction: string;
+  exceptionValue: string;
+  tags: string[];
+  exceptionId?: string;
+};
+
+export type ParcelHubExceptionSummary = {
+  id: string;
+  laneId: string;
+  severity: ParcelExceptionSeverity;
+  code: string;
+  title: string;
+  summary: string;
+  owner: string;
+  updatedAt: string;
+  valueAtRisk: string;
+  customerImpact: string;
+  recommendedAction: string;
+  affectedParcelIds: string[];
+  checkpointNotes: string[];
+};
+
+export type ParcelHubMetric = {
+  id: string;
+  label: string;
+  value: string;
+  detail: string;
+};
+
+export type ParcelHubLaneView = ParcelHubLane & {
+  parcels: ParcelHubParcel[];
+  packageCount: number;
+  delayedParcelCount: number;
+  exceptionCount: number;
+};
+
+export type ParcelHubExceptionView = ParcelHubExceptionSummary & {
+  lane: ParcelHubLane;
+  parcels: ParcelHubParcel[];
+};
+
+export type ParcelHubView = {
+  lanes: ParcelHubLaneView[];
+  metrics: ParcelHubMetric[];
+  exceptions: ParcelHubExceptionView[];
+  highlightedException: ParcelHubExceptionView;
+  totalParcelCount: number;
+  totalPackageCount: number;
+};
+
+export const parcelHubLanes: ParcelHubLane[] = [
+  {
+    id: "northeast-priority",
+    name: "Northeast Priority",
+    routeLabel: "Memphis -> Newark -> Boston",
+    summary:
+      "Medical kits and retail replenishment parcels are staged on the same late eastbound release.",
+    coordinator: "Lena Ortiz",
+    dock: "Door A3",
+    departureWindow: "Departs 18:40 ET",
+    serviceMix: "Overnight / 2-day",
+    health: "Watch",
+    capacityPercent: 78,
+  },
+  {
+    id: "midwest-recovery",
+    name: "Midwest Recovery",
+    routeLabel: "Dallas -> Kansas City -> Chicago",
+    summary:
+      "Reload timing is compressed after severe weather pushed two linehaul handoffs into the same lane.",
+    coordinator: "Theo Ramsey",
+    dock: "Door B1",
+    departureWindow: "Wheels up 19:05 CT",
+    serviceMix: "Deferred / Ground rescue",
+    health: "Exception",
+    capacityPercent: 91,
+  },
+  {
+    id: "sunbelt-sort",
+    name: "Sunbelt Sort",
+    routeLabel: "Phoenix -> Atlanta -> Miami",
+    summary:
+      "The southern parcel run is clearing on time with only small relabel work at the origin scan.",
+    coordinator: "Ari Patel",
+    dock: "Door C4",
+    departureWindow: "Departs 17:55 MT",
+    serviceMix: "Saver / Residential",
+    health: "Stable",
+    capacityPercent: 64,
+  },
+  {
+    id: "returns-consolidation",
+    name: "Returns Consolidation",
+    routeLabel: "Seattle -> Reno -> Los Angeles",
+    summary:
+      "Reverse logistics parcels are grouped for late-night linehaul after QA and claims review.",
+    coordinator: "Monica Reyes",
+    dock: "Door D2",
+    departureWindow: "Departs 20:15 PT",
+    serviceMix: "Returns / Refurb",
+    health: "Watch",
+    capacityPercent: 72,
+  },
+];
+
+export const parcelHubParcels: ParcelHubParcel[] = [
+  {
+    id: "parcel-bio-204817",
+    laneId: "northeast-priority",
+    trackingCode: "PH-2048-17",
+    recipient: "North Harbor Clinic",
+    destination: "Boston, MA",
+    packageCount: 8,
+    weightKg: 16.4,
+    serviceLevel: "Priority Medical",
+    status: "Exception",
+    owner: "Jules Harper",
+    summary:
+      "Cold-chain tote cleared manifesting but missed the final Newark sort confirmation.",
+    checkpointLabel: "Awaiting Newark scan reconciliation",
+    promiseWindow: "Deliver before Tue 09:30 local",
+    nextAction: "Confirm tote seal and release the hand-carried fallback bag.",
+    exceptionValue: "4 care kits at promise risk",
+    tags: ["Cold chain", "Clinic restock", "Escalated"],
+    exceptionId: "exception-newark-scan-gap",
+  },
+  {
+    id: "parcel-luma-774221",
+    laneId: "northeast-priority",
+    trackingCode: "PH-7742-21",
+    recipient: "Luma Retail Group",
+    destination: "Providence, RI",
+    packageCount: 12,
+    weightKg: 38.2,
+    serviceLevel: "2-Day Parcel",
+    status: "Queued",
+    owner: "Lena Ortiz",
+    summary:
+      "Floor-ready replenishment cartons are wrapped and waiting for the shared eastbound trailer.",
+    checkpointLabel: "Docked and sealed at Door A3",
+    promiseWindow: "Deliver by Wed 17:00 local",
+    nextAction: "Hold until the medical priority pallets clear the departure gate.",
+    exceptionValue: "No current exception value",
+    tags: ["Retail", "Store launch", "Trailer share"],
+  },
+  {
+    id: "parcel-halo-661093",
+    laneId: "northeast-priority",
+    trackingCode: "PH-6610-93",
+    recipient: "Halo Diagnostics",
+    destination: "Newark, NJ",
+    packageCount: 5,
+    weightKg: 11.7,
+    serviceLevel: "Overnight",
+    status: "Manifested",
+    owner: "Jules Harper",
+    summary:
+      "Replacement analyzers were manifested early and remain within the protected lane cut-off.",
+    checkpointLabel: "Manifest verified against airway bill",
+    promiseWindow: "Deliver before Tue 08:00 local",
+    nextAction: "Keep on the lead pallet and maintain direct unload handling.",
+    exceptionValue: "No current exception value",
+    tags: ["Diagnostic", "Overnight", "Protected"],
+  },
+  {
+    id: "parcel-atlas-122340",
+    laneId: "midwest-recovery",
+    trackingCode: "PH-1223-40",
+    recipient: "Atlas Home",
+    destination: "Chicago, IL",
+    packageCount: 16,
+    weightKg: 52.3,
+    serviceLevel: "Ground Rescue",
+    status: "Delayed",
+    owner: "Theo Ramsey",
+    summary:
+      "Replacement inventory missed the first transfer after a weather diversion shortened reload time.",
+    checkpointLabel: "Staged for rescue linehaul at Door B1",
+    promiseWindow: "Deliver by Tue 13:00 local",
+    nextAction: "Swap to the dedicated rescue shuttle if the reload window closes again.",
+    exceptionValue: "$8.2K margin exposure",
+    tags: ["Weather recovery", "Retail", "Rescue shuttle"],
+    exceptionId: "exception-chicago-reload-window",
+  },
+  {
+    id: "parcel-summit-880144",
+    laneId: "midwest-recovery",
+    trackingCode: "PH-8801-44",
+    recipient: "Summit Bio",
+    destination: "Aurora, IL",
+    packageCount: 9,
+    weightKg: 19.8,
+    serviceLevel: "Deferred Medical",
+    status: "Exception",
+    owner: "Theo Ramsey",
+    summary:
+      "Biotech samples are packaged and ready, but the late handoff can still slip beyond the safe reload window.",
+    checkpointLabel: "Waiting on linehaul reassignment",
+    promiseWindow: "Deliver before Tue 10:15 local",
+    nextAction: "Escalate to the Chicago gate supervisor for the late acceptance override.",
+    exceptionValue: "$10.2K promise exposure",
+    tags: ["Biotech", "Critical timing", "Gate override"],
+    exceptionId: "exception-chicago-reload-window",
+  },
+  {
+    id: "parcel-verdant-553109",
+    laneId: "sunbelt-sort",
+    trackingCode: "PH-5531-09",
+    recipient: "Verdant Market",
+    destination: "Miami, FL",
+    packageCount: 20,
+    weightKg: 46.1,
+    serviceLevel: "Residential Saver",
+    status: "Manifested",
+    owner: "Ari Patel",
+    summary:
+      "Promo bundles are manifested and tracking against the normal sort-to-linehaul window.",
+    checkpointLabel: "Origin sort completed on schedule",
+    promiseWindow: "Deliver by Thu 20:00 local",
+    nextAction: "Release on the standard southbound residential wave.",
+    exceptionValue: "No current exception value",
+    tags: ["Promo", "Residential", "On pace"],
+  },
+  {
+    id: "parcel-citrine-990883",
+    laneId: "sunbelt-sort",
+    trackingCode: "PH-9908-83",
+    recipient: "Citrine Beauty",
+    destination: "Atlanta, GA",
+    packageCount: 7,
+    weightKg: 14.5,
+    serviceLevel: "2-Day Parcel",
+    status: "Queued",
+    owner: "Ari Patel",
+    summary:
+      "Cosmetics refill cartons were relabeled at origin and are queued for the next sort departure.",
+    checkpointLabel: "Relabel complete, awaiting outbound cage release",
+    promiseWindow: "Deliver by Wed 18:30 local",
+    nextAction: "Verify the replacement labels on the last two cartons before cage close.",
+    exceptionValue: "Minor relabel effort only",
+    tags: ["Relabel", "Retail", "Queued"],
+  },
+  {
+    id: "parcel-nova-088142",
+    laneId: "returns-consolidation",
+    trackingCode: "PH-0881-42",
+    recipient: "Nova Devices Returns",
+    destination: "Reno, NV",
+    packageCount: 11,
+    weightKg: 27.6,
+    serviceLevel: "Returns Consolidation",
+    status: "Delayed",
+    owner: "Monica Reyes",
+    summary:
+      "Refurb units are repacked, but the claim code on one cage still needs manual verification.",
+    checkpointLabel: "QA cleared; claim code verification pending",
+    promiseWindow: "Linehaul close at Tue 21:10 local",
+    nextAction: "Attach the corrected claim label before the consolidation cage is sealed.",
+    exceptionValue: "11 units held off the refurb line",
+    tags: ["Refurb", "Claims", "Manual verify"],
+    exceptionId: "exception-claim-code-verification",
+  },
+  {
+    id: "parcel-kite-440205",
+    laneId: "returns-consolidation",
+    trackingCode: "PH-4402-05",
+    recipient: "Kite Audio Returns",
+    destination: "Los Angeles, CA",
+    packageCount: 6,
+    weightKg: 13.9,
+    serviceLevel: "Returns Consolidation",
+    status: "Queued",
+    owner: "Monica Reyes",
+    summary:
+      "Return authorizations and bench notes are attached; the cage is ready once the claim review finishes.",
+    checkpointLabel: "Queued in return cage 4",
+    promiseWindow: "Linehaul close at Tue 21:10 local",
+    nextAction: "Keep paired with the Nova Devices pallet for the LA drop.",
+    exceptionValue: "No direct exposure",
+    tags: ["Returns", "Bench notes", "Queued"],
+  },
+];
+
+export const parcelHubExceptions: ParcelHubExceptionSummary[] = [
+  {
+    id: "exception-chicago-reload-window",
+    laneId: "midwest-recovery",
+    severity: "Critical",
+    code: "CHI-REL-17",
+    title: "Chicago reload window is close to breach",
+    summary:
+      "Weather spillover has narrowed the recovery lane to a single late reload opportunity for two priority consignments.",
+    owner: "Theo Ramsey",
+    updatedAt: "Updated 16:10 CT",
+    valueAtRisk: "$18.4K across two recovery consignments",
+    customerImpact:
+      "Atlas Home and Summit Bio will miss promised restock windows if the late gate override is denied.",
+    recommendedAction:
+      "Move both consignments to the rescue shuttle and secure the gate override before 18:25 CT.",
+    affectedParcelIds: ["parcel-atlas-122340", "parcel-summit-880144"],
+    checkpointNotes: [
+      "Kansas City transfer arrived 42 minutes late after hail hold clearance.",
+      "Rescue shuttle still has 24 cubic feet available for a hard swap.",
+      "Chicago gate control requested final carton counts before approving the late unload.",
+    ],
+  },
+  {
+    id: "exception-newark-scan-gap",
+    laneId: "northeast-priority",
+    severity: "Action Required",
+    code: "EWR-SCN-09",
+    title: "Newark sort scan gap on cold-chain kits",
+    summary:
+      "The lane manifest is intact, but one clinic tote never posted the final protected-lane scan in Newark.",
+    owner: "Jules Harper",
+    updatedAt: "Updated 17:02 ET",
+    valueAtRisk: "4 care kits without final protected-lane confirmation",
+    customerImpact:
+      "North Harbor Clinic needs the kits on-site before the first appointment block tomorrow morning.",
+    recommendedAction:
+      "Reconcile the scan history, confirm the tote seal, and release the fallback courier bag if no scan appears by 17:20 ET.",
+    affectedParcelIds: ["parcel-bio-204817"],
+    checkpointNotes: [
+      "Seal verification photo was uploaded from the Memphis origin ramp.",
+      "Newark cage camera shows the tote crossing the protected lane handoff.",
+      "Fallback courier bag is staged at the Newark control desk.",
+    ],
+  },
+  {
+    id: "exception-claim-code-verification",
+    laneId: "returns-consolidation",
+    severity: "Monitor",
+    code: "RNO-CLM-22",
+    title: "Claim code verification is slowing the returns cage close",
+    summary:
+      "One refurb pallet cannot be sealed until the manual claim code matches the intake photos and return authorization.",
+    owner: "Monica Reyes",
+    updatedAt: "Updated 14:48 PT",
+    valueAtRisk: "11 refurb units waiting on bench release",
+    customerImpact:
+      "The refurb line loses a half-shift of intake if the pallet rolls to the next departure window.",
+    recommendedAction:
+      "Finish the claim review, print the corrected label, and close the Reno pallet before 19:40 PT.",
+    affectedParcelIds: ["parcel-nova-088142"],
+    checkpointNotes: [
+      "QA notes already confirm the device serials and cosmetic grade.",
+      "The replacement claim label is queued at the returns printer.",
+      "Reno intake can still absorb the pallet if it leaves on the current linehaul.",
+    ],
+  },
+];
+
+const severityRank: Record<ParcelExceptionSeverity, number> = {
+  Critical: 0,
+  "Action Required": 1,
+  Monitor: 2,
+};
+
+export function getParcelHubView(): ParcelHubView {
+  const laneMap = new Map(parcelHubLanes.map((lane) => [lane.id, lane]));
+
+  const lanes = parcelHubLanes.map((lane) => {
+    const parcels = parcelHubParcels.filter((parcel) => parcel.laneId === lane.id);
+    const exceptionCount = parcelHubExceptions.filter(
+      (exception) => exception.laneId === lane.id,
+    ).length;
+    const packageCount = parcels.reduce(
+      (sum, parcel) => sum + parcel.packageCount,
+      0,
+    );
+    const delayedParcelCount = parcels.filter(
+      (parcel) => parcel.status === "Delayed" || parcel.status === "Exception",
+    ).length;
+
+    return {
+      ...lane,
+      parcels,
+      packageCount,
+      delayedParcelCount,
+      exceptionCount,
+    };
+  });
+
+  const exceptions = parcelHubExceptions.map((exception) => {
+    const lane = laneMap.get(exception.laneId);
+
+    if (!lane) {
+      throw new Error(`Missing parcel hub lane for exception ${exception.id}`);
+    }
+
+    return {
+      ...exception,
+      lane,
+      parcels: parcelHubParcels.filter((parcel) =>
+        exception.affectedParcelIds.includes(parcel.id),
+      ),
+    };
+  });
+
+  const highlightedException = [...exceptions].sort((left, right) => {
+    const rankDifference =
+      severityRank[left.severity] - severityRank[right.severity];
+
+    if (rankDifference !== 0) {
+      return rankDifference;
+    }
+
+    return right.affectedParcelIds.length - left.affectedParcelIds.length;
+  })[0];
+
+  if (!highlightedException) {
+    throw new Error("Parcel hub view requires at least one exception summary");
+  }
+
+  const totalParcelCount = parcelHubParcels.length;
+  const totalPackageCount = parcelHubParcels.reduce(
+    (sum, parcel) => sum + parcel.packageCount,
+    0,
+  );
+  const watchCount = parcelHubParcels.filter(
+    (parcel) => parcel.status === "Delayed" || parcel.status === "Exception",
+  ).length;
+  const exceptionParcelCount = parcelHubParcels.filter(
+    (parcel) => parcel.exceptionId,
+  ).length;
+
+  const metrics: ParcelHubMetric[] = [
+    {
+      id: "active-lanes",
+      label: "Active lanes",
+      value: String(parcelHubLanes.length),
+      detail: "Four independently staged shipment lanes are visible on this route.",
+    },
+    {
+      id: "tracked-parcels",
+      label: "Tracked parcels",
+      value: String(totalParcelCount),
+      detail: `${totalPackageCount} packages are represented across the mock parcel summaries.`,
+    },
+    {
+      id: "watch-parcels",
+      label: "Watch or exception",
+      value: String(watchCount),
+      detail: "Parcels marked delayed or exception stay visible before lane release.",
+    },
+    {
+      id: "exception-summaries",
+      label: "Open exceptions",
+      value: String(parcelHubExceptions.length),
+      detail: `${exceptionParcelCount} parcels currently map to a tracked exception summary.`,
+    },
+  ];
+
+  return {
+    lanes,
+    metrics,
+    exceptions,
+    highlightedException,
+    totalParcelCount,
+    totalPackageCount,
+  };
+}

--- a/src/app/parcel-hub/page.test.tsx
+++ b/src/app/parcel-hub/page.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import ParcelHubPage from "./page";
+import { getParcelHubView } from "./_data/parcel-hub-data";
+
+describe("ParcelHubPage", () => {
+  it("renders the parcel hub route shell with metrics, exception summaries, and lane sections", () => {
+    render(<ParcelHubPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /monitor shipment lanes, parcel exceptions, and recovery moves from one parcel hub route/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /open recovery work/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /lane-by-lane parcel flow/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/archive browser route focuses on quick inspection/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders every configured metric card from the parcel hub view", () => {
+    const view = getParcelHubView();
+
+    render(<ParcelHubPage />);
+
+    const metricList = screen.getByRole("list", {
+      name: /parcel hub metrics/i,
+    });
+
+    expect(within(metricList).getAllByRole("listitem")).toHaveLength(
+      view.metrics.length,
+    );
+
+    for (const metric of view.metrics) {
+      const metricCard = within(metricList)
+        .getByText(metric.label)
+        .closest('[role="listitem"]');
+
+      expect(metricCard).toBeInTheDocument();
+      expect(metricCard).toHaveTextContent(metric.value);
+      expect(metricCard).toHaveTextContent(metric.detail);
+    }
+  });
+
+  it("renders each lane with the full parcel summary list and representative parcel details", () => {
+    const view = getParcelHubView();
+
+    render(<ParcelHubPage />);
+
+    for (const lane of view.lanes) {
+      const laneRegion = screen.getByRole("region", { name: lane.name });
+      const parcelList = within(laneRegion).getByRole("list", {
+        name: `${lane.name} parcels`,
+      });
+
+      expect(within(laneRegion).getByText(lane.routeLabel)).toBeInTheDocument();
+      expect(within(laneRegion).getByText(lane.summary)).toBeInTheDocument();
+      expect(within(parcelList).getAllByRole("article")).toHaveLength(
+        lane.parcels.length,
+      );
+    }
+
+    const summitParcel = screen.getByRole("article", {
+      name: /summit bio/i,
+    });
+
+    expect(summitParcel).toHaveTextContent("Exception");
+    expect(summitParcel).toHaveTextContent("PH-8801-44");
+    expect(summitParcel).toHaveTextContent("$10.2K promise exposure");
+    expect(summitParcel).toHaveTextContent(
+      /escalate to the chicago gate supervisor for the late acceptance override/i,
+    );
+  });
+
+  it("shows the exception summary cards and the highlighted exception detail with affected parcels", () => {
+    const view = getParcelHubView();
+    const highlightedException = view.highlightedException;
+
+    render(<ParcelHubPage />);
+
+    const exceptionSummaryList = screen.getByRole("list", {
+      name: /exception summaries/i,
+    });
+    const detailPanel = screen.getByRole("region", {
+      name: highlightedException.title,
+    });
+
+    expect(
+      within(exceptionSummaryList).getAllByRole("listitem"),
+    ).toHaveLength(view.exceptions.length);
+    expect(detailPanel).toHaveTextContent(highlightedException.owner);
+    expect(detailPanel).toHaveTextContent(highlightedException.valueAtRisk);
+    expect(detailPanel).toHaveTextContent(
+      highlightedException.recommendedAction,
+    );
+
+    const affectedParcelList = within(detailPanel).getByRole("list", {
+      name: /affected parcels/i,
+    });
+
+    expect(within(affectedParcelList).getAllByRole("article")).toHaveLength(
+      highlightedException.parcels.length,
+    );
+
+    for (const parcel of highlightedException.parcels) {
+      expect(
+        within(detailPanel).getByRole("heading", {
+          level: 3,
+          name: parcel.recipient,
+        }),
+      ).toBeInTheDocument();
+      expect(within(detailPanel).getByText(parcel.checkpointLabel)).toBeInTheDocument();
+    }
+  });
+});

--- a/src/app/parcel-hub/page.tsx
+++ b/src/app/parcel-hub/page.tsx
@@ -1,0 +1,65 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Parcel Hub",
+  description:
+    "Scaffolded parcel hub route for shipment lanes, parcel summaries, and exception detail work.",
+};
+
+export default function ParcelHubPage() {
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-12 sm:px-10 lg:px-12">
+      <section className="overflow-hidden rounded-[2rem] border border-slate-200 bg-white shadow-[0_24px_90px_rgba(15,23,42,0.08)]">
+        <div className="grid gap-8 px-6 py-10 sm:px-10 lg:grid-cols-[minmax(0,1.2fr)_minmax(260px,0.8fr)] lg:px-12 lg:py-14">
+          <div className="space-y-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-amber-700">
+              Issue 146 / Parcel Hub
+            </p>
+            <div className="space-y-4">
+              <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
+                Parcel hub route scaffold for shipment lanes and exception detail.
+              </h1>
+              <p className="max-w-2xl text-lg leading-8 text-slate-600">
+                This initial shell reserves the route for the lane data, parcel
+                summaries, exception presentation, and test coverage that follow
+                in the next subtasks.
+              </p>
+            </div>
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
+              >
+                Back to overview
+              </Link>
+              <a
+                href="#parcel-hub-next"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+              >
+                View planned sections
+              </a>
+            </div>
+          </div>
+
+          <aside className="rounded-[1.75rem] border border-slate-200/80 bg-slate-50 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Planned sections
+            </p>
+            <ul id="parcel-hub-next" className="mt-5 space-y-4">
+              <li className="rounded-2xl border border-slate-200 bg-white/80 px-4 py-4 text-sm leading-6 text-slate-600">
+                Mock shipment lanes with route-specific owner and status data
+              </li>
+              <li className="rounded-2xl border border-slate-200 bg-white/80 px-4 py-4 text-sm leading-6 text-slate-600">
+                Parcel summary cards with lane placement and exception states
+              </li>
+              <li className="rounded-2xl border border-slate-200 bg-white/80 px-4 py-4 text-sm leading-6 text-slate-600">
+                Focused exception detail presentation and render coverage
+              </li>
+            </ul>
+          </aside>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/parcel-hub/page.tsx
+++ b/src/app/parcel-hub/page.tsx
@@ -1,65 +1,16 @@
 import type { Metadata } from "next";
-import Link from "next/link";
+
+import { ParcelHubShell } from "./_components/parcel-hub-shell";
+import { getParcelHubView } from "./_data/parcel-hub-data";
 
 export const metadata: Metadata = {
   title: "Parcel Hub",
   description:
-    "Scaffolded parcel hub route for shipment lanes, parcel summaries, and exception detail work.",
+    "Mock parcel hub route with shipment lanes, parcel summaries, and exception detail coverage.",
 };
 
 export default function ParcelHubPage() {
-  return (
-    <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-12 sm:px-10 lg:px-12">
-      <section className="overflow-hidden rounded-[2rem] border border-slate-200 bg-white shadow-[0_24px_90px_rgba(15,23,42,0.08)]">
-        <div className="grid gap-8 px-6 py-10 sm:px-10 lg:grid-cols-[minmax(0,1.2fr)_minmax(260px,0.8fr)] lg:px-12 lg:py-14">
-          <div className="space-y-5">
-            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-amber-700">
-              Issue 146 / Parcel Hub
-            </p>
-            <div className="space-y-4">
-              <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-                Parcel hub route scaffold for shipment lanes and exception detail.
-              </h1>
-              <p className="max-w-2xl text-lg leading-8 text-slate-600">
-                This initial shell reserves the route for the lane data, parcel
-                summaries, exception presentation, and test coverage that follow
-                in the next subtasks.
-              </p>
-            </div>
-            <div className="flex flex-col gap-4 sm:flex-row">
-              <Link
-                href="/"
-                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
-              >
-                Back to overview
-              </Link>
-              <a
-                href="#parcel-hub-next"
-                className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
-              >
-                View planned sections
-              </a>
-            </div>
-          </div>
+  const view = getParcelHubView();
 
-          <aside className="rounded-[1.75rem] border border-slate-200/80 bg-slate-50 p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
-            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
-              Planned sections
-            </p>
-            <ul id="parcel-hub-next" className="mt-5 space-y-4">
-              <li className="rounded-2xl border border-slate-200 bg-white/80 px-4 py-4 text-sm leading-6 text-slate-600">
-                Mock shipment lanes with route-specific owner and status data
-              </li>
-              <li className="rounded-2xl border border-slate-200 bg-white/80 px-4 py-4 text-sm leading-6 text-slate-600">
-                Parcel summary cards with lane placement and exception states
-              </li>
-              <li className="rounded-2xl border border-slate-200 bg-white/80 px-4 py-4 text-sm leading-6 text-slate-600">
-                Focused exception detail presentation and render coverage
-              </li>
-            </ul>
-          </aside>
-        </div>
-      </section>
-    </main>
-  );
+  return <ParcelHubShell view={view} />;
 }

--- a/src/app/parcel-hub/parcel-hub.module.css
+++ b/src/app/parcel-hub/parcel-hub.module.css
@@ -1,0 +1,254 @@
+.pageShell {
+  position: relative;
+  isolation: isolate;
+}
+
+.pageShell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background:
+    radial-gradient(circle at top right, rgba(14, 165, 233, 0.14), transparent 28%),
+    radial-gradient(circle at left center, rgba(249, 115, 22, 0.12), transparent 24%);
+  opacity: 0.95;
+}
+
+.heroPanel {
+  position: relative;
+  overflow: hidden;
+}
+
+.heroPanel::after {
+  content: "";
+  position: absolute;
+  inset: auto -6rem -7rem auto;
+  width: 18rem;
+  height: 18rem;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(34, 211, 238, 0.18), transparent 70%);
+  pointer-events: none;
+}
+
+.metricCard {
+  border-color: rgba(255, 255, 255, 0.1);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.05));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 16px 40px rgba(2, 6, 23, 0.12);
+}
+
+.summaryCard {
+  position: relative;
+  overflow: hidden;
+  border-color: rgba(148, 163, 184, 0.22);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.96), rgba(248, 250, 252, 0.88));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.82),
+    0 18px 48px rgba(15, 23, 42, 0.06);
+}
+
+.summaryCard::after {
+  content: "";
+  position: absolute;
+  inset: auto -3rem -3rem auto;
+  width: 8rem;
+  height: 8rem;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(15, 23, 42, 0.06), transparent 72%);
+  pointer-events: none;
+}
+
+.summaryCard[data-severity="Monitor"] {
+  border-color: rgba(14, 165, 233, 0.2);
+}
+
+.summaryCard[data-severity="Action Required"] {
+  border-color: rgba(245, 158, 11, 0.24);
+  background:
+    linear-gradient(145deg, rgba(255, 251, 235, 0.96), rgba(255, 255, 255, 0.92));
+}
+
+.summaryCard[data-severity="Critical"] {
+  border-color: rgba(225, 29, 72, 0.26);
+  background:
+    linear-gradient(145deg, rgba(255, 241, 242, 0.98), rgba(255, 255, 255, 0.92));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.82),
+    0 22px 58px rgba(225, 29, 72, 0.1);
+}
+
+.laneSection {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(248, 250, 252, 0.82)),
+    rgba(255, 255, 255, 0.92);
+}
+
+.laneSection::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: 0.35rem;
+  background:
+    linear-gradient(90deg, var(--lane-accent), color-mix(in srgb, var(--lane-accent) 30%, white));
+}
+
+.laneSection[data-health="Stable"] {
+  --lane-accent: #10b981;
+}
+
+.laneSection[data-health="Watch"] {
+  --lane-accent: #f59e0b;
+}
+
+.laneSection[data-health="Exception"] {
+  --lane-accent: #e11d48;
+}
+
+.laneAsideCard {
+  background:
+    linear-gradient(180deg, rgba(248, 250, 252, 0.95), rgba(255, 255, 255, 0.88));
+}
+
+.capacityPanel {
+  border-color: rgba(148, 163, 184, 0.22);
+  background:
+    linear-gradient(180deg, rgba(248, 250, 252, 0.92), rgba(255, 255, 255, 0.88));
+}
+
+.capacityTrack {
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(226, 232, 240, 0.85);
+}
+
+.capacityBar {
+  height: 100%;
+  border-radius: 999px;
+  background:
+    linear-gradient(90deg, var(--lane-accent), color-mix(in srgb, var(--lane-accent) 18%, white));
+}
+
+.parcelCard {
+  position: relative;
+  overflow: hidden;
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease;
+}
+
+.parcelCard:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 60px rgba(15, 23, 42, 0.12);
+}
+
+.parcelCard[data-status="Manifested"] {
+  border-color: rgba(16, 185, 129, 0.18);
+  background:
+    linear-gradient(180deg, rgba(236, 253, 245, 0.36), rgba(255, 255, 255, 0.96));
+}
+
+.parcelCard[data-status="Queued"] {
+  border-color: rgba(148, 163, 184, 0.22);
+}
+
+.parcelCard[data-status="Delayed"] {
+  border-color: rgba(245, 158, 11, 0.28);
+  background:
+    linear-gradient(180deg, rgba(255, 251, 235, 0.9), rgba(255, 255, 255, 0.96));
+}
+
+.parcelCard[data-status="Exception"] {
+  border-color: rgba(225, 29, 72, 0.28);
+  background:
+    linear-gradient(180deg, rgba(255, 241, 242, 0.92), rgba(255, 255, 255, 0.96));
+  box-shadow: 0 20px 56px rgba(225, 29, 72, 0.1);
+}
+
+.parcelCard[data-status="Delayed"]::after,
+.parcelCard[data-status="Exception"]::after {
+  content: "";
+  position: absolute;
+  inset: auto -2rem -2rem auto;
+  width: 7rem;
+  height: 7rem;
+  border-radius: 999px;
+  pointer-events: none;
+}
+
+.parcelCard[data-status="Delayed"]::after {
+  background: radial-gradient(circle, rgba(245, 158, 11, 0.12), transparent 72%);
+}
+
+.parcelCard[data-status="Exception"]::after {
+  background: radial-gradient(circle, rgba(225, 29, 72, 0.16), transparent 72%);
+}
+
+.parcelCard > * {
+  position: relative;
+  z-index: 1;
+}
+
+.exceptionPanel {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(2, 6, 23, 0.96), rgba(15, 23, 42, 0.94));
+}
+
+.exceptionPanel::before {
+  content: "";
+  position: absolute;
+  inset: -2rem auto auto -4rem;
+  width: 10rem;
+  height: 10rem;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(34, 211, 238, 0.18), transparent 72%);
+  pointer-events: none;
+}
+
+.exceptionPanel[data-severity="Critical"] {
+  box-shadow: 0 26px 90px rgba(15, 23, 42, 0.24);
+}
+
+.detailSection {
+  border-color: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.detailCallout {
+  border-color: rgba(34, 211, 238, 0.24);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.affectedParcelCard {
+  border-color: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.noteCard {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+@media (min-width: 1280px) {
+  .exceptionPanel {
+    position: sticky;
+    top: 1.5rem;
+    align-self: start;
+  }
+}
+
+@media (max-width: 767px) {
+  .heroPanel::after {
+    right: -4rem;
+    bottom: -4rem;
+    width: 12rem;
+    height: 12rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `parcel-hub` route with mock shipment lanes, parcel summaries, and exception data
- compose the route with lane sections, parcel summary cards, exception summaries, and a highlighted exception detail panel
- add responsive route-local styling plus render tests covering route structure, parcel content, and exception visibility

## Testing
- `npm run test -- src/app/parcel-hub/page.test.tsx`
- `npm run lint`
- `npm run build`

Closes #146
