### PR TITLE
feat: add status-board shared entry overlap (#196)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -31,6 +31,13 @@
   --accent-violet: #7c3aed;
   --accent-violet-light: #ede9fe;
   --accent-violet-text: #5b21b6;
+
+  /* Status-board tokens */
+  --status-accent: #b45309;
+  --status-accent-light: rgba(180, 83, 9, 0.08);
+  --status-operational: #059669;
+  --status-degraded: #d97706;
+  --status-outage: #dc2626;
 }
 
 @theme inline {
@@ -291,4 +298,33 @@ a {
 
 .queue-parcel-link:hover::after {
   transform: translateX(2px);
+}
+
+/* ── Status-board shared styles ──────────────────────────── */
+
+.status-board .section-card {
+  border-radius: var(--section-radius);
+  padding: var(--section-padding-y) var(--section-padding-x);
+}
+
+.status-summary-card {
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.status-summary-card:hover {
+  border-color: var(--status-accent);
+  box-shadow: 0 4px 16px rgba(180, 83, 9, 0.10);
+}
+
+.status-service-card {
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease;
+}
+
+.status-service-card:hover {
+  border-color: rgba(148, 163, 184, 0.5);
+  background-color: rgba(255, 255, 255, 0.9);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -63,7 +63,7 @@ export default function RootLayout({
         {children}
         <footer className="mt-auto border-t border-[var(--line)] py-6 text-center">
           <p className="section-label text-slate-500">
-            Archive Signals &middot; Team Directory &middot; Built for conflict testing
+            Archive Signals &middot; Team Directory &middot; Status Board &middot; Built for conflict testing
           </p>
         </footer>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,6 +32,7 @@ const navLinks = [
   { href: "/experiment-registry", label: "Experiments" },
   { href: "/queue-monitor", label: "Queue Monitor" },
   { href: "/parcel-hub", label: "Parcel Hub" },
+  { href: "/status-board", label: "Status Board" },
 ] as const;
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,6 +53,12 @@ const queueParcelHighlights = [
   "Inter-hub transfer table tracking volume and priority between regions",
 ];
 
+const statusBoardHighlights = [
+  "Real-time service health grid with uptime percentages and status indicators",
+  "Incident timeline with severity badges and open/resolved state tracking",
+  "Summary bar with service counts, operational ratio, and open incident totals",
+];
+
 const teamDirectoryHighlights = [
   "Cross-functional directory with grouped profiles and availability states",
   "Spotlight panel featuring role highlights and shared skill breakdowns",
@@ -490,6 +496,59 @@ export default function Home() {
             </p>
             <ul className="mt-5 space-y-4">
               {queueParcelHighlights.map((item) => (
+                <li
+                  key={item}
+                  className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"
+                >
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="route-entry-link overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.06)]">
+        <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1fr)_minmax(260px,0.9fr)] lg:px-12 lg:py-10">
+          <div className="space-y-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-amber-800">
+              Issue 196 / Status Board
+            </p>
+            <div className="space-y-3">
+              <h2 className="max-w-2xl text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                Monitor service health, uptime trends, and active incidents
+                from a single status board.
+              </h2>
+              <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
+                The status board aggregates service-level health indicators,
+                uptime percentages, and a chronological incident feed so
+                operators can assess system posture at a glance.
+              </p>
+            </div>
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/status-board"
+                className="inline-flex items-center justify-center rounded-full bg-amber-800 px-6 py-3 text-sm font-semibold text-amber-50 transition hover:bg-amber-900"
+              >
+                Open status board
+              </Link>
+              <a
+                href="https://github.com/iamasx/api-test/issues/196"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Review issue scope
+              </a>
+            </div>
+          </div>
+
+          <div className="rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Board capabilities
+            </p>
+            <ul className="mt-5 space-y-4">
+              {statusBoardHighlights.map((item) => (
                 <li
                   key={item}
                   className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"

--- a/src/app/status-board/page.tsx
+++ b/src/app/status-board/page.tsx
@@ -6,7 +6,91 @@ export const metadata: Metadata = {
     "Real-time service health dashboard with uptime indicators and incident history.",
 };
 
+interface ServiceEntry {
+  name: string;
+  status: "operational" | "degraded" | "outage";
+  uptime: string;
+  lastIncident: string;
+}
+
+interface IncidentEntry {
+  id: string;
+  title: string;
+  severity: "critical" | "major" | "minor";
+  service: string;
+  openedAt: string;
+  resolvedAt: string | null;
+}
+
+const services: ServiceEntry[] = [
+  { name: "API Gateway", status: "operational", uptime: "99.98%", lastIncident: "12 days ago" },
+  { name: "Auth Service", status: "operational", uptime: "99.95%", lastIncident: "3 days ago" },
+  { name: "Data Pipeline", status: "degraded", uptime: "98.72%", lastIncident: "2 hours ago" },
+  { name: "Object Storage", status: "operational", uptime: "99.99%", lastIncident: "31 days ago" },
+  { name: "Search Index", status: "outage", uptime: "97.40%", lastIncident: "Ongoing" },
+  { name: "Notification Relay", status: "operational", uptime: "99.91%", lastIncident: "7 days ago" },
+];
+
+const recentIncidents: IncidentEntry[] = [
+  {
+    id: "INC-4021",
+    title: "Search Index cluster unresponsive after shard rebalance",
+    severity: "critical",
+    service: "Search Index",
+    openedAt: "2026-04-23T08:14:00Z",
+    resolvedAt: null,
+  },
+  {
+    id: "INC-4020",
+    title: "Data Pipeline throughput drop during upstream schema migration",
+    severity: "major",
+    service: "Data Pipeline",
+    openedAt: "2026-04-23T06:30:00Z",
+    resolvedAt: null,
+  },
+  {
+    id: "INC-4019",
+    title: "Auth Service elevated 401 rate from expired token cache",
+    severity: "minor",
+    service: "Auth Service",
+    openedAt: "2026-04-20T14:05:00Z",
+    resolvedAt: "2026-04-20T15:22:00Z",
+  },
+  {
+    id: "INC-4018",
+    title: "API Gateway intermittent 502s on /v2/batch endpoint",
+    severity: "major",
+    service: "API Gateway",
+    openedAt: "2026-04-11T09:48:00Z",
+    resolvedAt: "2026-04-11T11:03:00Z",
+  },
+];
+
+const statusColor: Record<ServiceEntry["status"], string> = {
+  operational: "bg-emerald-500",
+  degraded: "bg-amber-500",
+  outage: "bg-red-500",
+};
+
+const statusLabel: Record<ServiceEntry["status"], string> = {
+  operational: "Operational",
+  degraded: "Degraded",
+  outage: "Outage",
+};
+
+const severityStyle: Record<IncidentEntry["severity"], string> = {
+  critical:
+    "border-red-200 bg-red-50 text-red-700",
+  major:
+    "border-amber-200 bg-amber-50 text-amber-700",
+  minor:
+    "border-slate-200 bg-slate-50 text-slate-600",
+};
+
 export default function StatusBoardPage() {
+  const operational = services.filter((s) => s.status === "operational").length;
+  const total = services.length;
+
   return (
     <main className="status-board mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-12 sm:px-10 lg:px-12">
       <header className="space-y-3">
@@ -22,11 +106,78 @@ export default function StatusBoardPage() {
         </p>
       </header>
 
+      {/* ── Summary bar ── */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        <div className="status-summary-card rounded-[var(--card-radius)] border border-[var(--line)] bg-[var(--surface)] px-5 py-4">
+          <p className="section-label text-slate-500">Services</p>
+          <p className="mt-1 text-2xl font-semibold text-slate-950">{total}</p>
+        </div>
+        <div className="status-summary-card rounded-[var(--card-radius)] border border-[var(--line)] bg-[var(--surface)] px-5 py-4">
+          <p className="section-label text-slate-500">Operational</p>
+          <p className="mt-1 text-2xl font-semibold text-emerald-700">{operational}/{total}</p>
+        </div>
+        <div className="status-summary-card rounded-[var(--card-radius)] border border-[var(--line)] bg-[var(--surface)] px-5 py-4">
+          <p className="section-label text-slate-500">Open Incidents</p>
+          <p className="mt-1 text-2xl font-semibold text-red-700">
+            {recentIncidents.filter((i) => !i.resolvedAt).length}
+          </p>
+        </div>
+      </div>
+
+      {/* ── Service health grid ── */}
       <section className="section-card border border-[var(--line)] bg-[var(--surface)]">
-        <p className="section-label text-slate-500">System Status</p>
-        <p className="mt-4 text-base text-slate-600">
-          Service health indicators will appear here once mock data is loaded.
-        </p>
+        <p className="section-label text-slate-500">Service Health</p>
+        <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {services.map((svc) => (
+            <div
+              key={svc.name}
+              className="status-service-card flex items-start gap-3 rounded-2xl border border-slate-200 bg-white/75 px-4 py-4"
+            >
+              <span
+                className={`mt-1.5 inline-block h-2.5 w-2.5 shrink-0 rounded-full ${statusColor[svc.status]}`}
+              />
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-slate-900">{svc.name}</p>
+                <p className="mt-0.5 text-xs text-slate-500">
+                  {statusLabel[svc.status]} &middot; {svc.uptime} uptime
+                </p>
+                <p className="mt-0.5 text-xs text-slate-400">
+                  Last incident: {svc.lastIncident}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── Incident timeline ── */}
+      <section className="section-card border border-[var(--line)] bg-[var(--surface)]">
+        <p className="section-label text-slate-500">Recent Incidents</p>
+        <ul className="mt-5 space-y-3">
+          {recentIncidents.map((inc) => (
+            <li
+              key={inc.id}
+              className={`rounded-2xl border px-5 py-4 ${severityStyle[inc.severity]}`}
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-bold">{inc.id}</span>
+                <span className="rounded-full border border-current/20 px-2 py-0.5 text-[0.625rem] font-semibold uppercase tracking-wide">
+                  {inc.severity}
+                </span>
+                {!inc.resolvedAt && (
+                  <span className="ml-auto text-[0.625rem] font-semibold uppercase tracking-wide text-red-600">
+                    Open
+                  </span>
+                )}
+              </div>
+              <p className="mt-1.5 text-sm font-medium leading-snug">{inc.title}</p>
+              <p className="mt-1 text-xs opacity-70">
+                {inc.service} &middot; Opened {inc.openedAt.slice(0, 10)}
+                {inc.resolvedAt && ` · Resolved ${inc.resolvedAt.slice(0, 10)}`}
+              </p>
+            </li>
+          ))}
+        </ul>
       </section>
     </main>
   );

--- a/src/app/status-board/page.tsx
+++ b/src/app/status-board/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Status Board",
+  description:
+    "Real-time service health dashboard with uptime indicators and incident history.",
+};
+
+export default function StatusBoardPage() {
+  return (
+    <main className="status-board mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-12 sm:px-10 lg:px-12">
+      <header className="space-y-3">
+        <p className="section-label text-[var(--status-accent)]">
+          Status Board
+        </p>
+        <h1 className="heading-tight max-w-3xl text-4xl text-slate-950 sm:text-5xl">
+          Service health overview and incident timeline.
+        </h1>
+        <p className="max-w-2xl text-lg leading-8 text-slate-600">
+          Monitor uptime across critical services, review recent incidents, and
+          track resolution progress from a single view.
+        </p>
+      </header>
+
+      <section className="section-card border border-[var(--line)] bg-[var(--surface)]">
+        <p className="section-label text-slate-500">System Status</p>
+        <p className="mt-4 text-base text-slate-600">
+          Service health indicators will appear here once mock data is loaded.
+        </p>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds the `status-board` route with service health dashboard shell
- Updates shared `layout.tsx` nav, `globals.css` styles, and `page.tsx` landing entry
- Intentionally overlaps shared files for conflict testing per issue scope

Closes #196

## Test plan
- [ ] Verify `/status-board` route renders correctly
- [ ] Confirm nav link appears in shared layout
- [ ] Check landing page includes status-board entry section
- [ ] Validate global CSS additions do not break existing routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)