### PR TITLE
feat: add route notes sidebar to route planner

### DIFF
--- a/src/app/route-planner/_components/route-decision-sidebar.tsx
+++ b/src/app/route-planner/_components/route-decision-sidebar.tsx
@@ -44,7 +44,7 @@ export function RouteDecisionSidebar({
   return (
     <aside
       aria-label="Route decision sidebar"
-      className={`${styles.sidebarPanel} ${styles.stickyRail} rounded-[1.9rem] border border-white/10 p-6`}
+      className={`${styles.sidebarPanel} rounded-[1.9rem] border border-white/10 p-6`}
     >
       <div className="space-y-5">
         <div>

--- a/src/app/route-planner/_components/route-notes-sidebar.tsx
+++ b/src/app/route-planner/_components/route-notes-sidebar.tsx
@@ -1,0 +1,85 @@
+import {
+  notePriorityLabels,
+  notePriorityStyles,
+  type RouteNote,
+} from "../_data/route-planner-data";
+import styles from "../route-planner.module.css";
+
+type RouteNotesSidebarProps = {
+  notes: RouteNote[];
+};
+
+export function RouteNotesSidebar({ notes }: RouteNotesSidebarProps) {
+  const highCount = notes.filter((note) => note.priority === "high").length;
+
+  return (
+    <aside
+      aria-label="Route notes"
+      className={`${styles.sidebarPanel} rounded-[1.9rem] border border-white/10 p-6`}
+    >
+      <div className="space-y-5">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.26em] text-slate-400">
+            Notes
+          </p>
+          <h2 className="mt-3 text-3xl font-semibold tracking-tight text-white">
+            Route notes
+          </h2>
+          <p className="mt-3 text-sm leading-6 text-slate-300">
+            Shift-level observations and context from the planning team, pinned
+            to the route so nothing falls through a handoff.
+          </p>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+          <div className="rounded-[1.4rem] border border-white/8 bg-white/5 px-4 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+              Total notes
+            </p>
+            <p className="mt-2 text-3xl font-semibold tracking-tight text-white">
+              {notes.length}
+            </p>
+          </div>
+          <div className="rounded-[1.4rem] border border-white/8 bg-white/5 px-4 py-4">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+              High priority
+            </p>
+            <p className="mt-2 text-3xl font-semibold tracking-tight text-white">
+              {highCount}
+            </p>
+          </div>
+        </div>
+
+        <ul aria-label="Route notes list" className="space-y-3">
+          {notes.map((note) => (
+            <li key={note.id}>
+              <article
+                className={`${styles.decisionCard} rounded-[1.4rem] border border-white/10 px-4 py-4`}
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="max-w-52 space-y-1">
+                    <p className="text-sm font-semibold text-white">
+                      {note.title}
+                    </p>
+                    <p className="text-sm text-slate-300">{note.author}</p>
+                  </div>
+                  <span
+                    className={`${styles.statusBadge} inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${notePriorityStyles[note.priority]}`}
+                  >
+                    {notePriorityLabels[note.priority]}
+                  </span>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-slate-300">
+                  {note.body}
+                </p>
+                <p className="mt-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                  {note.timestamp}
+                </p>
+              </article>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </aside>
+  );
+}

--- a/src/app/route-planner/_data/route-planner-data.ts
+++ b/src/app/route-planner/_data/route-planner-data.ts
@@ -1,6 +1,7 @@
 export type SegmentStatus = "on-time" | "delayed" | "blocked";
 export type ConstraintTone = "clear" | "watch" | "critical";
 export type DecisionState = "ready" | "review" | "hold";
+export type NotePriority = "high" | "medium" | "low";
 
 export interface RoutePlannerStat {
   label: string;
@@ -58,6 +59,16 @@ export interface RouteDecision {
   owner: string;
   deadline: string;
   detail: string;
+}
+
+export interface RouteNote {
+  id: string;
+  title: string;
+  priority: NotePriority;
+  author: string;
+  timestamp: string;
+  body: string;
+  segmentId: string | null;
 }
 
 export const routePlannerOverview = {
@@ -289,3 +300,63 @@ export const routeDecisionQueue = [
     detail: "Only required if the route slips beyond the current crew-hours threshold.",
   },
 ] satisfies RouteDecision[];
+
+export const notePriorityStyles: Record<NotePriority, string> = {
+  high: "border-rose-300/20 bg-rose-300/10 text-rose-50",
+  medium: "border-amber-300/20 bg-amber-300/10 text-amber-50",
+  low: "border-slate-300/20 bg-slate-300/10 text-slate-200",
+};
+
+export const notePriorityLabels: Record<NotePriority, string> = {
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+};
+
+export const routeNotes = [
+  {
+    id: "note-bridge-fallback",
+    title: "Bridge fallback timing is tighter than it looks",
+    priority: "high",
+    author: "A. Navarro",
+    timestamp: "08:42 MDT",
+    body: "The south bypass adds 78 minutes but the dock priority penalty makes it closer to 95 minutes of real impact. If we trigger the bypass, notify destination ops immediately so they can hold door 14A.",
+    segmentId: "seg-04",
+  },
+  {
+    id: "note-crew-hours-buffer",
+    title: "Crew-hours buffer depends on Ellensburg staging",
+    priority: "medium",
+    author: "Dispatch lead",
+    timestamp: "08:15 MDT",
+    body: "The relief driver in Ellensburg is only available until the 15:00 transfer cutoff. If Silver Ridge slips past 12:40, we lose the option to swap without rebooking from Yakima at premium rates.",
+    segmentId: "seg-03",
+  },
+  {
+    id: "note-weather-update",
+    title: "Next weather sweep could change corridor status",
+    priority: "medium",
+    author: "Weather desk",
+    timestamp: "07:55 MDT",
+    body: "Snowfall intensity dropped in the last update, but the forecast model shows a secondary band arriving around 10:30 MDT. If it materialises, expect chain controls to tighten again on Silver Ridge.",
+    segmentId: null,
+  },
+  {
+    id: "note-dock-stacking",
+    title: "Two premium trailers already stacked at Tacoma",
+    priority: "high",
+    author: "Destination ops",
+    timestamp: "08:30 MDT",
+    body: "Gate 7 and gate 9 are already committed to inbound premium loads. If Route 48 slips past the first dock wave, the next available premium slot is 90 minutes later and requires a yard shunt.",
+    segmentId: "seg-05",
+  },
+  {
+    id: "note-seal-audit",
+    title: "Cold-load seal audit passed without exceptions",
+    priority: "low",
+    author: "Origin dispatch",
+    timestamp: "07:40 MDT",
+    body: "All three seal numbers matched the manifest. Temperature logger confirmed the compartment held below threshold during the overnight pre-cool cycle.",
+    segmentId: "seg-01",
+  },
+] satisfies RouteNote[];

--- a/src/app/route-planner/page.test.tsx
+++ b/src/app/route-planner/page.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   routeConstraints,
   routeDecisionQueue,
+  routeNotes,
   routePlannerOverview,
   routePlannerStats,
   routeSegmentGroups,
@@ -120,6 +121,46 @@ describe("RoutePlannerPage", () => {
       expect(within(sidebar).getByText(decision.title)).toBeInTheDocument();
       expect(within(sidebar).getByText(decision.owner)).toBeInTheDocument();
       expect(within(sidebar).getByText(decision.deadline)).toBeInTheDocument();
+    }
+  });
+
+  it("renders the route notes sidebar with all notes and summary counts", () => {
+    render(<RoutePlannerPage />);
+
+    const notesSidebar = screen.getByLabelText(/route notes/i);
+
+    expect(
+      within(notesSidebar).getByRole("heading", { name: /route notes/i }),
+    ).toBeInTheDocument();
+
+    const notesList = within(notesSidebar).getByRole("list", {
+      name: /route notes list/i,
+    });
+    expect(within(notesList).getAllByRole("listitem")).toHaveLength(
+      routeNotes.length,
+    );
+
+    const highCount = routeNotes.filter(
+      (note) => note.priority === "high",
+    ).length;
+    const totalCountCard = within(notesSidebar)
+      .getByText("Total notes")
+      .closest("div");
+    const highCountCard = within(notesSidebar)
+      .getByText("High priority")
+      .closest("div");
+
+    expect(
+      within(totalCountCard as HTMLElement).getByText(String(routeNotes.length)),
+    ).toBeInTheDocument();
+    expect(
+      within(highCountCard as HTMLElement).getByText(String(highCount)),
+    ).toBeInTheDocument();
+
+    for (const note of routeNotes) {
+      expect(within(notesSidebar).getByText(note.title)).toBeInTheDocument();
+      expect(within(notesSidebar).getByText(note.author)).toBeInTheDocument();
+      expect(within(notesSidebar).getByText(note.timestamp)).toBeInTheDocument();
     }
   });
 });

--- a/src/app/route-planner/page.tsx
+++ b/src/app/route-planner/page.tsx
@@ -2,12 +2,14 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 import { RouteDecisionSidebar } from "./_components/route-decision-sidebar";
+import { RouteNotesSidebar } from "./_components/route-notes-sidebar";
 import { SegmentGroup } from "./_components/segment-group";
 import { SummaryBanners } from "./_components/summary-banners";
 import styles from "./route-planner.module.css";
 import {
   routeConstraints,
   routeDecisionQueue,
+  routeNotes,
   routePlannerOverview,
   routePlannerStats,
   routeSegmentGroups,
@@ -98,11 +100,15 @@ export default function RoutePlannerPage() {
             ))}
           </div>
 
-          <RouteDecisionSidebar
-            decisions={routeDecisionQueue}
-            timingSignals={routeTimingSignals}
-            constraints={routeConstraints}
-          />
+          <div className="space-y-6 xl:sticky xl:top-8 xl:self-start">
+            <RouteDecisionSidebar
+              decisions={routeDecisionQueue}
+              timingSignals={routeTimingSignals}
+              constraints={routeConstraints}
+            />
+
+            <RouteNotesSidebar notes={routeNotes} />
+          </div>
         </section>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- Add a notes sidebar to the route planner route with shift-level observations and planning context
- Include mock route note data (5 notes with priority, author, timestamp, and segment links)
- Build `RouteNotesSidebar` component with priority badges, note cards, and summary metrics
- Refactor sidebar layout so decision sidebar and notes sidebar share a sticky container

Closes #170

## Test plan
- [ ] Verify route planner page renders with both decision sidebar and notes sidebar
- [ ] Confirm all 5 route notes display with correct titles, authors, and priorities
- [ ] Check high-priority and total-notes summary counts are accurate
- [ ] Validate responsive layout across breakpoints
- [ ] Run `npm test` to confirm all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)