### PR TITLE
feat: add telemetry-desk shared app-shell overlap

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,6 +38,12 @@
   --status-operational: #059669;
   --status-degraded: #d97706;
   --status-outage: #dc2626;
+
+  /* Telemetry desk accent palette */
+  --telemetry-accent: #0369a1;
+  --telemetry-accent-light: rgba(3, 105, 161, 0.08);
+  --telemetry-accent-glow: rgba(3, 105, 161, 0.15);
+  --telemetry-surface: rgba(240, 249, 255, 0.9);
 }
 
 @theme inline {
@@ -327,4 +333,43 @@ a {
 .status-service-card:hover {
   border-color: rgba(148, 163, 184, 0.5);
   background-color: rgba(255, 255, 255, 0.9);
+}
+
+/* ── Telemetry desk accent utilities ─────────────────────── */
+
+.telemetry-hero {
+  background: linear-gradient(
+    135deg,
+    var(--telemetry-surface) 0%,
+    var(--surface) 100%
+  );
+}
+
+.telemetry-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(3, 105, 161, 0.25);
+  background: var(--telemetry-accent-light);
+  padding: 0.25rem 0.75rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--telemetry-accent);
+}
+
+.telemetry-badge::before {
+  content: "";
+  width: 0.375rem;
+  height: 0.375rem;
+  border-radius: 9999px;
+  background: var(--telemetry-accent);
+  animation: telemetry-pulse 2.5s ease-in-out infinite;
+}
+
+@keyframes telemetry-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -64,7 +64,7 @@ export default function RootLayout({
         {children}
         <footer className="mt-auto border-t border-[var(--line)] py-6 text-center">
           <p className="section-label text-slate-500">
-            Archive Signals &middot; Team Directory &middot; Status Board &middot; Built for conflict testing
+            Archive Signals &middot; Telemetry &middot; Team Directory &middot; Status Board &middot; Built for conflict testing
           </p>
         </footer>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,6 +33,7 @@ const navLinks = [
   { href: "/queue-monitor", label: "Queue Monitor" },
   { href: "/parcel-hub", label: "Parcel Hub" },
   { href: "/status-board", label: "Status Board" },
+  { href: "/telemetry-desk", label: "Telemetry" },
 ] as const;
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,6 +59,12 @@ const statusBoardHighlights = [
   "Summary bar with service counts, operational ratio, and open incident totals",
 ];
 
+const telemetryDeskHighlights = [
+  "Live signal source health with throughput, latency, and uptime metrics",
+  "KPI summary cards showing healthy, degraded, and down source counts",
+  "Severity-tagged alert feed with timestamps and operational context",
+];
+
 const teamDirectoryHighlights = [
   "Cross-functional directory with grouped profiles and availability states",
   "Spotlight panel featuring role highlights and shared skill breakdowns",
@@ -549,6 +555,59 @@ export default function Home() {
             </p>
             <ul className="mt-5 space-y-4">
               {statusBoardHighlights.map((item) => (
+                <li
+                  key={item}
+                  className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"
+                >
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="route-entry-link overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--telemetry-surface)] shadow-[0_20px_90px_rgba(15,23,42,0.06)]">
+        <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1fr)_minmax(260px,0.9fr)] lg:px-12 lg:py-10">
+          <div className="space-y-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-[var(--telemetry-accent)]">
+              Issue 200 / Telemetry Desk
+            </p>
+            <div className="space-y-3">
+              <h2 className="max-w-2xl text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                Monitor signal health, ingestion throughput, and pipeline alerts
+                from a unified telemetry surface.
+              </h2>
+              <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
+                The telemetry desk consolidates live signal sources, latency
+                monitors, and alert feeds into a single operational view for
+                teams managing archive ingestion pipelines.
+              </p>
+            </div>
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/telemetry-desk"
+                className="inline-flex items-center justify-center rounded-full bg-[var(--telemetry-accent)] px-6 py-3 text-sm font-semibold text-white transition hover:bg-sky-800"
+              >
+                Open telemetry desk
+              </Link>
+              <a
+                href="https://github.com/iamasx/api-test/issues/200"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Review issue scope
+              </a>
+            </div>
+          </div>
+
+          <div className="rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Telemetry capabilities
+            </p>
+            <ul className="mt-5 space-y-4">
+              {telemetryDeskHighlights.map((item) => (
                 <li
                   key={item}
                   className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"

--- a/src/app/telemetry-desk/page.tsx
+++ b/src/app/telemetry-desk/page.tsx
@@ -1,0 +1,190 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Telemetry Desk",
+  description:
+    "Live telemetry streams, signal health monitors, and ingestion pipeline status for archive-driven teams.",
+};
+
+const signalSources = [
+  {
+    id: "src-1",
+    name: "Ingest Pipeline Alpha",
+    status: "healthy" as const,
+    throughput: "12.4k events/s",
+    latency: "23ms p99",
+    uptime: "99.97%",
+  },
+  {
+    id: "src-2",
+    name: "Archive Replay Stream",
+    status: "degraded" as const,
+    throughput: "3.1k events/s",
+    latency: "142ms p99",
+    uptime: "98.2%",
+  },
+  {
+    id: "src-3",
+    name: "Field Sensor Network",
+    status: "healthy" as const,
+    throughput: "8.7k events/s",
+    latency: "34ms p99",
+    uptime: "99.91%",
+  },
+  {
+    id: "src-4",
+    name: "Experiment Telemetry Bus",
+    status: "down" as const,
+    throughput: "0 events/s",
+    latency: "—",
+    uptime: "91.4%",
+  },
+];
+
+const recentAlerts = [
+  {
+    id: "alert-1",
+    severity: "critical",
+    message: "Experiment Telemetry Bus unresponsive for 12m",
+    timestamp: "2026-04-23T05:48:00Z",
+  },
+  {
+    id: "alert-2",
+    severity: "warning",
+    message: "Archive Replay latency exceeding 100ms p99 threshold",
+    timestamp: "2026-04-23T05:32:00Z",
+  },
+  {
+    id: "alert-3",
+    severity: "info",
+    message: "Ingest Pipeline Alpha scaled to 3 replicas",
+    timestamp: "2026-04-23T05:10:00Z",
+  },
+];
+
+function statusColor(status: "healthy" | "degraded" | "down") {
+  switch (status) {
+    case "healthy":
+      return "bg-emerald-500";
+    case "degraded":
+      return "bg-amber-500";
+    case "down":
+      return "bg-red-500";
+  }
+}
+
+function severityBadge(severity: string) {
+  switch (severity) {
+    case "critical":
+      return "border-red-300 bg-red-50 text-red-700";
+    case "warning":
+      return "border-amber-300 bg-amber-50 text-amber-700";
+    default:
+      return "border-sky-300 bg-sky-50 text-sky-700";
+  }
+}
+
+export default function TelemetryDeskPage() {
+  const healthyCount = signalSources.filter(
+    (s) => s.status === "healthy"
+  ).length;
+  const degradedCount = signalSources.filter(
+    (s) => s.status === "degraded"
+  ).length;
+  const downCount = signalSources.filter((s) => s.status === "down").length;
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-[var(--section-gap)] px-6 py-12 sm:px-10 lg:px-12">
+      {/* Hero */}
+      <section className="telemetry-hero section-card border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.08)]">
+        <div className="space-y-4">
+          <p className="section-label text-[var(--telemetry-accent)]">
+            Telemetry Desk
+          </p>
+          <h1 className="heading-tight max-w-3xl text-4xl text-slate-950 sm:text-5xl">
+            Signal health, ingestion throughput, and pipeline status at a glance.
+          </h1>
+          <p className="max-w-2xl text-lg leading-8 text-slate-600">
+            The telemetry desk consolidates live signal sources, latency
+            monitors, and alert feeds into a single operational view for
+            teams managing archive ingestion pipelines.
+          </p>
+        </div>
+
+        {/* KPI row */}
+        <div className="mt-8 grid gap-4 sm:grid-cols-3">
+          <div className="rounded-[var(--card-radius)] border border-emerald-200 bg-emerald-50 px-5 py-4">
+            <p className="section-label text-emerald-600">Healthy</p>
+            <p className="mt-1 text-3xl font-semibold text-emerald-700">
+              {healthyCount}
+            </p>
+          </div>
+          <div className="rounded-[var(--card-radius)] border border-amber-200 bg-amber-50 px-5 py-4">
+            <p className="section-label text-amber-600">Degraded</p>
+            <p className="mt-1 text-3xl font-semibold text-amber-700">
+              {degradedCount}
+            </p>
+          </div>
+          <div className="rounded-[var(--card-radius)] border border-red-200 bg-red-50 px-5 py-4">
+            <p className="section-label text-red-600">Down</p>
+            <p className="mt-1 text-3xl font-semibold text-red-700">
+              {downCount}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Signal sources */}
+      <section className="section-card border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.06)]">
+        <p className="section-label text-slate-500">Signal Sources</p>
+        <div className="mt-6 space-y-4">
+          {signalSources.map((source) => (
+            <div
+              key={source.id}
+              className="flex items-center gap-4 rounded-2xl border border-slate-200 bg-white/75 px-5 py-4"
+            >
+              <span
+                className={`h-3 w-3 shrink-0 rounded-full ${statusColor(source.status)}`}
+              />
+              <div className="min-w-0 flex-1">
+                <p className="font-medium text-slate-900">{source.name}</p>
+                <p className="mt-0.5 text-sm text-slate-500">
+                  {source.throughput} · {source.latency} · Uptime{" "}
+                  {source.uptime}
+                </p>
+              </div>
+              <span className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+                {source.status}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Recent alerts */}
+      <section className="section-card border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.06)]">
+        <p className="section-label text-slate-500">Recent Alerts</p>
+        <div className="mt-6 space-y-3">
+          {recentAlerts.map((alert) => (
+            <div
+              key={alert.id}
+              className="flex items-start gap-3 rounded-2xl border border-slate-200 bg-white/75 px-5 py-4"
+            >
+              <span
+                className={`mt-0.5 inline-block rounded-full border px-2.5 py-0.5 text-xs font-semibold uppercase ${severityBadge(alert.severity)}`}
+              >
+                {alert.severity}
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="text-sm text-slate-700">{alert.message}</p>
+                <p className="mt-1 text-xs text-slate-400">
+                  {new Date(alert.timestamp).toLocaleString()}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `telemetry-desk` route with signal health monitoring, KPI cards, and alert feed
- Updates shared `layout.tsx` nav with Telemetry link
- Applies global style tokens and landing page entry for telemetry-desk
- Intentionally overlaps `layout.tsx`, `globals.css`, and `page.tsx` for conflict testing

Closes #200

## Test plan
- [ ] Verify `/telemetry-desk` route renders signal sources, KPIs, and alerts
- [ ] Verify nav bar includes Telemetry link
- [ ] Verify landing page has Telemetry Desk section
- [ ] Verify global styles include telemetry accent tokens
- [ ] Confirm diff is at least 120 changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)