### PR TITLE
feat: build team directory route with profile groups

### DIFF
--- a/src/app/team-directory/page.test.tsx
+++ b/src/app/team-directory/page.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import TeamDirectoryPage from "./page";
-import { teamGroups } from "@/data/team-directory";
+import { teamGroups, getDirectoryMetrics, getRoleHighlights } from "@/data/team-directory";
 
 describe("TeamDirectoryPage", () => {
   it("renders the route hero and spotlight content", () => {
@@ -55,5 +55,66 @@ describe("TeamDirectoryPage", () => {
         /open for two architecture reviews and one launch-readiness check this week/i,
       ).length,
     ).toBeGreaterThan(0);
+  });
+
+  it("renders the breadcrumb navigation", () => {
+    render(<TeamDirectoryPage />);
+
+    const breadcrumb = screen.getByRole("navigation", { name: /breadcrumb/i });
+    expect(breadcrumb).toBeInTheDocument();
+    expect(breadcrumb).toHaveTextContent("Home");
+    expect(breadcrumb).toHaveTextContent("Team Directory");
+  });
+
+  it("renders the data insights group and its members", () => {
+    render(<TeamDirectoryPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: "Data Insights",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 3, name: "Felix Braun" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 3, name: "Camila Santos" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 3, name: "Liam Park" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the directory-at-a-glance summary section", () => {
+    render(<TeamDirectoryPage />);
+
+    const metrics = getDirectoryMetrics(teamGroups);
+    expect(
+      screen.getByText(
+        `Coverage across ${metrics.totalGroups} groups and ${metrics.timezoneCount} time zones`,
+      ),
+    ).toBeInTheDocument();
+
+    for (const group of teamGroups) {
+      expect(screen.getAllByText(group.name).length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("renders the available-now metric card in the hero", () => {
+    render(<TeamDirectoryPage />);
+
+    const metrics = getDirectoryMetrics(teamGroups);
+    expect(screen.getAllByText(String(metrics.availableNow)).length).toBeGreaterThan(0);
+  });
+
+  it("displays role highlights with correct counts", () => {
+    render(<TeamDirectoryPage />);
+
+    const highlights = getRoleHighlights(teamGroups);
+    for (const highlight of highlights) {
+      expect(screen.getByText(highlight.label)).toBeInTheDocument();
+      expect(screen.getByText(highlight.description)).toBeInTheDocument();
+    }
   });
 });

--- a/src/app/team-directory/page.tsx
+++ b/src/app/team-directory/page.tsx
@@ -110,6 +110,42 @@ export default function TeamDirectoryPage() {
         />
       </div>
 
+      <section className="mt-10 rounded-[32px] border border-slate-200 bg-white/80 p-6 shadow-sm backdrop-blur sm:p-8">
+        <p className="text-xs font-semibold tracking-[0.24em] uppercase text-slate-500">
+          Directory at a glance
+        </p>
+        <h2 className="mt-2 text-2xl font-semibold tracking-tight text-slate-950 sm:text-3xl">
+          Coverage across {metrics.totalGroups} groups and {metrics.timezoneCount} time zones
+        </h2>
+        <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {teamGroups.map((group) => {
+            const available = group.members.filter(
+              (m) => m.availability === "Available now",
+            ).length;
+            return (
+              <div
+                key={group.id}
+                className="rounded-[20px] border border-slate-200 bg-slate-50/80 p-4"
+              >
+                <p className="text-sm font-semibold text-slate-950">{group.name}</p>
+                <p className="mt-1 text-xs text-slate-500">{group.mission}</p>
+                <div className="mt-3 flex items-center gap-2">
+                  <span className="text-2xl font-semibold text-slate-950">
+                    {group.members.length}
+                  </span>
+                  <span className="text-sm text-slate-500">members</span>
+                  {available > 0 && (
+                    <span className="ml-auto rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-800">
+                      {available} free
+                    </span>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
       <section id="directory-groups" className="mt-10">
         <div className="mb-6 flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
           <div>

--- a/src/app/team-directory/page.tsx
+++ b/src/app/team-directory/page.tsx
@@ -21,7 +21,18 @@ export default function TeamDirectoryPage() {
   const roleHighlights = getRoleHighlights(teamGroups);
 
   return (
-    <main className="mx-auto w-full max-w-7xl px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
+    <main className="relative min-h-screen overflow-hidden bg-[radial-gradient(circle_at_top_left,rgba(255,201,113,0.12),transparent_32%),radial-gradient(circle_at_bottom_right,rgba(99,102,241,0.1),transparent_28%)] px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 top-0 h-80 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.06),transparent_60%)]"
+      />
+      <div className="relative mx-auto w-full max-w-7xl">
+      <nav aria-label="Breadcrumb" className="mb-6 flex items-center gap-2 text-sm text-slate-500">
+        <Link href="/" className="transition-colors hover:text-slate-900">Home</Link>
+        <span aria-hidden>/</span>
+        <span className="font-medium text-slate-900">Team Directory</span>
+      </nav>
+
       <section className="rounded-[36px] bg-slate-950 p-8 text-white shadow-[0_40px_130px_rgba(15,23,42,0.32)] sm:p-10 lg:p-12">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <p className="text-xs font-semibold tracking-[0.28em] uppercase text-[#ffc971]">
@@ -79,6 +90,12 @@ export default function TeamDirectoryPage() {
               </p>
               <p className="mt-3 text-4xl font-semibold">{metrics.timezoneCount}</p>
             </div>
+            <div className="rounded-[24px] border border-white/10 bg-emerald-500/12 p-5">
+              <p className="text-xs font-semibold tracking-[0.18em] uppercase text-emerald-200/70">
+                Available now
+              </p>
+              <p className="mt-3 text-4xl font-semibold text-emerald-300">{metrics.availableNow}</p>
+            </div>
           </div>
         </div>
       </section>
@@ -114,6 +131,7 @@ export default function TeamDirectoryPage() {
           ))}
         </div>
       </section>
+      </div>
     </main>
   );
 }

--- a/src/components/team-directory/group-section.tsx
+++ b/src/components/team-directory/group-section.tsx
@@ -7,6 +7,12 @@ type GroupSectionProps = {
 
 export function GroupSection({ group }: GroupSectionProps) {
   const headingId = `${group.id}-heading`;
+  const availableCount = group.members.filter(
+    (m) => m.availability === "Available now",
+  ).length;
+  const headsDownCount = group.members.filter(
+    (m) => m.availability === "Heads down",
+  ).length;
 
   return (
     <section
@@ -44,6 +50,22 @@ export function GroupSection({ group }: GroupSectionProps) {
               <p className="mt-2 text-sm leading-6 text-slate-800">{group.rhythm}</p>
             </div>
           </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="rounded-full bg-slate-950 px-3 py-1 text-xs font-semibold text-white">
+            {group.members.length} members
+          </span>
+          {availableCount > 0 && (
+            <span className="rounded-full border border-emerald-200 bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-900">
+              {availableCount} available
+            </span>
+          )}
+          {headsDownCount > 0 && (
+            <span className="rounded-full border border-amber-200 bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-900">
+              {headsDownCount} heads down
+            </span>
+          )}
         </div>
 
         <div className="flex flex-wrap gap-2">

--- a/src/components/team-directory/profile-card.tsx
+++ b/src/components/team-directory/profile-card.tsx
@@ -14,16 +14,16 @@ type ProfileCardProps = {
 
 export function ProfileCard({ member }: ProfileCardProps) {
   return (
-    <article className="flex h-full flex-col rounded-[24px] border border-slate-200 bg-white/90 p-6 shadow-[0_24px_60px_rgba(15,23,42,0.08)] backdrop-blur">
+    <article className="group flex h-full flex-col rounded-[24px] border border-slate-200 bg-white/90 p-6 shadow-[0_24px_60px_rgba(15,23,42,0.08)] backdrop-blur transition-shadow duration-200 hover:shadow-[0_28px_70px_rgba(15,23,42,0.14)]">
       <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h3 className="text-xl font-semibold tracking-tight text-slate-950">
+        <div className="min-w-0 flex-1">
+          <h3 className="truncate text-xl font-semibold tracking-tight text-slate-950">
             {member.name}
           </h3>
-          <p className="mt-1 text-sm font-medium text-slate-700">{member.role}</p>
+          <p className="mt-1 truncate text-sm font-medium text-slate-700">{member.role}</p>
         </div>
         <span
-          className={`rounded-full border px-3 py-1 text-xs font-semibold tracking-[0.18em] uppercase ${availabilityStyles[member.availability]}`}
+          className={`shrink-0 rounded-full border px-3 py-1 text-xs font-semibold tracking-[0.18em] uppercase ${availabilityStyles[member.availability]}`}
         >
           {member.availability}
         </span>
@@ -61,7 +61,7 @@ export function ProfileCard({ member }: ProfileCardProps) {
           {member.skills.map((skill) => (
             <span
               key={skill}
-              className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-700"
+              className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-medium text-slate-700 transition-colors group-hover:border-slate-300"
             >
               {skill}
             </span>
@@ -69,7 +69,7 @@ export function ProfileCard({ member }: ProfileCardProps) {
         </div>
       </div>
 
-      <div className="mt-5">
+      <div className="mt-5 flex-1">
         <p className="text-xs font-semibold tracking-[0.18em] uppercase text-slate-500">
           Current focus
         </p>

--- a/src/data/team-directory.ts
+++ b/src/data/team-directory.ts
@@ -282,8 +282,6 @@ export const teamGroups: TeamGroup[] = [
       },
     ],
   },
-];
-
   {
     id: "data-insights",
     name: "Data Insights",

--- a/src/data/team-directory.ts
+++ b/src/data/team-directory.ts
@@ -284,6 +284,90 @@ export const teamGroups: TeamGroup[] = [
   },
 ];
 
+  {
+    id: "data-insights",
+    name: "Data Insights",
+    summary:
+      "Turns raw usage data, pipeline health metrics, and experiment results into actionable recommendations for product and engineering.",
+    mission: "Analytics, experimentation, and data infrastructure",
+    coverage: "Berlin, São Paulo, and Melbourne with async handoffs anchored to shared dashboards.",
+    rhythm: "Weekly metrics review on Wednesday and a bi-weekly experiment readout with product leads.",
+    roleHighlights: [
+      "Analytics engineering ownership of key pipelines",
+      "Experimentation design and statistical rigor",
+      "Data platform reliability across ingestion and serving layers",
+    ],
+    members: [
+      {
+        id: "felix-braun",
+        name: "Felix Braun",
+        role: "Analytics Engineer",
+        location: "Berlin, Germany",
+        timezone: "UTC+2",
+        availability: "Available now",
+        capacityNote: "Open for pipeline reviews and dashboard pairing sessions this week.",
+        bio: "Builds and maintains the core analytics pipelines that product teams use for daily decision-making.",
+        skills: [
+          "SQL modeling",
+          "Pipeline orchestration",
+          "Dashboard design",
+          "Data quality",
+        ],
+        focus: [
+          "Migrating legacy event streams to the new schema registry",
+          "Reducing pipeline latency for real-time activation dashboards",
+        ],
+        roleHighlight:
+          "Owns the data quality framework that gates every customer-facing metric report.",
+      },
+      {
+        id: "camila-santos",
+        name: "Camila Santos",
+        role: "Data Scientist",
+        location: "São Paulo, Brazil",
+        timezone: "UTC-3",
+        availability: "Heads down",
+        capacityNote: "Deep in experiment analysis until Friday; available for async questions.",
+        bio: "Designs experiments and builds statistical models that help product teams understand what moves the needle.",
+        skills: [
+          "Experimentation",
+          "Statistical modeling",
+          "Causal inference",
+          "Python analytics",
+        ],
+        focus: [
+          "Analyzing results from the onboarding flow A/B test",
+          "Building a reusable sample-size calculator for the team",
+        ],
+        roleHighlight:
+          "Provides the statistical sign-off that product teams need before shipping experiment winners.",
+      },
+      {
+        id: "liam-park",
+        name: "Liam Park",
+        role: "Data Platform Engineer",
+        location: "Melbourne, Australia",
+        timezone: "UTC+10",
+        availability: "On-call later",
+        capacityNote: "On platform on-call rotation starting tomorrow morning AEST.",
+        bio: "Keeps the data infrastructure reliable, fast, and cost-efficient so analysts and scientists can focus on insights.",
+        skills: [
+          "Data infrastructure",
+          "Stream processing",
+          "Cost optimization",
+          "Observability",
+        ],
+        focus: [
+          "Scaling the event ingestion layer for a traffic surge next month",
+          "Automating cost anomaly detection across warehouse compute",
+        ],
+        roleHighlight:
+          "The go-to person when a pipeline breaks at 3 AM — keeps the data flowing so dashboards stay green.",
+      },
+    ],
+  },
+];
+
 export const featuredProfileId = "mara-chen";
 
 export const allTeamMembers = teamGroups.flatMap((group) => group.members);


### PR DESCRIPTION
## Summary
- Build a team-directory route that groups people by team and shows compact profile cards with role and availability details
- Adds mock team/role/availability data, grouped profile cards, and a featured-member panel

## Test plan
- [ ] Route renders multiple team groups
- [ ] Profile cards show meaningful metadata
- [ ] Featured/spotlight panel is present
- [ ] Tests cover major render paths
- [ ] PR diff exceeds 150 changed lines

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)