### PR TITLE
feat: queue-monitor and parcel-hub shared overlap (#197)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -232,3 +232,63 @@ a {
   transform: translateY(-2px);
   box-shadow: 0 8px 30px rgba(15, 23, 42, 0.12);
 }
+
+/* ── Queue-monitor & parcel-hub shared styles ────────────── */
+
+:root {
+  --queue-accent: #d97706;
+  --queue-accent-light: rgba(217, 119, 6, 0.08);
+  --parcel-accent: #059669;
+  --parcel-accent-light: rgba(5, 150, 105, 0.08);
+}
+
+.queue-monitor-hero,
+.parcel-hub-hero {
+  position: relative;
+}
+
+.queue-monitor-hero::after,
+.parcel-hub-hero::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    var(--queue-accent) 0%,
+    var(--parcel-accent) 100%
+  );
+  opacity: 0.6;
+}
+
+.queue-lane-card {
+  border-left: 3px solid var(--queue-accent-light);
+}
+
+.queue-lane-card:hover {
+  border-left-color: var(--queue-accent);
+}
+
+.parcel-hub-card {
+  border-left: 3px solid var(--parcel-accent-light);
+}
+
+.parcel-hub-card:hover {
+  border-left-color: var(--parcel-accent);
+}
+
+.queue-parcel-link {
+  position: relative;
+}
+
+.queue-parcel-link::after {
+  content: "\2192";
+  margin-left: 0.375rem;
+  transition: transform 0.15s ease;
+}
+
+.queue-parcel-link:hover::after {
+  transform: translateX(2px);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,6 +30,8 @@ const navLinks = [
   { href: "/field-guide", label: "Field Guide" },
   { href: "/operations-center", label: "Ops Center" },
   { href: "/experiment-registry", label: "Experiments" },
+  { href: "/queue-monitor", label: "Queue Monitor" },
+  { href: "/parcel-hub", label: "Parcel Hub" },
 ] as const;
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,6 +46,13 @@ const commandLogHighlights = [
   "Activity summary showing category, team, and status breakdowns",
 ];
 
+const queueParcelHighlights = [
+  "Real-time queue depth across five operational lanes with throughput rates",
+  "Regional parcel hub cards with SLA compliance and in-transit volume",
+  "Cross-linked parcels connecting queue lanes to their assigned hub",
+  "Inter-hub transfer table tracking volume and priority between regions",
+];
+
 const teamDirectoryHighlights = [
   "Cross-functional directory with grouped profiles and availability states",
   "Spotlight panel featuring role highlights and shared skill breakdowns",
@@ -424,6 +431,65 @@ export default function Home() {
             </p>
             <ul className="mt-5 space-y-4">
               {commandLogHighlights.map((item) => (
+                <li
+                  key={item}
+                  className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"
+                >
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="route-entry-link overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.06)]">
+        <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1fr)_minmax(260px,0.9fr)] lg:px-12 lg:py-10">
+          <div className="space-y-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-amber-700">
+              Issue 197 / Queue &amp; Parcel Integration
+            </p>
+            <div className="space-y-3">
+              <h2 className="max-w-2xl text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                Monitor queue lanes and parcel hub volumes from linked
+                operational surfaces.
+              </h2>
+              <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
+                The queue monitor and parcel hub routes share cross-linked data
+                so operators can trace items from inbound queues through regional
+                hubs to final dispatch without switching dashboards.
+              </p>
+            </div>
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/queue-monitor"
+                className="inline-flex items-center justify-center rounded-full bg-amber-700 px-6 py-3 text-sm font-semibold text-amber-50 transition hover:bg-amber-800"
+              >
+                Open queue monitor
+              </Link>
+              <Link
+                href="/parcel-hub"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+              >
+                Open parcel hub
+              </Link>
+              <a
+                href="https://github.com/iamasx/api-test/issues/197"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Review issue scope
+              </a>
+            </div>
+          </div>
+
+          <div className="rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Integration highlights
+            </p>
+            <ul className="mt-5 space-y-4">
+              {queueParcelHighlights.map((item) => (
                 <li
                   key={item}
                   className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"

--- a/src/app/parcel-hub/page.tsx
+++ b/src/app/parcel-hub/page.tsx
@@ -1,0 +1,295 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Parcel Hub",
+  description:
+    "Regional parcel hub dashboard with volume tracking, queue monitor integration, and SLA metrics.",
+};
+
+const hubs = [
+  {
+    id: "west",
+    name: "West Hub",
+    region: "Pacific Northwest",
+    parcelsInTransit: 1284,
+    parcelsDelivered: 4390,
+    slaCompliance: 96.2,
+    activeQueues: 3,
+    status: "operational" as const,
+  },
+  {
+    id: "central",
+    name: "Central Hub",
+    region: "Midwest",
+    parcelsInTransit: 2107,
+    parcelsDelivered: 6812,
+    slaCompliance: 94.8,
+    activeQueues: 4,
+    status: "operational" as const,
+  },
+  {
+    id: "east",
+    name: "East Hub",
+    region: "Northeast Corridor",
+    parcelsInTransit: 1893,
+    parcelsDelivered: 5641,
+    slaCompliance: 91.3,
+    activeQueues: 5,
+    status: "degraded" as const,
+  },
+  {
+    id: "south",
+    name: "South Hub",
+    region: "Gulf States",
+    parcelsInTransit: 978,
+    parcelsDelivered: 3205,
+    slaCompliance: 97.1,
+    activeQueues: 2,
+    status: "operational" as const,
+  },
+];
+
+const recentTransfers = [
+  {
+    id: "TRF-801",
+    from: "West Hub",
+    to: "Central Hub",
+    count: 48,
+    priority: "standard",
+  },
+  {
+    id: "TRF-802",
+    from: "East Hub",
+    to: "South Hub",
+    count: 23,
+    priority: "express",
+  },
+  {
+    id: "TRF-803",
+    from: "Central Hub",
+    to: "West Hub",
+    count: 61,
+    priority: "standard",
+  },
+  {
+    id: "TRF-804",
+    from: "South Hub",
+    to: "East Hub",
+    count: 15,
+    priority: "express",
+  },
+  {
+    id: "TRF-805",
+    from: "West Hub",
+    to: "East Hub",
+    count: 34,
+    priority: "standard",
+  },
+];
+
+const hubStatusColor: Record<string, string> = {
+  operational: "bg-emerald-100 text-emerald-800 border-emerald-200",
+  degraded: "bg-amber-100 text-amber-800 border-amber-200",
+  offline: "bg-red-100 text-red-800 border-red-200",
+};
+
+export default function ParcelHubPage() {
+  const totalInTransit = hubs.reduce((s, h) => s + h.parcelsInTransit, 0);
+  const totalDelivered = hubs.reduce((s, h) => s + h.parcelsDelivered, 0);
+  const avgSla = (
+    hubs.reduce((s, h) => s + h.slaCompliance, 0) / hubs.length
+  ).toFixed(1);
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
+      {/* Hero */}
+      <section className="parcel-hub-hero overflow-hidden rounded-[2.25rem] border border-slate-200 bg-[linear-gradient(135deg,#ecfdf5_0%,#ffffff_42%,#fefce8_100%)] shadow-[0_30px_100px_rgba(15,23,42,0.1)]">
+        <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1.3fr)_minmax(260px,0.7fr)] lg:px-12 lg:py-12">
+          <div className="space-y-6">
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="ops-badge">Hub Network</span>
+              <p className="rounded-full bg-white px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.18)]">
+                Parcel logistics
+              </p>
+            </div>
+
+            <div className="space-y-4">
+              <h1 className="heading-tight max-w-3xl text-4xl text-slate-950 sm:text-5xl">
+                Track parcel volume, SLA compliance, and hub-to-hub transfers.
+              </h1>
+              <p className="max-w-2xl text-base leading-8 text-slate-600 sm:text-lg">
+                The parcel hub dashboard consolidates regional volume snapshots,
+                inter-hub transfer activity, and live queue monitor
+                cross-references so dispatchers can balance load across the
+                network.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
+              >
+                Back to overview
+              </Link>
+              <Link
+                href="/queue-monitor"
+                className="queue-parcel-link inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+              >
+                Open queue monitor
+              </Link>
+            </div>
+          </div>
+
+          <aside className="rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
+            <p className="section-label text-slate-500">Network snapshot</p>
+            <div className="mt-4 space-y-3">
+              <div className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+                  In transit
+                </p>
+                <p className="mt-1 text-2xl font-semibold text-slate-950">
+                  {totalInTransit.toLocaleString()}
+                </p>
+              </div>
+              <div className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+                  Delivered today
+                </p>
+                <p className="mt-1 text-2xl font-semibold text-slate-950">
+                  {totalDelivered.toLocaleString()}
+                </p>
+              </div>
+              <div className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+                  Avg SLA compliance
+                </p>
+                <p className="mt-1 text-2xl font-semibold text-slate-950">
+                  {avgSla}%
+                </p>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      {/* Hub cards */}
+      <section className="space-y-5">
+        <div className="space-y-2">
+          <p className="section-label text-slate-500">Regional hubs</p>
+          <h2 className="heading-tight text-3xl text-slate-950">
+            Hub status overview
+          </h2>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          {hubs.map((hub) => (
+            <div
+              key={hub.id}
+              className="parcel-hub-card rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-sm transition hover:shadow-md"
+            >
+              <div className="flex items-center justify-between">
+                <h3 className="text-base font-semibold text-slate-900">
+                  {hub.name}
+                </h3>
+                <span
+                  className={`rounded-full border px-2 py-0.5 text-[0.6875rem] font-semibold uppercase tracking-wide ${hubStatusColor[hub.status]}`}
+                >
+                  {hub.status}
+                </span>
+              </div>
+              <p className="mt-1 text-sm text-slate-500">{hub.region}</p>
+
+              <div className="mt-4 grid grid-cols-3 gap-3 text-center">
+                <div>
+                  <p className="text-xl font-semibold text-slate-950">
+                    {hub.parcelsInTransit.toLocaleString()}
+                  </p>
+                  <p className="text-[0.6875rem] text-slate-500">In transit</p>
+                </div>
+                <div>
+                  <p className="text-xl font-semibold text-slate-950">
+                    {hub.slaCompliance}%
+                  </p>
+                  <p className="text-[0.6875rem] text-slate-500">SLA</p>
+                </div>
+                <div>
+                  <p className="text-xl font-semibold text-slate-950">
+                    {hub.activeQueues}
+                  </p>
+                  <p className="text-[0.6875rem] text-slate-500">
+                    <Link
+                      href="/queue-monitor"
+                      className="text-[var(--ops-accent)] underline-offset-2 hover:underline"
+                    >
+                      Queues
+                    </Link>
+                  </p>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Transfers */}
+      <section className="space-y-5">
+        <div className="space-y-2">
+          <p className="section-label text-slate-500">Inter-hub activity</p>
+          <h2 className="heading-tight text-3xl text-slate-950">
+            Recent transfers
+          </h2>
+        </div>
+
+        <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white/80">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr className="border-b border-slate-100 bg-slate-50/60">
+                <th className="px-4 py-3 font-semibold text-slate-600">
+                  Transfer
+                </th>
+                <th className="px-4 py-3 font-semibold text-slate-600">
+                  From
+                </th>
+                <th className="px-4 py-3 font-semibold text-slate-600">To</th>
+                <th className="px-4 py-3 font-semibold text-slate-600">
+                  Parcels
+                </th>
+                <th className="px-4 py-3 font-semibold text-slate-600">
+                  Priority
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {recentTransfers.map((t) => (
+                <tr
+                  key={t.id}
+                  className="border-b border-slate-100 last:border-0"
+                >
+                  <td className="px-4 py-3 font-medium text-slate-900">
+                    {t.id}
+                  </td>
+                  <td className="px-4 py-3 text-slate-600">{t.from}</td>
+                  <td className="px-4 py-3 text-slate-600">{t.to}</td>
+                  <td className="px-4 py-3 text-slate-600">{t.count}</td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-[0.6875rem] font-semibold uppercase ${
+                        t.priority === "express"
+                          ? "bg-amber-100 text-amber-800"
+                          : "bg-slate-100 text-slate-600"
+                      }`}
+                    >
+                      {t.priority}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/queue-monitor/page.tsx
+++ b/src/app/queue-monitor/page.tsx
@@ -1,0 +1,231 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Queue Monitor",
+  description:
+    "Real-time queue depth monitoring with throughput metrics and parcel-hub cross-links.",
+};
+
+const queueLanes = [
+  {
+    id: "inbound",
+    label: "Inbound",
+    depth: 142,
+    throughput: "38/min",
+    status: "healthy" as const,
+    trend: "+4%",
+  },
+  {
+    id: "sorting",
+    label: "Sorting",
+    depth: 87,
+    throughput: "31/min",
+    status: "warning" as const,
+    trend: "-2%",
+  },
+  {
+    id: "dispatch",
+    label: "Dispatch",
+    depth: 56,
+    throughput: "29/min",
+    status: "healthy" as const,
+    trend: "+1%",
+  },
+  {
+    id: "returns",
+    label: "Returns",
+    depth: 23,
+    throughput: "12/min",
+    status: "critical" as const,
+    trend: "-11%",
+  },
+  {
+    id: "held",
+    label: "Held / Review",
+    depth: 9,
+    throughput: "3/min",
+    status: "warning" as const,
+    trend: "+7%",
+  },
+];
+
+const parcelCrossLinks = [
+  { parcelId: "PCL-4401", lane: "Sorting", hub: "West Hub", eta: "14:32" },
+  { parcelId: "PCL-4402", lane: "Dispatch", hub: "Central Hub", eta: "14:45" },
+  { parcelId: "PCL-4403", lane: "Returns", hub: "East Hub", eta: "15:10" },
+  { parcelId: "PCL-4404", lane: "Inbound", hub: "West Hub", eta: "13:58" },
+];
+
+const statusColor: Record<string, string> = {
+  healthy: "bg-emerald-100 text-emerald-800 border-emerald-200",
+  warning: "bg-amber-100 text-amber-800 border-amber-200",
+  critical: "bg-red-100 text-red-800 border-red-200",
+};
+
+export default function QueueMonitorPage() {
+  const totalDepth = queueLanes.reduce((sum, l) => sum + l.depth, 0);
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
+      {/* Hero */}
+      <section className="queue-monitor-hero overflow-hidden rounded-[2.25rem] border border-slate-200 bg-[linear-gradient(135deg,#fefce8_0%,#ffffff_42%,#ecfdf5_100%)] shadow-[0_30px_100px_rgba(15,23,42,0.1)]">
+        <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1.3fr)_minmax(260px,0.7fr)] lg:px-12 lg:py-12">
+          <div className="space-y-6">
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="ops-badge">Live Monitoring</span>
+              <p className="rounded-full bg-white px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.18)]">
+                Queue telemetry
+              </p>
+            </div>
+
+            <div className="space-y-4">
+              <h1 className="heading-tight max-w-3xl text-4xl text-slate-950 sm:text-5xl">
+                Monitor queue depth, throughput, and lane health in real time.
+              </h1>
+              <p className="max-w-2xl text-base leading-8 text-slate-600 sm:text-lg">
+                The queue monitor tracks parcel volume across five operational
+                lanes, surfacing bottlenecks and cross-linking items to their
+                assigned parcel hub for end-to-end visibility.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
+              >
+                Back to overview
+              </Link>
+              <Link
+                href="/parcel-hub"
+                className="queue-parcel-link inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+              >
+                Open parcel hub
+              </Link>
+            </div>
+          </div>
+
+          <aside className="rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
+            <p className="section-label text-slate-500">Queue snapshot</p>
+            <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+              {totalDepth} items
+            </p>
+            <p className="mt-1 text-sm text-slate-500">
+              across {queueLanes.length} active lanes
+            </p>
+
+            <div className="mt-5 space-y-3">
+              <div className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+                  Avg throughput
+                </p>
+                <p className="mt-1 text-lg font-semibold text-slate-950">
+                  22.6 items/min
+                </p>
+              </div>
+              <div className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+                  Cross-hub parcels
+                </p>
+                <p className="mt-1 text-lg font-semibold text-slate-950">
+                  {parcelCrossLinks.length} tracked
+                </p>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </section>
+
+      {/* Lane cards */}
+      <section className="space-y-5">
+        <div className="space-y-2">
+          <p className="section-label text-slate-500">Lane overview</p>
+          <h2 className="heading-tight text-3xl text-slate-950">
+            Active queue lanes
+          </h2>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {queueLanes.map((lane) => (
+            <div
+              key={lane.id}
+              className="queue-lane-card rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-sm transition hover:shadow-md"
+            >
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-slate-700">
+                  {lane.label}
+                </h3>
+                <span
+                  className={`rounded-full border px-2 py-0.5 text-[0.6875rem] font-semibold uppercase tracking-wide ${statusColor[lane.status]}`}
+                >
+                  {lane.status}
+                </span>
+              </div>
+              <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+                {lane.depth}
+              </p>
+              <div className="mt-2 flex items-center gap-3 text-sm text-slate-500">
+                <span>{lane.throughput}</span>
+                <span className="text-xs font-medium text-slate-400">
+                  {lane.trend}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Parcel cross-links */}
+      <section className="space-y-5">
+        <div className="space-y-2">
+          <p className="section-label text-slate-500">
+            Parcel hub cross-references
+          </p>
+          <h2 className="heading-tight text-3xl text-slate-950">
+            Tracked parcels
+          </h2>
+        </div>
+
+        <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white/80">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr className="border-b border-slate-100 bg-slate-50/60">
+                <th className="px-4 py-3 font-semibold text-slate-600">
+                  Parcel ID
+                </th>
+                <th className="px-4 py-3 font-semibold text-slate-600">
+                  Lane
+                </th>
+                <th className="px-4 py-3 font-semibold text-slate-600">Hub</th>
+                <th className="px-4 py-3 font-semibold text-slate-600">ETA</th>
+              </tr>
+            </thead>
+            <tbody>
+              {parcelCrossLinks.map((p) => (
+                <tr
+                  key={p.parcelId}
+                  className="border-b border-slate-100 last:border-0"
+                >
+                  <td className="px-4 py-3 font-medium text-slate-900">
+                    {p.parcelId}
+                  </td>
+                  <td className="px-4 py-3 text-slate-600">{p.lane}</td>
+                  <td className="px-4 py-3 text-slate-600">
+                    <Link
+                      href="/parcel-hub"
+                      className="text-[var(--ops-accent)] underline-offset-2 hover:underline"
+                    >
+                      {p.hub}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-slate-600">{p.eta}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `queue-monitor` route with lane depth tracking, throughput metrics, and parcel cross-links
- Add `parcel-hub` route with regional hub cards, SLA compliance, and inter-hub transfer table
- Cross-link both surfaces bidirectionally for integration overlap
- Update shared layout nav with new route entries
- Update `globals.css` with queue/parcel shared styles
- Update landing page with combined section linking both routes

Closes #197

## Conflict surface
- `src/app/queue-monitor/page.tsx`
- `src/app/parcel-hub/page.tsx`
- `src/app/page.tsx`
- `src/app/globals.css`
- `src/app/layout.tsx`

## Test plan
- [ ] Verify both routes render correctly
- [ ] Verify cross-links between queue-monitor and parcel-hub work
- [ ] Verify landing page section links to both routes
- [ ] Verify nav links appear in shared layout
- [ ] Confirm diff exceeds 120 changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)