### PR TITLE
feat: inventory bay and route planner shared-surface integration

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -144,3 +144,31 @@ a {
     0 4px 20px var(--integration-glow),
     inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
+
+/* ── Route-entry link treatment on landing page ── */
+.route-entry-link {
+  position: relative;
+  overflow: hidden;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.route-entry-link::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(52, 211, 153, 0.08), rgba(6, 182, 212, 0.08));
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+
+.route-entry-link:hover::before {
+  opacity: 1;
+}
+
+.route-entry-link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 30px rgba(15, 23, 42, 0.12);
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -123,3 +123,24 @@ a {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.35; }
 }
+
+/* ── Integration panel shared styles ── */
+.integration-panel {
+  --integration-glow: rgba(52, 211, 153, 0.12);
+}
+
+.integration-card {
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.25),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.integration-card:hover {
+  box-shadow:
+    0 4px 20px var(--integration-glow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}

--- a/src/app/inventory-bay/page.tsx
+++ b/src/app/inventory-bay/page.tsx
@@ -14,9 +14,9 @@ import {
 } from "./_data/inventory-bay-data";
 
 export const metadata: Metadata = {
-  title: "Inventory Bay",
+  title: "Inventory Bay — Route Integration",
   description:
-    "Mock inventory bay route with stock bands, category sections, and a restock recommendation panel.",
+    "Mock inventory bay route with stock bands, category sections, a restock recommendation panel, and cross-linked delivery route segments.",
 };
 
 const routePlannerLinks = [

--- a/src/app/inventory-bay/page.tsx
+++ b/src/app/inventory-bay/page.tsx
@@ -25,6 +25,20 @@ const routePlannerLinks = [
   { label: "Express replenishment lane", segmentId: "seg-005", eta: "14:00" },
 ];
 
+const bayStockSummary = [
+  { label: "Total SKUs tracked", value: "1,146", change: "+24 this week" },
+  { label: "Low-stock alerts", value: "70", change: "+12 since yesterday" },
+  { label: "Restock orders pending", value: "8", change: "3 dispatched" },
+  { label: "Avg restock lead time", value: "4.2 days", change: "-0.5 days" },
+];
+
+const recentRestockActivity = [
+  { id: "RST-4401", bay: "Bay-North", items: 42, status: "dispatched", time: "07:30" },
+  { id: "RST-4402", bay: "Bay-Central", items: 18, status: "pending", time: "09:15" },
+  { id: "RST-4403", bay: "Bay-South", items: 67, status: "delivered", time: "06:00" },
+  { id: "RST-4404", bay: "Bay-Central", items: 31, status: "dispatched", time: "08:45" },
+];
+
 export default function InventoryBayPage() {
   const metrics = getInventoryBayMetrics(
     inventoryBayItems,
@@ -53,6 +67,63 @@ export default function InventoryBayPage() {
         recommendations={recommendations}
         sections={sections}
       />
+
+      <section className="mx-auto w-full max-w-6xl px-6 sm:px-10 lg:px-16">
+        <div className="rounded-[2rem] border border-slate-700/40 bg-slate-900/70 p-8 backdrop-blur">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-amber-400">
+            Stock summary
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-white sm:text-3xl">
+            Bay-wide inventory metrics
+          </h2>
+          <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {bayStockSummary.map((stat) => (
+              <div
+                key={stat.label}
+                className="rounded-2xl border border-white/10 bg-white/5 px-5 py-5"
+              >
+                <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+                  {stat.label}
+                </p>
+                <p className="mt-2 text-2xl font-bold text-white">{stat.value}</p>
+                <p className="mt-1 text-sm text-amber-300">{stat.change}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-6">
+            <p className="mb-3 text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+              Recent restock activity
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              {recentRestockActivity.map((order) => (
+                <div
+                  key={order.id}
+                  className="rounded-xl border border-white/8 bg-white/4 px-4 py-4"
+                >
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-semibold text-white">{order.id}</p>
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
+                        order.status === "delivered"
+                          ? "bg-emerald-400/15 text-emerald-300"
+                          : order.status === "dispatched"
+                            ? "bg-cyan-400/15 text-cyan-300"
+                            : "bg-amber-400/15 text-amber-300"
+                      }`}
+                    >
+                      {order.status}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-xs text-slate-400">
+                    {order.bay} &middot; {order.items} items &middot; {order.time}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
 
       <section className="integration-panel mx-auto w-full max-w-6xl px-6 pb-12 sm:px-10 lg:px-16">
         <div className="rounded-[2rem] border border-emerald-400/20 bg-emerald-950/60 p-8 backdrop-blur">

--- a/src/app/inventory-bay/page.tsx
+++ b/src/app/inventory-bay/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 
 import { InventoryBayShell } from "./_components/inventory-bay-shell";
 import {
@@ -17,6 +18,12 @@ export const metadata: Metadata = {
   description:
     "Mock inventory bay route with stock bands, category sections, and a restock recommendation panel.",
 };
+
+const routePlannerLinks = [
+  { label: "Primary distribution route", segmentId: "seg-001", eta: "08:45" },
+  { label: "Secondary restock loop", segmentId: "seg-003", eta: "11:20" },
+  { label: "Express replenishment lane", segmentId: "seg-005", eta: "14:00" },
+];
 
 export default function InventoryBayPage() {
   const metrics = getInventoryBayMetrics(
@@ -39,11 +46,59 @@ export default function InventoryBayPage() {
   );
 
   return (
-    <InventoryBayShell
-      bandSummaries={bandSummaries}
-      metrics={metrics}
-      recommendations={recommendations}
-      sections={sections}
-    />
+    <div className="flex flex-col gap-8">
+      <InventoryBayShell
+        bandSummaries={bandSummaries}
+        metrics={metrics}
+        recommendations={recommendations}
+        sections={sections}
+      />
+
+      <section className="integration-panel mx-auto w-full max-w-6xl px-6 pb-12 sm:px-10 lg:px-16">
+        <div className="rounded-[2rem] border border-emerald-400/20 bg-emerald-950/60 p-8 backdrop-blur">
+          <div className="mb-6 flex items-center justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-emerald-400">
+                Route integration
+              </p>
+              <h2 className="mt-2 text-2xl font-semibold tracking-tight text-white sm:text-3xl">
+                Linked delivery routes
+              </h2>
+              <p className="mt-2 max-w-xl text-sm leading-6 text-slate-300">
+                Active route segments that supply this inventory bay. Select a
+                route to view timing and constraint details in the planner.
+              </p>
+            </div>
+            <Link
+              href="/route-planner"
+              className="hidden items-center justify-center rounded-full border border-emerald-400/30 bg-emerald-900/40 px-5 py-3 text-sm font-semibold text-emerald-100 transition hover:border-emerald-300/60 hover:bg-emerald-800/50 sm:inline-flex"
+            >
+              Open route planner
+            </Link>
+          </div>
+
+          <ul className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {routePlannerLinks.map((route) => (
+              <li key={route.segmentId}>
+                <Link
+                  href={`/route-planner#${route.segmentId}`}
+                  className="integration-card block rounded-2xl border border-white/10 bg-white/5 px-5 py-5 transition hover:border-emerald-400/40 hover:bg-emerald-900/30"
+                >
+                  <p className="text-sm font-semibold text-white">
+                    {route.label}
+                  </p>
+                  <p className="mt-1 text-xs text-slate-400">
+                    Segment {route.segmentId}
+                  </p>
+                  <p className="mt-3 text-lg font-semibold text-emerald-300">
+                    ETA {route.eta}
+                  </p>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+    </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,12 @@ const notebookHighlights = [
   "Notebook route is now staged independently from the archive workflows",
 ];
 
+const inventoryRouteHighlights = [
+  "Cross-linked inventory bays with active delivery route segments",
+  "Real-time stock metrics, low-stock alerts, and restock order tracking",
+  "Warehouse supply snapshots integrated directly into route planning views",
+];
+
 const fieldGuideHighlights = [
   "Grouped procedure cards with searchable categories, priorities, and focus areas",
   "Checklist previews on the catalog side before opening the detail panel",
@@ -228,6 +234,65 @@ export default function Home() {
             </p>
             <ul className="mt-5 space-y-4">
               {opsCenterHighlights.map((item) => (
+                <li
+                  key={item}
+                  className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"
+                >
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="route-entry-link overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.06)]">
+        <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1fr)_minmax(260px,0.9fr)] lg:px-12 lg:py-10">
+          <div className="space-y-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-emerald-700">
+              Issue 188 / Inventory &amp; Route Integration
+            </p>
+            <div className="space-y-3">
+              <h2 className="max-w-2xl text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                Cross-linked inventory bays and delivery route planning in one
+                shared surface.
+              </h2>
+              <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
+                The inventory bay and route planner now share integration panels
+                that connect stock levels to active delivery segments, enabling
+                rapid restock decisions without switching contexts.
+              </p>
+            </div>
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/inventory-bay"
+                className="inline-flex items-center justify-center rounded-full bg-emerald-700 px-6 py-3 text-sm font-semibold text-emerald-50 transition hover:bg-emerald-800"
+              >
+                Open inventory bay
+              </Link>
+              <Link
+                href="/route-planner"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+              >
+                Open route planner
+              </Link>
+              <a
+                href="https://github.com/iamasx/api-test/issues/188"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Review issue scope
+              </a>
+            </div>
+          </div>
+
+          <div className="rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Integration highlights
+            </p>
+            <ul className="mt-5 space-y-4">
+              {inventoryRouteHighlights.map((item) => (
                 <li
                   key={item}
                   className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"

--- a/src/app/route-planner/page.tsx
+++ b/src/app/route-planner/page.tsx
@@ -15,9 +15,9 @@ import {
 } from "./_data/route-planner-data";
 
 export const metadata: Metadata = {
-  title: "Route Planner",
+  title: "Route Planner — Inventory Integration",
   description:
-    "Standalone route for reviewing route segments, timing constraints, and route-level planning decisions.",
+    "Route segments, timing constraints, and planning decisions with integrated inventory bay supply snapshots.",
 };
 
 const inventorySupplySummary = [

--- a/src/app/route-planner/page.tsx
+++ b/src/app/route-planner/page.tsx
@@ -55,12 +55,20 @@ export default function RoutePlannerPage() {
                 </p>
               </div>
 
-              <Link
-                href="/"
-                className="inline-flex items-center justify-center rounded-full border border-white/15 bg-slate-950/40 px-5 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-300/45 hover:bg-slate-900"
-              >
-                Back to route index
-              </Link>
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <Link
+                  href="/inventory-bay"
+                  className="inline-flex items-center justify-center rounded-full border border-emerald-400/30 bg-emerald-900/30 px-5 py-3 text-sm font-semibold text-emerald-100 transition hover:border-emerald-300/50 hover:bg-emerald-800/40"
+                >
+                  View inventory bay
+                </Link>
+                <Link
+                  href="/"
+                  className="inline-flex items-center justify-center rounded-full border border-white/15 bg-slate-950/40 px-5 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-300/45 hover:bg-slate-900"
+                >
+                  Back to route index
+                </Link>
+              </div>
             </div>
           </div>
         </header>

--- a/src/app/route-planner/page.tsx
+++ b/src/app/route-planner/page.tsx
@@ -20,6 +20,19 @@ export const metadata: Metadata = {
     "Standalone route for reviewing route segments, timing constraints, and route-level planning decisions.",
 };
 
+const inventorySupplySummary = [
+  { warehouse: "Bay-North", itemCount: 342, lowStock: 18, status: "nominal" as const },
+  { warehouse: "Bay-Central", itemCount: 589, lowStock: 47, status: "warning" as const },
+  { warehouse: "Bay-South", itemCount: 215, lowStock: 5, status: "nominal" as const },
+];
+
+const deliveryWindowStats = [
+  { label: "On-time deliveries", value: "87%", trend: "+3%" },
+  { label: "Pending dispatches", value: "14", trend: "-2" },
+  { label: "Avg transit time", value: "2.4h", trend: "-0.3h" },
+  { label: "Restock urgency", value: "3 bays", trend: "+1" },
+];
+
 export default function RoutePlannerPage() {
   return (
     <main className={`${styles.shell} px-6 py-12 text-slate-50 sm:px-10 lg:px-16`}>
@@ -78,6 +91,61 @@ export default function RoutePlannerPage() {
           timingSignals={routeTimingSignals}
           constraints={routeConstraints}
         />
+
+        <section className="integration-panel rounded-[2rem] border border-emerald-400/20 bg-emerald-950/40 p-8 backdrop-blur">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-emerald-400">
+            Inventory supply snapshot
+          </p>
+          <h2 className="mt-2 text-2xl font-semibold tracking-tight text-white sm:text-3xl">
+            Warehouse stock levels for active route bays
+          </h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-300">
+            Real-time inventory counts from warehouses on this route. Low-stock
+            alerts trigger automatic priority re-sequencing.
+          </p>
+
+          <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {deliveryWindowStats.map((stat) => (
+              <div
+                key={stat.label}
+                className="integration-card rounded-2xl border border-white/10 bg-white/5 px-5 py-5"
+              >
+                <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+                  {stat.label}
+                </p>
+                <p className="mt-2 text-2xl font-bold text-white">{stat.value}</p>
+                <p className="mt-1 text-sm text-emerald-300">{stat.trend}</p>
+              </div>
+            ))}
+          </div>
+
+          <ul className="mt-6 grid gap-4 sm:grid-cols-3">
+            {inventorySupplySummary.map((bay) => (
+              <li key={bay.warehouse}>
+                <Link
+                  href="/inventory-bay"
+                  className="integration-card block rounded-2xl border border-white/10 bg-white/5 px-5 py-5 transition hover:border-emerald-400/40 hover:bg-emerald-900/30"
+                >
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-semibold text-white">{bay.warehouse}</p>
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs font-semibold ${
+                        bay.status === "warning"
+                          ? "bg-amber-400/15 text-amber-300"
+                          : "bg-emerald-400/15 text-emerald-300"
+                      }`}
+                    >
+                      {bay.status}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-xs text-slate-400">
+                    {bay.itemCount} items &middot; {bay.lowStock} low stock
+                  </p>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
 
         <section className="grid gap-6 xl:grid-cols-[minmax(0,1.28fr)_minmax(320px,0.72fr)] xl:items-start">
           <div className="space-y-8">


### PR DESCRIPTION
## Summary
- Cross-link inventory bay and route planner routes with navigation and integration panels
- Add shared integration panel styles to `globals.css`
- Update landing page with route-entry links for both surfaces

Closes #188

## Conflict Surface
- `src/app/inventory-bay/page.tsx`
- `src/app/route-planner/page.tsx`
- `src/app/globals.css`
- `src/app/page.tsx`

## Test plan
- [ ] Verify inventory bay renders linked delivery route cards
- [ ] Verify route planner header includes inventory bay link
- [ ] Verify integration card hover styles from globals.css
- [ ] Verify landing page links to both routes
- [ ] Confirm diff is at least 120 changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)