### PR TITLE
feat: build scenario explorer route with recommendation panel

### DIFF
--- a/src/app/scenario-explorer/_components/comparison-note-card.tsx
+++ b/src/app/scenario-explorer/_components/comparison-note-card.tsx
@@ -1,0 +1,32 @@
+import type { ComparisonNote } from "../_data/scenario-explorer-data";
+import styles from "../scenario-explorer.module.css";
+
+const toneClass: Record<string, string> = {
+  steady: styles.noteToneSteady,
+  watch: styles.noteToneWatch,
+  risk: styles.noteToneRisk,
+};
+
+export function ComparisonNoteCard({ note }: { note: ComparisonNote }) {
+  return (
+    <article className={`${styles.noteCard} ${toneClass[note.tone]} space-y-2`}>
+      <h3 className="text-base font-semibold tracking-tight text-slate-950">
+        {note.title}
+      </h3>
+
+      <p className="text-sm leading-6 text-slate-600">{note.body}</p>
+
+      <p className="text-xs text-slate-400">
+        Related scenarios:{" "}
+        {note.relatedScenarios.map((id) => (
+          <span
+            key={id}
+            className="mr-1.5 inline-block rounded-md border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-[11px] font-medium text-slate-500"
+          >
+            {id}
+          </span>
+        ))}
+      </p>
+    </article>
+  );
+}

--- a/src/app/scenario-explorer/_components/recommendation-panel.tsx
+++ b/src/app/scenario-explorer/_components/recommendation-panel.tsx
@@ -1,0 +1,60 @@
+import type { Recommendation } from "../_data/scenario-explorer-data";
+import styles from "../scenario-explorer.module.css";
+
+const toneBadge: Record<string, string> = {
+  steady: styles.badgeToneSteady,
+  watch: styles.badgeToneWatch,
+  risk: styles.badgeToneRisk,
+};
+
+const priorityLabel: Record<string, string> = {
+  high: "High priority",
+  medium: "Medium priority",
+  low: "Low priority",
+};
+
+export function RecommendationPanel({
+  recommendations,
+}: {
+  recommendations: Recommendation[];
+}) {
+  return (
+    <aside
+      className={`${styles.recommendationPanel} rounded-[1.75rem] border border-slate-200/50 bg-white/80 p-5 shadow-[0_18px_60px_rgba(15,23,42,0.07)] backdrop-blur sm:p-6`}
+      aria-label="Recommendations"
+    >
+      <div className="space-y-1">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">
+          Recommendations
+        </p>
+        <h2 className="text-xl font-semibold tracking-tight text-slate-950">
+          Suggested next moves
+        </h2>
+      </div>
+
+      <div className="mt-5 space-y-4">
+        {recommendations.map((rec) => (
+          <div
+            key={rec.id}
+            className={`${styles.recCard} space-y-2`}
+          >
+            <div className="flex items-center gap-2">
+              <span className={`${styles.badge} ${toneBadge[rec.tone]}`}>
+                {rec.tone}
+              </span>
+              <span className="text-[11px] font-semibold uppercase tracking-wider text-slate-400">
+                {priorityLabel[rec.priority]}
+              </span>
+            </div>
+
+            <p className="text-sm font-semibold leading-5 text-slate-900">
+              {rec.label}
+            </p>
+
+            <p className="text-sm leading-6 text-slate-600">{rec.rationale}</p>
+          </div>
+        ))}
+      </div>
+    </aside>
+  );
+}

--- a/src/app/scenario-explorer/_components/scenario-summary-card.tsx
+++ b/src/app/scenario-explorer/_components/scenario-summary-card.tsx
@@ -1,0 +1,55 @@
+import type { ScenarioSummary } from "../_data/scenario-explorer-data";
+import styles from "../scenario-explorer.module.css";
+
+const toneBg: Record<string, string> = {
+  steady: styles.scenarioToneSteady,
+  watch: styles.scenarioToneWatch,
+  risk: styles.scenarioToneRisk,
+};
+
+const toneBadge: Record<string, string> = {
+  steady: styles.badgeToneSteady,
+  watch: styles.badgeToneWatch,
+  risk: styles.badgeToneRisk,
+};
+
+export function ScenarioSummaryCard({ scenario }: { scenario: ScenarioSummary }) {
+  return (
+    <article
+      className={`${styles.scenarioCard} ${toneBg[scenario.tone]} space-y-3`}
+      role="listitem"
+    >
+      <div className="flex items-center gap-2">
+        <span className={`${styles.badge} ${toneBadge[scenario.tone]}`}>
+          {scenario.tone}
+        </span>
+      </div>
+
+      <h3 className="text-lg font-semibold tracking-tight text-slate-950">
+        {scenario.title}
+      </h3>
+
+      <p className="text-sm leading-6 text-slate-600">{scenario.description}</p>
+
+      <div className="flex gap-4 text-xs font-medium text-slate-500">
+        <span>
+          Likelihood: <strong className="text-slate-700">{scenario.likelihood}</strong>
+        </span>
+        <span>
+          Impact: <strong className="text-slate-700">{scenario.impact}</strong>
+        </span>
+      </div>
+
+      <ul className="space-y-1.5 pt-1">
+        {scenario.keyFactors.map((factor) => (
+          <li
+            key={factor}
+            className="rounded-lg border border-slate-200/60 bg-white/60 px-3 py-2 text-sm leading-5 text-slate-700"
+          >
+            {factor}
+          </li>
+        ))}
+      </ul>
+    </article>
+  );
+}

--- a/src/app/scenario-explorer/_data/scenario-explorer-data.ts
+++ b/src/app/scenario-explorer/_data/scenario-explorer-data.ts
@@ -1,0 +1,188 @@
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+export type Tone = "steady" | "watch" | "risk";
+
+export interface ScenarioSummary {
+  id: string;
+  title: string;
+  description: string;
+  tone: Tone;
+  likelihood: string;
+  impact: string;
+  keyFactors: string[];
+}
+
+export interface ComparisonNote {
+  id: string;
+  title: string;
+  body: string;
+  tone: Tone;
+  relatedScenarios: string[];
+}
+
+export interface Recommendation {
+  id: string;
+  label: string;
+  rationale: string;
+  tone: Tone;
+  priority: "high" | "medium" | "low";
+}
+
+export interface ScenarioExplorerView {
+  hero: {
+    eyebrow: string;
+    title: string;
+    description: string;
+  };
+  scenarios: ScenarioSummary[];
+  comparisons: ComparisonNote[];
+  recommendations: Recommendation[];
+  metrics: { label: string; value: string; detail: string }[];
+}
+
+/* ------------------------------------------------------------------ */
+/*  Mock data                                                          */
+/* ------------------------------------------------------------------ */
+
+const scenarios: ScenarioSummary[] = [
+  {
+    id: "sc-1",
+    title: "Steady-state growth",
+    description:
+      "Organic adoption continues at the current trajectory with no external disruptions. Revenue grows predictably while operational costs scale linearly.",
+    tone: "steady",
+    likelihood: "High",
+    impact: "Moderate",
+    keyFactors: [
+      "Retention rate holds above 92%",
+      "No major competitor launches",
+      "Infrastructure costs track linearly with usage",
+    ],
+  },
+  {
+    id: "sc-2",
+    title: "Accelerated expansion",
+    description:
+      "A partnership announcement or viral adoption event drives a 3x spike in signups over two quarters. Engineering capacity must scale faster than planned.",
+    tone: "watch",
+    likelihood: "Medium",
+    impact: "High",
+    keyFactors: [
+      "Onboarding pipeline must handle 3x throughput",
+      "Support staffing gap widens",
+      "Database migration timeline compresses",
+    ],
+  },
+  {
+    id: "sc-3",
+    title: "Market contraction",
+    description:
+      "Economic headwinds reduce enterprise budgets, leading to slower deal cycles and increased churn in mid-market segments.",
+    tone: "risk",
+    likelihood: "Low–Medium",
+    impact: "High",
+    keyFactors: [
+      "Enterprise deal velocity drops 40%",
+      "Mid-market churn rises to 8%",
+      "Hiring freeze likely in Q3",
+    ],
+  },
+  {
+    id: "sc-4",
+    title: "Regulatory shift",
+    description:
+      "New data-residency regulations require infrastructure changes in two regions. Compliance deadlines compress the roadmap for the platform team.",
+    tone: "watch",
+    likelihood: "Medium",
+    impact: "Moderate",
+    keyFactors: [
+      "Data residency enforcement by end of Q4",
+      "Two additional cloud regions required",
+      "Legal review backlog increases",
+    ],
+  },
+];
+
+const comparisons: ComparisonNote[] = [
+  {
+    id: "cmp-1",
+    title: "Growth vs. contraction staffing",
+    body: "Under accelerated expansion, the hiring plan needs to front-load engineering and support roles. In a contraction scenario, the same roles face a freeze. Planning for both means keeping offer pipelines warm without over-committing headcount.",
+    tone: "watch",
+    relatedScenarios: ["sc-2", "sc-3"],
+  },
+  {
+    id: "cmp-2",
+    title: "Infrastructure readiness overlap",
+    body: "Both the expansion and regulatory scenarios demand additional cloud regions. Prioritizing multi-region infrastructure now addresses two scenarios simultaneously and reduces duplicated effort later.",
+    tone: "steady",
+    relatedScenarios: ["sc-2", "sc-4"],
+  },
+  {
+    id: "cmp-3",
+    title: "Revenue sensitivity to churn",
+    body: "The contraction scenario's churn impact is partially offset if steady-state retention initiatives are already in place. Investing in retention tooling is a hedge that pays off across multiple futures.",
+    tone: "risk",
+    relatedScenarios: ["sc-1", "sc-3"],
+  },
+];
+
+const recommendations: Recommendation[] = [
+  {
+    id: "rec-1",
+    label: "Invest in multi-region infrastructure early",
+    rationale:
+      "Covers the expansion and regulatory scenarios while keeping the steady-state path low-risk. The cost is incremental and the optionality is high.",
+    tone: "steady",
+    priority: "high",
+  },
+  {
+    id: "rec-2",
+    label: "Maintain a flexible hiring pipeline",
+    rationale:
+      "Keep interview loops active without extending hard offers until demand signals are clearer. This preserves the ability to scale up or pull back within one quarter.",
+    tone: "watch",
+    priority: "high",
+  },
+  {
+    id: "rec-3",
+    label: "Strengthen retention and onboarding tooling",
+    rationale:
+      "Reduces churn risk in a downturn and absorbs growth in an upturn. A low-cost investment with compounding returns regardless of which scenario plays out.",
+    tone: "steady",
+    priority: "medium",
+  },
+  {
+    id: "rec-4",
+    label: "Run a quarterly scenario review",
+    rationale:
+      "Keeps assumptions fresh and catches early signals that shift likelihood. Avoids the trap of planning once and forgetting to adapt.",
+    tone: "watch",
+    priority: "low",
+  },
+];
+
+/* ------------------------------------------------------------------ */
+/*  View builder                                                       */
+/* ------------------------------------------------------------------ */
+
+export function getScenarioExplorerView(): ScenarioExplorerView {
+  return {
+    hero: {
+      eyebrow: "Scenario Explorer",
+      title: "Compare futures, decide now",
+      description:
+        "Four plausible scenarios, side-by-side comparison notes, and actionable recommendations so the team can plan with clarity instead of guessing.",
+    },
+    scenarios,
+    comparisons,
+    recommendations,
+    metrics: [
+      { label: "Scenarios", value: String(scenarios.length), detail: "Distinct planning futures tracked" },
+      { label: "Comparisons", value: String(comparisons.length), detail: "Cross-scenario trade-off notes" },
+      { label: "Recommendations", value: String(recommendations.length), detail: "Actionable next steps proposed" },
+    ],
+  };
+}

--- a/src/app/scenario-explorer/page.test.tsx
+++ b/src/app/scenario-explorer/page.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import ScenarioExplorerPage from "./page";
+
+describe("ScenarioExplorerPage", () => {
+  it("renders the hero section with title and description", () => {
+    render(<ScenarioExplorerPage />);
+
+    expect(
+      screen.getByText("Compare futures, decide now"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/scenario summaries, trade-offs, and recommendations/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Scenario Explorer")).toBeInTheDocument();
+  });
+
+  it("renders all scenario summary cards with meaningful content", () => {
+    render(<ScenarioExplorerPage />);
+
+    const scenarioList = screen.getByRole("list", {
+      name: /scenario summaries/i,
+    });
+
+    expect(
+      within(scenarioList).getByText("Steady-state growth"),
+    ).toBeInTheDocument();
+    expect(
+      within(scenarioList).getByText("Accelerated expansion"),
+    ).toBeInTheDocument();
+    expect(
+      within(scenarioList).getByText("Market contraction"),
+    ).toBeInTheDocument();
+    expect(
+      within(scenarioList).getByText("Regulatory shift"),
+    ).toBeInTheDocument();
+
+    expect(
+      within(scenarioList).getByText(/retention rate holds above 92%/i),
+    ).toBeInTheDocument();
+    expect(
+      within(scenarioList).getByText(/enterprise deal velocity drops 40%/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders comparison notes with cross-scenario references", () => {
+    render(<ScenarioExplorerPage />);
+
+    expect(
+      screen.getByText("Growth vs. contraction staffing"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Infrastructure readiness overlap"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Revenue sensitivity to churn"),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(/prioritizing multi-region infrastructure/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the recommendation panel with actionable items", () => {
+    render(<ScenarioExplorerPage />);
+
+    const recPanel = screen.getByLabelText(/recommendations/i);
+
+    expect(
+      within(recPanel).getByText("Suggested next moves"),
+    ).toBeInTheDocument();
+    expect(
+      within(recPanel).getByText(
+        "Invest in multi-region infrastructure early",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(recPanel).getByText("Maintain a flexible hiring pipeline"),
+    ).toBeInTheDocument();
+    expect(
+      within(recPanel).getByText(
+        "Strengthen retention and onboarding tooling",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(recPanel).getByText("Run a quarterly scenario review"),
+    ).toBeInTheDocument();
+
+    expect(within(recPanel).getAllByText(/high priority/i)).toHaveLength(2);
+  });
+
+  it("renders hero metrics with correct counts", () => {
+    render(<ScenarioExplorerPage />);
+
+    expect(
+      screen.getByText("Distinct planning futures tracked"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Cross-scenario trade-off notes"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Actionable next steps proposed"),
+    ).toBeInTheDocument();
+  });
+
+  it("displays tone badges on scenario cards", () => {
+    render(<ScenarioExplorerPage />);
+
+    const scenarioList = screen.getByRole("list", {
+      name: /scenario summaries/i,
+    });
+
+    expect(within(scenarioList).getAllByText("steady")).toHaveLength(1);
+    expect(within(scenarioList).getAllByText("watch")).toHaveLength(2);
+    expect(within(scenarioList).getAllByText("risk")).toHaveLength(1);
+  });
+});

--- a/src/app/scenario-explorer/page.tsx
+++ b/src/app/scenario-explorer/page.tsx
@@ -1,5 +1,10 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 
+import { ComparisonNoteCard } from "./_components/comparison-note-card";
+import { RecommendationPanel } from "./_components/recommendation-panel";
+import { ScenarioSummaryCard } from "./_components/scenario-summary-card";
+import { getScenarioExplorerView } from "./_data/scenario-explorer-data";
 import styles from "./scenario-explorer.module.css";
 
 export const metadata: Metadata = {
@@ -9,23 +14,127 @@ export const metadata: Metadata = {
 };
 
 export default function ScenarioExplorerPage() {
+  const view = getScenarioExplorerView();
+
   return (
     <main className={styles.shell}>
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
+        {/* Hero */}
         <section
           className={`${styles.surfaceCard} ${styles.heroPanel} rounded-[2rem] p-8 sm:p-10`}
         >
-          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-500">
-            Route Shell
-          </p>
-          <h1 className="mt-4 max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl lg:text-6xl">
-            Scenario Explorer
-          </h1>
-          <p className="mt-4 max-w-3xl text-base leading-8 text-slate-600 sm:text-lg">
-            This route is scaffolded and ready for scenario summaries,
-            comparisons, and recommendation guidance.
-          </p>
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-500">
+              {view.hero.eyebrow}
+            </p>
+            <Link
+              href="/"
+              className="rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+            >
+              Back to overview
+            </Link>
+          </div>
+
+          <div className="mt-8 grid gap-8 xl:grid-cols-[minmax(0,1.3fr)_minmax(19rem,0.85fr)] xl:items-start">
+            <div className="space-y-4">
+              <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl lg:text-6xl">
+                {view.hero.title}
+              </h1>
+              <p className="max-w-3xl text-base leading-8 text-slate-600 sm:text-lg">
+                {view.hero.description}
+              </p>
+            </div>
+
+            <aside className={`${styles.heroAside} rounded-[1.75rem] p-5 sm:p-6`}>
+              <div className="space-y-5">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-sky-100/72">
+                  Planning pulse
+                </p>
+                <p className="mt-3 text-3xl font-semibold tracking-tight text-white">
+                  Scenario summaries, trade-offs, and recommendations in one view.
+                </p>
+
+                <div className="grid gap-3">
+                  {view.metrics.map((metric) => (
+                    <div key={metric.label} className={styles.heroMetricCard}>
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-white/60">
+                        {metric.label}
+                      </p>
+                      <p className="mt-2 text-3xl font-semibold text-white">
+                        {metric.value}
+                      </p>
+                      <p className="mt-2 text-sm leading-6 text-white/72">
+                        {metric.detail}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </aside>
+          </div>
         </section>
+
+        {/* Scenario summaries */}
+        <section aria-labelledby="scenario-summaries" className="space-y-5">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                Scenarios
+              </p>
+              <h2
+                id="scenario-summaries"
+                className="text-3xl font-semibold tracking-tight text-slate-950"
+              >
+                Planning futures at a glance
+              </h2>
+            </div>
+            <p className="max-w-3xl text-sm leading-7 text-slate-600">
+              Each card captures a distinct future with its likelihood, impact,
+              and the key factors that would drive it.
+            </p>
+          </div>
+
+          <div
+            aria-label="Scenario summaries"
+            className={styles.scenarioGrid}
+            role="list"
+          >
+            {view.scenarios.map((scenario) => (
+              <ScenarioSummaryCard key={scenario.id} scenario={scenario} />
+            ))}
+          </div>
+        </section>
+
+        {/* Comparisons + Recommendations */}
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(22rem,0.9fr)]">
+          <section aria-labelledby="comparison-notes" className="space-y-5">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                  Comparison notes
+                </p>
+                <h2
+                  id="comparison-notes"
+                  className="text-3xl font-semibold tracking-tight text-slate-950"
+                >
+                  Cross-scenario trade-offs
+                </h2>
+              </div>
+              <p className="max-w-3xl text-sm leading-7 text-slate-600">
+                Notes that surface overlaps, tensions, and shared
+                dependencies between scenarios.
+              </p>
+            </div>
+
+            <div className={styles.noteList}>
+              {view.comparisons.map((note) => (
+                <ComparisonNoteCard key={note.id} note={note} />
+              ))}
+            </div>
+          </section>
+
+          <RecommendationPanel recommendations={view.recommendations} />
+        </div>
       </div>
     </main>
   );

--- a/src/app/scenario-explorer/page.tsx
+++ b/src/app/scenario-explorer/page.tsx
@@ -1,18 +1,32 @@
+import type { Metadata } from "next";
+
+import styles from "./scenario-explorer.module.css";
+
+export const metadata: Metadata = {
+  title: "Scenario Explorer",
+  description:
+    "Scenario explorer route for scenario summaries, comparison notes, and recommendation guidance.",
+};
+
 export default function ScenarioExplorerPage() {
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-5xl items-center justify-center px-6 py-16">
-      <section className="w-full rounded-[32px] border border-black/10 bg-white/80 p-10 shadow-[0_20px_80px_-40px_rgba(15,23,42,0.45)] backdrop-blur">
-        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">
-          Route Shell
-        </p>
-        <h1 className="mt-4 text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-          Scenario Explorer
-        </h1>
-        <p className="mt-4 max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
-          This route is scaffolded and ready for scenario summaries,
-          comparisons, and recommendation guidance.
-        </p>
-      </section>
+    <main className={styles.shell}>
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
+        <section
+          className={`${styles.surfaceCard} ${styles.heroPanel} rounded-[2rem] p-8 sm:p-10`}
+        >
+          <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-500">
+            Route Shell
+          </p>
+          <h1 className="mt-4 max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl lg:text-6xl">
+            Scenario Explorer
+          </h1>
+          <p className="mt-4 max-w-3xl text-base leading-8 text-slate-600 sm:text-lg">
+            This route is scaffolded and ready for scenario summaries,
+            comparisons, and recommendation guidance.
+          </p>
+        </section>
+      </div>
     </main>
   );
 }

--- a/src/app/scenario-explorer/scenario-explorer.module.css
+++ b/src/app/scenario-explorer/scenario-explorer.module.css
@@ -43,3 +43,185 @@
   position: relative;
   z-index: 1;
 }
+
+.heroAside {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.9), rgba(26, 38, 54, 0.96)),
+    linear-gradient(135deg, rgba(99, 102, 241, 0.18), transparent 60%);
+  color: #f8fafc;
+  box-shadow: 0 28px 70px rgba(15, 23, 42, 0.22);
+}
+
+.heroMetricCard {
+  border-radius: 1.3rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(15, 23, 42, 0.12));
+  padding: 1rem;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Scenario summary cards                                             */
+/* ------------------------------------------------------------------ */
+
+.scenarioGrid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.scenarioCard {
+  position: relative;
+  overflow: hidden;
+  min-height: 100%;
+  border-radius: 1.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 1.3rem;
+  box-shadow:
+    0 18px 44px rgba(15, 23, 42, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.scenarioCard::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0.36rem;
+  border-radius: 999px;
+}
+
+.scenarioToneSteady {
+  background: linear-gradient(180deg, rgba(236, 253, 245, 0.92), rgba(255, 255, 255, 0.84));
+}
+
+.scenarioToneSteady::before {
+  background: #10b981;
+}
+
+.scenarioToneWatch {
+  background: linear-gradient(180deg, rgba(255, 247, 237, 0.96), rgba(255, 255, 255, 0.84));
+}
+
+.scenarioToneWatch::before {
+  background: #f59e0b;
+}
+
+.scenarioToneRisk {
+  background: linear-gradient(180deg, rgba(255, 241, 242, 0.96), rgba(255, 255, 255, 0.84));
+}
+
+.scenarioToneRisk::before {
+  background: #f43f5e;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Badges                                                             */
+/* ------------------------------------------------------------------ */
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 0.4rem 0.7rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.badgeToneSteady {
+  border-color: rgba(16, 185, 129, 0.24);
+  background: rgba(236, 253, 245, 0.94);
+  color: #047857;
+}
+
+.badgeToneWatch {
+  border-color: rgba(245, 158, 11, 0.24);
+  background: rgba(255, 247, 237, 0.94);
+  color: #b45309;
+}
+
+.badgeToneRisk {
+  border-color: rgba(244, 63, 94, 0.22);
+  background: rgba(255, 241, 242, 0.94);
+  color: #be123c;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Comparison note cards                                              */
+/* ------------------------------------------------------------------ */
+
+.noteList {
+  display: grid;
+  gap: 1rem;
+}
+
+.noteCard {
+  position: relative;
+  overflow: hidden;
+  border-radius: 1.4rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(255, 255, 255, 0.88);
+  padding: 1rem;
+  box-shadow:
+    0 18px 46px rgba(15, 23, 42, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+.noteCard::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0.32rem;
+  border-radius: 999px;
+}
+
+.noteToneSteady::before {
+  background: #10b981;
+}
+
+.noteToneWatch::before {
+  background: #f59e0b;
+}
+
+.noteToneRisk::before {
+  background: #f43f5e;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Recommendation panel                                               */
+/* ------------------------------------------------------------------ */
+
+.recommendationPanel {
+  align-self: start;
+}
+
+.recCard {
+  border-radius: 1.15rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(248, 250, 252, 0.76);
+  padding: 0.95rem 1rem;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Responsive adjustments                                             */
+/* ------------------------------------------------------------------ */
+
+@media (min-width: 1280px) {
+  .recommendationPanel {
+    position: sticky;
+    top: 1.5rem;
+  }
+}
+
+@media (max-width: 767px) {
+  .surfaceCard,
+  .scenarioCard,
+  .noteCard,
+  .recCard {
+    border-radius: 1.3rem;
+  }
+}

--- a/src/app/scenario-explorer/scenario-explorer.module.css
+++ b/src/app/scenario-explorer/scenario-explorer.module.css
@@ -1,0 +1,45 @@
+.shell {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top left, rgba(99, 102, 241, 0.16), transparent 26%),
+    radial-gradient(circle at top right, rgba(16, 185, 129, 0.14), transparent 22%),
+    linear-gradient(180deg, #f7f3ea 0%, #f2efe8 40%, #e8edf3 100%);
+}
+
+.surfaceCard {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.74));
+  box-shadow:
+    0 28px 90px rgba(15, 23, 42, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.72);
+  backdrop-filter: blur(18px);
+}
+
+.heroPanel::before {
+  content: "";
+  position: absolute;
+  inset: auto -5rem -7rem auto;
+  height: 19rem;
+  width: 19rem;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(99, 102, 241, 0.22), transparent 70%);
+  z-index: 0;
+}
+
+.heroPanel::after {
+  content: "";
+  position: absolute;
+  inset: -6rem auto auto -4rem;
+  height: 15rem;
+  width: 15rem;
+  border-radius: 999px;
+  background: radial-gradient(circle, rgba(16, 185, 129, 0.16), transparent 72%);
+  z-index: 0;
+}
+
+.heroPanel > * {
+  position: relative;
+  z-index: 1;
+}


### PR DESCRIPTION
## Summary
- Adds a `scenario-explorer` route with scenario summaries, comparison notes, and a recommendation panel.
- Creates route-local mock data, styled components, and tests.

Closes #169

## Test plan
- [ ] Route renders multiple scenario summaries
- [ ] Comparison / guidance content is visible and meaningful
- [ ] Recommendation section is present
- [ ] Tests cover major render behavior
- [ ] Final PR diff is at least 150 changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)