### PR TITLE
feat: handoff-journal route with CI conflict test (#199)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,5 +31,8 @@ jobs:
       - name: Run lint
         run: npm run lint
 
+      - name: Validate handoff-journal route structure
+        run: test -f src/app/handoff-journal/data.ts || (echo "ERROR: handoff-journal data module missing" && exit 1)
+
       - name: Run production build
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "Archive Signals – experiment registry, field guides, and operational dashboards",
-  "keywords": ["api-test", "command-log", "operations"],
+  "keywords": ["api-test", "command-log", "operations", "handoff-journal"],
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/src/app/handoff-journal/data.ts
+++ b/src/app/handoff-journal/data.ts
@@ -1,0 +1,100 @@
+export type HandoffStatus = "open" | "resolved" | "escalated";
+
+export type HandoffEntry = {
+  id: string;
+  timestamp: string;
+  fromOperator: string;
+  toOperator: string;
+  status: HandoffStatus;
+  summary: string;
+  tags: string[];
+  priority: "low" | "medium" | "high" | "critical";
+};
+
+export const handoffEntries: HandoffEntry[] = [
+  {
+    id: "HJ-001",
+    timestamp: "2026-04-23T06:00:00Z",
+    fromOperator: "M. Chen",
+    toOperator: "R. Alvarez",
+    status: "open",
+    summary:
+      "Ingest pipeline for sensor-grid-7 is throttled at 40% capacity. Awaiting infra team confirmation on memory limits before scaling.",
+    tags: ["pipeline", "infra"],
+    priority: "high",
+  },
+  {
+    id: "HJ-002",
+    timestamp: "2026-04-23T06:00:00Z",
+    fromOperator: "M. Chen",
+    toOperator: "R. Alvarez",
+    status: "escalated",
+    summary:
+      "Compliance audit flagged three archive partitions with missing retention labels. Legal review required before end of week.",
+    tags: ["compliance", "archive"],
+    priority: "critical",
+  },
+  {
+    id: "HJ-003",
+    timestamp: "2026-04-23T06:00:00Z",
+    fromOperator: "M. Chen",
+    toOperator: "R. Alvarez",
+    status: "resolved",
+    summary:
+      "Rebalanced route planner weights after overnight demand spike in sector 12. All delivery windows now within SLA.",
+    tags: ["routing", "sla"],
+    priority: "medium",
+  },
+  {
+    id: "HJ-004",
+    timestamp: "2026-04-22T18:00:00Z",
+    fromOperator: "T. Nakamura",
+    toOperator: "M. Chen",
+    status: "resolved",
+    summary:
+      "Deployed hotfix for experiment-registry search index. Full reindex completed at 17:42 UTC with no data loss.",
+    tags: ["search", "deploy"],
+    priority: "medium",
+  },
+  {
+    id: "HJ-005",
+    timestamp: "2026-04-22T18:00:00Z",
+    fromOperator: "T. Nakamura",
+    toOperator: "M. Chen",
+    status: "open",
+    summary:
+      "Field guide procedure FG-204 has conflicting checklist steps between v2 and v3. Needs content owner review before next publish cycle.",
+    tags: ["field-guide", "content"],
+    priority: "low",
+  },
+  {
+    id: "HJ-006",
+    timestamp: "2026-04-22T18:00:00Z",
+    fromOperator: "T. Nakamura",
+    toOperator: "M. Chen",
+    status: "escalated",
+    summary:
+      "Operations center KPI feed showing stale data for fleet utilization metric. Dashboard cache invalidation may be stuck.",
+    tags: ["ops-center", "monitoring"],
+    priority: "high",
+  },
+];
+
+export function getHandoffMetrics(entries: HandoffEntry[]) {
+  const byStatus = { open: 0, resolved: 0, escalated: 0 };
+  const byPriority = { low: 0, medium: 0, high: 0, critical: 0 };
+
+  for (const entry of entries) {
+    byStatus[entry.status]++;
+    byPriority[entry.priority]++;
+  }
+
+  return {
+    total: entries.length,
+    byStatus,
+    byPriority,
+    uniqueOperators: new Set(
+      entries.flatMap((e) => [e.fromOperator, e.toOperator])
+    ).size,
+  };
+}

--- a/src/app/handoff-journal/data.ts
+++ b/src/app/handoff-journal/data.ts
@@ -11,6 +11,37 @@ export type HandoffEntry = {
   priority: "low" | "medium" | "high" | "critical";
 };
 
+export type ShiftRotation = {
+  id: string;
+  shiftLabel: string;
+  startTime: string;
+  endTime: string;
+  outgoing: string;
+  incoming: string;
+  entryCount: number;
+};
+
+export const shiftRotations: ShiftRotation[] = [
+  {
+    id: "SR-01",
+    shiftLabel: "Night → Morning",
+    startTime: "2026-04-23T06:00:00Z",
+    endTime: "2026-04-23T14:00:00Z",
+    outgoing: "M. Chen",
+    incoming: "R. Alvarez",
+    entryCount: 3,
+  },
+  {
+    id: "SR-02",
+    shiftLabel: "Afternoon → Night",
+    startTime: "2026-04-22T18:00:00Z",
+    endTime: "2026-04-23T06:00:00Z",
+    outgoing: "T. Nakamura",
+    incoming: "M. Chen",
+    entryCount: 3,
+  },
+];
+
 export const handoffEntries: HandoffEntry[] = [
   {
     id: "HJ-001",

--- a/src/app/handoff-journal/page.tsx
+++ b/src/app/handoff-journal/page.tsx
@@ -1,18 +1,14 @@
 import type { Metadata } from "next";
+import {
+  handoffEntries,
+  getHandoffMetrics,
+  type HandoffEntry,
+} from "./data";
 
 export const metadata: Metadata = {
   title: "Handoff Journal",
   description:
     "Shift-change handoff journal for tracking open items, blockers, and ownership transitions across operator rotations.",
-};
-
-type HandoffEntry = {
-  id: string;
-  timestamp: string;
-  fromOperator: string;
-  toOperator: string;
-  status: "open" | "resolved" | "escalated";
-  summary: string;
 };
 
 const STATUS_COLORS: Record<HandoffEntry["status"], string> = {
@@ -27,7 +23,27 @@ const STATUS_LABELS: Record<HandoffEntry["status"], string> = {
   escalated: "Escalated",
 };
 
+const PRIORITY_COLORS: Record<HandoffEntry["priority"], string> = {
+  low: "text-slate-500",
+  medium: "text-blue-600",
+  high: "text-orange-600",
+  critical: "text-red-600",
+};
+
+function formatTimestamp(iso: string) {
+  const d = new Date(iso);
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
 export default function HandoffJournalPage() {
+  const metrics = getHandoffMetrics(handoffEntries);
+
   return (
     <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-8 px-6 py-12 sm:px-10 lg:px-12">
       <header className="space-y-3">
@@ -44,47 +60,97 @@ export default function HandoffJournalPage() {
         </p>
       </header>
 
+      <div className="grid gap-4 sm:grid-cols-4">
+        <div className="rounded-xl border border-[var(--line)] bg-[var(--surface)] p-4">
+          <p className="text-sm font-semibold uppercase tracking-wider text-slate-500">
+            Total
+          </p>
+          <p className="mt-1 text-2xl font-semibold text-slate-900">
+            {metrics.total}
+          </p>
+        </div>
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-4">
+          <p className="text-sm font-semibold uppercase tracking-wider text-amber-700">
+            Open
+          </p>
+          <p className="mt-1 text-2xl font-semibold text-amber-800">
+            {metrics.byStatus.open}
+          </p>
+        </div>
+        <div className="rounded-xl border border-red-200 bg-red-50 p-4">
+          <p className="text-sm font-semibold uppercase tracking-wider text-red-700">
+            Escalated
+          </p>
+          <p className="mt-1 text-2xl font-semibold text-red-800">
+            {metrics.byStatus.escalated}
+          </p>
+        </div>
+        <div className="rounded-xl border border-green-200 bg-green-50 p-4">
+          <p className="text-sm font-semibold uppercase tracking-wider text-green-700">
+            Resolved
+          </p>
+          <p className="mt-1 text-2xl font-semibold text-green-800">
+            {metrics.byStatus.resolved}
+          </p>
+        </div>
+      </div>
+
       <section className="rounded-2xl border border-[var(--line)] bg-[var(--surface)] p-6">
         <div className="flex items-center justify-between">
           <h2 className="text-xl font-semibold text-slate-900">
             Journal Entries
           </h2>
           <p className="text-sm text-slate-500">
-            No entries loaded &mdash; data module pending
+            {metrics.uniqueOperators} operators &middot; {metrics.total} entries
           </p>
         </div>
 
-        <div className="mt-6 flex flex-col items-center gap-4 rounded-xl border border-dashed border-slate-300 bg-slate-50 py-12">
-          <div className="rounded-full bg-orange-100 p-3">
-            <svg
-              className="h-6 w-6 text-orange-600"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
+        <ul className="mt-6 space-y-4">
+          {handoffEntries.map((entry) => (
+            <li
+              key={entry.id}
+              className="rounded-xl border border-slate-200 bg-white p-4"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
-              />
-            </svg>
-          </div>
-          <p className="text-sm font-medium text-slate-600">
-            Handoff entries will appear here once the data module is connected.
-          </p>
-          <p className="text-xs text-slate-400">
-            Status legend:{" "}
-            {Object.entries(STATUS_LABELS).map(([key, label]) => (
-              <span
-                key={key}
-                className={`ml-1 inline-block rounded-full border px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[key as HandoffEntry["status"]]}`}
-              >
-                {label}
-              </span>
-            ))}
-          </p>
-        </div>
+              <div className="flex flex-wrap items-start justify-between gap-2">
+                <div className="flex items-center gap-3">
+                  <span className="text-sm font-mono font-semibold text-slate-400">
+                    {entry.id}
+                  </span>
+                  <span
+                    className={`inline-block rounded-full border px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[entry.status]}`}
+                  >
+                    {STATUS_LABELS[entry.status]}
+                  </span>
+                  <span
+                    className={`text-xs font-semibold uppercase tracking-wider ${PRIORITY_COLORS[entry.priority]}`}
+                  >
+                    {entry.priority}
+                  </span>
+                </div>
+                <span className="text-xs text-slate-400">
+                  {formatTimestamp(entry.timestamp)}
+                </span>
+              </div>
+              <p className="mt-2 text-sm leading-6 text-slate-700">
+                {entry.summary}
+              </p>
+              <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-slate-500">
+                <span>
+                  {entry.fromOperator} &rarr; {entry.toOperator}
+                </span>
+                <span className="text-slate-300">|</span>
+                {entry.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-full bg-slate-100 px-2 py-0.5 text-slate-600"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </li>
+          ))}
+        </ul>
       </section>
 
       <section className="rounded-2xl border border-[var(--line)] bg-[var(--surface)] p-6">

--- a/src/app/handoff-journal/page.tsx
+++ b/src/app/handoff-journal/page.tsx
@@ -1,0 +1,126 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Handoff Journal",
+  description:
+    "Shift-change handoff journal for tracking open items, blockers, and ownership transitions across operator rotations.",
+};
+
+type HandoffEntry = {
+  id: string;
+  timestamp: string;
+  fromOperator: string;
+  toOperator: string;
+  status: "open" | "resolved" | "escalated";
+  summary: string;
+};
+
+const STATUS_COLORS: Record<HandoffEntry["status"], string> = {
+  open: "bg-amber-100 text-amber-800 border-amber-300",
+  resolved: "bg-green-100 text-green-800 border-green-300",
+  escalated: "bg-red-100 text-red-800 border-red-300",
+};
+
+const STATUS_LABELS: Record<HandoffEntry["status"], string> = {
+  open: "Open",
+  resolved: "Resolved",
+  escalated: "Escalated",
+};
+
+export default function HandoffJournalPage() {
+  return (
+    <main className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-8 px-6 py-12 sm:px-10 lg:px-12">
+      <header className="space-y-3">
+        <p className="text-sm font-semibold uppercase tracking-[0.28em] text-orange-700">
+          Issue 199 / Handoff Journal
+        </p>
+        <h1 className="text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
+          Shift Handoff Journal
+        </h1>
+        <p className="max-w-2xl text-lg leading-8 text-slate-600">
+          Track open items, ownership transitions, and blockers across operator
+          shift rotations. Each entry captures the outgoing and incoming
+          operator, current status, and a summary of what needs attention.
+        </p>
+      </header>
+
+      <section className="rounded-2xl border border-[var(--line)] bg-[var(--surface)] p-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-xl font-semibold text-slate-900">
+            Journal Entries
+          </h2>
+          <p className="text-sm text-slate-500">
+            No entries loaded &mdash; data module pending
+          </p>
+        </div>
+
+        <div className="mt-6 flex flex-col items-center gap-4 rounded-xl border border-dashed border-slate-300 bg-slate-50 py-12">
+          <div className="rounded-full bg-orange-100 p-3">
+            <svg
+              className="h-6 w-6 text-orange-600"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+              />
+            </svg>
+          </div>
+          <p className="text-sm font-medium text-slate-600">
+            Handoff entries will appear here once the data module is connected.
+          </p>
+          <p className="text-xs text-slate-400">
+            Status legend:{" "}
+            {Object.entries(STATUS_LABELS).map(([key, label]) => (
+              <span
+                key={key}
+                className={`ml-1 inline-block rounded-full border px-2 py-0.5 text-xs font-medium ${STATUS_COLORS[key as HandoffEntry["status"]]}`}
+              >
+                {label}
+              </span>
+            ))}
+          </p>
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-[var(--line)] bg-[var(--surface)] p-6">
+        <h2 className="text-xl font-semibold text-slate-900">
+          Handoff Protocol
+        </h2>
+        <div className="mt-4 grid gap-4 sm:grid-cols-3">
+          <div className="rounded-xl border border-slate-200 bg-white p-4">
+            <p className="text-sm font-semibold uppercase tracking-wider text-orange-700">
+              Step 1
+            </p>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              Outgoing operator logs all open items with current status and
+              any blockers encountered during the shift.
+            </p>
+          </div>
+          <div className="rounded-xl border border-slate-200 bg-white p-4">
+            <p className="text-sm font-semibold uppercase tracking-wider text-orange-700">
+              Step 2
+            </p>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              Incoming operator reviews each entry, confirms ownership
+              transfer, and updates priority or escalation flags.
+            </p>
+          </div>
+          <div className="rounded-xl border border-slate-200 bg-white p-4">
+            <p className="text-sm font-semibold uppercase tracking-wider text-orange-700">
+              Step 3
+            </p>
+            <p className="mt-2 text-sm leading-6 text-slate-600">
+              Both operators sign off on the journal. Unresolved escalations
+              are forwarded to the next rotation automatically.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/handoff-journal/page.tsx
+++ b/src/app/handoff-journal/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import {
   handoffEntries,
+  shiftRotations,
   getHandoffMetrics,
   type HandoffEntry,
 } from "./data";
@@ -151,6 +152,37 @@ export default function HandoffJournalPage() {
             </li>
           ))}
         </ul>
+      </section>
+
+      <section className="rounded-2xl border border-[var(--line)] bg-[var(--surface)] p-6">
+        <h2 className="text-xl font-semibold text-slate-900">
+          Shift Rotations
+        </h2>
+        <div className="mt-4 grid gap-4 sm:grid-cols-2">
+          {shiftRotations.map((rotation) => (
+            <div
+              key={rotation.id}
+              className="rounded-xl border border-slate-200 bg-white p-4"
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-mono text-xs font-semibold text-slate-400">
+                  {rotation.id}
+                </span>
+                <span className="rounded-full bg-orange-100 px-2 py-0.5 text-xs font-medium text-orange-700">
+                  {rotation.shiftLabel}
+                </span>
+              </div>
+              <p className="mt-2 text-sm text-slate-700">
+                {rotation.outgoing} &rarr; {rotation.incoming}
+              </p>
+              <p className="mt-1 text-xs text-slate-400">
+                {rotation.entryCount} entries &middot;{" "}
+                {formatTimestamp(rotation.startTime)} &ndash;{" "}
+                {formatTimestamp(rotation.endTime)}
+              </p>
+            </div>
+          ))}
+        </div>
       </section>
 
       <section className="rounded-2xl border border-[var(--line)] bg-[var(--surface)] p-6">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,6 +33,7 @@ const navLinks = [
   { href: "/queue-monitor", label: "Queue Monitor" },
   { href: "/parcel-hub", label: "Parcel Hub" },
   { href: "/status-board", label: "Status Board" },
+  { href: "/handoff-journal", label: "Handoff Journal" },
 ] as const;
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,6 +59,13 @@ const statusBoardHighlights = [
   "Summary bar with service counts, operational ratio, and open incident totals",
 ];
 
+const handoffJournalHighlights = [
+  "Chronological shift-change entries with status badges and priority levels",
+  "Operator transition tracking with from/to attribution and tag-based filtering",
+  "Shift rotation panels showing time windows and entry counts per handoff",
+  "Summary metrics for open, escalated, and resolved items across rotations",
+];
+
 const teamDirectoryHighlights = [
   "Cross-functional directory with grouped profiles and availability states",
   "Spotlight panel featuring role highlights and shared skill breakdowns",
@@ -549,6 +556,59 @@ export default function Home() {
             </p>
             <ul className="mt-5 space-y-4">
               {statusBoardHighlights.map((item) => (
+                <li
+                  key={item}
+                  className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"
+                >
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.06)]">
+        <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1fr)_minmax(260px,0.9fr)] lg:px-12 lg:py-10">
+          <div className="space-y-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-orange-700">
+              Issue 199 / Handoff Journal
+            </p>
+            <div className="space-y-3">
+              <h2 className="max-w-2xl text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                Track shift-change handoffs with status tracking, operator
+                attribution, and rotation timelines.
+              </h2>
+              <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
+                The handoff journal captures open items, blockers, and ownership
+                transitions between operator shifts so nothing falls through
+                during rotation changes.
+              </p>
+            </div>
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/handoff-journal"
+                className="inline-flex items-center justify-center rounded-full bg-orange-700 px-6 py-3 text-sm font-semibold text-orange-50 transition hover:bg-orange-800"
+              >
+                Open handoff journal
+              </Link>
+              <a
+                href="https://github.com/iamasx/api-test/issues/199"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Review issue scope
+              </a>
+            </div>
+          </div>
+
+          <div className="rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Journal features
+            </p>
+            <ul className="mt-5 space-y-4">
+              {handoffJournalHighlights.map((item) => (
                 <li
                   key={item}
                   className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"


### PR DESCRIPTION
## Summary
- Adds `handoff-journal` route with shift-change protocol layout, status badges, and operator handoff steps
- Touches shared files (`package.json`, `.github/workflows/build.yml`, `src/app/layout.tsx`, `src/app/page.tsx`) for conflict-surface testing
- First revision deliberately fails CI (missing `data.ts` validation step) — repaired in a follow-up commit

## Test plan
- [ ] First CI run should fail on the handoff-journal data module check
- [ ] Subsequent push fixes CI and keeps the PR open
- [ ] Shared files are edited alongside route work
- [ ] Final diff is at least 120 changed lines

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)