### PR TITLE
feat: add status-board route with service health dashboard

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -36,5 +36,8 @@ jobs:
       - name: Run tests
         run: npx vitest run src/app/command-log/
 
+      - name: Status board health check
+        run: npm run status-board:check
+
       - name: Build project
         run: npm run build

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -36,8 +36,5 @@ jobs:
       - name: Run tests
         run: npx vitest run src/app/command-log/
 
-      - name: Status board health check
-        run: npm run status-board:check
-
       - name: Build project
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "Archive Signals – experiment registry, field guides, and operational dashboards",
-  "keywords": ["api-test", "command-log", "operations"],
+  "keywords": ["api-test", "command-log", "operations", "status-board"],
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -512,7 +512,7 @@ export default function Home() {
         <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1fr)_minmax(260px,0.9fr)] lg:px-12 lg:py-10">
           <div className="space-y-5">
             <p className="text-sm font-semibold uppercase tracking-[0.28em] text-amber-800">
-              Issue 196 / Status Board
+              Issue 198 / Status Board
             </p>
             <div className="space-y-3">
               <h2 className="max-w-2xl text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
@@ -533,7 +533,7 @@ export default function Home() {
                 Open status board
               </Link>
               <a
-                href="https://github.com/iamasx/api-test/issues/196"
+                href="https://github.com/iamasx/api-test/issues/198"
                 className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
                 target="_blank"
                 rel="noreferrer"

--- a/src/app/status-board/_components/health-summary.tsx
+++ b/src/app/status-board/_components/health-summary.tsx
@@ -1,0 +1,37 @@
+import type { StatusBoardView } from "../_data/status-board-data";
+
+const healthLabel = (summary: StatusBoardView["summary"]) => {
+  if (summary.down > 0) return { text: "Degraded — Outage Detected", color: "text-rose-700 bg-rose-50 border-rose-200" };
+  if (summary.degraded > 0) return { text: "Partially Degraded", color: "text-amber-700 bg-amber-50 border-amber-200" };
+  if (summary.maintenance > 0) return { text: "Operational — Maintenance Active", color: "text-sky-700 bg-sky-50 border-sky-200" };
+  return { text: "All Systems Operational", color: "text-emerald-700 bg-emerald-50 border-emerald-200" };
+};
+
+export function HealthSummary({ summary }: { summary: StatusBoardView["summary"] }) {
+  const label = healthLabel(summary);
+
+  return (
+    <div className={`rounded-2xl border p-6 ${label.color}`}>
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] opacity-60">System Status</p>
+      <p className="mt-2 text-2xl font-bold">{label.text}</p>
+      <div className="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <div>
+          <p className="text-xs font-medium opacity-60">Healthy</p>
+          <p className="text-xl font-semibold">{summary.healthy}/{summary.total}</p>
+        </div>
+        <div>
+          <p className="text-xs font-medium opacity-60">Degraded</p>
+          <p className="text-xl font-semibold">{summary.degraded}</p>
+        </div>
+        <div>
+          <p className="text-xs font-medium opacity-60">Down</p>
+          <p className="text-xl font-semibold">{summary.down}</p>
+        </div>
+        <div>
+          <p className="text-xs font-medium opacity-60">Avg Latency</p>
+          <p className="text-xl font-semibold">{summary.avgLatency}ms</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/status-board/_components/service-card.tsx
+++ b/src/app/status-board/_components/service-card.tsx
@@ -1,0 +1,46 @@
+import type { StatusItem } from "../_data/status-board-data";
+
+const statusColors: Record<StatusItem["status"], { bg: string; text: string; dot: string }> = {
+  healthy: { bg: "bg-emerald-50", text: "text-emerald-700", dot: "bg-emerald-500" },
+  degraded: { bg: "bg-amber-50", text: "text-amber-700", dot: "bg-amber-500" },
+  down: { bg: "bg-rose-50", text: "text-rose-700", dot: "bg-rose-500" },
+  maintenance: { bg: "bg-slate-100", text: "text-slate-600", dot: "bg-slate-400" },
+};
+
+export function ServiceCard({ item }: { item: StatusItem }) {
+  const colors = statusColors[item.status];
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white/80 p-5 shadow-sm transition hover:shadow-md">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <h3 className="truncate text-base font-semibold text-slate-900">{item.service}</h3>
+          <p className="mt-0.5 text-xs text-slate-500">{item.owner}</p>
+        </div>
+        <span
+          className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium ${colors.bg} ${colors.text}`}
+        >
+          <span className={`h-1.5 w-1.5 rounded-full ${colors.dot}`} />
+          {item.status}
+        </span>
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        <div className="rounded-lg bg-slate-50/80 px-3 py-2">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-400">Latency</p>
+          <p className="mt-0.5 text-lg font-semibold text-slate-800">
+            {item.latency > 0 ? `${item.latency}ms` : "—"}
+          </p>
+        </div>
+        <div className="rounded-lg bg-slate-50/80 px-3 py-2">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-slate-400">Uptime</p>
+          <p className="mt-0.5 text-lg font-semibold text-slate-800">{item.uptime}%</p>
+        </div>
+      </div>
+
+      <p className="mt-3 text-[11px] text-slate-400">
+        Last checked {new Date(item.lastChecked).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit" })}
+      </p>
+    </div>
+  );
+}

--- a/src/app/status-board/_components/uptime-bar.tsx
+++ b/src/app/status-board/_components/uptime-bar.tsx
@@ -1,0 +1,37 @@
+import type { StatusItem } from "../_data/status-board-data";
+
+const uptimeColor = (uptime: number) => {
+  if (uptime >= 99.9) return "bg-emerald-500";
+  if (uptime >= 99.5) return "bg-amber-400";
+  return "bg-rose-500";
+};
+
+export function UptimeBar({ items }: { items: StatusItem[] }) {
+  const sorted = [...items].sort((a, b) => b.uptime - a.uptime);
+  const overallUptime =
+    sorted.length > 0 ? (sorted.reduce((acc, s) => acc + s.uptime, 0) / sorted.length).toFixed(2) : "0.00";
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white/80 p-6 shadow-sm">
+      <div className="flex items-baseline justify-between">
+        <h3 className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-500">Uptime Overview</h3>
+        <p className="text-2xl font-bold text-slate-900">{overallUptime}%</p>
+      </div>
+
+      <div className="mt-5 space-y-3">
+        {sorted.map((svc) => (
+          <div key={svc.id} className="flex items-center gap-3">
+            <span className="w-28 truncate text-xs font-medium text-slate-600">{svc.service}</span>
+            <div className="relative h-2 flex-1 overflow-hidden rounded-full bg-slate-100">
+              <div
+                className={`absolute inset-y-0 left-0 rounded-full ${uptimeColor(svc.uptime)}`}
+                style={{ width: `${Math.min(svc.uptime, 100)}%` }}
+              />
+            </div>
+            <span className="w-14 text-right text-xs font-semibold text-slate-700">{svc.uptime}%</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/status-board/_data/status-board-data.ts
+++ b/src/app/status-board/_data/status-board-data.ts
@@ -1,0 +1,144 @@
+export interface StatusItem {
+  id: string;
+  service: string;
+  status: "healthy" | "degraded" | "down" | "maintenance";
+  latency: number;
+  uptime: number;
+  lastChecked: string;
+  owner: string;
+}
+
+export interface IncidentNote {
+  id: string;
+  serviceId: string;
+  timestamp: string;
+  message: string;
+  severity: "info" | "warning" | "critical";
+}
+
+const statusItems: StatusItem[] = [
+  {
+    id: "svc-001",
+    service: "API Gateway",
+    status: "healthy",
+    latency: 42,
+    uptime: 99.98,
+    lastChecked: "2026-04-23T08:12:00Z",
+    owner: "Platform Team",
+  },
+  {
+    id: "svc-002",
+    service: "Auth Service",
+    status: "degraded",
+    latency: 310,
+    uptime: 99.72,
+    lastChecked: "2026-04-23T08:11:30Z",
+    owner: "Identity Squad",
+  },
+  {
+    id: "svc-003",
+    service: "Payment Processor",
+    status: "healthy",
+    latency: 88,
+    uptime: 99.95,
+    lastChecked: "2026-04-23T08:12:00Z",
+    owner: "Payments Team",
+  },
+  {
+    id: "svc-004",
+    service: "Notification Hub",
+    status: "down",
+    latency: 0,
+    uptime: 97.31,
+    lastChecked: "2026-04-23T07:58:00Z",
+    owner: "Messaging Team",
+  },
+  {
+    id: "svc-005",
+    service: "Search Index",
+    status: "healthy",
+    latency: 67,
+    uptime: 99.91,
+    lastChecked: "2026-04-23T08:12:00Z",
+    owner: "Discovery Team",
+  },
+  {
+    id: "svc-006",
+    service: "CDN Edge",
+    status: "maintenance",
+    latency: 0,
+    uptime: 99.88,
+    lastChecked: "2026-04-23T06:00:00Z",
+    owner: "Infrastructure",
+  },
+  {
+    id: "svc-007",
+    service: "Data Pipeline",
+    status: "healthy",
+    latency: 125,
+    uptime: 99.84,
+    lastChecked: "2026-04-23T08:11:45Z",
+    owner: "Data Engineering",
+  },
+  {
+    id: "svc-008",
+    service: "Object Storage",
+    status: "healthy",
+    latency: 35,
+    uptime: 99.99,
+    lastChecked: "2026-04-23T08:12:00Z",
+    owner: "Infrastructure",
+  },
+];
+
+const incidentNotes: IncidentNote[] = [
+  {
+    id: "inc-001",
+    serviceId: "svc-004",
+    timestamp: "2026-04-23T07:55:00Z",
+    message: "Notification Hub unreachable — investigating upstream provider outage.",
+    severity: "critical",
+  },
+  {
+    id: "inc-002",
+    serviceId: "svc-002",
+    timestamp: "2026-04-23T07:40:00Z",
+    message: "Auth Service latency elevated after config rollout. Rollback in progress.",
+    severity: "warning",
+  },
+  {
+    id: "inc-003",
+    serviceId: "svc-006",
+    timestamp: "2026-04-23T05:30:00Z",
+    message: "Scheduled CDN Edge maintenance window — traffic rerouted to secondary PoPs.",
+    severity: "info",
+  },
+];
+
+export interface StatusBoardView {
+  services: StatusItem[];
+  incidents: IncidentNote[];
+  summary: {
+    total: number;
+    healthy: number;
+    degraded: number;
+    down: number;
+    maintenance: number;
+    avgLatency: number;
+  };
+}
+
+export function getStatusBoardView(): StatusBoardView {
+  const healthy = statusItems.filter((s) => s.status === "healthy").length;
+  const degraded = statusItems.filter((s) => s.status === "degraded").length;
+  const down = statusItems.filter((s) => s.status === "down").length;
+  const maintenance = statusItems.filter((s) => s.status === "maintenance").length;
+  const active = statusItems.filter((s) => s.latency > 0);
+  const avgLatency = active.length > 0 ? Math.round(active.reduce((a, s) => a + s.latency, 0) / active.length) : 0;
+
+  return {
+    services: statusItems,
+    incidents: incidentNotes,
+    summary: { total: statusItems.length, healthy, degraded, down, maintenance, avgLatency },
+  };
+}

--- a/src/app/status-board/page.tsx
+++ b/src/app/status-board/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 
+import { HealthSummary } from "./_components/health-summary";
 import { ServiceCard } from "./_components/service-card";
 import { UptimeBar } from "./_components/uptime-bar";
 import { getStatusBoardView } from "./_data/status-board-data";
@@ -63,6 +64,9 @@ export default function StatusBoardPage() {
             </div>
           </div>
         </section>
+
+        {/* Health summary banner */}
+        <HealthSummary summary={summary} />
 
         {/* Service grid */}
         <section>

--- a/src/app/status-board/page.tsx
+++ b/src/app/status-board/page.tsx
@@ -1,184 +1,115 @@
 import type { Metadata } from "next";
+import Link from "next/link";
+
+import { ServiceCard } from "./_components/service-card";
+import { UptimeBar } from "./_components/uptime-bar";
+import { getStatusBoardView } from "./_data/status-board-data";
 
 export const metadata: Metadata = {
   title: "Status Board",
-  description:
-    "Real-time service health dashboard with uptime indicators and incident history.",
-};
-
-interface ServiceEntry {
-  name: string;
-  status: "operational" | "degraded" | "outage";
-  uptime: string;
-  lastIncident: string;
-}
-
-interface IncidentEntry {
-  id: string;
-  title: string;
-  severity: "critical" | "major" | "minor";
-  service: string;
-  openedAt: string;
-  resolvedAt: string | null;
-}
-
-const services: ServiceEntry[] = [
-  { name: "API Gateway", status: "operational", uptime: "99.98%", lastIncident: "12 days ago" },
-  { name: "Auth Service", status: "operational", uptime: "99.95%", lastIncident: "3 days ago" },
-  { name: "Data Pipeline", status: "degraded", uptime: "98.72%", lastIncident: "2 hours ago" },
-  { name: "Object Storage", status: "operational", uptime: "99.99%", lastIncident: "31 days ago" },
-  { name: "Search Index", status: "outage", uptime: "97.40%", lastIncident: "Ongoing" },
-  { name: "Notification Relay", status: "operational", uptime: "99.91%", lastIncident: "7 days ago" },
-];
-
-const recentIncidents: IncidentEntry[] = [
-  {
-    id: "INC-4021",
-    title: "Search Index cluster unresponsive after shard rebalance",
-    severity: "critical",
-    service: "Search Index",
-    openedAt: "2026-04-23T08:14:00Z",
-    resolvedAt: null,
-  },
-  {
-    id: "INC-4020",
-    title: "Data Pipeline throughput drop during upstream schema migration",
-    severity: "major",
-    service: "Data Pipeline",
-    openedAt: "2026-04-23T06:30:00Z",
-    resolvedAt: null,
-  },
-  {
-    id: "INC-4019",
-    title: "Auth Service elevated 401 rate from expired token cache",
-    severity: "minor",
-    service: "Auth Service",
-    openedAt: "2026-04-20T14:05:00Z",
-    resolvedAt: "2026-04-20T15:22:00Z",
-  },
-  {
-    id: "INC-4018",
-    title: "API Gateway intermittent 502s on /v2/batch endpoint",
-    severity: "major",
-    service: "API Gateway",
-    openedAt: "2026-04-11T09:48:00Z",
-    resolvedAt: "2026-04-11T11:03:00Z",
-  },
-];
-
-const statusColor: Record<ServiceEntry["status"], string> = {
-  operational: "bg-emerald-500",
-  degraded: "bg-amber-500",
-  outage: "bg-red-500",
-};
-
-const statusLabel: Record<ServiceEntry["status"], string> = {
-  operational: "Operational",
-  degraded: "Degraded",
-  outage: "Outage",
-};
-
-const severityStyle: Record<IncidentEntry["severity"], string> = {
-  critical:
-    "border-red-200 bg-red-50 text-red-700",
-  major:
-    "border-amber-200 bg-amber-50 text-amber-700",
-  minor:
-    "border-slate-200 bg-slate-50 text-slate-600",
+  description: "Service health dashboard with live status, latency metrics, and incident timeline.",
 };
 
 export default function StatusBoardPage() {
-  const operational = services.filter((s) => s.status === "operational").length;
-  const total = services.length;
+  const { services, incidents, summary } = getStatusBoardView();
 
   return (
-    <main className="status-board mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-12 sm:px-10 lg:px-12">
-      <header className="space-y-3">
-        <p className="section-label text-[var(--status-accent)]">
-          Status Board
-        </p>
-        <h1 className="heading-tight max-w-3xl text-4xl text-slate-950 sm:text-5xl">
-          Service health overview and incident timeline.
-        </h1>
-        <p className="max-w-2xl text-lg leading-8 text-slate-600">
-          Monitor uptime across critical services, review recent incidents, and
-          track resolution progress from a single view.
-        </p>
-      </header>
-
-      {/* ── Summary bar ── */}
-      <div className="grid gap-4 sm:grid-cols-3">
-        <div className="status-summary-card rounded-[var(--card-radius)] border border-[var(--line)] bg-[var(--surface)] px-5 py-4">
-          <p className="section-label text-slate-500">Services</p>
-          <p className="mt-1 text-2xl font-semibold text-slate-950">{total}</p>
-        </div>
-        <div className="status-summary-card rounded-[var(--card-radius)] border border-[var(--line)] bg-[var(--surface)] px-5 py-4">
-          <p className="section-label text-slate-500">Operational</p>
-          <p className="mt-1 text-2xl font-semibold text-emerald-700">{operational}/{total}</p>
-        </div>
-        <div className="status-summary-card rounded-[var(--card-radius)] border border-[var(--line)] bg-[var(--surface)] px-5 py-4">
-          <p className="section-label text-slate-500">Open Incidents</p>
-          <p className="mt-1 text-2xl font-semibold text-red-700">
-            {recentIncidents.filter((i) => !i.resolvedAt).length}
-          </p>
-        </div>
-      </div>
-
-      {/* ── Service health grid ── */}
-      <section className="section-card border border-[var(--line)] bg-[var(--surface)]">
-        <p className="section-label text-slate-500">Service Health</p>
-        <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {services.map((svc) => (
-            <div
-              key={svc.name}
-              className="status-service-card flex items-start gap-3 rounded-2xl border border-slate-200 bg-white/75 px-4 py-4"
+    <main className="min-h-screen bg-[#f0f4f8]">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
+        {/* Header */}
+        <section className="rounded-[2rem] bg-white/90 p-8 shadow-sm sm:p-10">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-500">
+              Service Health
+            </p>
+            <Link
+              href="/"
+              className="rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
             >
-              <span
-                className={`mt-1.5 inline-block h-2.5 w-2.5 shrink-0 rounded-full ${statusColor[svc.status]}`}
-              />
-              <div className="min-w-0">
-                <p className="text-sm font-semibold text-slate-900">{svc.name}</p>
-                <p className="mt-0.5 text-xs text-slate-500">
-                  {statusLabel[svc.status]} &middot; {svc.uptime} uptime
-                </p>
-                <p className="mt-0.5 text-xs text-slate-400">
-                  Last incident: {svc.lastIncident}
-                </p>
-              </div>
+              Back to overview
+            </Link>
+          </div>
+
+          <div className="mt-8 space-y-4">
+            <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl lg:text-6xl">
+              Status Board
+            </h1>
+            <p className="max-w-3xl text-base leading-8 text-slate-600 sm:text-lg">
+              Real-time service health overview with latency metrics, uptime tracking, and active incident notes.
+            </p>
+          </div>
+
+          {/* Summary counters */}
+          <div className="mt-8 flex flex-wrap gap-4">
+            <div className="rounded-xl border border-slate-200 bg-slate-50/80 px-5 py-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Services</p>
+              <p className="mt-1 text-2xl font-semibold text-slate-900">{summary.total}</p>
             </div>
-          ))}
-        </div>
-      </section>
+            <div className="rounded-xl border border-emerald-200 bg-emerald-50/80 px-5 py-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-500">Healthy</p>
+              <p className="mt-1 text-2xl font-semibold text-emerald-700">{summary.healthy}</p>
+            </div>
+            <div className="rounded-xl border border-amber-200 bg-amber-50/80 px-5 py-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-500">Degraded</p>
+              <p className="mt-1 text-2xl font-semibold text-amber-700">{summary.degraded}</p>
+            </div>
+            <div className="rounded-xl border border-rose-200 bg-rose-50/80 px-5 py-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-rose-500">Down</p>
+              <p className="mt-1 text-2xl font-semibold text-rose-700">{summary.down}</p>
+            </div>
+            <div className="rounded-xl border border-slate-200 bg-slate-50/80 px-5 py-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Avg Latency</p>
+              <p className="mt-1 text-2xl font-semibold text-slate-900">{summary.avgLatency}ms</p>
+            </div>
+          </div>
+        </section>
 
-      {/* ── Incident timeline ── */}
-      <section className="section-card border border-[var(--line)] bg-[var(--surface)]">
-        <p className="section-label text-slate-500">Recent Incidents</p>
-        <ul className="mt-5 space-y-3">
-          {recentIncidents.map((inc) => (
-            <li
-              key={inc.id}
-              className={`rounded-2xl border px-5 py-4 ${severityStyle[inc.severity]}`}
-            >
-              <div className="flex items-center gap-2">
-                <span className="text-xs font-bold">{inc.id}</span>
-                <span className="rounded-full border border-current/20 px-2 py-0.5 text-[0.625rem] font-semibold uppercase tracking-wide">
-                  {inc.severity}
-                </span>
-                {!inc.resolvedAt && (
-                  <span className="ml-auto text-[0.625rem] font-semibold uppercase tracking-wide text-red-600">
-                    Open
-                  </span>
-                )}
-              </div>
-              <p className="mt-1.5 text-sm font-medium leading-snug">{inc.title}</p>
-              <p className="mt-1 text-xs opacity-70">
-                {inc.service} &middot; Opened {inc.openedAt.slice(0, 10)}
-                {inc.resolvedAt && ` · Resolved ${inc.resolvedAt.slice(0, 10)}`}
-              </p>
-            </li>
-          ))}
-        </ul>
-      </section>
+        {/* Service grid */}
+        <section>
+          <h2 className="mb-5 text-lg font-semibold text-slate-800">All Services</h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {services.map((svc) => (
+              <ServiceCard key={svc.id} item={svc} />
+            ))}
+          </div>
+        </section>
+
+        {/* Uptime overview */}
+        <UptimeBar items={services} />
+
+        {/* Incident timeline */}
+        <section className="rounded-[2rem] bg-white/90 p-8 shadow-sm sm:p-10">
+          <h2 className="text-lg font-semibold text-slate-800">Active Incidents</h2>
+          <div className="mt-6 space-y-4">
+            {incidents.map((note) => {
+              const severityStyles: Record<string, string> = {
+                critical: "border-rose-200 bg-rose-50/60 text-rose-700",
+                warning: "border-amber-200 bg-amber-50/60 text-amber-700",
+                info: "border-sky-200 bg-sky-50/60 text-sky-700",
+              };
+              return (
+                <div
+                  key={note.id}
+                  className={`rounded-xl border p-4 ${severityStyles[note.severity] ?? "border-slate-200 bg-slate-50"}`}
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="rounded-full bg-white/70 px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wider">
+                      {note.severity}
+                    </span>
+                    <span className="text-xs opacity-70">
+                      {new Date(note.timestamp).toLocaleTimeString("en-US", {
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      })}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-sm leading-6">{note.message}</p>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Add `status-board` route with service health cards, latency/uptime metrics, and incident timeline
- Touch `package.json` keywords and `.github/workflows/quality-gate.yml` for conflict surface testing
- First revision intentionally includes a CI step referencing a non-existent script (`status-board:check`) to validate failure handling

## Test plan
- [ ] Verify first CI run fails on the missing `status-board:check` script
- [ ] Confirm status-board route renders service cards and incident notes
- [ ] Verify shared file edits in `package.json` and `quality-gate.yml`
- [ ] Final diff is at least 120 changed lines

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)