### PR TITLE
feat: build shift planner route

### DIFF
--- a/src/app/shift-planner/_components/coverage-matrix-section.tsx
+++ b/src/app/shift-planner/_components/coverage-matrix-section.tsx
@@ -3,22 +3,23 @@ import type {
   CoverageLane,
   CoverageSegmentView,
 } from "../_data/shift-planner-data";
+import styles from "../shift-planner.module.css";
 
 type CoverageMatrixSectionProps = {
   segment: CoverageSegmentView;
 };
 
 const cellToneClassNames = {
-  staffed: "border-emerald-200 bg-emerald-50/70 text-emerald-950",
-  thin: "border-amber-200 bg-amber-50/80 text-amber-950",
-  missing: "border-rose-200 bg-rose-50/80 text-rose-950",
-  flex: "border-sky-200 bg-sky-50/80 text-sky-950",
+  staffed: styles.coverageStaffed,
+  thin: styles.coverageThin,
+  missing: styles.coverageMissing,
+  flex: styles.coverageFlex,
 };
 
 const summaryToneClassNames = {
-  steady: "border-emerald-200 bg-emerald-50/70 text-emerald-900",
-  watch: "border-amber-200 bg-amber-50/80 text-amber-900",
-  risk: "border-rose-200 bg-rose-50/80 text-rose-900",
+  steady: styles.segmentMetricToneSteady,
+  watch: styles.segmentMetricToneWatch,
+  risk: styles.segmentMetricToneRisk,
 };
 
 function getCell(lane: CoverageLane, roleId: string) {
@@ -43,7 +44,7 @@ export function CoverageMatrixSection({
   return (
     <article
       aria-labelledby={headingId}
-      className="rounded-[1.8rem] border border-slate-200 bg-white/85 p-6 shadow-[0_24px_80px_rgba(15,23,42,0.08)]"
+      className={`${styles.segmentCard} rounded-[1.8rem] p-6`}
       role="listitem"
     >
       <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
@@ -74,7 +75,7 @@ export function CoverageMatrixSection({
         {segment.summaries.map((summary) => (
           <div
             key={summary.id}
-            className={`rounded-[1.35rem] border px-4 py-4 ${summaryToneClassNames[summary.tone]}`}
+            className={`${styles.segmentMetric} ${summaryToneClassNames[summary.tone]} rounded-[1.35rem] px-4 py-4`}
           >
             <p className="text-[11px] font-semibold uppercase tracking-[0.18em]">
               {summary.label}
@@ -92,7 +93,7 @@ export function CoverageMatrixSection({
       <div className="mt-6 overflow-x-auto">
         <table
           aria-label={segment.label}
-          className="min-w-[1020px] w-full border-separate border-spacing-y-3"
+          className={`${styles.matrixTable} min-w-[1020px] w-full`}
         >
           <thead>
             <tr className="text-left align-bottom text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
@@ -116,7 +117,7 @@ export function CoverageMatrixSection({
             {segment.lanes.map((lane) => (
               <tr key={lane.id} className="align-top">
                 <th
-                  className="rounded-l-[1.4rem] border border-r-0 border-slate-200 bg-slate-50/80 px-4 py-4 text-left"
+                  className={`${styles.laneCell} px-4 py-4 text-left`}
                   scope="row"
                 >
                   <div className="space-y-2">
@@ -127,7 +128,7 @@ export function CoverageMatrixSection({
                   </div>
                 </th>
 
-                <td className="border border-l-0 border-r-0 border-slate-200 bg-slate-50/80 px-4 py-4">
+                <td className={`${styles.focusCell} px-4 py-4`}>
                   <div className="space-y-2 text-sm text-slate-600">
                     <p className="font-medium text-slate-900">{lane.focus}</p>
                     <p>{lane.queueDepth}</p>
@@ -136,14 +137,17 @@ export function CoverageMatrixSection({
 
                 {segment.columns.map((column) => {
                   const cell = getCell(lane, column.id);
+                  const isFirstColumn = column.id === segment.columns[0]?.id;
+                  const isLastColumn =
+                    column.id === segment.columns[segment.columns.length - 1]?.id;
 
                   return (
                     <td
                       key={`${lane.id}-${column.id}`}
-                      className="border border-l-0 border-r-0 border-slate-200 bg-slate-50/80 px-3 py-4"
+                      className={`${styles.coverageCellWrap} ${isFirstColumn ? styles.coverageCellWrapFirst : ""} ${isLastColumn ? styles.coverageCellWrapLast : ""} px-3 py-4`}
                     >
                       <div
-                        className={`rounded-[1.25rem] border px-3 py-3 ${cellToneClassNames[cell.tone]}`}
+                        className={`${styles.coverageCell} ${cellToneClassNames[cell.tone]}`}
                       >
                         <p className="text-[11px] font-semibold uppercase tracking-[0.18em] opacity-80">
                           {formatCoverageValue(cell)}
@@ -159,7 +163,7 @@ export function CoverageMatrixSection({
                   );
                 })}
 
-                <td className="rounded-r-[1.4rem] border border-l-0 border-slate-200 bg-slate-50/80 px-4 py-4">
+                <td className={`${styles.noteCell} px-4 py-4`}>
                   <p className="text-sm leading-6 text-slate-600">{lane.note}</p>
                 </td>
               </tr>

--- a/src/app/shift-planner/_components/coverage-matrix-section.tsx
+++ b/src/app/shift-planner/_components/coverage-matrix-section.tsx
@@ -1,0 +1,172 @@
+import type {
+  CoverageCell,
+  CoverageLane,
+  CoverageSegmentView,
+} from "../_data/shift-planner-data";
+
+type CoverageMatrixSectionProps = {
+  segment: CoverageSegmentView;
+};
+
+const cellToneClassNames = {
+  staffed: "border-emerald-200 bg-emerald-50/70 text-emerald-950",
+  thin: "border-amber-200 bg-amber-50/80 text-amber-950",
+  missing: "border-rose-200 bg-rose-50/80 text-rose-950",
+  flex: "border-sky-200 bg-sky-50/80 text-sky-950",
+};
+
+const summaryToneClassNames = {
+  steady: "border-emerald-200 bg-emerald-50/70 text-emerald-900",
+  watch: "border-amber-200 bg-amber-50/80 text-amber-900",
+  risk: "border-rose-200 bg-rose-50/80 text-rose-900",
+};
+
+function getCell(lane: CoverageLane, roleId: string) {
+  const cell = lane.cells.find((item) => item.roleId === roleId);
+
+  if (!cell) {
+    throw new Error(`Missing coverage cell for role ${roleId} in lane ${lane.id}`);
+  }
+
+  return cell;
+}
+
+function formatCoverageValue(cell: CoverageCell) {
+  return `${cell.assigned}/${cell.required}`;
+}
+
+export function CoverageMatrixSection({
+  segment,
+}: CoverageMatrixSectionProps) {
+  const headingId = `${segment.id}-heading`;
+
+  return (
+    <article
+      aria-labelledby={headingId}
+      className="rounded-[1.8rem] border border-slate-200 bg-white/85 p-6 shadow-[0_24px_80px_rgba(15,23,42,0.08)]"
+      role="listitem"
+    >
+      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-3">
+            <p className="rounded-full border border-slate-300 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-600">
+              {segment.window}
+            </p>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+              {segment.supervisor}
+            </p>
+          </div>
+          <div className="space-y-2">
+            <h3
+              id={headingId}
+              className="text-2xl font-semibold tracking-tight text-slate-950"
+            >
+              {segment.label}
+            </h3>
+            <p className="max-w-3xl text-sm leading-7 text-slate-600">
+              {segment.summary}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-6 grid gap-3 sm:grid-cols-3">
+        {segment.summaries.map((summary) => (
+          <div
+            key={summary.id}
+            className={`rounded-[1.35rem] border px-4 py-4 ${summaryToneClassNames[summary.tone]}`}
+          >
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em]">
+              {summary.label}
+            </p>
+            <p className="mt-2 text-3xl font-semibold tracking-tight">
+              {summary.value}
+            </p>
+            <p className="mt-2 text-sm leading-6 opacity-80">
+              {summary.detail}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-6 overflow-x-auto">
+        <table
+          aria-label={segment.label}
+          className="min-w-[1020px] w-full border-separate border-spacing-y-3"
+        >
+          <thead>
+            <tr className="text-left align-bottom text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+              <th className="px-3 pb-2">Lane</th>
+              <th className="px-3 pb-2">Focus</th>
+              {segment.columns.map((column) => (
+                <th key={column.id} className="min-w-[10rem] px-3 pb-2">
+                  <div className="space-y-1">
+                    <span>{column.label}</span>
+                    <p className="text-[10px] font-medium normal-case tracking-normal text-slate-400">
+                      {column.detail}
+                    </p>
+                  </div>
+                </th>
+              ))}
+              <th className="min-w-[15rem] px-3 pb-2">Coverage note</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            {segment.lanes.map((lane) => (
+              <tr key={lane.id} className="align-top">
+                <th
+                  className="rounded-l-[1.4rem] border border-r-0 border-slate-200 bg-slate-50/80 px-4 py-4 text-left"
+                  scope="row"
+                >
+                  <div className="space-y-2">
+                    <p className="text-base font-semibold tracking-tight text-slate-950">
+                      {lane.label}
+                    </p>
+                    <p className="text-sm text-slate-600">{lane.lead}</p>
+                  </div>
+                </th>
+
+                <td className="border border-l-0 border-r-0 border-slate-200 bg-slate-50/80 px-4 py-4">
+                  <div className="space-y-2 text-sm text-slate-600">
+                    <p className="font-medium text-slate-900">{lane.focus}</p>
+                    <p>{lane.queueDepth}</p>
+                  </div>
+                </td>
+
+                {segment.columns.map((column) => {
+                  const cell = getCell(lane, column.id);
+
+                  return (
+                    <td
+                      key={`${lane.id}-${column.id}`}
+                      className="border border-l-0 border-r-0 border-slate-200 bg-slate-50/80 px-3 py-4"
+                    >
+                      <div
+                        className={`rounded-[1.25rem] border px-3 py-3 ${cellToneClassNames[cell.tone]}`}
+                      >
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] opacity-80">
+                          {formatCoverageValue(cell)}
+                        </p>
+                        <p className="mt-2 text-sm font-semibold leading-5">
+                          {cell.assignees}
+                        </p>
+                        <p className="mt-2 text-sm leading-6 opacity-80">
+                          {cell.detail}
+                        </p>
+                      </div>
+                    </td>
+                  );
+                })}
+
+                <td className="rounded-r-[1.4rem] border border-l-0 border-slate-200 bg-slate-50/80 px-4 py-4">
+                  <p className="text-sm leading-6 text-slate-600">{lane.note}</p>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </article>
+  );
+}

--- a/src/app/shift-planner/_components/handoff-notes-panel.tsx
+++ b/src/app/shift-planner/_components/handoff-notes-panel.tsx
@@ -1,0 +1,122 @@
+import type { HandoffNote } from "../_data/shift-planner-data";
+
+type HandoffNotesPanelProps = {
+  notes: HandoffNote[];
+};
+
+const statusClassNames = {
+  confirmed: "border-emerald-200 bg-emerald-50/80 text-emerald-900",
+  watch: "border-amber-200 bg-amber-50/80 text-amber-900",
+  pending: "border-rose-200 bg-rose-50/80 text-rose-900",
+};
+
+export function HandoffNotesPanel({ notes }: HandoffNotesPanelProps) {
+  const confirmedNotes = notes.filter((note) => note.status === "confirmed").length;
+  const watchNotes = notes.filter((note) => note.status === "watch").length;
+  const pendingNotes = notes.filter((note) => note.status === "pending").length;
+
+  return (
+    <aside
+      aria-labelledby="shift-planner-handoffs"
+      className="rounded-[1.8rem] border border-slate-200 bg-white/85 p-6 shadow-[0_24px_80px_rgba(15,23,42,0.08)]"
+    >
+      <div className="space-y-6">
+        <div className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+            Handoff notes
+          </p>
+          <h2
+            id="shift-planner-handoffs"
+            className="text-3xl font-semibold tracking-tight text-slate-950"
+          >
+            Shift handoff notes
+          </h2>
+          <p className="text-sm leading-6 text-slate-600">
+            Preserve the staffing decisions that matter most when work moves
+            between supervisors, lunch bridges, and the after-hours queue.
+          </p>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-3">
+          <div className="rounded-[1.3rem] border border-slate-200 bg-slate-50/80 px-4 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+              Confirmed
+            </p>
+            <p className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">
+              {confirmedNotes}
+            </p>
+          </div>
+          <div className="rounded-[1.3rem] border border-slate-200 bg-slate-50/80 px-4 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+              On watch
+            </p>
+            <p className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">
+              {watchNotes}
+            </p>
+          </div>
+          <div className="rounded-[1.3rem] border border-slate-200 bg-slate-50/80 px-4 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+              Pending
+            </p>
+            <p className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">
+              {pendingNotes}
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-4" role="list" aria-label="Shift handoff notes">
+          {notes.map((note) => (
+            <article
+              key={note.id}
+              className="rounded-[1.45rem] border border-slate-200 bg-slate-50/80 p-5"
+              role="listitem"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="space-y-2">
+                  <h3 className="text-xl font-semibold tracking-tight text-slate-950">
+                    {note.title}
+                  </h3>
+                  <p className="text-sm text-slate-600">
+                    {note.owner} · {note.window}
+                  </p>
+                </div>
+
+                <span
+                  className={`rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${statusClassNames[note.status]}`}
+                >
+                  {note.status}
+                </span>
+              </div>
+
+              <p className="mt-4 text-sm leading-6 text-slate-600">
+                {note.summary}
+              </p>
+
+              <div className="mt-4 rounded-[1.2rem] border border-slate-200 bg-white px-4 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                  Blocking context
+                </p>
+                <ul className="mt-3 space-y-3" aria-label={`${note.title} blockers`}>
+                  {note.blockers.map((blocker) => (
+                    <li key={blocker} className="text-sm leading-6 text-slate-700">
+                      {blocker}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="mt-4 rounded-[1.2rem] border border-slate-200 bg-white px-4 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                  Next step
+                </p>
+                <p className="mt-2 text-sm leading-6 text-slate-700">
+                  {note.nextStep}
+                </p>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/app/shift-planner/_components/handoff-notes-panel.tsx
+++ b/src/app/shift-planner/_components/handoff-notes-panel.tsx
@@ -1,13 +1,20 @@
 import type { HandoffNote } from "../_data/shift-planner-data";
+import styles from "../shift-planner.module.css";
 
 type HandoffNotesPanelProps = {
   notes: HandoffNote[];
 };
 
 const statusClassNames = {
-  confirmed: "border-emerald-200 bg-emerald-50/80 text-emerald-900",
-  watch: "border-amber-200 bg-amber-50/80 text-amber-900",
-  pending: "border-rose-200 bg-rose-50/80 text-rose-900",
+  confirmed: styles.toneConfirmed,
+  watch: styles.toneWatch,
+  pending: styles.tonePending,
+};
+
+const handoffCardToneClassNames = {
+  confirmed: styles.handoffConfirmed,
+  watch: styles.handoffWatch,
+  pending: styles.handoffPending,
 };
 
 export function HandoffNotesPanel({ notes }: HandoffNotesPanelProps) {
@@ -18,7 +25,7 @@ export function HandoffNotesPanel({ notes }: HandoffNotesPanelProps) {
   return (
     <aside
       aria-labelledby="shift-planner-handoffs"
-      className="rounded-[1.8rem] border border-slate-200 bg-white/85 p-6 shadow-[0_24px_80px_rgba(15,23,42,0.08)]"
+      className={`${styles.panelCard} rounded-[1.8rem] p-6`}
     >
       <div className="space-y-6">
         <div className="space-y-3">
@@ -38,7 +45,7 @@ export function HandoffNotesPanel({ notes }: HandoffNotesPanelProps) {
         </div>
 
         <div className="grid gap-3 sm:grid-cols-3">
-          <div className="rounded-[1.3rem] border border-slate-200 bg-slate-50/80 px-4 py-4">
+          <div className={`${styles.warningStat} rounded-[1.3rem] px-4 py-4`}>
             <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
               Confirmed
             </p>
@@ -46,7 +53,7 @@ export function HandoffNotesPanel({ notes }: HandoffNotesPanelProps) {
               {confirmedNotes}
             </p>
           </div>
-          <div className="rounded-[1.3rem] border border-slate-200 bg-slate-50/80 px-4 py-4">
+          <div className={`${styles.warningStat} rounded-[1.3rem] px-4 py-4`}>
             <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
               On watch
             </p>
@@ -54,7 +61,7 @@ export function HandoffNotesPanel({ notes }: HandoffNotesPanelProps) {
               {watchNotes}
             </p>
           </div>
-          <div className="rounded-[1.3rem] border border-slate-200 bg-slate-50/80 px-4 py-4">
+          <div className={`${styles.warningStat} rounded-[1.3rem] px-4 py-4`}>
             <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
               Pending
             </p>
@@ -68,7 +75,7 @@ export function HandoffNotesPanel({ notes }: HandoffNotesPanelProps) {
           {notes.map((note) => (
             <article
               key={note.id}
-              className="rounded-[1.45rem] border border-slate-200 bg-slate-50/80 p-5"
+              className={`${styles.handoffCard} ${handoffCardToneClassNames[note.status]} rounded-[1.45rem] p-5`}
               role="listitem"
             >
               <div className="flex items-start justify-between gap-4">
@@ -82,7 +89,7 @@ export function HandoffNotesPanel({ notes }: HandoffNotesPanelProps) {
                 </div>
 
                 <span
-                  className={`rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${statusClassNames[note.status]}`}
+                  className={`${styles.toneBadge} ${statusClassNames[note.status]}`}
                 >
                   {note.status}
                 </span>
@@ -92,11 +99,14 @@ export function HandoffNotesPanel({ notes }: HandoffNotesPanelProps) {
                 {note.summary}
               </p>
 
-              <div className="mt-4 rounded-[1.2rem] border border-slate-200 bg-white px-4 py-4">
+              <div className={`${styles.infoBlock} mt-4 rounded-[1.2rem] px-4 py-4`}>
                 <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
                   Blocking context
                 </p>
-                <ul className="mt-3 space-y-3" aria-label={`${note.title} blockers`}>
+                <ul
+                  className={styles.bulletList}
+                  aria-label={`${note.title} blockers`}
+                >
                   {note.blockers.map((blocker) => (
                     <li key={blocker} className="text-sm leading-6 text-slate-700">
                       {blocker}
@@ -105,7 +115,7 @@ export function HandoffNotesPanel({ notes }: HandoffNotesPanelProps) {
                 </ul>
               </div>
 
-              <div className="mt-4 rounded-[1.2rem] border border-slate-200 bg-white px-4 py-4">
+              <div className={`${styles.infoBlock} mt-4 rounded-[1.2rem] px-4 py-4`}>
                 <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
                   Next step
                 </p>

--- a/src/app/shift-planner/_components/staffing-warning-panel.tsx
+++ b/src/app/shift-planner/_components/staffing-warning-panel.tsx
@@ -2,6 +2,7 @@ import type {
   CoverageSegment,
   OpenShiftWarning,
 } from "../_data/shift-planner-data";
+import styles from "../shift-planner.module.css";
 
 type StaffingWarningPanelProps = {
   warnings: OpenShiftWarning[];
@@ -9,8 +10,13 @@ type StaffingWarningPanelProps = {
 };
 
 const severityClassNames = {
-  watch: "border-amber-200 bg-amber-50/80 text-amber-900",
-  critical: "border-rose-200 bg-rose-50/80 text-rose-900",
+  watch: styles.toneWatch,
+  critical: styles.toneCritical,
+};
+
+const warningCardToneClassNames = {
+  watch: styles.warningWatch,
+  critical: styles.warningCritical,
 };
 
 function getSegmentLabelMap(segments: Pick<CoverageSegment, "id" | "label">[]) {
@@ -33,7 +39,7 @@ export function StaffingWarningPanel({
   return (
     <aside
       aria-labelledby="shift-planner-warnings"
-      className="rounded-[1.8rem] border border-slate-200 bg-white/85 p-6 shadow-[0_24px_80px_rgba(15,23,42,0.08)]"
+      className={`${styles.panelCard} rounded-[1.8rem] p-6`}
     >
       <div className="space-y-6">
         <div className="space-y-3">
@@ -53,7 +59,7 @@ export function StaffingWarningPanel({
         </div>
 
         <div className="grid gap-3 sm:grid-cols-2">
-          <div className="rounded-[1.3rem] border border-slate-200 bg-slate-50/80 px-4 py-4">
+          <div className={`${styles.warningStat} rounded-[1.3rem] px-4 py-4`}>
             <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
               Active warnings
             </p>
@@ -61,7 +67,7 @@ export function StaffingWarningPanel({
               {warnings.length}
             </p>
           </div>
-          <div className="rounded-[1.3rem] border border-slate-200 bg-slate-50/80 px-4 py-4">
+          <div className={`${styles.warningStat} rounded-[1.3rem] px-4 py-4`}>
             <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
               Critical warnings
             </p>
@@ -78,7 +84,7 @@ export function StaffingWarningPanel({
           {warnings.map((warning) => (
             <article
               key={warning.id}
-              className="rounded-[1.45rem] border border-slate-200 bg-slate-50/80 p-5"
+              className={`${styles.warningCard} ${warningCardToneClassNames[warning.severity]} rounded-[1.45rem] p-5`}
               role="listitem"
             >
               <div className="flex items-start justify-between gap-4">
@@ -92,7 +98,7 @@ export function StaffingWarningPanel({
                 </div>
 
                 <span
-                  className={`rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${severityClassNames[warning.severity]}`}
+                  className={`${styles.toneBadge} ${severityClassNames[warning.severity]}`}
                 >
                   {warning.severity}
                 </span>
@@ -106,14 +112,14 @@ export function StaffingWarningPanel({
                 {warning.affectedSegments.map((segmentId) => (
                   <span
                     key={`${warning.id}-${segmentId}`}
-                    className="rounded-full border border-slate-300 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-600"
+                    className={`${styles.segmentPill} rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-600`}
                   >
                     {segmentLabelMap[segmentId]}
                   </span>
                 ))}
               </div>
 
-              <div className="mt-4 rounded-[1.2rem] border border-slate-200 bg-white px-4 py-4">
+              <div className={`${styles.infoBlock} mt-4 rounded-[1.2rem] px-4 py-4`}>
                 <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
                   Recommended move
                 </p>

--- a/src/app/shift-planner/_components/staffing-warning-panel.tsx
+++ b/src/app/shift-planner/_components/staffing-warning-panel.tsx
@@ -1,0 +1,130 @@
+import type {
+  CoverageSegment,
+  OpenShiftWarning,
+} from "../_data/shift-planner-data";
+
+type StaffingWarningPanelProps = {
+  warnings: OpenShiftWarning[];
+  segments: Pick<CoverageSegment, "id" | "label">[];
+};
+
+const severityClassNames = {
+  watch: "border-amber-200 bg-amber-50/80 text-amber-900",
+  critical: "border-rose-200 bg-rose-50/80 text-rose-900",
+};
+
+function getSegmentLabelMap(segments: Pick<CoverageSegment, "id" | "label">[]) {
+  return Object.fromEntries(segments.map((segment) => [segment.id, segment.label]));
+}
+
+export function StaffingWarningPanel({
+  warnings,
+  segments,
+}: StaffingWarningPanelProps) {
+  const segmentLabelMap = getSegmentLabelMap(segments);
+  const criticalWarnings = warnings.filter(
+    (warning) => warning.severity === "critical",
+  ).length;
+  const seatGapTotal = warnings.reduce(
+    (total, warning) => total + warning.seatGap,
+    0,
+  );
+
+  return (
+    <aside
+      aria-labelledby="shift-planner-warnings"
+      className="rounded-[1.8rem] border border-slate-200 bg-white/85 p-6 shadow-[0_24px_80px_rgba(15,23,42,0.08)]"
+    >
+      <div className="space-y-6">
+        <div className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+            Staffing warnings
+          </p>
+          <h2
+            id="shift-planner-warnings"
+            className="text-3xl font-semibold tracking-tight text-slate-950"
+          >
+            Open shift warnings
+          </h2>
+          <p className="text-sm leading-6 text-slate-600">
+            Keep the seat gaps with the highest operational cost visible while
+            staffing moves are still changing from segment to segment.
+          </p>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="rounded-[1.3rem] border border-slate-200 bg-slate-50/80 px-4 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+              Active warnings
+            </p>
+            <p className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">
+              {warnings.length}
+            </p>
+          </div>
+          <div className="rounded-[1.3rem] border border-slate-200 bg-slate-50/80 px-4 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+              Critical warnings
+            </p>
+            <p className="mt-2 text-3xl font-semibold tracking-tight text-slate-950">
+              {criticalWarnings}
+            </p>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              {seatGapTotal} total uncovered seats are represented across the current warning set.
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-4" role="list" aria-label="Open shift warnings">
+          {warnings.map((warning) => (
+            <article
+              key={warning.id}
+              className="rounded-[1.45rem] border border-slate-200 bg-slate-50/80 p-5"
+              role="listitem"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="space-y-2">
+                  <h3 className="text-xl font-semibold tracking-tight text-slate-950">
+                    {warning.title}
+                  </h3>
+                  <p className="text-sm text-slate-600">
+                    {warning.owner} · {warning.window}
+                  </p>
+                </div>
+
+                <span
+                  className={`rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${severityClassNames[warning.severity]}`}
+                >
+                  {warning.severity}
+                </span>
+              </div>
+
+              <p className="mt-4 text-sm leading-6 text-slate-600">
+                {warning.summary}
+              </p>
+
+              <div className="mt-4 flex flex-wrap gap-2">
+                {warning.affectedSegments.map((segmentId) => (
+                  <span
+                    key={`${warning.id}-${segmentId}`}
+                    className="rounded-full border border-slate-300 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-600"
+                  >
+                    {segmentLabelMap[segmentId]}
+                  </span>
+                ))}
+              </div>
+
+              <div className="mt-4 rounded-[1.2rem] border border-slate-200 bg-white px-4 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                  Recommended move
+                </p>
+                <p className="mt-2 text-sm leading-6 text-slate-700">
+                  {warning.action}
+                </p>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/app/shift-planner/_data/shift-planner-data.ts
+++ b/src/app/shift-planner/_data/shift-planner-data.ts
@@ -1,0 +1,870 @@
+export type CoverageTone = "staffed" | "thin" | "missing" | "flex";
+export type PlannerTone = "steady" | "watch" | "risk";
+export type WarningSeverity = "watch" | "critical";
+export type HandoffStatus = "confirmed" | "watch" | "pending";
+
+export interface PlannerSummaryCard {
+  id: string;
+  label: string;
+  value: string;
+  detail: string;
+  tone: PlannerTone;
+}
+
+export interface CoverageColumn {
+  id: string;
+  label: string;
+  detail: string;
+}
+
+export interface CoverageCell {
+  roleId: CoverageColumn["id"];
+  assigned: number;
+  required: number;
+  assignees: string;
+  tone: CoverageTone;
+  detail: string;
+}
+
+export interface CoverageLane {
+  id: string;
+  label: string;
+  lead: string;
+  focus: string;
+  queueDepth: string;
+  note: string;
+  cells: CoverageCell[];
+}
+
+export interface CoverageSegment {
+  id: string;
+  label: string;
+  window: string;
+  supervisor: string;
+  summary: string;
+  columns: CoverageColumn[];
+  lanes: CoverageLane[];
+}
+
+export interface SegmentSummary {
+  id: string;
+  label: string;
+  value: string;
+  detail: string;
+  tone: PlannerTone;
+}
+
+export interface CoverageSegmentView extends CoverageSegment {
+  summaries: SegmentSummary[];
+}
+
+export interface OpenShiftWarning {
+  id: string;
+  title: string;
+  severity: WarningSeverity;
+  window: string;
+  owner: string;
+  summary: string;
+  action: string;
+  seatGap: number;
+  affectedSegments: CoverageSegment["id"][];
+}
+
+export interface HandoffNote {
+  id: string;
+  title: string;
+  window: string;
+  owner: string;
+  status: HandoffStatus;
+  summary: string;
+  blockers: string[];
+  nextStep: string;
+}
+
+export interface ShiftPlannerView {
+  summary: typeof shiftPlannerOverview;
+  summaryCards: PlannerSummaryCard[];
+  coverageSegments: CoverageSegmentView[];
+  openShiftWarnings: OpenShiftWarning[];
+  handoffNotes: HandoffNote[];
+}
+
+export const shiftPlannerOverview = {
+  eyebrow: "Shift Planner",
+  title: "Map coverage depth, open shifts, and handoff risks before the next staffing move lands.",
+  description:
+    "This standalone staffing route pulls coverage matrices, open-shift warnings, and handoff notes into one operator-facing surface so the staffing picture can ship without depending on the other routes.",
+  commandPost: "Service Ops East",
+  shiftLabel: "Monday split coverage · 06:00-18:00",
+};
+
+export const coverageColumns = [
+  {
+    id: "intake",
+    label: "Intake",
+    detail: "Front-door queue ownership",
+  },
+  {
+    id: "triage",
+    label: "Triage",
+    detail: "Prioritization and queue control",
+  },
+  {
+    id: "escalations",
+    label: "Escalations",
+    detail: "Complex cases and vendor holds",
+  },
+  {
+    id: "dispatch",
+    label: "Dispatch",
+    detail: "Outbound coordination and callbacks",
+  },
+  {
+    id: "flex",
+    label: "Flex",
+    detail: "Cross-cover and break relief",
+  },
+] satisfies CoverageColumn[];
+
+export const coverageSegments = [
+  {
+    id: "opening-wave",
+    label: "Opening wave",
+    window: "06:00-10:00",
+    supervisor: "Maya Trent / Shift lead",
+    summary:
+      "The opening push has enough frontline depth to absorb early queue spikes, but one escalation seat and one flex seat remain uncovered before staggered starts finish landing.",
+    columns: coverageColumns,
+    lanes: [
+      {
+        id: "north-pod-open",
+        label: "North pod",
+        lead: "Jae Solis",
+        focus: "Priority callbacks and first-wave intake",
+        queueDepth: "12 active conversations",
+        note: "North pod is carrying the reserve buffer while central finishes its late-start coverage.",
+        cells: [
+          {
+            roleId: "intake",
+            assigned: 3,
+            required: 3,
+            assignees: "Jae, Mina, Cole",
+            tone: "staffed",
+            detail: "All three intake seats are active for the opening burst.",
+          },
+          {
+            roleId: "triage",
+            assigned: 2,
+            required: 2,
+            assignees: "Lina, Omar",
+            tone: "staffed",
+            detail: "Triage can absorb reroutes until central lunch coverage begins.",
+          },
+          {
+            roleId: "escalations",
+            assigned: 1,
+            required: 1,
+            assignees: "Priya",
+            tone: "staffed",
+            detail: "The named escalation specialist is live for vendor-critical work.",
+          },
+          {
+            roleId: "dispatch",
+            assigned: 1,
+            required: 1,
+            assignees: "Theo",
+            tone: "staffed",
+            detail: "Dispatch is fully covered for first-wave outbound callbacks.",
+          },
+          {
+            roleId: "flex",
+            assigned: 1,
+            required: 1,
+            assignees: "Marlon",
+            tone: "flex",
+            detail: "Flex coverage is live and can slide into central triage on demand.",
+          },
+        ],
+      },
+      {
+        id: "central-pod-open",
+        label: "Central pod",
+        lead: "Nina Desai",
+        focus: "Queue shaping and live escalations",
+        queueDepth: "18 waiting, 4 high priority",
+        note: "Central pod is the most exposed until the late-start triage specialist signs in.",
+        cells: [
+          {
+            roleId: "intake",
+            assigned: 3,
+            required: 3,
+            assignees: "Nina, Asha, Victor",
+            tone: "staffed",
+            detail: "All intake positions are staffed for the busiest launch window.",
+          },
+          {
+            roleId: "triage",
+            assigned: 1,
+            required: 2,
+            assignees: "Parker",
+            tone: "thin",
+            detail: "One triage seat is carrying both queue review and overflow routing.",
+          },
+          {
+            roleId: "escalations",
+            assigned: 1,
+            required: 1,
+            assignees: "Bea",
+            tone: "staffed",
+            detail: "Escalations are covered, but the buffer is narrow if a vendor case spikes.",
+          },
+          {
+            roleId: "dispatch",
+            assigned: 1,
+            required: 1,
+            assignees: "Kian",
+            tone: "staffed",
+            detail: "Dispatch coverage is steady for callback routing and field transfers.",
+          },
+          {
+            roleId: "flex",
+            assigned: 0,
+            required: 1,
+            assignees: "Open seat",
+            tone: "missing",
+            detail: "The break-relief seat is still open until the reserve floater is assigned.",
+          },
+        ],
+      },
+      {
+        id: "south-pod-open",
+        label: "South pod",
+        lead: "Elena Park",
+        focus: "Partner queue and multilingual overflow",
+        queueDepth: "9 live tickets",
+        note: "South pod keeps language coverage stable, but the escalation seat is still open.",
+        cells: [
+          {
+            roleId: "intake",
+            assigned: 2,
+            required: 2,
+            assignees: "Elena, Hugo",
+            tone: "staffed",
+            detail: "The partner intake queue is stable and fully staffed.",
+          },
+          {
+            roleId: "triage",
+            assigned: 2,
+            required: 2,
+            assignees: "Isa, Rowan",
+            tone: "staffed",
+            detail: "Triage is balanced and can absorb overflow from north pod.",
+          },
+          {
+            roleId: "escalations",
+            assigned: 0,
+            required: 1,
+            assignees: "Open seat",
+            tone: "missing",
+            detail: "No named escalation analyst is online until the late-start specialist signs in.",
+          },
+          {
+            roleId: "dispatch",
+            assigned: 1,
+            required: 1,
+            assignees: "Moe",
+            tone: "staffed",
+            detail: "Dispatch is stable for partner handoffs and outbound follow-up.",
+          },
+          {
+            roleId: "flex",
+            assigned: 1,
+            required: 1,
+            assignees: "Sia",
+            tone: "flex",
+            detail: "Flex coverage is active for bilingual overflow and break coverage.",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "midshift-bridge",
+    label: "Midshift bridge",
+    window: "10:00-14:00",
+    supervisor: "Jordan Pike / Staffing manager",
+    summary:
+      "Lunch overlap compresses intake, dispatch, and relief coverage at the same time, so the bridge hours need explicit move-by-move staffing decisions instead of passive monitoring.",
+    columns: coverageColumns,
+    lanes: [
+      {
+        id: "north-pod-bridge",
+        label: "North pod",
+        lead: "Jae Solis",
+        focus: "Renewal callbacks and wait-time control",
+        queueDepth: "17 waiting, 3 outbound holds",
+        note: "North pod can carry callback volume, but intake and flex both thin out during lunch.",
+        cells: [
+          {
+            roleId: "intake",
+            assigned: 2,
+            required: 3,
+            assignees: "Jae, Mina",
+            tone: "thin",
+            detail: "One intake seat is on lunch, leaving callback work exposed to queue spikes.",
+          },
+          {
+            roleId: "triage",
+            assigned: 2,
+            required: 2,
+            assignees: "Lina, Omar",
+            tone: "staffed",
+            detail: "Triage stays fully staffed through the bridge window.",
+          },
+          {
+            roleId: "escalations",
+            assigned: 1,
+            required: 1,
+            assignees: "Priya",
+            tone: "staffed",
+            detail: "The escalation desk is stable for complex callbacks.",
+          },
+          {
+            roleId: "dispatch",
+            assigned: 1,
+            required: 1,
+            assignees: "Theo",
+            tone: "staffed",
+            detail: "Dispatch remains available for outbound scheduling.",
+          },
+          {
+            roleId: "flex",
+            assigned: 0,
+            required: 1,
+            assignees: "Open seat",
+            tone: "missing",
+            detail: "No float coverage is named while north intake runs a reduced crew.",
+          },
+        ],
+      },
+      {
+        id: "central-pod-bridge",
+        label: "Central pod",
+        lead: "Nina Desai",
+        focus: "Vendor escalations and overflow control",
+        queueDepth: "22 waiting, 6 urgent",
+        note: "Central pod has the deepest queue and loses dispatch coverage for most of the bridge window.",
+        cells: [
+          {
+            roleId: "intake",
+            assigned: 3,
+            required: 3,
+            assignees: "Nina, Asha, Victor",
+            tone: "staffed",
+            detail: "Intake is fully staffed, keeping the central queue from hard-blocking.",
+          },
+          {
+            roleId: "triage",
+            assigned: 2,
+            required: 2,
+            assignees: "Parker, Bea",
+            tone: "staffed",
+            detail: "Triage has full coverage and can absorb overflow from south.",
+          },
+          {
+            roleId: "escalations",
+            assigned: 1,
+            required: 1,
+            assignees: "Nadia",
+            tone: "staffed",
+            detail: "Escalations stay covered, but only with one analyst live.",
+          },
+          {
+            roleId: "dispatch",
+            assigned: 0,
+            required: 1,
+            assignees: "Open seat",
+            tone: "missing",
+            detail: "Dispatch is uncovered while the usual owner is in training.",
+          },
+          {
+            roleId: "flex",
+            assigned: 1,
+            required: 1,
+            assignees: "Kian",
+            tone: "flex",
+            detail: "The reserve floater is live and can cover dispatch only if triage holds steady.",
+          },
+        ],
+      },
+      {
+        id: "south-pod-bridge",
+        label: "South pod",
+        lead: "Elena Park",
+        focus: "Partner queue and translation support",
+        queueDepth: "14 live tickets, 2 reopeners",
+        note: "South pod keeps specialist work moving, but its triage and relief seats both thin out.",
+        cells: [
+          {
+            roleId: "intake",
+            assigned: 2,
+            required: 2,
+            assignees: "Elena, Hugo",
+            tone: "staffed",
+            detail: "Partner intake stays fully staffed through the lunch bridge.",
+          },
+          {
+            roleId: "triage",
+            assigned: 1,
+            required: 2,
+            assignees: "Isa",
+            tone: "thin",
+            detail: "One person is covering both queue review and translation overflow.",
+          },
+          {
+            roleId: "escalations",
+            assigned: 1,
+            required: 1,
+            assignees: "Rowan",
+            tone: "staffed",
+            detail: "Escalations are covered for partner holds and approvals.",
+          },
+          {
+            roleId: "dispatch",
+            assigned: 1,
+            required: 1,
+            assignees: "Moe",
+            tone: "staffed",
+            detail: "Dispatch coverage remains available for partner callbacks.",
+          },
+          {
+            roleId: "flex",
+            assigned: 0,
+            required: 1,
+            assignees: "Open seat",
+            tone: "missing",
+            detail: "The relief seat is unassigned across the lunch bridge.",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "closeout-handoff",
+    label: "Closeout handoff",
+    window: "14:00-18:00",
+    supervisor: "Loren Vega / Floor supervisor",
+    summary:
+      "Late-day coverage recovers overall, but the partner desk still closes with one missing flex seat, which makes the final handoff notes more important than the raw headcount suggests.",
+    columns: coverageColumns,
+    lanes: [
+      {
+        id: "harbor-desk-close",
+        label: "Harbor desk",
+        lead: "Mina Ho",
+        focus: "Same-day callbacks and wrap-up notes",
+        queueDepth: "7 active, 5 scheduled callbacks",
+        note: "Harbor desk is fully staffed and can lend relief coverage to partner work if needed.",
+        cells: [
+          {
+            roleId: "intake",
+            assigned: 2,
+            required: 2,
+            assignees: "Mina, Cole",
+            tone: "staffed",
+            detail: "Intake is fully covered for the closeout window.",
+          },
+          {
+            roleId: "triage",
+            assigned: 2,
+            required: 2,
+            assignees: "Lina, Omar",
+            tone: "staffed",
+            detail: "Triage remains fully staffed for same-day triage and wrap decisions.",
+          },
+          {
+            roleId: "escalations",
+            assigned: 1,
+            required: 1,
+            assignees: "Priya",
+            tone: "staffed",
+            detail: "Escalations stay stable through the end-of-day queue sweep.",
+          },
+          {
+            roleId: "dispatch",
+            assigned: 1,
+            required: 1,
+            assignees: "Theo",
+            tone: "staffed",
+            detail: "Dispatch is fully covered for final outbound callbacks.",
+          },
+          {
+            roleId: "flex",
+            assigned: 1,
+            required: 1,
+            assignees: "Marlon",
+            tone: "flex",
+            detail: "Flex coverage is active and can absorb last-minute closeout tasks.",
+          },
+        ],
+      },
+      {
+        id: "partner-desk-close",
+        label: "Partner desk",
+        lead: "Elena Park",
+        focus: "Partner backlog and language support",
+        queueDepth: "11 open partner tickets",
+        note: "Partner desk keeps its specialist lane staffed, but one intake seat and the flex seat remain exposed.",
+        cells: [
+          {
+            roleId: "intake",
+            assigned: 1,
+            required: 2,
+            assignees: "Elena",
+            tone: "thin",
+            detail: "One intake seat is carrying both backlog cleanup and new partner work.",
+          },
+          {
+            roleId: "triage",
+            assigned: 1,
+            required: 1,
+            assignees: "Isa",
+            tone: "staffed",
+            detail: "Triage coverage is stable for closeout prioritization.",
+          },
+          {
+            roleId: "escalations",
+            assigned: 1,
+            required: 1,
+            assignees: "Rowan",
+            tone: "staffed",
+            detail: "The specialist lane is staffed for late vendor decisions.",
+          },
+          {
+            roleId: "dispatch",
+            assigned: 1,
+            required: 1,
+            assignees: "Moe",
+            tone: "staffed",
+            detail: "Dispatch is staffed for final partner callbacks.",
+          },
+          {
+            roleId: "flex",
+            assigned: 0,
+            required: 1,
+            assignees: "Open seat",
+            tone: "missing",
+            detail: "No backup operator is named for partner work if wrap time slips.",
+          },
+        ],
+      },
+      {
+        id: "after-hours-queue-close",
+        label: "After-hours queue",
+        lead: "Noah Reese",
+        focus: "Deferred cases and overnight prep",
+        queueDepth: "6 handoff items",
+        note: "After-hours prep is stable and can take one extra callback block if partner work spills.",
+        cells: [
+          {
+            roleId: "intake",
+            assigned: 2,
+            required: 2,
+            assignees: "Noah, Tali",
+            tone: "staffed",
+            detail: "Deferred intake is fully staffed for the handoff block.",
+          },
+          {
+            roleId: "triage",
+            assigned: 1,
+            required: 1,
+            assignees: "Ari",
+            tone: "staffed",
+            detail: "Triage coverage is stable for overnight prep notes.",
+          },
+          {
+            roleId: "escalations",
+            assigned: 1,
+            required: 1,
+            assignees: "Drew",
+            tone: "staffed",
+            detail: "Escalations are staffed for the last delayed cases.",
+          },
+          {
+            roleId: "dispatch",
+            assigned: 1,
+            required: 1,
+            assignees: "Soren",
+            tone: "staffed",
+            detail: "Dispatch remains covered for overnight callback scheduling.",
+          },
+          {
+            roleId: "flex",
+            assigned: 1,
+            required: 1,
+            assignees: "Mika",
+            tone: "flex",
+            detail: "Flex coverage is live for final wrap tasks and spillover work.",
+          },
+        ],
+      },
+    ],
+  },
+] satisfies CoverageSegment[];
+
+export const openShiftWarnings = [
+  {
+    id: "warning-south-escalations",
+    title: "South pod escalation seat is still unassigned for the opening wave",
+    severity: "critical",
+    window: "06:30-09:30",
+    owner: "Leo Brooks / Escalations manager",
+    summary:
+      "The south pod opens without a named escalation specialist, so high-touch partner cases must be rerouted until the late-start analyst signs in.",
+    action:
+      "Route vendor-critical work to north pod and hold new partner escalations for the 09:30 staffing check-in.",
+    seatGap: 1,
+    affectedSegments: ["opening-wave"],
+  },
+  {
+    id: "warning-central-triage",
+    title: "Central pod triage is thin until the staggered lunch bridge settles",
+    severity: "watch",
+    window: "08:45-11:15",
+    owner: "Maya Trent / Shift lead",
+    summary:
+      "One triage operator is covering both queue review and overflow routing while central holds the deepest live backlog on the floor.",
+    action:
+      "Move the north flex operator into central triage if waiting conversations stay above 18 for more than two check-ins.",
+    seatGap: 1,
+    affectedSegments: ["opening-wave", "midshift-bridge"],
+  },
+  {
+    id: "warning-central-dispatch",
+    title: "Central dispatch goes dark across the midday bridge",
+    severity: "critical",
+    window: "11:00-13:30",
+    owner: "Jordan Pike / Staffing manager",
+    summary:
+      "The central pod loses dispatch coverage while the usual owner is in training, creating a hard dependency on flex coverage staying available.",
+    action:
+      "Pin Kian to dispatch unless the urgent queue breaches six, and push noncritical callbacks into the closeout block.",
+    seatGap: 1,
+    affectedSegments: ["midshift-bridge"],
+  },
+  {
+    id: "warning-partner-closeout",
+    title: "Partner desk closes without a backup flex operator",
+    severity: "watch",
+    window: "15:30-18:00",
+    owner: "Loren Vega / Floor supervisor",
+    summary:
+      "The closeout window has enough specialist depth, but no extra flex seat is available if partner wrap-up work runs long.",
+    action:
+      "Borrow harbor flex coverage for the final 30 minutes if partner backlog stays above ten open tickets.",
+    seatGap: 1,
+    affectedSegments: ["closeout-handoff"],
+  },
+] satisfies OpenShiftWarning[];
+
+export const handoffNotes = [
+  {
+    id: "handoff-1",
+    title: "Opening supervisor handoff",
+    window: "05:50-06:10",
+    owner: "Maya Trent",
+    status: "confirmed",
+    summary:
+      "The opening supervisor handoff already captured queue goals, reserve rules, and which backlog tags can wait until the lunch bridge.",
+    blockers: [
+      "No active blockers for the opening briefing.",
+      "North pod owns reserve coverage until central flex is assigned.",
+    ],
+    nextStep: "Carry the reserve rule into the 08:45 staffing review without changing queue ownership.",
+  },
+  {
+    id: "handoff-2",
+    title: "Lunch bridge staffing handoff",
+    window: "09:45-10:15",
+    owner: "Jordan Pike",
+    status: "watch",
+    summary:
+      "The lunch bridge needs an explicit note about who covers central dispatch and when north flex is allowed to move off reserve duty.",
+    blockers: [
+      "Central dispatch has no primary owner during the bridge window.",
+      "North intake loses one seat at the same time flex coverage is exposed.",
+    ],
+    nextStep: "Publish the move order before 09:45 so pods do not make conflicting relief decisions.",
+  },
+  {
+    id: "handoff-3",
+    title: "Vendor escalation carry-forward",
+    window: "13:40-14:05",
+    owner: "Leo Brooks",
+    status: "pending",
+    summary:
+      "The vendor queue needs a clean handoff note because one partner approval is still waiting on the south escalation seat that opened late.",
+    blockers: [
+      "One vendor approval remains unresolved after the opening-wave coverage gap.",
+      "Partner desk closeout already starts with a thin intake seat.",
+    ],
+    nextStep: "Attach the unresolved approval number and the named callback owner before the closeout supervisor signs off.",
+  },
+  {
+    id: "handoff-4",
+    title: "Closeout to after-hours handoff",
+    window: "17:30-18:00",
+    owner: "Loren Vega",
+    status: "confirmed",
+    summary:
+      "After-hours prep is stable, and the remaining work is mostly about preserving callback ownership and the final partner backlog count.",
+    blockers: [
+      "No blocking staffing gaps outside the partner flex seat.",
+      "Harbor desk can still lend one operator if closeout slips.",
+    ],
+    nextStep: "Record the final partner backlog count and the callback owner list in the after-hours log.",
+  },
+] satisfies HandoffNote[];
+
+export function getCoverageGap(cell: CoverageCell) {
+  return Math.max(cell.required - cell.assigned, 0);
+}
+
+function getSegmentPlannedSeats(segment: CoverageSegment) {
+  return segment.lanes.reduce(
+    (segmentTotal, lane) =>
+      segmentTotal +
+      lane.cells.reduce((laneTotal, cell) => laneTotal + cell.required, 0),
+    0,
+  );
+}
+
+function getSegmentStaffedSeats(segment: CoverageSegment) {
+  return segment.lanes.reduce(
+    (segmentTotal, lane) =>
+      segmentTotal +
+      lane.cells.reduce((laneTotal, cell) => laneTotal + cell.assigned, 0),
+    0,
+  );
+}
+
+function getSegmentGapCount(segment: CoverageSegment) {
+  return segment.lanes.reduce(
+    (segmentTotal, lane) =>
+      segmentTotal +
+      lane.cells.reduce((laneTotal, cell) => laneTotal + getCoverageGap(cell), 0),
+    0,
+  );
+}
+
+function getSegmentFlexCount(segment: CoverageSegment) {
+  return segment.lanes.reduce(
+    (segmentTotal, lane) =>
+      segmentTotal +
+      lane.cells.filter((cell) => cell.tone === "flex" && cell.assigned > 0).length,
+    0,
+  );
+}
+
+function getSegmentWatchLaneCount(segment: CoverageSegment) {
+  return segment.lanes.filter((lane) =>
+    lane.cells.some((cell) => cell.tone === "thin" || cell.tone === "missing"),
+  ).length;
+}
+
+function getSegmentSummaries(segment: CoverageSegment): SegmentSummary[] {
+  const staffedSeats = getSegmentStaffedSeats(segment);
+  const plannedSeats = getSegmentPlannedSeats(segment);
+  const gapCount = getSegmentGapCount(segment);
+  const flexCount = getSegmentFlexCount(segment);
+  const watchLanes = getSegmentWatchLaneCount(segment);
+
+  return [
+    {
+      id: `${segment.id}-staffed`,
+      label: "Staffed seats",
+      value: `${staffedSeats}/${plannedSeats}`,
+      detail: "Assigned seats against the planned coverage target for this segment.",
+      tone: gapCount > 2 ? "watch" : "steady",
+    },
+    {
+      id: `${segment.id}-gaps`,
+      label: "Open gaps",
+      value: String(gapCount),
+      detail: "Seats that are thin or fully unassigned inside this segment.",
+      tone: gapCount > 2 ? "risk" : gapCount > 0 ? "watch" : "steady",
+    },
+    {
+      id: `${segment.id}-flex`,
+      label: "Flex seats live",
+      value: String(flexCount),
+      detail: `${watchLanes} lanes still need watch coverage during this window.`,
+      tone: flexCount === 0 ? "risk" : watchLanes > 1 ? "watch" : "steady",
+    },
+  ];
+}
+
+export function getShiftPlannerView(): ShiftPlannerView {
+  const plannedSeats = coverageSegments.reduce(
+    (total, segment) => total + getSegmentPlannedSeats(segment),
+    0,
+  );
+  const staffedSeats = coverageSegments.reduce(
+    (total, segment) => total + getSegmentStaffedSeats(segment),
+    0,
+  );
+  const openSeatGaps = coverageSegments.reduce(
+    (total, segment) => total + getSegmentGapCount(segment),
+    0,
+  );
+  const flexSeats = coverageSegments.reduce(
+    (total, segment) => total + getSegmentFlexCount(segment),
+    0,
+  );
+  const criticalWarnings = openShiftWarnings.filter(
+    (warning) => warning.severity === "critical",
+  ).length;
+  const handoffsOnWatch = handoffNotes.filter(
+    (note) => note.status === "watch" || note.status === "pending",
+  ).length;
+
+  return {
+    summary: shiftPlannerOverview,
+    summaryCards: [
+      {
+        id: "coverage-segments",
+        label: "Coverage segments",
+        value: String(coverageSegments.length),
+        detail: "Opening, midday bridge, and closeout coverage windows share one staffing surface.",
+        tone: "steady",
+      },
+      {
+        id: "planned-seats",
+        label: "Planned seats",
+        value: `${staffedSeats}/${plannedSeats}`,
+        detail: "Assigned seats across intake, triage, escalations, dispatch, and flex coverage.",
+        tone: openSeatGaps > 6 ? "watch" : "steady",
+      },
+      {
+        id: "open-seat-gaps",
+        label: "Open seat gaps",
+        value: String(openSeatGaps),
+        detail: `${criticalWarnings} critical warnings are attached to missing seats and timing overlap.`,
+        tone: openSeatGaps > 6 ? "risk" : openSeatGaps > 0 ? "watch" : "steady",
+      },
+      {
+        id: "handoffs-on-watch",
+        label: "Handoffs on watch",
+        value: String(handoffsOnWatch),
+        detail: `${flexSeats} flex seats are active, but note quality still matters for the lunch bridge and closeout carry-forward.`,
+        tone: handoffsOnWatch > 1 ? "watch" : "steady",
+      },
+    ],
+    coverageSegments: coverageSegments.map((segment) => ({
+      ...segment,
+      summaries: getSegmentSummaries(segment),
+    })),
+    openShiftWarnings,
+    handoffNotes,
+  };
+}

--- a/src/app/shift-planner/page.test.tsx
+++ b/src/app/shift-planner/page.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  getShiftPlannerView,
+  handoffNotes,
+  openShiftWarnings,
+} from "./_data/shift-planner-data";
+import ShiftPlannerPage from "./page";
+
+describe("ShiftPlannerPage", () => {
+  it("renders the hero, command-post metadata, and summary cards", () => {
+    const view = getShiftPlannerView();
+
+    render(<ShiftPlannerPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: view.summary.title,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(view.summary.commandPost)).toBeInTheDocument();
+    expect(screen.getByText(view.summary.shiftLabel)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /back to route index/i }),
+    ).toHaveAttribute("href", "/");
+
+    const summarySection = screen.getByLabelText(/shift planner summary cards/i);
+
+    for (const card of view.summaryCards) {
+      expect(within(summarySection).getByText(card.label)).toBeInTheDocument();
+      expect(within(summarySection).getByText(card.value)).toBeInTheDocument();
+      expect(within(summarySection).getByText(card.detail)).toBeInTheDocument();
+    }
+  });
+
+  it("renders every coverage segment with grouped summaries and lane-level matrix content", () => {
+    const view = getShiftPlannerView();
+
+    render(<ShiftPlannerPage />);
+
+    const coverageList = screen.getByRole("list", {
+      name: /coverage segments/i,
+    });
+
+    expect(within(coverageList).getAllByRole("listitem")).toHaveLength(
+      view.coverageSegments.length,
+    );
+
+    for (const segment of view.coverageSegments) {
+      const section = screen
+        .getByRole("heading", { level: 3, name: segment.label })
+        .closest('[role="listitem"]');
+      const matrix = screen.getByRole("table", { name: segment.label });
+
+      expect(section).toBeInTheDocument();
+      expect(section).toHaveTextContent(segment.window);
+      expect(section).toHaveTextContent(segment.supervisor);
+      expect(section).toHaveTextContent(segment.summary);
+      expect(matrix).toBeInTheDocument();
+
+      for (const summary of segment.summaries) {
+        const summaryCard = within(section as HTMLElement)
+          .getByText(summary.label)
+          .closest("div");
+
+        expect(summaryCard).toBeInTheDocument();
+        expect(within(summaryCard as HTMLElement).getByText(summary.value)).toBeInTheDocument();
+      }
+
+      for (const lane of segment.lanes) {
+        expect(within(matrix).getByText(lane.label)).toBeInTheDocument();
+        expect(within(matrix).getByText(lane.lead)).toBeInTheDocument();
+        expect(within(matrix).getByText(lane.focus)).toBeInTheDocument();
+        expect(within(matrix).getByText(lane.queueDepth)).toBeInTheDocument();
+
+        for (const cell of lane.cells) {
+          expect(
+            within(matrix).getAllByText(`${cell.assigned}/${cell.required}`).length,
+          ).toBeGreaterThan(0);
+          expect(within(matrix).getAllByText(cell.assignees).length).toBeGreaterThan(0);
+          expect(within(matrix).getByText(cell.detail)).toBeInTheDocument();
+        }
+      }
+    }
+  });
+
+  it("renders warning cards with affected coverage segments and recommended actions", () => {
+    render(<ShiftPlannerPage />);
+
+    const warningList = screen.getByRole("list", {
+      name: /open shift warnings/i,
+    });
+
+    expect(within(warningList).getAllByRole("listitem")).toHaveLength(
+      openShiftWarnings.length,
+    );
+
+    expect(screen.getByText("Active warnings")).toBeInTheDocument();
+    expect(screen.getByText("Critical warnings")).toBeInTheDocument();
+
+    for (const warning of openShiftWarnings) {
+      const card = within(warningList)
+        .getByRole("heading", { level: 3, name: warning.title })
+        .closest('[role="listitem"]');
+
+      expect(card).toBeInTheDocument();
+      expect(card).toHaveTextContent(warning.owner);
+      expect(card).toHaveTextContent(warning.window);
+      expect(card).toHaveTextContent(warning.summary);
+      expect(card).toHaveTextContent(warning.action);
+    }
+  });
+
+  it("renders handoff notes with note status, blockers, and next-step content", () => {
+    render(<ShiftPlannerPage />);
+
+    const handoffList = screen.getByRole("list", {
+      name: /shift handoff notes/i,
+    });
+
+    expect(handoffList.querySelectorAll(":scope > article")).toHaveLength(
+      handoffNotes.length,
+    );
+
+    for (const note of handoffNotes) {
+      const card = within(handoffList)
+        .getByRole("heading", { level: 3, name: note.title })
+        .closest('[role="listitem"]');
+      const blockerList = within(card as HTMLElement).getByRole("list", {
+        name: `${note.title} blockers`,
+      });
+
+      expect(card).toBeInTheDocument();
+      expect(card).toHaveTextContent(note.owner);
+      expect(card).toHaveTextContent(note.window);
+      expect(card).toHaveTextContent(note.status);
+      expect(card).toHaveTextContent(note.summary);
+      expect(card).toHaveTextContent(note.nextStep);
+
+      for (const blocker of note.blockers) {
+        expect(within(blockerList).getByText(blocker)).toBeInTheDocument();
+      }
+    }
+  });
+});

--- a/src/app/shift-planner/page.tsx
+++ b/src/app/shift-planner/page.tsx
@@ -1,38 +1,132 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
+import { CoverageMatrixSection } from "./_components/coverage-matrix-section";
+import { HandoffNotesPanel } from "./_components/handoff-notes-panel";
+import { StaffingWarningPanel } from "./_components/staffing-warning-panel";
+import { getShiftPlannerView } from "./_data/shift-planner-data";
+
 export const metadata: Metadata = {
   title: "Shift Planner",
   description: "Review shift coverage, staffing warnings, and handoff notes on a dedicated route.",
 };
 
+const summaryToneClassNames = {
+  steady: "border-emerald-200 bg-emerald-50/70 text-emerald-950",
+  watch: "border-amber-200 bg-amber-50/80 text-amber-950",
+  risk: "border-rose-200 bg-rose-50/80 text-rose-950",
+};
+
 export default function ShiftPlannerPage() {
+  const view = getShiftPlannerView();
+
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 py-12 sm:px-10 lg:px-12">
-      <section className="rounded-[2rem] border border-slate-200 bg-white/80 p-8 shadow-[0_20px_80px_rgba(15,23,42,0.08)] backdrop-blur">
-        <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
-          <div className="max-w-3xl space-y-4">
-            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-emerald-700">
-              Shift Planner
+    <main className="mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
+      <section className="rounded-[2.2rem] border border-slate-200 bg-white/85 p-8 shadow-[0_24px_90px_rgba(15,23,42,0.08)] backdrop-blur sm:p-10 lg:p-12">
+        <div className="flex flex-col gap-8 xl:grid xl:grid-cols-[minmax(0,1.25fr)_minmax(18rem,0.75fr)] xl:items-start">
+          <div className="space-y-6">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <p className="text-sm font-semibold uppercase tracking-[0.28em] text-emerald-700">
+                {view.summary.eyebrow}
+              </p>
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+              >
+                Back to route index
+              </Link>
+            </div>
+
+            <div className="space-y-4">
+              <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl lg:text-6xl">
+                {view.summary.title}
+              </h1>
+              <p className="max-w-3xl text-base leading-8 text-slate-600 sm:text-lg">
+                {view.summary.description}
+              </p>
+            </div>
+          </div>
+
+          <aside className="rounded-[1.8rem] border border-slate-200 bg-slate-50/85 p-6">
+            <div className="space-y-5">
+              <div>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  Command post
+                </p>
+                <p className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">
+                  {view.summary.commandPost}
+                </p>
+              </div>
+
+              <div className="rounded-[1.35rem] border border-slate-200 bg-white px-4 py-4">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                  Active staffing window
+                </p>
+                <p className="mt-2 text-base font-semibold text-slate-950">
+                  {view.summary.shiftLabel}
+                </p>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      <section
+        aria-label="Shift planner summary cards"
+        className="grid gap-4 lg:grid-cols-2 xl:grid-cols-4"
+      >
+        {view.summaryCards.map((card) => (
+          <article
+            key={card.id}
+            className={`rounded-[1.6rem] border px-5 py-5 shadow-[0_18px_70px_rgba(15,23,42,0.06)] ${summaryToneClassNames[card.tone]}`}
+          >
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em]">
+              {card.label}
             </p>
-            <h1 className="text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-              Coverage matrices, open-shift warnings, and handoff notes in one route.
-            </h1>
-            <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
-              This scaffold establishes the standalone staffing route before the
-              route-local data, matrix sections, and tests land in follow-up
-              commits.
+            <p className="mt-3 text-4xl font-semibold tracking-tight">
+              {card.value}
+            </p>
+            <p className="mt-3 text-sm leading-6 opacity-85">
+              {card.detail}
+            </p>
+          </article>
+        ))}
+      </section>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.42fr)_minmax(21rem,0.9fr)]">
+        <section aria-labelledby="shift-planner-matrices" className="space-y-6">
+          <div className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Coverage matrices
+            </p>
+            <h2
+              id="shift-planner-matrices"
+              className="text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl"
+            >
+              Coverage segments with seat-level depth and queue context
+            </h2>
+            <p className="max-w-3xl text-sm leading-7 text-slate-600">
+              Each segment pairs seat counts with named operators, queue
+              posture, and lane-level notes so staffing moves stay grounded in
+              real coverage tradeoffs instead of flat totals.
             </p>
           </div>
 
-          <Link
-            href="/"
-            className="inline-flex items-center justify-center rounded-full border border-slate-300 px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
-          >
-            Back to route index
-          </Link>
+          <div className="space-y-6" role="list" aria-label="Coverage segments">
+            {view.coverageSegments.map((segment) => (
+              <CoverageMatrixSection key={segment.id} segment={segment} />
+            ))}
+          </div>
+        </section>
+
+        <div className="space-y-6">
+          <StaffingWarningPanel
+            segments={view.coverageSegments}
+            warnings={view.openShiftWarnings}
+          />
+          <HandoffNotesPanel notes={view.handoffNotes} />
         </div>
-      </section>
+      </div>
     </main>
   );
 }

--- a/src/app/shift-planner/page.tsx
+++ b/src/app/shift-planner/page.tsx
@@ -5,6 +5,7 @@ import { CoverageMatrixSection } from "./_components/coverage-matrix-section";
 import { HandoffNotesPanel } from "./_components/handoff-notes-panel";
 import { StaffingWarningPanel } from "./_components/staffing-warning-panel";
 import { getShiftPlannerView } from "./_data/shift-planner-data";
+import styles from "./shift-planner.module.css";
 
 export const metadata: Metadata = {
   title: "Shift Planner",
@@ -12,119 +13,123 @@ export const metadata: Metadata = {
 };
 
 const summaryToneClassNames = {
-  steady: "border-emerald-200 bg-emerald-50/70 text-emerald-950",
-  watch: "border-amber-200 bg-amber-50/80 text-amber-950",
-  risk: "border-rose-200 bg-rose-50/80 text-rose-950",
+  steady: styles.summaryToneSteady,
+  watch: styles.summaryToneWatch,
+  risk: styles.summaryToneRisk,
 };
 
 export default function ShiftPlannerPage() {
   const view = getShiftPlannerView();
 
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
-      <section className="rounded-[2.2rem] border border-slate-200 bg-white/85 p-8 shadow-[0_24px_90px_rgba(15,23,42,0.08)] backdrop-blur sm:p-10 lg:p-12">
-        <div className="flex flex-col gap-8 xl:grid xl:grid-cols-[minmax(0,1.25fr)_minmax(18rem,0.75fr)] xl:items-start">
-          <div className="space-y-6">
-            <div className="flex flex-wrap items-center justify-between gap-4">
-              <p className="text-sm font-semibold uppercase tracking-[0.28em] text-emerald-700">
-                {view.summary.eyebrow}
-              </p>
-              <Link
-                href="/"
-                className="inline-flex items-center justify-center rounded-full border border-slate-300 px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
-              >
-                Back to route index
-              </Link>
-            </div>
-
-            <div className="space-y-4">
-              <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl lg:text-6xl">
-                {view.summary.title}
-              </h1>
-              <p className="max-w-3xl text-base leading-8 text-slate-600 sm:text-lg">
-                {view.summary.description}
-              </p>
-            </div>
-          </div>
-
-          <aside className="rounded-[1.8rem] border border-slate-200 bg-slate-50/85 p-6">
-            <div className="space-y-5">
-              <div>
-                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
-                  Command post
+    <main className={styles.shell}>
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
+        <section
+          className={`${styles.heroPanel} rounded-[2.2rem] p-8 sm:p-10 lg:p-12`}
+        >
+          <div className="flex flex-col gap-8 xl:grid xl:grid-cols-[minmax(0,1.25fr)_minmax(18rem,0.75fr)] xl:items-start">
+            <div className="space-y-6">
+              <div className="flex flex-wrap items-center justify-between gap-4">
+                <p className="text-sm font-semibold uppercase tracking-[0.28em] text-emerald-700">
+                  {view.summary.eyebrow}
                 </p>
-                <p className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">
-                  {view.summary.commandPost}
-                </p>
+                <Link
+                  href="/"
+                  className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white/80 px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+                >
+                  Back to route index
+                </Link>
               </div>
 
-              <div className="rounded-[1.35rem] border border-slate-200 bg-white px-4 py-4">
-                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
-                  Active staffing window
-                </p>
-                <p className="mt-2 text-base font-semibold text-slate-950">
-                  {view.summary.shiftLabel}
+              <div className="space-y-4">
+                <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl lg:text-6xl">
+                  {view.summary.title}
+                </h1>
+                <p className="max-w-3xl text-base leading-8 text-slate-600 sm:text-lg">
+                  {view.summary.description}
                 </p>
               </div>
             </div>
-          </aside>
-        </div>
-      </section>
 
-      <section
-        aria-label="Shift planner summary cards"
-        className="grid gap-4 lg:grid-cols-2 xl:grid-cols-4"
-      >
-        {view.summaryCards.map((card) => (
-          <article
-            key={card.id}
-            className={`rounded-[1.6rem] border px-5 py-5 shadow-[0_18px_70px_rgba(15,23,42,0.06)] ${summaryToneClassNames[card.tone]}`}
-          >
-            <p className="text-[11px] font-semibold uppercase tracking-[0.2em]">
-              {card.label}
-            </p>
-            <p className="mt-3 text-4xl font-semibold tracking-tight">
-              {card.value}
-            </p>
-            <p className="mt-3 text-sm leading-6 opacity-85">
-              {card.detail}
-            </p>
-          </article>
-        ))}
-      </section>
+            <aside className={`${styles.metaCard} rounded-[1.8rem] p-6`}>
+              <div className="space-y-5">
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                    Command post
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold tracking-tight text-slate-950">
+                    {view.summary.commandPost}
+                  </p>
+                </div>
 
-      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.42fr)_minmax(21rem,0.9fr)]">
-        <section aria-labelledby="shift-planner-matrices" className="space-y-6">
-          <div className="space-y-3">
-            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
-              Coverage matrices
-            </p>
-            <h2
-              id="shift-planner-matrices"
-              className="text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl"
-            >
-              Coverage segments with seat-level depth and queue context
-            </h2>
-            <p className="max-w-3xl text-sm leading-7 text-slate-600">
-              Each segment pairs seat counts with named operators, queue
-              posture, and lane-level notes so staffing moves stay grounded in
-              real coverage tradeoffs instead of flat totals.
-            </p>
-          </div>
-
-          <div className="space-y-6" role="list" aria-label="Coverage segments">
-            {view.coverageSegments.map((segment) => (
-              <CoverageMatrixSection key={segment.id} segment={segment} />
-            ))}
+                <div className={styles.metaBlock}>
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
+                    Active staffing window
+                  </p>
+                  <p className="mt-2 text-base font-semibold text-slate-950">
+                    {view.summary.shiftLabel}
+                  </p>
+                </div>
+              </div>
+            </aside>
           </div>
         </section>
 
-        <div className="space-y-6">
-          <StaffingWarningPanel
-            segments={view.coverageSegments}
-            warnings={view.openShiftWarnings}
-          />
-          <HandoffNotesPanel notes={view.handoffNotes} />
+        <section
+          aria-label="Shift planner summary cards"
+          className="grid gap-4 lg:grid-cols-2 xl:grid-cols-4"
+        >
+          {view.summaryCards.map((card) => (
+            <article
+              key={card.id}
+              className={`${styles.summaryCard} ${summaryToneClassNames[card.tone]} rounded-[1.6rem] px-5 py-5`}
+            >
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em]">
+                {card.label}
+              </p>
+              <p className="mt-3 text-4xl font-semibold tracking-tight">
+                {card.value}
+              </p>
+              <p className="mt-3 text-sm leading-6 opacity-85">
+                {card.detail}
+              </p>
+            </article>
+          ))}
+        </section>
+
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.42fr)_minmax(21rem,0.9fr)]">
+          <section aria-labelledby="shift-planner-matrices" className="space-y-6">
+            <div className="space-y-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                Coverage matrices
+              </p>
+              <h2
+                id="shift-planner-matrices"
+                className="text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl"
+              >
+                Coverage segments with seat-level depth and queue context
+              </h2>
+              <p className="max-w-3xl text-sm leading-7 text-slate-600">
+                Each segment pairs seat counts with named operators, queue
+                posture, and lane-level notes so staffing moves stay grounded
+                in real coverage tradeoffs instead of flat totals.
+              </p>
+            </div>
+
+            <div className="space-y-6" role="list" aria-label="Coverage segments">
+              {view.coverageSegments.map((segment) => (
+                <CoverageMatrixSection key={segment.id} segment={segment} />
+              ))}
+            </div>
+          </section>
+
+          <div className={styles.sidebarStack}>
+            <StaffingWarningPanel
+              segments={view.coverageSegments}
+              warnings={view.openShiftWarnings}
+            />
+            <HandoffNotesPanel notes={view.handoffNotes} />
+          </div>
         </div>
       </div>
     </main>

--- a/src/app/shift-planner/page.tsx
+++ b/src/app/shift-planner/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Shift Planner",
+  description: "Review shift coverage, staffing warnings, and handoff notes on a dedicated route.",
+};
+
+export default function ShiftPlannerPage() {
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col px-6 py-12 sm:px-10 lg:px-12">
+      <section className="rounded-[2rem] border border-slate-200 bg-white/80 p-8 shadow-[0_20px_80px_rgba(15,23,42,0.08)] backdrop-blur">
+        <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+          <div className="max-w-3xl space-y-4">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-emerald-700">
+              Shift Planner
+            </p>
+            <h1 className="text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
+              Coverage matrices, open-shift warnings, and handoff notes in one route.
+            </h1>
+            <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
+              This scaffold establishes the standalone staffing route before the
+              route-local data, matrix sections, and tests land in follow-up
+              commits.
+            </p>
+          </div>
+
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center rounded-full border border-slate-300 px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+          >
+            Back to route index
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/shift-planner/shift-planner.module.css
+++ b/src/app/shift-planner/shift-planner.module.css
@@ -1,0 +1,448 @@
+.shell {
+  --planner-line: rgba(100, 116, 139, 0.18);
+  --planner-line-strong: rgba(71, 85, 105, 0.22);
+  --planner-surface: rgba(255, 252, 245, 0.82);
+  --planner-surface-strong: rgba(255, 255, 255, 0.92);
+  --planner-shadow: 0 28px 100px rgba(15, 23, 42, 0.1);
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at top left, rgba(20, 184, 166, 0.16), transparent 24%),
+    radial-gradient(circle at top right, rgba(245, 158, 11, 0.18), transparent 22%),
+    radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.14), transparent 28%),
+    linear-gradient(180deg, #fcf5ea 0%, #f7f1e5 44%, #eef3f5 100%);
+}
+
+.shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(130deg, rgba(255, 255, 255, 0.28), transparent 34%),
+    repeating-linear-gradient(
+      90deg,
+      rgba(148, 163, 184, 0.08) 0,
+      rgba(148, 163, 184, 0.08) 1px,
+      transparent 1px,
+      transparent 76px
+    ),
+    repeating-linear-gradient(
+      180deg,
+      rgba(148, 163, 184, 0.06) 0,
+      rgba(148, 163, 184, 0.06) 1px,
+      transparent 1px,
+      transparent 76px
+    );
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.9), transparent 97%);
+}
+
+.heroPanel {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background:
+    linear-gradient(140deg, rgba(15, 118, 110, 0.08), rgba(255, 255, 255, 0.88) 30%, rgba(255, 248, 235, 0.88)),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.68), rgba(255, 255, 255, 0.4));
+  box-shadow: 0 34px 120px rgba(15, 23, 42, 0.1);
+  backdrop-filter: blur(18px);
+}
+
+.heroPanel::before {
+  content: "";
+  position: absolute;
+  inset: auto -5rem -6rem auto;
+  height: 16rem;
+  width: 16rem;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(20, 184, 166, 0.24), transparent 68%);
+  z-index: -1;
+}
+
+.heroPanel::after {
+  content: "";
+  position: absolute;
+  inset: -5rem auto auto -4rem;
+  height: 13rem;
+  width: 13rem;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(245, 158, 11, 0.2), transparent 72%);
+  z-index: -1;
+}
+
+.metaCard {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(246, 248, 250, 0.78));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.72);
+}
+
+.metaBlock {
+  border-radius: 1.4rem;
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(255, 255, 255, 0.8);
+  padding: 1rem 1rem 1.05rem;
+}
+
+.summaryCard {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: var(--planner-surface);
+  box-shadow: var(--planner-shadow);
+  backdrop-filter: blur(14px);
+}
+
+.summaryCard::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0.38rem;
+  border-radius: 999px;
+}
+
+.summaryToneSteady {
+  background:
+    linear-gradient(180deg, rgba(236, 253, 245, 0.92), rgba(255, 255, 255, 0.82));
+}
+
+.summaryToneSteady::before {
+  background: #10b981;
+}
+
+.summaryToneWatch {
+  background:
+    linear-gradient(180deg, rgba(255, 247, 237, 0.94), rgba(255, 255, 255, 0.82));
+}
+
+.summaryToneWatch::before {
+  background: #f59e0b;
+}
+
+.summaryToneRisk {
+  background:
+    linear-gradient(180deg, rgba(255, 241, 242, 0.94), rgba(255, 255, 255, 0.82));
+}
+
+.summaryToneRisk::before {
+  background: #f43f5e;
+}
+
+.sidebarStack {
+  display: grid;
+  gap: 1.5rem;
+  align-content: start;
+}
+
+.panelCard {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(249, 250, 251, 0.8));
+  box-shadow: var(--planner-shadow);
+  backdrop-filter: blur(16px);
+}
+
+.segmentCard {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 252, 0.82));
+  box-shadow: var(--planner-shadow);
+  backdrop-filter: blur(16px);
+}
+
+.segmentMetric {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.68);
+}
+
+.segmentMetric::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0.3rem;
+  border-radius: 999px;
+}
+
+.segmentMetricToneSteady {
+  background:
+    linear-gradient(180deg, rgba(236, 253, 245, 0.9), rgba(255, 255, 255, 0.82));
+}
+
+.segmentMetricToneSteady::before {
+  background: #10b981;
+}
+
+.segmentMetricToneWatch {
+  background:
+    linear-gradient(180deg, rgba(255, 247, 237, 0.94), rgba(255, 255, 255, 0.84));
+}
+
+.segmentMetricToneWatch::before {
+  background: #f59e0b;
+}
+
+.segmentMetricToneRisk {
+  background:
+    linear-gradient(180deg, rgba(255, 241, 242, 0.94), rgba(255, 255, 255, 0.84));
+}
+
+.segmentMetricToneRisk::before {
+  background: #f43f5e;
+}
+
+.matrixTable {
+  border-collapse: separate;
+  border-spacing: 0 0.85rem;
+}
+
+.matrixTable thead th {
+  padding-bottom: 0.65rem;
+}
+
+.laneCell,
+.focusCell,
+.noteCell {
+  border: 1px solid var(--planner-line);
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+}
+
+.laneCell {
+  border-right: 0;
+  border-radius: 1.45rem 0 0 1.45rem;
+}
+
+.focusCell {
+  border-left: 0;
+  border-right: 0;
+}
+
+.noteCell {
+  border-left: 0;
+  border-radius: 0 1.45rem 1.45rem 0;
+}
+
+.coverageCellWrap {
+  border-top: 1px solid var(--planner-line);
+  border-bottom: 1px solid var(--planner-line);
+  background: rgba(255, 255, 255, 0.78);
+}
+
+.coverageCellWrapFirst {
+  border-left: 1px solid var(--planner-line);
+}
+
+.coverageCellWrapLast {
+  border-right: 1px solid var(--planner-line);
+}
+
+.coverageCell {
+  position: relative;
+  min-height: 100%;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 1.2rem;
+  padding: 0.85rem 0.9rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.62);
+}
+
+.coverageCell::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0.28rem;
+  border-radius: 999px;
+}
+
+.coverageStaffed {
+  border-color: rgba(16, 185, 129, 0.2);
+  background:
+    linear-gradient(180deg, rgba(236, 253, 245, 0.94), rgba(255, 255, 255, 0.82));
+}
+
+.coverageStaffed::before {
+  background: #10b981;
+}
+
+.coverageThin {
+  border-color: rgba(245, 158, 11, 0.22);
+  background:
+    linear-gradient(180deg, rgba(255, 247, 237, 0.96), rgba(255, 255, 255, 0.82));
+}
+
+.coverageThin::before {
+  background: #f59e0b;
+}
+
+.coverageMissing {
+  border-color: rgba(244, 63, 94, 0.24);
+  background:
+    linear-gradient(180deg, rgba(255, 241, 242, 0.96), rgba(255, 255, 255, 0.84));
+}
+
+.coverageMissing::before {
+  background: #f43f5e;
+}
+
+.coverageFlex {
+  border-color: rgba(14, 165, 233, 0.22);
+  background:
+    linear-gradient(180deg, rgba(240, 249, 255, 0.96), rgba(255, 255, 255, 0.84));
+}
+
+.coverageFlex::before {
+  background: #0ea5e9;
+}
+
+.warningStat {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(255, 255, 255, 0.75);
+}
+
+.warningCard,
+.handoffCard {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.84), rgba(248, 250, 252, 0.78));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.72);
+}
+
+.warningCard::before,
+.handoffCard::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0.3rem;
+  border-radius: 999px;
+}
+
+.warningWatch::before,
+.handoffWatch::before {
+  background: #f59e0b;
+}
+
+.warningCritical::before,
+.handoffPending::before {
+  background: #f43f5e;
+}
+
+.handoffConfirmed::before {
+  background: #10b981;
+}
+
+.toneBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 0.35rem 0.8rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.toneWatch {
+  border-color: rgba(245, 158, 11, 0.22);
+  background: rgba(255, 247, 237, 0.9);
+  color: #9a3412;
+}
+
+.toneCritical,
+.tonePending {
+  border-color: rgba(244, 63, 94, 0.22);
+  background: rgba(255, 241, 242, 0.9);
+  color: #9f1239;
+}
+
+.toneConfirmed {
+  border-color: rgba(16, 185, 129, 0.22);
+  background: rgba(236, 253, 245, 0.9);
+  color: #047857;
+}
+
+.segmentPill {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(255, 255, 255, 0.74);
+}
+
+.infoBlock {
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  background: rgba(255, 255, 255, 0.86);
+}
+
+.bulletList {
+  margin: 0.75rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.7rem;
+}
+
+.bulletList li {
+  position: relative;
+  padding-left: 1rem;
+  color: #334155;
+}
+
+.bulletList li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.7rem;
+  height: 0.34rem;
+  width: 0.34rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.42);
+}
+
+@media (min-width: 1280px) {
+  .sidebarStack {
+    position: sticky;
+    top: 1.5rem;
+  }
+}
+
+@media (max-width: 1279px) {
+  .sidebarStack {
+    position: static;
+  }
+}
+
+@media (max-width: 767px) {
+  .heroPanel,
+  .summaryCard,
+  .panelCard,
+  .segmentCard {
+    border-radius: 1.45rem;
+  }
+
+  .metaBlock,
+  .warningStat,
+  .warningCard,
+  .handoffCard,
+  .infoBlock,
+  .segmentMetric {
+    border-radius: 1.1rem;
+  }
+
+  .matrixTable {
+    border-spacing: 0 0.65rem;
+  }
+
+  .laneCell {
+    border-radius: 1.2rem 0 0 1.2rem;
+  }
+
+  .noteCell {
+    border-radius: 0 1.2rem 1.2rem 0;
+  }
+}


### PR DESCRIPTION
## Summary
- add the standalone shift-planner route with route-local staffing data and page composition
- render coverage matrices, open shift warnings, and handoff notes with responsive styling and explicit staffed/thin/missing state treatments
- add render-path coverage for the route and verify lint, targeted vitest, and a production build

## Testing
- npm run lint -- src/app/shift-planner
- npm run test -- src/app/shift-planner/page.test.tsx
- npm run build

Closes #148