### PR TITLE
feat: add checkpoint grid route with milestone tiles

### DIFF
--- a/src/app/checkpoint-grid/_components/milestone-tile.tsx
+++ b/src/app/checkpoint-grid/_components/milestone-tile.tsx
@@ -11,6 +11,12 @@ const toneClassNames = {
   risk: styles.milestoneToneRisk,
 };
 
+const priorityClassNames = {
+  High: styles.priorityHigh,
+  Medium: styles.priorityMedium,
+  Low: styles.priorityLow,
+};
+
 export function MilestoneTile({ milestone }: MilestoneTileProps) {
   return (
     <article
@@ -19,15 +25,29 @@ export function MilestoneTile({ milestone }: MilestoneTileProps) {
     >
       <div className="flex items-start justify-between gap-4">
         <div className="space-y-3">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-500">
-            {milestone.phase}
-          </p>
+          <div className="flex items-center gap-3">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-500">
+              {milestone.phase}
+            </p>
+            <span className={`${styles.priorityBadge} ${priorityClassNames[milestone.priority]}`}>
+              {milestone.priority}
+            </span>
+          </div>
           <div className="space-y-2">
             <h3 className="text-2xl font-semibold tracking-tight text-slate-950">
               {milestone.title}
             </h3>
             <p className="text-sm leading-6 text-slate-600">{milestone.summary}</p>
           </div>
+          {milestone.tags.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {milestone.tags.map((tag) => (
+                <span key={tag} className={styles.tagPill}>
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
 
         <span className={`${styles.badge} ${toneClassNames[milestone.tone]}`}>
@@ -53,6 +73,12 @@ export function MilestoneTile({ milestone }: MilestoneTileProps) {
             Progress
           </p>
           <p className="mt-2 text-sm font-medium text-slate-900">{milestone.completion}% complete</p>
+          <div className={styles.progressBar} aria-label={`${milestone.completion}% complete`}>
+            <div
+              className={`${styles.progressFill} ${toneClassNames[milestone.tone]}`}
+              style={{ width: `${milestone.completion}%` }}
+            />
+          </div>
         </div>
       </div>
 

--- a/src/app/checkpoint-grid/_components/progress-summary-card.tsx
+++ b/src/app/checkpoint-grid/_components/progress-summary-card.tsx
@@ -1,4 +1,4 @@
-import type { CheckpointProgressSummary } from "../_data/checkpoint-grid-data";
+import type { CheckpointProgressSummary, CheckpointTrend } from "../_data/checkpoint-grid-data";
 import styles from "../checkpoint-grid.module.css";
 
 type ProgressSummaryCardProps = {
@@ -11,15 +11,35 @@ const toneClassNames = {
   risk: styles.metricToneRisk,
 };
 
+const trendLabels: Record<CheckpointTrend, string> = {
+  up: "Trending up",
+  down: "Trending down",
+  flat: "Holding steady",
+};
+
+const trendSymbols: Record<CheckpointTrend, string> = {
+  up: "\u2191",
+  down: "\u2193",
+  flat: "\u2192",
+};
+
 export function ProgressSummaryCard({ summary }: ProgressSummaryCardProps) {
   return (
     <article
       className={`${styles.metricCard} ${toneClassNames[summary.tone]}`}
       role="listitem"
     >
-      <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
-        {summary.label}
-      </p>
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500">
+          {summary.label}
+        </p>
+        <span
+          className={`${styles.trendBadge} ${styles[`trend${summary.trend.charAt(0).toUpperCase()}${summary.trend.slice(1)}`]}`}
+          title={trendLabels[summary.trend]}
+        >
+          {trendSymbols[summary.trend]}
+        </span>
+      </div>
       <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
         {summary.value}
       </p>

--- a/src/app/checkpoint-grid/_components/status-breakdown-bar.tsx
+++ b/src/app/checkpoint-grid/_components/status-breakdown-bar.tsx
@@ -1,0 +1,45 @@
+import type { StatusBreakdownItem } from "../_data/checkpoint-grid-data";
+import styles from "../checkpoint-grid.module.css";
+
+type StatusBreakdownBarProps = {
+  items: StatusBreakdownItem[];
+};
+
+const toneClassNames = {
+  steady: styles.breakdownSteady,
+  watch: styles.breakdownWatch,
+  risk: styles.breakdownRisk,
+};
+
+export function StatusBreakdownBar({ items }: StatusBreakdownBarProps) {
+  return (
+    <div className={styles.breakdownContainer}>
+      <div className={styles.breakdownTrack} role="img" aria-label="Status breakdown">
+        {items.map((item) => (
+          <div
+            key={item.id}
+            className={`${styles.breakdownSegment} ${toneClassNames[item.tone]}`}
+            style={{ width: `${item.percentage}%` }}
+            title={`${item.status}: ${item.count} (${item.percentage}%)`}
+          />
+        ))}
+      </div>
+      <div className={styles.breakdownLegend} role="list" aria-label="Status breakdown legend">
+        {items.map((item) => (
+          <div key={item.id} className={styles.breakdownLegendItem} role="listitem">
+            <span className={`${styles.breakdownDot} ${toneClassNames[item.tone]}`} />
+            <span className="text-sm text-slate-700">
+              {item.status}
+            </span>
+            <span className="text-sm font-semibold text-slate-950">
+              {item.count}
+            </span>
+            <span className="text-xs text-slate-500">
+              ({item.percentage}%)
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/checkpoint-grid/_data/checkpoint-grid-data.ts
+++ b/src/app/checkpoint-grid/_data/checkpoint-grid-data.ts
@@ -6,6 +6,8 @@ export type CheckpointHeroMetric = {
   detail: string;
 };
 
+export type CheckpointPriority = "High" | "Medium" | "Low";
+
 export type CheckpointMilestone = {
   id: string;
   phase: string;
@@ -15,11 +17,15 @@ export type CheckpointMilestone = {
   status: "Complete" | "In Progress" | "Blocked";
   tone: CheckpointTone;
   completion: number;
+  priority: CheckpointPriority;
+  tags: string[];
   summary: string;
   deliverables: string[];
   dependencies: string[];
   nextReview: string;
 };
+
+export type CheckpointTrend = "up" | "down" | "flat";
 
 export type CheckpointProgressSummary = {
   id: string;
@@ -27,6 +33,15 @@ export type CheckpointProgressSummary = {
   value: string;
   detail: string;
   support: string;
+  tone: CheckpointTone;
+  trend: CheckpointTrend;
+};
+
+export type StatusBreakdownItem = {
+  id: string;
+  status: "Complete" | "In Progress" | "Blocked";
+  count: number;
+  percentage: number;
   tone: CheckpointTone;
 };
 
@@ -75,6 +90,8 @@ export const checkpointMilestones: CheckpointMilestone[] = [
     status: "Complete",
     tone: "steady",
     completion: 100,
+    priority: "High",
+    tags: ["planning", "scope"],
     summary:
       "Issue boundaries, mock-data assumptions, and the dedicated route shell are approved so implementation can move without borrowing from other workstreams.",
     deliverables: [
@@ -97,6 +114,8 @@ export const checkpointMilestones: CheckpointMilestone[] = [
     status: "In Progress",
     tone: "watch",
     completion: 78,
+    priority: "High",
+    tags: ["ui", "components"],
     summary:
       "Milestone cards are in active assembly, with phase labels, completion signals, and planning detail grouped into consistent tiles.",
     deliverables: [
@@ -119,6 +138,8 @@ export const checkpointMilestones: CheckpointMilestone[] = [
     status: "In Progress",
     tone: "watch",
     completion: 64,
+    priority: "Medium",
+    tags: ["delivery", "metrics"],
     summary:
       "Summary cards are mapping the overall board posture so reviewers can scan coverage, completion, open decisions, and test intent before reading the full grid.",
     deliverables: [
@@ -141,6 +162,8 @@ export const checkpointMilestones: CheckpointMilestone[] = [
     status: "Blocked",
     tone: "risk",
     completion: 46,
+    priority: "Medium",
+    tags: ["qa", "review"],
     summary:
       "The review stream is currently blocked behind the tile and summary layout, but the data model is ready to expose note outcomes, timestamps, and next actions.",
     deliverables: [
@@ -163,6 +186,8 @@ export const checkpointMilestones: CheckpointMilestone[] = [
     status: "Blocked",
     tone: "steady",
     completion: 32,
+    priority: "Low",
+    tags: ["testing", "handoff"],
     summary:
       "Verification is blocked until the route content settles, then it closes the loop with route tests, a build pass, and focused handoff notes for reviewers.",
     deliverables: [
@@ -175,6 +200,30 @@ export const checkpointMilestones: CheckpointMilestone[] = [
       "Keep the PR focused on the new route and route-local data.",
     ],
     nextReview: "Complete verification immediately after the route markup settles.",
+  },
+  {
+    id: "responsive-polish",
+    phase: "Checkpoint 06",
+    title: "Responsive polish and visual state consistency across breakpoints",
+    owner: "Avery Holt / UI Systems",
+    window: "Apr 21",
+    status: "Blocked",
+    tone: "watch",
+    completion: 18,
+    priority: "Medium",
+    tags: ["ui", "responsive"],
+    summary:
+      "Final visual pass to confirm that milestone tiles, summary cards, and note panels maintain their intended hierarchy on narrow screens and high-density layouts.",
+    deliverables: [
+      "Audit every component for consistent border-radius and spacing under 768px.",
+      "Verify that tone-based accent bars remain visible when tiles stack vertically.",
+      "Confirm the review-notes panel scrolls gracefully when content exceeds the viewport.",
+    ],
+    dependencies: [
+      "All tile content and summary values must be finalized before the responsive audit.",
+      "Coordinate with QA to run a device matrix check before merge.",
+    ],
+    nextReview: "Schedule a final cross-browser review after content and tests are locked.",
   },
 ];
 
@@ -231,6 +280,19 @@ export const reviewNotes: ReviewNote[] = [
     action:
       "Expose the next step under each note and keep unresolved outcomes visually distinct from approved ones.",
   },
+  {
+    id: "rn-05",
+    title: "Validate tag and priority metadata renders correctly on tiles",
+    reviewer: "Eli Booker",
+    role: "Engineering",
+    loggedAt: "Apr 20, 11:30",
+    outcome: "Watching",
+    tone: "watch",
+    summary:
+      "The newly added priority badges and tag pills need a visual consistency check to make sure they don't crowd the tile header on smaller viewports.",
+    action:
+      "Run a layout check on the milestone tiles at 320px and 768px breakpoints before marking the responsive checkpoint complete.",
+  },
 ];
 
 export const checkpointCadence: CheckpointCadenceItem[] = [
@@ -274,12 +336,13 @@ export function getCheckpointGridView() {
     (note) => note.outcome !== "Approved",
   ).length;
   const averageCompletion = getAverageCompletion(checkpointMilestones);
+  const totalMilestones = checkpointMilestones.length;
 
   const heroMetrics: CheckpointHeroMetric[] = [
     {
       label: "Average completion",
       value: `${averageCompletion}%`,
-      detail: "Across all five checkpoint tiles in the planning sequence.",
+      detail: `Across all ${totalMilestones} checkpoint tiles in the planning sequence.`,
     },
     {
       label: "Milestones in flight",
@@ -302,6 +365,7 @@ export function getCheckpointGridView() {
         "The board spans kickoff, tile assembly, summary framing, review notes, and final verification.",
       support: `${completedMilestones} complete, ${activeMilestones} in progress, ${blockedMilestones} blocked.`,
       tone: "steady",
+      trend: "up",
     },
     {
       id: "progress",
@@ -311,6 +375,7 @@ export function getCheckpointGridView() {
         "Completion reflects the average progress across all checkpoint tiles rather than a single optimistic status.",
       support: "Active work is concentrated in the tile system and progress summary sections.",
       tone: "watch",
+      trend: "up",
     },
     {
       id: "reviews",
@@ -320,6 +385,7 @@ export function getCheckpointGridView() {
         "Unapproved notes still need follow-through before the route is clean for review handoff.",
       support: "Spacing, metric clarity, and actionable QA notes remain the current follow-up areas.",
       tone: unresolvedReviewNotes > 2 ? "risk" : "watch",
+      trend: unresolvedReviewNotes > 2 ? "down" : "flat",
     },
     {
       id: "verification",
@@ -329,6 +395,31 @@ export function getCheckpointGridView() {
         "The final checkpoint is reserved for route-level assertions and a build pass once content settles.",
       support: "Coverage targets the hero, summary cards, milestone tiles, and recent review-note content.",
       tone: "steady",
+      trend: "flat",
+    },
+  ];
+
+  const statusBreakdown: StatusBreakdownItem[] = [
+    {
+      id: "status-complete",
+      status: "Complete",
+      count: completedMilestones,
+      percentage: Math.round((completedMilestones / totalMilestones) * 100),
+      tone: "steady",
+    },
+    {
+      id: "status-in-progress",
+      status: "In Progress",
+      count: activeMilestones,
+      percentage: Math.round((activeMilestones / totalMilestones) * 100),
+      tone: "watch",
+    },
+    {
+      id: "status-blocked",
+      status: "Blocked",
+      count: blockedMilestones,
+      percentage: Math.round((blockedMilestones / totalMilestones) * 100),
+      tone: "risk",
     },
   ];
 
@@ -336,6 +427,7 @@ export function getCheckpointGridView() {
     summary: checkpointGridSummary,
     heroMetrics,
     progressSummaries,
+    statusBreakdown,
     milestones: checkpointMilestones,
     reviewNotes,
     cadence: checkpointCadence,

--- a/src/app/checkpoint-grid/checkpoint-grid.module.css
+++ b/src/app/checkpoint-grid/checkpoint-grid.module.css
@@ -245,6 +245,145 @@
   background: #f43f5e;
 }
 
+.priorityBadge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.priorityHigh {
+  background: rgba(239, 68, 68, 0.12);
+  color: #dc2626;
+}
+
+.priorityMedium {
+  background: rgba(245, 158, 11, 0.12);
+  color: #d97706;
+}
+
+.priorityLow {
+  background: rgba(34, 197, 94, 0.12);
+  color: #16a34a;
+}
+
+.tagPill {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(255, 255, 255, 0.6);
+  padding: 0.15rem 0.6rem;
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.progressBar {
+  margin-top: 0.5rem;
+  height: 0.35rem;
+  width: 100%;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.18);
+  overflow: hidden;
+}
+
+.progressFill {
+  height: 100%;
+  border-radius: 999px;
+  transition: width 0.3s ease;
+}
+
+.progressFill.milestoneToneSteady {
+  background: #10b981;
+}
+
+.progressFill.milestoneToneWatch {
+  background: #f59e0b;
+}
+
+.progressFill.milestoneToneRisk {
+  background: #f43f5e;
+}
+
+.trendBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.trendUp {
+  background: rgba(16, 185, 129, 0.14);
+  color: #10b981;
+}
+
+.trendDown {
+  background: rgba(244, 63, 94, 0.14);
+  color: #f43f5e;
+}
+
+.trendFlat {
+  background: rgba(148, 163, 184, 0.14);
+  color: #64748b;
+}
+
+.breakdownContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.breakdownTrack {
+  display: flex;
+  height: 0.75rem;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.breakdownSegment {
+  height: 100%;
+  transition: width 0.3s ease;
+}
+
+.breakdownSteady {
+  background: #10b981;
+}
+
+.breakdownWatch {
+  background: #f59e0b;
+}
+
+.breakdownRisk {
+  background: #f43f5e;
+}
+
+.breakdownLegend {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.breakdownLegendItem {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.breakdownDot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+}
+
 @media (min-width: 1280px) {
   .notePanel {
     position: sticky;

--- a/src/app/checkpoint-grid/page.tsx
+++ b/src/app/checkpoint-grid/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { MilestoneTile } from "./_components/milestone-tile";
 import { ProgressSummaryCard } from "./_components/progress-summary-card";
 import { ReviewNotesPanel } from "./_components/review-notes-panel";
+import { StatusBreakdownBar } from "./_components/status-breakdown-bar";
 import { getCheckpointGridView } from "./_data/checkpoint-grid-data";
 import styles from "./checkpoint-grid.module.css";
 
@@ -88,6 +89,28 @@ export default function CheckpointGridPage() {
               </div>
             </aside>
           </div>
+        </section>
+
+        <section aria-labelledby="checkpoint-status-breakdown" className="space-y-5">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                At a glance
+              </p>
+              <h2
+                id="checkpoint-status-breakdown"
+                className="text-3xl font-semibold tracking-tight text-slate-950"
+              >
+                Status breakdown
+              </h2>
+            </div>
+            <p className="max-w-3xl text-sm leading-7 text-slate-600">
+              A visual distribution of milestone statuses across the planning
+              board so you can spot bottlenecks before reading the full grid.
+            </p>
+          </div>
+
+          <StatusBreakdownBar items={view.statusBreakdown} />
         </section>
 
         <section aria-labelledby="checkpoint-progress-summaries" className="space-y-5">


### PR DESCRIPTION
## Summary
- Extends the checkpoint-grid route with priority badges, tag metadata, trend indicators on progress summaries, and a status breakdown view model
- Adds a 6th milestone (responsive polish) and a 5th review note for tag/priority validation
- Enhances milestone tiles, progress summary cards, and the page layout with new visual elements

Closes #172

## Test plan
- [ ] Verify milestone tiles render priority badges and tag pills
- [ ] Confirm progress summary cards show trend indicators
- [ ] Check status breakdown section appears between hero and progress summaries
- [ ] Run existing tests and verify they pass with updated data
- [ ] Validate responsive layout on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)