### PR TITLE
feat: add operations-center shared chrome with overlap

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,6 +6,9 @@
   --surface: rgba(255, 251, 240, 0.86);
   --surface-strong: #fffaf2;
   --line: rgba(148, 163, 184, 0.3);
+  --nav-height: 3.5rem;
+  --ops-accent: #0e7490;
+  --ops-accent-light: rgba(14, 116, 144, 0.08);
 }
 
 @theme inline {
@@ -41,4 +44,82 @@ a {
 ::selection {
   background: rgba(251, 191, 36, 0.3);
   color: var(--foreground);
+}
+
+/* ── Shared app chrome ─────────────────────────────────────── */
+
+.app-nav {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--nav-height);
+  padding-inline: 1.5rem;
+  background: rgba(255, 251, 240, 0.82);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--line);
+}
+
+.app-nav__brand {
+  font-weight: 700;
+  font-size: 0.9375rem;
+  letter-spacing: -0.01em;
+  color: var(--foreground);
+}
+
+.app-nav__links {
+  display: flex;
+  gap: 1.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.app-nav__link {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: rgba(15, 23, 42, 0.6);
+  transition: color 0.15s;
+}
+
+.app-nav__link:hover {
+  color: var(--foreground);
+}
+
+.app-nav__link--active {
+  color: var(--ops-accent);
+  font-weight: 600;
+}
+
+/* ── Operations-center accent utilities ───────────────────── */
+
+.ops-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(14, 116, 144, 0.25);
+  background: var(--ops-accent-light);
+  padding: 0.25rem 0.75rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ops-accent);
+}
+
+.ops-badge::before {
+  content: "";
+  width: 0.375rem;
+  height: 0.375rem;
+  border-radius: 9999px;
+  background: var(--ops-accent);
+  animation: ops-pulse 2s ease-in-out infinite;
+}
+
+@keyframes ops-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
@@ -18,8 +19,15 @@ export const metadata: Metadata = {
     template: "%s | Archive Signals",
   },
   description:
-    "An archive-focused Next.js route with snapshot cards, metadata badges, and a detail panel.",
+    "An archive-focused Next.js app with snapshot cards, metadata badges, and an operations-center dashboard.",
 };
+
+const navLinks = [
+  { href: "/archive-browser", label: "Archive" },
+  { href: "/research-notebook", label: "Notebook" },
+  { href: "/field-guide", label: "Field Guide" },
+  { href: "/operations-center", label: "Ops Center" },
+] as const;
 
 export default function RootLayout({
   children,
@@ -31,7 +39,23 @@ export default function RootLayout({
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="flex min-h-full flex-col">{children}</body>
+      <body className="flex min-h-full flex-col">
+        <nav className="app-nav" aria-label="Primary">
+          <Link href="/" className="app-nav__brand">
+            Archive Signals
+          </Link>
+          <ul className="app-nav__links">
+            {navLinks.map((link) => (
+              <li key={link.href}>
+                <Link href={link.href} className="app-nav__link">
+                  {link.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/app/operations-center/page.tsx
+++ b/src/app/operations-center/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 
 import { ActivityFeed } from "./_components/activity-feed";
 import { AlertList } from "./_components/alert-list";
@@ -28,6 +29,16 @@ export default function OperationsCenterPage() {
   return (
     <main className={styles.shell}>
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-5 py-8 sm:px-8 sm:py-10 lg:px-10 lg:py-12">
+        <div className="flex items-center gap-4">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-1.5 rounded-full border border-slate-300 bg-white/60 px-4 py-1.5 text-xs font-semibold text-slate-600 transition hover:border-slate-400 hover:text-slate-900"
+          >
+            <span aria-hidden="true">&larr;</span> Home
+          </Link>
+          <span className="ops-badge">Live dashboard</span>
+        </div>
+
         <section className={`${styles.surfaceCard} ${styles.heroPanel} p-6 sm:p-8 lg:p-10`}>
           <div className="grid gap-8 lg:grid-cols-[minmax(0,1.5fr)_minmax(280px,0.95fr)] lg:items-start">
             <div className="space-y-6">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,13 @@ const fieldGuideHighlights = [
   "Reference-ready procedure detail for active response handoffs",
 ];
 
+const opsCenterHighlights = [
+  "Live KPI cards with progress bars for on-time departures, fleet use, and exception backlog",
+  "Prioritized alert queue with severity badges, owner attribution, and playbook guidance",
+  "Chronological activity feed tracking automated reroutes and shift-lead decisions",
+  "Shift posture summary with immediate-focus and coverage notes for the command desk",
+];
+
 export default function Home() {
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-12 sm:px-10 lg:px-12">
@@ -168,6 +175,59 @@ export default function Home() {
             </p>
             <ul className="mt-5 space-y-4">
               {fieldGuideHighlights.map((item) => (
+                <li
+                  key={item}
+                  className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"
+                >
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.06)]">
+        <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1fr)_minmax(260px,0.9fr)] lg:px-12 lg:py-10">
+          <div className="space-y-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-cyan-700">
+              Issue 186 / Operations Center
+            </p>
+            <div className="space-y-3">
+              <h2 className="max-w-2xl text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                Monitor live network health, dispatch risk, and intervention
+                velocity from a single dashboard.
+              </h2>
+              <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
+                The operations center consolidates KPI snapshots, live alert
+                queues, and shift activity into a command-desk view designed for
+                operators keeping critical lanes in sync.
+              </p>
+            </div>
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/operations-center"
+                className="inline-flex items-center justify-center rounded-full bg-cyan-700 px-6 py-3 text-sm font-semibold text-cyan-50 transition hover:bg-cyan-800"
+              >
+                Open operations center
+              </Link>
+              <a
+                href="https://github.com/iamasx/api-test/issues/186"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Review issue scope
+              </a>
+            </div>
+          </div>
+
+          <div className="rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Dashboard capabilities
+            </p>
+            <ul className="mt-5 space-y-4">
+              {opsCenterHighlights.map((item) => (
                 <li
                   key={item}
                   className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"


### PR DESCRIPTION
## Summary
- Add a shared sticky navigation bar in the root layout linking all major routes including the operations center
- Update `globals.css` with nav-bar styles and operations-center accent utilities
- Add an operations-center landing section on the home page with capability highlights
- Refine the operations-center route with a breadcrumb back-link and live-dashboard badge

## Conflict Surface
Intentionally touches shared files for merge-conflict testing:
- `src/app/layout.tsx` — new nav bar chrome
- `src/app/globals.css` — new CSS custom properties and nav styles
- `src/app/page.tsx` — new landing section
- `src/app/operations-center/page.tsx` — breadcrumb and badge additions

Closes #186

## Test plan
- [ ] Verify the sticky nav bar renders on all routes
- [ ] Verify the operations-center link on the home page navigates correctly
- [ ] Verify the breadcrumb on `/operations-center` links back to home
- [ ] Confirm the live-dashboard badge pulses with the ops-pulse animation
- [ ] Run `vitest` to verify existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)