### PR TITLE
feat: finalize field guide route polish

### DIFF
--- a/src/app/field-guide/_components/field-guide-shell.tsx
+++ b/src/app/field-guide/_components/field-guide-shell.tsx
@@ -247,7 +247,7 @@ export function FieldGuideShell({
           {shellHighlights.map((highlight) => (
             <div
               key={highlight.label}
-              className="rounded-[1.7rem] border border-slate-200/80 bg-white/82 px-5 py-5 shadow-[0_18px_70px_-48px_rgba(15,23,42,0.35)]"
+              className={`${styles.routeHighlightCard} rounded-[1.7rem] border border-slate-200/80 bg-white/82 px-5 py-5 shadow-[0_18px_70px_-48px_rgba(15,23,42,0.35)]`}
             >
               <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
                 {highlight.label}
@@ -280,7 +280,9 @@ export function FieldGuideShell({
           aria-label="Field guide workspace summary"
           className="grid gap-4 xl:grid-cols-[minmax(0,1.3fr)_minmax(280px,0.7fr)]"
         >
-          <div className="rounded-[1.8rem] border border-slate-200/80 bg-white/78 px-5 py-5 shadow-[0_18px_70px_-48px_rgba(15,23,42,0.38)]">
+          <div
+            className={`${styles.workspacePanel} rounded-[1.8rem] border border-slate-200/80 bg-white/78 px-5 py-5 shadow-[0_18px_70px_-48px_rgba(15,23,42,0.38)]`}
+          >
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
               Active Filters
             </p>
@@ -308,7 +310,9 @@ export function FieldGuideShell({
             </p>
           </div>
 
-          <div className="rounded-[1.8rem] border border-slate-200/80 bg-slate-950 px-5 py-5 text-white shadow-[0_24px_80px_-50px_rgba(15,23,42,0.65)]">
+          <div
+            className={`${styles.workspacePanelDark} rounded-[1.8rem] border border-slate-200/80 bg-slate-950 px-5 py-5 text-white shadow-[0_24px_80px_-50px_rgba(15,23,42,0.65)]`}
+          >
             <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
               Selected Focus
             </p>
@@ -354,7 +358,9 @@ export function FieldGuideShell({
                     aria-labelledby={`field-guide-group-${group.category.id}`}
                     className="space-y-4"
                   >
-                    <div className="flex flex-col gap-3 rounded-[1.6rem] border border-slate-200/75 bg-white/72 px-5 py-4 shadow-[0_18px_60px_-50px_rgba(15,23,42,0.38)] sm:flex-row sm:items-end sm:justify-between">
+                    <div
+                      className={`${styles.groupHeader} flex flex-col gap-3 rounded-[1.6rem] border border-slate-200/75 bg-white/72 px-5 py-4 shadow-[0_18px_60px_-50px_rgba(15,23,42,0.38)] sm:flex-row sm:items-end sm:justify-between`}
+                    >
                       <div>
                         <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
                           Procedure Group

--- a/src/app/field-guide/_components/procedure-card.tsx
+++ b/src/app/field-guide/_components/procedure-card.tsx
@@ -4,6 +4,7 @@ import {
   getFieldGuideCategoryById,
   type FieldGuideProcedure,
 } from "../_lib/field-guide-data";
+import styles from "../field-guide.module.css";
 
 type ProcedureCardProps = {
   procedure: FieldGuideProcedure;
@@ -25,7 +26,9 @@ export function ProcedureCard({
       type="button"
       aria-label={procedure.title}
       onClick={() => onSelect(procedure.id)}
-      className={`w-full rounded-[1.9rem] border p-5 text-left transition ${
+      className={`${styles.procedureCard} ${
+        selected ? styles.selectedProcedureCard : ""
+      } w-full rounded-[1.9rem] border p-5 text-left transition ${
         selected
           ? "border-slate-950 bg-slate-950 text-white shadow-[0_28px_80px_-38px_rgba(15,23,42,0.9)]"
           : "border-slate-200/80 bg-white/85 text-slate-950 hover:border-slate-300 hover:bg-white"
@@ -149,7 +152,7 @@ export function ProcedureCard({
       </div>
 
       <div
-        className={`mt-5 rounded-[1.4rem] border px-4 py-4 ${
+        className={`${styles.checklistPreview} mt-5 rounded-[1.4rem] border px-4 py-4 ${
           selected
             ? "border-white/10 bg-white/7"
             : "border-black/6 bg-black/[0.03]"

--- a/src/app/field-guide/_components/procedure-detail-panel.tsx
+++ b/src/app/field-guide/_components/procedure-detail-panel.tsx
@@ -4,6 +4,7 @@ import {
   getFieldGuideCategoryById,
   type FieldGuideProcedure,
 } from "../_lib/field-guide-data";
+import styles from "../field-guide.module.css";
 
 type ProcedureDetailPanelProps = {
   procedure: FieldGuideProcedure;
@@ -39,7 +40,7 @@ export function ProcedureDetailPanel({
   return (
     <aside
       aria-label="Selected procedure details"
-      className="rounded-[2rem] border border-slate-900/90 bg-slate-950 p-6 text-white shadow-[0_32px_110px_-45px_rgba(15,23,42,0.92)] xl:sticky xl:top-6"
+      className={`${styles.detailPanel} rounded-[2rem] border border-slate-900/90 bg-slate-950 p-6 text-white shadow-[0_32px_110px_-45px_rgba(15,23,42,0.92)] xl:sticky xl:top-6`}
     >
       <div className="flex items-start justify-between gap-4">
         <div>

--- a/src/app/field-guide/_components/procedure-filter-bar.tsx
+++ b/src/app/field-guide/_components/procedure-filter-bar.tsx
@@ -6,6 +6,7 @@ import type {
   FieldGuidePriorityOption,
   ProcedurePriority,
 } from "../_lib/field-guide-data";
+import styles from "../field-guide.module.css";
 
 type ProcedureFilterBarProps = {
   options: FieldGuideCategoryOption[];
@@ -45,7 +46,9 @@ export function ProcedureFilterBar({
   }
 
   return (
-    <section className="rounded-[2rem] border border-slate-200/80 bg-white/82 p-5 shadow-[0_18px_70px_-42px_rgba(15,23,42,0.45)] backdrop-blur">
+    <section
+      className={`${styles.filterPanel} rounded-[2rem] border border-slate-200/80 bg-white/82 p-5 shadow-[0_18px_70px_-42px_rgba(15,23,42,0.45)] backdrop-blur`}
+    >
       <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-500">

--- a/src/app/field-guide/field-guide.module.css
+++ b/src/app/field-guide/field-guide.module.css
@@ -69,3 +69,140 @@
     radial-gradient(circle at top, rgba(20, 184, 166, 0.08), transparent 42%),
     linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(248, 250, 252, 0.85));
 }
+
+.routeHighlightCard {
+  position: relative;
+  overflow: hidden;
+  background-image:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(248, 250, 252, 0.88)),
+    radial-gradient(circle at top right, rgba(45, 212, 191, 0.12), transparent 34%);
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease;
+}
+
+.routeHighlightCard::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.28), transparent 48%),
+    repeating-linear-gradient(
+      135deg,
+      rgba(148, 163, 184, 0.08) 0,
+      rgba(148, 163, 184, 0.08) 1px,
+      transparent 1px,
+      transparent 22px
+    );
+  pointer-events: none;
+}
+
+.routeHighlightCard:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 28px 80px -56px rgba(15, 23, 42, 0.45);
+}
+
+.filterPanel {
+  position: relative;
+  overflow: hidden;
+}
+
+.filterPanel::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(45, 212, 191, 0.7), rgba(14, 165, 233, 0.35), transparent);
+}
+
+.workspacePanel,
+.workspacePanelDark,
+.groupHeader,
+.procedureCard,
+.checklistPreview,
+.detailPanel {
+  position: relative;
+  overflow: hidden;
+}
+
+.workspacePanel::after,
+.workspacePanelDark::after,
+.groupHeader::after,
+.checklistPreview::after,
+.detailPanel::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.workspacePanel::after {
+  background:
+    radial-gradient(circle at top right, rgba(20, 184, 166, 0.08), transparent 32%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.26), transparent 52%);
+}
+
+.workspacePanelDark::after {
+  background:
+    radial-gradient(circle at top right, rgba(45, 212, 191, 0.14), transparent 36%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 52%);
+}
+
+.groupHeader {
+  background-image:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(248, 250, 252, 0.82)),
+    radial-gradient(circle at top right, rgba(20, 184, 166, 0.12), transparent 30%);
+}
+
+.groupHeader::after {
+  background: linear-gradient(90deg, rgba(15, 23, 42, 0.04), transparent 48%);
+}
+
+.procedureCard {
+  transition:
+    transform 180ms ease,
+    box-shadow 180ms ease,
+    border-color 180ms ease;
+}
+
+.procedureCard:hover {
+  transform: translateY(-2px);
+}
+
+.selectedProcedureCard::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border: 1px solid rgba(45, 212, 191, 0.32);
+  border-radius: inherit;
+  pointer-events: none;
+}
+
+.checklistPreview::after {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.12), transparent 52%);
+}
+
+.detailPanel::after {
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 42%),
+    radial-gradient(circle at top right, rgba(45, 212, 191, 0.14), transparent 34%);
+  opacity: 0.72;
+}
+
+.detailPanel > * {
+  position: relative;
+  z-index: 1;
+}
+
+@media (max-width: 768px) {
+  .heroPanel::before {
+    width: 12rem;
+  }
+
+  .groupHeader {
+    background-image:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(248, 250, 252, 0.88)),
+      radial-gradient(circle at top center, rgba(20, 184, 166, 0.14), transparent 42%);
+  }
+}

--- a/src/app/field-guide/page.test.tsx
+++ b/src/app/field-guide/page.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import FieldGuidePage from "./page";
 
 describe("FieldGuidePage", () => {
-  it("renders the route hero, search controls, and default detail panel", () => {
+  it("renders the route hero, grouped controls, and default detail panel", () => {
     render(<FieldGuidePage />);
 
     expect(
@@ -19,19 +19,34 @@ describe("FieldGuidePage", () => {
     expect(
       screen.getByRole("navigation", { name: /field guide categories/i }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("navigation", { name: /procedure priorities/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/field guide focus areas/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/field guide workspace summary/i),
+    ).toBeInTheDocument();
 
     const detailPanel = screen.getByLabelText(/selected procedure details/i);
 
     expect(
       within(detailPanel).getByText("Grid Sag Bridge Activation"),
     ).toBeInTheDocument();
+    expect(screen.getByText(/selected focus/i)).toBeInTheDocument();
     expect(within(detailPanel).getByText(/priority note/i)).toBeInTheDocument();
     expect(within(detailPanel).getByText(/crew checklist/i)).toBeInTheDocument();
     expect(within(detailPanel).getByText(/reference notes/i)).toBeInTheDocument();
   });
 
-  it("renders multiple procedure cards with meaningful metadata", () => {
+  it("renders grouped procedure cards with checklist previews and metadata", () => {
     render(<FieldGuidePage />);
+
+    expect(
+      screen.getByRole("heading", { name: /power recovery/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /site restart/i }),
+    ).toBeInTheDocument();
 
     expect(
       screen.getByRole("button", { name: /grid sag bridge activation/i }),
@@ -45,9 +60,22 @@ describe("FieldGuidePage", () => {
     expect(
       screen.getByRole("button", { name: /mast failover brief/i }),
     ).toHaveTextContent("3 checklist items");
+
+    const gridSagCard = screen.getByRole("button", {
+      name: /grid sag bridge activation/i,
+    });
+
+    expect(gridSagCard).toHaveTextContent("Checklist Preview");
+    expect(gridSagCard).toHaveTextContent(
+      /arc-safe gloves and face shield are on before the cabinet is opened/i,
+    );
+    expect(gridSagCard).toHaveTextContent("+2 more checks in the detail panel");
+    expect(
+      screen.getByRole("button", { name: /buffer coil warm start/i }),
+    ).toBeInTheDocument();
   });
 
-  it("filters procedures by category and updates the visible detail selection", async () => {
+  it("filters procedures by category, priority, and focus area", async () => {
     const user = userEvent.setup();
 
     render(<FieldGuidePage />);
@@ -60,21 +88,58 @@ describe("FieldGuidePage", () => {
         name: /signal integrity/i,
       }),
     );
+    await user.click(
+      screen.getByRole("button", { name: /elevated/i }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: /signal recovery/i }),
+    );
 
-    expect(
-      screen.getByRole("button", { name: /relay drift verification/i }),
-    ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /mast failover brief/i }),
     ).toBeInTheDocument();
     expect(
+      screen.queryByRole("button", { name: /relay drift verification/i }),
+    ).not.toBeInTheDocument();
+    expect(
       screen.queryByRole("button", { name: /grid sag bridge activation/i }),
     ).not.toBeInTheDocument();
+
+    const workspaceSummary = screen.getByLabelText(/field guide workspace summary/i);
+
+    expect(within(workspaceSummary).getByText("Signal Integrity")).toBeInTheDocument();
+    expect(
+      within(workspaceSummary).getByText("Priority: Elevated"),
+    ).toBeInTheDocument();
+    expect(
+      within(workspaceSummary).getByText("Focus: Signal recovery"),
+    ).toBeInTheDocument();
 
     const detailPanel = screen.getByLabelText(/selected procedure details/i);
 
     expect(
-      within(detailPanel).getByText("Relay Drift Verification"),
+      within(detailPanel).getByText("Mast Failover Brief"),
+    ).toBeInTheDocument();
+  });
+
+  it("updates the detail panel with focus summaries, checklist totals, and references", async () => {
+    const user = userEvent.setup();
+
+    render(<FieldGuidePage />);
+
+    await user.click(
+      screen.getByRole("button", { name: /air scrubber handoff brief/i }),
+    );
+
+    const detailPanel = screen.getByLabelText(/selected procedure details/i);
+
+    expect(
+      within(detailPanel).getByText("Air Scrubber Handoff Brief"),
+    ).toBeInTheDocument();
+    expect(within(detailPanel).getByText("2026-04-18")).toBeInTheDocument();
+    expect(within(detailPanel).getByText("Perimeter control")).toBeInTheDocument();
+    expect(
+      within(detailPanel).getByText("Ventilation tech once the cable path and airflow are confirmed"),
     ).toBeInTheDocument();
   });
 
@@ -101,6 +166,7 @@ describe("FieldGuidePage", () => {
     expect(
       within(detailPanel).getByText("Mast Failover Brief"),
     ).toBeInTheDocument();
+    expect(screen.getByText("Query: FG-233")).toBeInTheDocument();
 
     await user.clear(searchInput);
     await user.type(searchInput, "zzz");

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import Home from "./page";
+
+describe("Home", () => {
+  it("renders the landing page sections for archive browser, research notebook, and field guide", () => {
+    render(<Home />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: /controlled conflict drill b landing page headline/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        name: /open the notebook shell for experiments, observations, and status summaries/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        name: /open the field guide route for searchable procedures, grouped checklists, and reference detail/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("links the field guide launch card to the route and issue tracker", () => {
+    render(<Home />);
+
+    const fieldGuideHeading = screen.getByRole("heading", {
+      name: /open the field guide route for searchable procedures, grouped checklists, and reference detail/i,
+    });
+    const fieldGuideSection = fieldGuideHeading.closest("section");
+
+    expect(fieldGuideSection).not.toBeNull();
+
+    const scopedSection = within(fieldGuideSection as HTMLElement);
+
+    expect(
+      scopedSection.getByRole("link", { name: /open field guide/i }),
+    ).toHaveAttribute("href", "/field-guide");
+    expect(
+      scopedSection.getByRole("link", { name: /review issue scope/i }),
+    ).toHaveAttribute("href", "https://github.com/iamasx/api-test/issues/142");
+    expect(
+      scopedSection.getByText(
+        /grouped procedure cards with searchable categories, priorities, and focus areas/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      scopedSection.getByText(
+        /checklist previews on the catalog side before opening the detail panel/i,
+      ),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- apply the remaining field-guide responsive styling and shared visual treatments
- extend field-guide render coverage plus landing-page coverage for the new route entry
- carry the post-merge follow-up work that landed after PR #159 was merged

## Testing
- npm run lint
- npm test
- npm run build

Follow-up to #159