### PR TITLE
feat: add watchtower route with alert digest

### DIFF
--- a/src/app/watchtower/_data/watchtower-data.ts
+++ b/src/app/watchtower/_data/watchtower-data.ts
@@ -1,0 +1,108 @@
+export type WatchtowerAlertSeverity = "critical" | "elevated" | "watch";
+export type WatchtowerHealthTone = "stable" | "watch" | "risk";
+export type WatchtowerNoteStatus = "queued" | "tracking" | "closed";
+
+export const watchtowerOverview = {
+  eyebrow: "Watchtower route / Alert digest",
+  title: "Scan alert drift, service health, and operator notes before the next rotation.",
+  description:
+    "The watchtower route compresses high-signal alerts, short health summaries, and operator context into a single handoff view for the next duty lead.",
+  digestWindow: "Digest window · 18:00 to 22:00 UTC",
+  focusNote:
+    "Two critical digests still need explicit operator approval before automation can widen traffic again.",
+  reviewWindow: "22:20 UTC",
+  shiftLead: "Shift lead · N. Alvarez",
+};
+
+export const watchtowerAlerts = [
+  {
+    severity: "critical" as const,
+    service: "Orbital relay mesh",
+    title: "Fallback relays are saturating the north relay spine.",
+    scope: "21 relays / 3 regions",
+    owner: "M. Chen",
+    digest:
+      "Queue pressure crossed the auto-shed threshold twice after the west mesh reroute, so traffic is holding on manual trims until the next clean sample.",
+    nextStep: "Approve a 12-minute route trim before 22:20 UTC.",
+    affectedSystems: ["mesh-east-2", "north-spine cache", "fallback batch 4"],
+  },
+  {
+    severity: "elevated" as const,
+    service: "Payload scanner lane",
+    title: "Scanner calibration drift is slowing parcel verification.",
+    scope: "4 scanner cells",
+    owner: "R. Singh",
+    digest:
+      "Verification retries climbed to 8.3% after the last firmware pull, which is still within failover range but now exceeding the shift target.",
+    nextStep: "Hold inbound surges until calibration pass C finishes.",
+    affectedSystems: ["scan-west-4", "handoff queue", "firmware mirror"],
+  },
+  {
+    severity: "critical" as const,
+    service: "Manifest handoff",
+    title: "Manifest receipts are arriving behind the operator review window.",
+    scope: "2 late cutover lanes",
+    owner: "L. Ortega",
+    digest:
+      "Late receipts are not dropping traffic, but they are now compressing the audit review window enough to threaten the next automated closeout.",
+    nextStep: "Keep closeout manual for the next two digest cycles.",
+    affectedSystems: ["receipt stream", "lane-c7", "audit closeout bot"],
+  },
+];
+
+export const watchtowerHealthSummaries = [
+  {
+    tone: "risk" as const,
+    title: "Relay mesh health",
+    signal: "Capacity margin 68%",
+    owner: "Transit network",
+    summary:
+      "Manual trims are keeping the mesh stable, but the reserve margin is now thin enough that another burst would force wider shedding.",
+    recommendation: "Keep bulk traffic capped until relay drift clears.",
+  },
+  {
+    tone: "watch" as const,
+    title: "Verification lane health",
+    signal: "Retry rate 8.3%",
+    owner: "Dock systems",
+    summary:
+      "Scanner throughput is still acceptable for current volume, although the current retry profile will create queue drag if inbound demand spikes.",
+    recommendation: "Finish calibration pass C before lifting intake caps.",
+  },
+  {
+    tone: "stable" as const,
+    title: "Operator coverage health",
+    signal: "Coverage confidence 94%",
+    owner: "Shift command",
+    summary:
+      "Crew overlap and specialist coverage remain strong enough to absorb manual interventions without extending the next handoff.",
+    recommendation: "Use the reserve reviewer to shadow critical receipts only.",
+  },
+];
+
+export const watchtowerOperatorNotes = [
+  {
+    status: "tracking" as const,
+    channel: "Ops chat",
+    author: "N. Alvarez",
+    time: "21:42 UTC",
+    note: "Keep the north relay trim manual until queue depth stays below 68% for two consecutive samples.",
+    followUp: "Review after the 22:10 UTC digest snapshot.",
+  },
+  {
+    status: "queued" as const,
+    channel: "Dock review",
+    author: "R. Singh",
+    time: "21:37 UTC",
+    note: "Bundle scanner drift updates into one operator post so the incoming shift does not chase duplicate recalibration notes.",
+    followUp: "Publish a single rollup before handoff.",
+  },
+  {
+    status: "closed" as const,
+    channel: "Audit lane",
+    author: "L. Ortega",
+    time: "21:31 UTC",
+    note: "Receipt lag is manageable as long as the closeout bot stays paused and lane C7 remains on a human review path.",
+    followUp: "Confirm pause state in the 22:20 UTC review.",
+  },
+];

--- a/src/app/watchtower/page.test.tsx
+++ b/src/app/watchtower/page.test.tsx
@@ -16,6 +16,7 @@ afterEach(() => {
 describe("WatchtowerPage", () => {
   it("renders the route shell headings, pulse copy, and primary actions", () => {
     render(<WatchtowerPage />);
+    console.log("watchtower heading", watchtowerOverview.title);
 
     expect(screen.getByRole("heading", { name: watchtowerOverview.title })).toBeInTheDocument();
     expect(screen.getByText(watchtowerOverview.digestWindow)).toBeInTheDocument();
@@ -43,6 +44,7 @@ describe("WatchtowerPage", () => {
 
   it("renders every alert digest card with scope, ownership, systems, and next steps", () => {
     render(<WatchtowerPage />);
+    console.log("watchtower alert count", watchtowerAlerts.length);
 
     const alertList = screen.getByRole("list", { name: /watchtower alert digest cards/i });
 

--- a/src/app/watchtower/page.test.tsx
+++ b/src/app/watchtower/page.test.tsx
@@ -1,0 +1,103 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  watchtowerAlerts,
+  watchtowerHealthSummaries,
+  watchtowerOperatorNotes,
+  watchtowerOverview,
+} from "./_data/watchtower-data";
+import WatchtowerPage from "./page";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("WatchtowerPage", () => {
+  it("renders the route shell headings, pulse copy, and primary actions", () => {
+    render(<WatchtowerPage />);
+
+    expect(screen.getByRole("heading", { name: watchtowerOverview.title })).toBeInTheDocument();
+    expect(screen.getByText(watchtowerOverview.digestWindow)).toBeInTheDocument();
+    expect(screen.getByText(watchtowerOverview.shiftLead)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        name: /alert digest cards built for the next operator handoff/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        name: /short health summaries for the systems that shape the handoff/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /jump to alert digest/i }),
+    ).toHaveAttribute("href", "#watchtower-digest");
+    expect(
+      screen.getByRole("link", { name: /review health summaries/i }),
+    ).toHaveAttribute("href", "#watchtower-health");
+    expect(
+      screen.getByRole("link", { name: /back to route index/i }),
+    ).toHaveAttribute("href", "/");
+  });
+
+  it("renders every alert digest card with scope, ownership, systems, and next steps", () => {
+    render(<WatchtowerPage />);
+
+    const alertList = screen.getByRole("list", { name: /watchtower alert digest cards/i });
+
+    expect(alertList.querySelectorAll(':scope > [role="listitem"]')).toHaveLength(watchtowerAlerts.length);
+
+    for (const alert of watchtowerAlerts) {
+      const card = within(alertList)
+        .getByRole("heading", { name: alert.title })
+        .closest('[role="listitem"]');
+
+      expect(card).toBeTruthy();
+      expect(card?.textContent).toContain(alert.service);
+      expect(card?.textContent).toContain(alert.scope);
+      expect(card?.textContent).toContain(alert.owner);
+      expect(card?.textContent).toContain(alert.nextStep);
+      expect(card?.textContent).toContain(alert.affectedSystems[0]);
+    }
+  });
+
+  it("renders health summaries with signals, owners, and recommendations", () => {
+    render(<WatchtowerPage />);
+
+    const healthSection = screen.getByLabelText(/watchtower health summaries/i);
+
+    for (const summary of watchtowerHealthSummaries) {
+      expect(within(healthSection).getByText(summary.title)).toBeInTheDocument();
+      expect(within(healthSection).getByText(summary.signal)).toBeInTheDocument();
+      expect(within(healthSection).getByText(summary.owner)).toBeInTheDocument();
+      expect(within(healthSection).getByText(summary.recommendation)).toBeInTheDocument();
+    }
+
+    expect(within(healthSection).getByText("Stable")).toBeInTheDocument();
+    expect(within(healthSection).getByText("Watch")).toBeInTheDocument();
+    expect(within(healthSection).getByText("Risk")).toBeInTheDocument();
+  });
+
+  it("renders the operator notes rail with the handoff anchor and every note entry", () => {
+    render(<WatchtowerPage />);
+
+    const notesRail = screen.getByLabelText(/operator notes rail/i);
+    const noteList = screen.getByRole("list", { name: /watchtower operator note entries/i });
+
+    expect(within(notesRail).getByText(watchtowerOverview.focusNote)).toBeInTheDocument();
+    expect(noteList.querySelectorAll(':scope > [role="listitem"]')).toHaveLength(watchtowerOperatorNotes.length);
+
+    for (const note of watchtowerOperatorNotes) {
+      const card = within(noteList)
+        .getByText(note.author)
+        .closest('[role="listitem"]');
+
+      expect(card).toBeTruthy();
+      expect(card?.textContent).toContain(note.channel);
+      expect(card?.textContent).toContain(note.time);
+      expect(card?.textContent).toContain(note.note);
+      expect(card?.textContent).toContain(note.followUp);
+    }
+  });
+});

--- a/src/app/watchtower/page.tsx
+++ b/src/app/watchtower/page.tsx
@@ -1,0 +1,270 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import styles from "./watchtower.module.css";
+import {
+  watchtowerAlerts,
+  watchtowerHealthSummaries,
+  watchtowerOperatorNotes,
+  watchtowerOverview,
+} from "./_data/watchtower-data";
+
+export const metadata: Metadata = {
+  title: "Watchtower",
+  description:
+    "Alert digest cards, service health summaries, and a compact operator notes rail for the next shift handoff.",
+};
+
+const alertToneClasses = {
+  critical: styles.alertCritical,
+  elevated: styles.alertElevated,
+  watch: styles.alertWatch,
+};
+
+const alertToneLabels = {
+  critical: "Critical",
+  elevated: "Elevated",
+  watch: "Watch",
+};
+
+const healthToneClasses = {
+  stable: styles.healthStable,
+  watch: styles.healthWatch,
+  risk: styles.healthRisk,
+};
+
+const healthToneLabels = {
+  stable: "Stable",
+  watch: "Watch",
+  risk: "Risk",
+};
+
+const noteStatusClasses = {
+  queued: styles.noteQueued,
+  tracking: styles.noteTracking,
+  closed: styles.noteClosed,
+};
+
+const noteStatusLabels = {
+  queued: "Queued",
+  tracking: "Tracking",
+  closed: "Closed",
+};
+
+export default function WatchtowerPage() {
+  const criticalAlerts = watchtowerAlerts.filter(
+    (alert) => alert.severity === "critical",
+  ).length;
+  const watchSummaries = watchtowerHealthSummaries.filter(
+    (summary) => summary.tone !== "stable",
+  ).length;
+  const activeNotes = watchtowerOperatorNotes.filter((note) => note.status !== "closed").length;
+
+  return (
+    <main className={`${styles.shell} px-6 py-12 text-slate-50 sm:px-10 lg:px-16`}>
+      <div className="relative mx-auto flex w-full max-w-7xl flex-col gap-6">
+        <header
+          className={`${styles.hero} rounded-[2rem] border border-white/10 p-8 backdrop-blur sm:p-10`}
+        >
+          <div className="grid gap-6 xl:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)]">
+            <div className="space-y-5">
+              <p className="text-sm font-semibold uppercase tracking-[0.28em] text-amber-100/80">
+                {watchtowerOverview.eyebrow}
+              </p>
+              <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-balance text-white sm:text-5xl lg:text-6xl">
+                {watchtowerOverview.title}
+              </h1>
+              <p className="max-w-3xl text-base leading-8 text-slate-200 sm:text-lg">
+                {watchtowerOverview.description}
+              </p>
+
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <a
+                  href="#watchtower-digest"
+                  className="inline-flex items-center justify-center rounded-full bg-amber-300 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-amber-200"
+                >
+                  Jump to alert digest
+                </a>
+                <a
+                  href="#watchtower-health"
+                  className="inline-flex items-center justify-center rounded-full border border-white/14 bg-white/8 px-5 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-300/35 hover:bg-white/12"
+                >
+                  Review health summaries
+                </a>
+                <Link
+                  href="/"
+                  className="inline-flex items-center justify-center rounded-full border border-white/14 bg-slate-950/30 px-5 py-3 text-sm font-semibold text-slate-100 transition hover:border-white/28 hover:bg-slate-900/60"
+                >
+                  Back to route index
+                </Link>
+              </div>
+            </div>
+            <aside className={`${styles.panel} rounded-[1.6rem] border border-white/10 p-6`}>
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+                Handoff pulse
+              </p>
+              <p className="mt-3 text-lg font-semibold text-white">
+                {watchtowerOverview.digestWindow}
+              </p>
+              <p className="mt-3 text-sm leading-7 text-slate-200">
+                {watchtowerOverview.focusNote}
+              </p>
+              <p className="mt-4 text-sm font-medium text-cyan-100">
+                {watchtowerOverview.shiftLead}
+              </p>
+              <div className="mt-5 grid gap-3 sm:grid-cols-3">
+                {[
+                  { label: "Critical digests", value: String(criticalAlerts) },
+                  { label: "Watch summaries", value: String(watchSummaries) },
+                  { label: "Active notes", value: String(activeNotes) },
+                ].map((stat) => (
+                  <div key={stat.label} className="rounded-[1.2rem] border border-white/10 bg-white/6 px-4 py-4">
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">{stat.label}</p>
+                    <p className="mt-2 text-2xl font-semibold tracking-tight text-white">{stat.value}</p>
+                  </div>
+                ))}
+              </div>
+            </aside>
+          </div>
+        </header>
+
+        <div className={styles.contentGrid}>
+          <div className={styles.stack}>
+            <section
+              aria-label="Watchtower alert digest"
+              className={`${styles.panel} rounded-[1.9rem] border border-white/10 p-6`}
+              id="watchtower-digest"
+            >
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+                <div className="space-y-2">
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+                    Alert digest cards
+                  </p>
+                  <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+                    Alert digest cards built for the next operator handoff
+                  </h2>
+                </div>
+                <p className="max-w-2xl text-sm leading-7 text-slate-300">
+                  Each card compresses service scope, digest context, affected
+                  systems, and the next operator decision into one scan-ready
+                  block.
+                </p>
+              </div>
+              <div aria-label="Watchtower alert digest cards" className={`${styles.list} mt-6`} role="list">
+                {watchtowerAlerts.map((alert) => (
+                  <article
+                    key={alert.title}
+                    className={`${styles.alertCard} ${alertToneClasses[alert.severity]} rounded-[1.6rem] border px-5 py-5`}
+                    role="listitem"
+                  >
+                    <div className="flex flex-wrap gap-2">
+                      <span className={`${styles.pill} rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-white`}>
+                        {alertToneLabels[alert.severity]}
+                      </span>
+                      <span className="rounded-full border border-white/10 bg-white/4 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-300">
+                        {alert.service}
+                      </span>
+                    </div>
+                    <h3 className="mt-3 text-2xl font-semibold tracking-tight text-white">{alert.title}</h3>
+                    <p className="mt-2 text-sm text-slate-300">{alert.scope} · {alert.owner}</p>
+                    <p className="mt-4 max-w-4xl text-sm leading-7 text-slate-200">{alert.digest}</p>
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      {alert.affectedSystems.map((system) => (
+                        <span key={system} className={`${styles.pill} rounded-full px-3 py-1 text-xs text-slate-200`}>
+                          {system}
+                        </span>
+                      ))}
+                    </div>
+                    <p className="mt-4 text-sm leading-7 text-cyan-100">{alert.nextStep}</p>
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <section
+              aria-label="Watchtower health summaries"
+              className={`${styles.panel} rounded-[1.9rem] border border-white/10 p-6`}
+              id="watchtower-health"
+            >
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+                <div className="space-y-2">
+                  <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+                    Health summaries
+                  </p>
+                  <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+                    Short health summaries for the systems that shape the handoff
+                  </h2>
+                </div>
+                <p className="max-w-2xl text-sm leading-7 text-slate-300">
+                  These summaries stay short on purpose: one signal, one owner,
+                  one recommendation, and no hidden secondary state.
+                </p>
+              </div>
+
+              <div className={`${styles.healthGrid} mt-6`}>
+                {watchtowerHealthSummaries.map((summary) => (
+                  <article
+                    key={summary.title}
+                    className={`${styles.healthCard} ${healthToneClasses[summary.tone]} rounded-[1.5rem] border px-5 py-5`}
+                  >
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">{healthToneLabels[summary.tone]}</p>
+                    <h3 className="mt-3 text-xl font-semibold text-white">{summary.title}</h3>
+                    <p className="mt-2 text-sm font-medium text-cyan-100">{summary.signal}</p>
+                    <p className="mt-3 text-sm leading-7 text-slate-200">{summary.summary}</p>
+                    <div className="mt-5 rounded-[1.2rem] border border-white/10 bg-white/5 px-4 py-4">
+                      <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">Owner</p>
+                      <p className="mt-2 text-sm text-slate-100">{summary.owner}</p>
+                      <p className="mt-3 text-sm leading-7 text-slate-200">{summary.recommendation}</p>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </section>
+          </div>
+
+          <aside
+            aria-label="Operator notes rail"
+            className={`${styles.rail} rounded-[1.9rem] border border-white/10 p-5`}
+          >
+            <div className={styles.stickyRail}>
+              <section className="rounded-[1.5rem] border border-white/10 bg-white/5 p-5">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+                  Operator notes rail
+                </p>
+                <h2 className="mt-3 text-2xl font-semibold tracking-tight text-white">
+                  Compact notes that survive the handoff
+                </h2>
+                <p className="mt-3 text-sm leading-7 text-slate-300">
+                  Notes stay compact so the incoming operator can scan intent,
+                  ownership, and follow-up without reopening the full incident
+                  trail.
+                </p>
+              </section>
+
+              <div aria-label="Watchtower operator note entries" className={styles.list} role="list">
+                {watchtowerOperatorNotes.map((note) => (
+                  <article
+                    key={`${note.author}-${note.time}`}
+                    className={`${styles.noteCard} ${noteStatusClasses[note.status]} rounded-[1.4rem] border px-4 py-4`}
+                    role="listitem"
+                  >
+                    <div className="flex flex-wrap gap-2">
+                      <span className={`${styles.pill} rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-white`}>
+                        {noteStatusLabels[note.status]}
+                      </span>
+                      <span className="text-xs font-medium uppercase tracking-[0.14em] text-slate-400">{note.channel}</span>
+                    </div>
+                    <p className="mt-3 text-sm font-semibold text-white">{note.author}</p>
+                    <p className="mt-1 text-xs uppercase tracking-[0.14em] text-slate-400">{note.time}</p>
+                    <p className="mt-3 text-sm leading-7 text-slate-200">{note.note}</p>
+                    <p className="mt-3 text-sm leading-7 text-cyan-100">{note.followUp}</p>
+                  </article>
+                ))}
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/watchtower/watchtower.module.css
+++ b/src/app/watchtower/watchtower.module.css
@@ -1,0 +1,191 @@
+.shell {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 14% 18%, rgba(251, 191, 36, 0.16), transparent 24%),
+    radial-gradient(circle at 86% 14%, rgba(34, 211, 238, 0.16), transparent 22%),
+    radial-gradient(circle at 50% 100%, rgba(248, 113, 113, 0.14), transparent 28%),
+    linear-gradient(180deg, #08111b 0%, #0d1b2f 48%, #030712 100%);
+}
+
+.shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(120deg, rgba(255, 255, 255, 0.04), transparent 45%),
+    repeating-linear-gradient(
+      90deg,
+      rgba(148, 163, 184, 0.05) 0,
+      rgba(148, 163, 184, 0.05) 1px,
+      transparent 1px,
+      transparent 72px
+    );
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 1), transparent 96%);
+}
+
+.hero {
+  position: relative;
+  background:
+    linear-gradient(145deg, rgba(15, 23, 42, 0.82), rgba(8, 15, 30, 0.94)),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(15, 23, 42, 0.14));
+  box-shadow: 0 38px 120px rgba(2, 6, 23, 0.42);
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  right: -5rem;
+  top: -4rem;
+  width: 18rem;
+  height: 18rem;
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgba(34, 211, 238, 0.22), transparent 66%);
+  filter: blur(18px);
+  pointer-events: none;
+}
+
+.panel,
+.rail {
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.8), rgba(8, 15, 30, 0.94));
+  box-shadow: 0 30px 90px rgba(2, 6, 23, 0.26);
+}
+
+.contentGrid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.stack,
+.list {
+  display: grid;
+  gap: 1rem;
+}
+
+.alertCard {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.82), rgba(6, 11, 24, 0.96));
+  box-shadow: 0 26px 70px rgba(2, 6, 23, 0.28);
+}
+
+.alertCard::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 1.25rem;
+  bottom: 1.25rem;
+  width: 0.34rem;
+  border-radius: 9999px;
+  opacity: 0.95;
+}
+
+.alertCritical {
+  border-color: rgba(251, 113, 133, 0.3);
+}
+
+.alertCritical::before {
+  background: linear-gradient(180deg, rgba(244, 63, 94, 0.98), rgba(190, 24, 93, 0.88));
+  box-shadow: 0 0 24px rgba(251, 113, 133, 0.35);
+}
+
+.alertElevated {
+  border-color: rgba(251, 191, 36, 0.28);
+}
+
+.alertElevated::before {
+  background: linear-gradient(180deg, rgba(245, 158, 11, 0.98), rgba(249, 115, 22, 0.88));
+  box-shadow: 0 0 24px rgba(251, 191, 36, 0.35);
+}
+
+.alertWatch {
+  border-color: rgba(34, 211, 238, 0.24);
+}
+
+.alertWatch::before {
+  background: linear-gradient(180deg, rgba(6, 182, 212, 0.98), rgba(14, 165, 233, 0.86));
+  box-shadow: 0 0 24px rgba(34, 211, 238, 0.3);
+}
+
+.pill {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.healthGrid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.healthCard {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(15, 23, 42, 0.3));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.healthStable {
+  border-color: rgba(52, 211, 153, 0.24);
+}
+
+.healthWatch {
+  border-color: rgba(251, 191, 36, 0.24);
+}
+
+.healthRisk {
+  border-color: rgba(251, 113, 133, 0.28);
+}
+
+.stickyRail {
+  position: sticky;
+  top: 2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.noteCard {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(15, 23, 42, 0.26));
+}
+
+.noteQueued {
+  border-color: rgba(251, 191, 36, 0.24);
+}
+
+.noteTracking {
+  border-color: rgba(34, 211, 238, 0.24);
+}
+
+.noteClosed {
+  border-color: rgba(148, 163, 184, 0.2);
+}
+
+@media (min-width: 1200px) {
+  .contentGrid {
+    grid-template-columns: minmax(0, 1.18fr) minmax(300px, 0.82fr);
+    align-items: start;
+  }
+}
+
+@media (max-width: 1199px) {
+  .stickyRail {
+    position: static;
+  }
+}
+
+@media (max-width: 640px) {
+  .hero,
+  .panel,
+  .rail,
+  .alertCard,
+  .healthCard,
+  .noteCard {
+    border-radius: 1.5rem;
+  }
+
+  .alertCard::before {
+    top: 1rem;
+    bottom: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `watchtower` app route with alert digest cards, health summaries, and a compact operator notes rail
- add typed mock data for alert, health, and operator-note content
- add route render tests covering the main watchtower sections

## Testing
- `npx eslint src/app/watchtower/page.tsx src/app/watchtower/page.test.tsx src/app/watchtower/_data/watchtower-data.ts`
- `npx tsc --noEmit`
- `npx vitest run src/app/watchtower/page.test.tsx` *(blocked locally: this session is on Node 20.15.0 while the installed Vitest/Vite/jsdom stack requires Node 20.19+ and fails during startup before tests execute)*

Closes #206