### PR TITLE
feat: add navigator hub shared shell route

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,10 @@
   --nav-height: 3.5rem;
   --ops-accent: #0e7490;
   --ops-accent-light: rgba(14, 116, 144, 0.08);
+  --navigator-accent: #0891b2;
+  --navigator-accent-light: rgba(8, 145, 178, 0.12);
+  --navigator-accent-soft: rgba(34, 211, 238, 0.08);
+  --navigator-ink: #164e63;
 
   /* Shared typography tokens */
   --heading-tracking-tight: -0.025em;
@@ -62,7 +66,8 @@ body {
   background: var(--background);
   color: var(--foreground);
   background-image:
-    radial-gradient(circle at top, rgba(251, 191, 36, 0.22), transparent 36%),
+    radial-gradient(circle at top, rgba(251, 191, 36, 0.18), transparent 32%),
+    radial-gradient(circle at right 18%, rgba(8, 145, 178, 0.14), transparent 26%),
     linear-gradient(180deg, #fcf8ef 0%, #f4efe7 52%, #ebe5d9 100%);
   font-family: var(--font-geist-sans), Arial, Helvetica, sans-serif;
 }
@@ -122,11 +127,27 @@ a {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: var(--nav-height);
-  padding-inline: 1.5rem;
-  background: rgba(255, 251, 240, 0.82);
+  gap: 1rem;
+  min-height: var(--nav-height);
+  padding: 0.875rem 1.5rem;
+  background: rgba(255, 251, 240, 0.86);
   backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--line);
+}
+
+.app-nav__cluster {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.app-nav__eyebrow {
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(8, 145, 178, 0.75);
 }
 
 .app-nav__brand {
@@ -138,6 +159,7 @@ a {
 
 .app-nav__links {
   display: flex;
+  flex-wrap: wrap;
   gap: 1.25rem;
   list-style: none;
   margin: 0;
@@ -158,6 +180,19 @@ a {
 .app-nav__link--active {
   color: var(--ops-accent);
   font-weight: 600;
+}
+
+.app-nav__meta {
+  border-radius: 9999px;
+  border: 1px solid rgba(8, 145, 178, 0.18);
+  background: rgba(255, 255, 255, 0.58);
+  padding: 0.4rem 0.8rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--navigator-ink);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85);
 }
 
 /* ── Operations-center accent utilities ───────────────────── */
@@ -238,6 +273,122 @@ a {
 .route-entry-link:hover {
   transform: translateY(-2px);
   box-shadow: 0 8px 30px rgba(15, 23, 42, 0.12);
+}
+
+/* ── Navigator-hub shared shell styles ────────────────────── */
+
+.navigator-shell-card {
+  position: relative;
+  isolation: isolate;
+}
+
+.navigator-shell-card::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    rgba(8, 145, 178, 0.7) 0%,
+    rgba(34, 211, 238, 0.38) 48%,
+    rgba(251, 191, 36, 0.55) 100%
+  );
+  opacity: 0.7;
+}
+
+.navigator-shell-link {
+  position: relative;
+}
+
+.navigator-shell-link::after {
+  content: "\2192";
+  margin-left: 0.45rem;
+  transition: transform 0.15s ease;
+}
+
+.navigator-shell-link:hover::after {
+  transform: translateX(2px);
+}
+
+.navigator-hub-orbit {
+  position: relative;
+}
+
+.navigator-hub-section {
+  position: relative;
+  overflow: hidden;
+}
+
+.navigator-hub-track {
+  transition:
+    transform 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.navigator-hub-track:hover {
+  transform: translateY(-2px);
+  border-color: rgba(8, 145, 178, 0.24);
+  box-shadow: 0 18px 34px rgba(14, 116, 144, 0.1);
+}
+
+.navigator-hub-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(8, 145, 178, 0.18);
+  background: rgba(255, 255, 255, 0.72);
+  padding: 0.35rem 0.8rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--navigator-ink);
+}
+
+.navigator-hub-kicker::before {
+  content: "";
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 9999px;
+  background: var(--navigator-accent);
+  box-shadow: 0 0 0 0.25rem rgba(8, 145, 178, 0.12);
+}
+
+.navigator-hub-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 9999px;
+  border: 1px solid rgba(8, 145, 178, 0.18);
+  background: var(--navigator-accent-light);
+  padding: 0.35rem 0.75rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--navigator-ink);
+}
+
+.navigator-hub-note {
+  border-left: 3px solid rgba(8, 145, 178, 0.28);
+}
+
+@media (max-width: 960px) {
+  .app-nav {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .app-nav__links {
+    width: 100%;
+    overflow-x: auto;
+    padding-bottom: 0.125rem;
+  }
+
+  .app-nav__meta {
+    display: none;
+  }
 }
 
 /* ── Queue-monitor & parcel-hub shared styles ────────────── */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,11 +19,12 @@ export const metadata: Metadata = {
     template: "%s | Archive Signals",
   },
   description:
-    "Operational dashboards, experiment registries, and field guides for archive-driven teams.",
+    "Operational dashboards, navigator handoff surfaces, experiment registries, and field guides for archive-driven teams.",
 };
 
 const navLinks = [
   { href: "/", label: "Home" },
+  { href: "/navigator-hub", label: "Navigator Hub" },
   { href: "/team-directory", label: "Team Directory" },
   { href: "/archive-browser", label: "Archive" },
   { href: "/research-notebook", label: "Notebook" },
@@ -47,9 +48,12 @@ export default function RootLayout({
     >
       <body className="flex min-h-full flex-col bg-slate-50/40">
         <nav className="app-nav" aria-label="Primary">
-          <Link href="/" className="app-nav__brand">
-            Archive Signals
-          </Link>
+          <div className="app-nav__cluster">
+            <p className="app-nav__eyebrow">Conflict surface</p>
+            <Link href="/" className="app-nav__brand">
+              Archive Signals
+            </Link>
+          </div>
           <ul className="app-nav__links">
             {navLinks.map((link) => (
               <li key={link.href}>
@@ -59,11 +63,13 @@ export default function RootLayout({
               </li>
             ))}
           </ul>
+          <p className="app-nav__meta">Navigator overlap active</p>
         </nav>
         {children}
         <footer className="mt-auto border-t border-[var(--line)] py-6 text-center">
           <p className="section-label text-slate-500">
-            Archive Signals &middot; Team Directory &middot; Status Board &middot; Built for conflict testing
+            Archive Signals &middot; Navigator Hub &middot; Status Board &middot;
+            Built for conflict testing
           </p>
         </footer>
       </body>

--- a/src/app/navigator-hub/page.tsx
+++ b/src/app/navigator-hub/page.tsx
@@ -1,0 +1,275 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Navigator Hub",
+  description:
+    "Shared handoff route for corridor status, intervention rails, and overlap-friendly shell presentation.",
+};
+
+const corridorLanes = [
+  { name: "North Bridge", status: "stable", handoff: "Queue merge confirmed", owner: "Lane Control", window: "18:20-18:40", note: "Inbound medical crates cleared the bridge split, so the return lane can stay on schedule." },
+  { name: "Quay Spine", status: "watch", handoff: "Parcel reroute pending", owner: "Hub Dispatch", window: "18:28-18:52", note: "One express parcel cluster still needs reassignment before the dock window closes." },
+  { name: "Relay Cutover", status: "watch", handoff: "Command review queued", owner: "Signal Desk", window: "18:34-19:05", note: "Operator notes show healthy throughput, but escalation logging is trailing by one checkpoint." },
+  { name: "South Return", status: "stable", handoff: "Fleet handoff ready", owner: "Return Lead", window: "18:45-19:10", note: "The recovery lane is clear enough to absorb secondary load without breaking the outbound rhythm." },
+];
+
+const interventionRails = [
+  { title: "Queue pressure rail", href: "/queue-monitor", action: "Open queue monitor", detail: "Check lane depth, queue age, and transfer readiness before committing a bridge switch." },
+  { title: "Parcel balancing rail", href: "/parcel-hub", action: "Open parcel hub", detail: "Verify hub-to-hub volume and SLA risk before moving the quay spine off its current schedule." },
+  { title: "Escalation rail", href: "/command-log", action: "Open command log", detail: "Review the active event stream when the navigator call needs to explain a reroute or pause." },
+];
+
+const cadenceSteps = [
+  { time: "18:18", title: "Shared shell review", summary: "Confirm the landing page, global shell, and route nav all reflect the current navigator entry point." },
+  { time: "18:26", title: "Queue and parcel cross-check", summary: "Compare queue depth against parcel hub volume before the quay spine shifts into the next window." },
+  { time: "18:41", title: "Command trace update", summary: "Log the chosen intervention rail so downstream operators can reconstruct why the route changed." },
+];
+
+const overlapSignals = [
+  "Landing page hero now points at Navigator Hub instead of a standalone archive-only entry.",
+  "Global shell navigation and footer messaging include the new route to widen the merge surface.",
+  "Shared visual tokens and shell cards are reused across the common app shell.",
+];
+
+const statusClasses: Record<string, string> = {
+  stable: "border-emerald-200 bg-emerald-50 text-emerald-800",
+  watch: "border-amber-200 bg-amber-50 text-amber-800",
+};
+
+export default function NavigatorHubPage() {
+  const stableCorridors = corridorLanes.filter((lane) => lane.status === "stable").length;
+  const watchCorridors = corridorLanes.filter((lane) => lane.status === "watch").length;
+  const handoffWindows = corridorLanes.map((lane) => lane.window).join(" / ");
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
+      <section className="navigator-hub-orbit navigator-shell-card overflow-hidden rounded-[2.4rem] border border-slate-200 bg-[linear-gradient(135deg,#ecfeff_0%,#ffffff_45%,#fff7ed_100%)] shadow-[0_30px_100px_rgba(15,23,42,0.1)]">
+        <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1.16fr)_minmax(300px,0.84fr)] lg:px-12 lg:py-12">
+          <div className="space-y-6">
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="ops-badge">Navigator Hub</span>
+              <span className="navigator-hub-badge">Shared shell route</span>
+            </div>
+
+            <div className="space-y-4">
+              <h1 className="heading-tight max-w-4xl text-4xl text-slate-950 sm:text-5xl">
+                Coordinate corridor handoffs, intervention rails, and shared
+                entry points from one route.
+              </h1>
+              <p className="max-w-3xl text-base leading-8 text-slate-600 sm:text-lg">
+                Navigator Hub is intentionally wired into the same landing page,
+                layout shell, and global presentation layer other routes depend
+                on. It gives operators a single place to review corridor health,
+                choose the next escalation rail, and keep shell-wide cues in
+                sync during overlap-heavy releases.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
+              >
+                Back to overview
+              </Link>
+              <Link
+                href="/operations-center"
+                className="navigator-shell-link inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+              >
+                Open ops center
+              </Link>
+              <a
+                href="https://github.com/iamasx/api-test/issues/216"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Review issue
+              </a>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-3">
+              <article className="rounded-[1.4rem] border border-white/70 bg-white/78 px-4 py-4 shadow-[0_12px_36px_rgba(15,23,42,0.08)]">
+                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  Stable corridors
+                </p>
+                <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+                  {stableCorridors}
+                </p>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  Corridors ready to carry secondary load without a new
+                  escalation branch.
+                </p>
+              </article>
+              <article className="rounded-[1.4rem] border border-white/70 bg-white/78 px-4 py-4 shadow-[0_12px_36px_rgba(15,23,42,0.08)]">
+                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  Watch corridors
+                </p>
+                <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+                  {watchCorridors}
+                </p>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  Active routes that still require queue, parcel, or command
+                  confirmation before the next handoff.
+                </p>
+              </article>
+              <article className="rounded-[1.4rem] border border-white/70 bg-white/78 px-4 py-4 shadow-[0_12px_36px_rgba(15,23,42,0.08)]">
+                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  Handoff windows
+                </p>
+                <p className="mt-3 text-lg font-semibold tracking-tight text-slate-950">
+                  {handoffWindows}
+                </p>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  Planned windows keep the corridor review aligned with the
+                  linked route dashboards.
+                </p>
+              </article>
+            </div>
+          </div>
+
+          <aside className="navigator-shell-card rounded-[1.8rem] border border-slate-200/80 bg-white/78 p-6 shadow-[0_22px_70px_rgba(15,23,42,0.1)]">
+            <p className="section-label text-slate-500">Overlap signals</p>
+            <ul className="mt-5 space-y-4">
+              {overlapSignals.map((signal) => (
+                <li
+                  key={signal}
+                  className="navigator-hub-note rounded-[1.4rem] border border-slate-200 bg-slate-50/90 px-4 py-4 text-sm leading-6 text-slate-600"
+                >
+                  {signal}
+                </li>
+              ))}
+            </ul>
+          </aside>
+        </div>
+      </section>
+
+      <section className="navigator-hub-section overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.08)]">
+        <div className="relative grid gap-6 px-6 py-8 sm:px-10 lg:px-12 lg:py-10">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-2">
+              <p className="navigator-hub-kicker">Corridor handoff board</p>
+              <h2 className="max-w-3xl text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                Review each lane before choosing the next intervention rail.
+              </h2>
+            </div>
+            <p className="max-w-2xl text-sm leading-7 text-slate-600">
+              Every lane card shows the active owner, the current handoff
+              status, and the scheduling window the shell needs to keep visible
+              during the release drill.
+            </p>
+          </div>
+
+          <div className="grid gap-4 lg:grid-cols-2">
+            {corridorLanes.map((lane) => (
+              <article
+                key={lane.name}
+                className="navigator-hub-track rounded-[1.6rem] border border-slate-200 bg-white/85 p-5 shadow-[0_12px_36px_rgba(15,23,42,0.06)]"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-lg font-semibold text-slate-950">
+                      {lane.name}
+                    </p>
+                    <p className="mt-1 text-sm text-slate-500">{lane.owner}</p>
+                  </div>
+                  <span
+                    className={`rounded-full border px-3 py-1 text-[0.6875rem] font-semibold uppercase tracking-[0.14em] ${statusClasses[lane.status]}`}
+                  >
+                    {lane.status}
+                  </span>
+                </div>
+
+                <div className="mt-5 grid gap-3 sm:grid-cols-2">
+                  <div className="rounded-[1.2rem] border border-slate-200 bg-slate-50/90 px-4 py-3">
+                    <p className="text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                      Current handoff
+                    </p>
+                    <p className="mt-2 text-sm font-semibold text-slate-900">
+                      {lane.handoff}
+                    </p>
+                  </div>
+                  <div className="rounded-[1.2rem] border border-slate-200 bg-slate-50/90 px-4 py-3">
+                    <p className="text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                      Window
+                    </p>
+                    <p className="mt-2 text-sm font-semibold text-slate-900">
+                      {lane.window}
+                    </p>
+                  </div>
+                </div>
+
+                <p className="mt-4 text-sm leading-7 text-slate-600">
+                  {lane.note}
+                </p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[minmax(0,1.04fr)_minmax(320px,0.96fr)]">
+        <div className="rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] p-6 shadow-[0_20px_90px_rgba(15,23,42,0.06)] sm:p-8">
+          <div className="space-y-2">
+            <p className="section-label text-slate-500">Intervention rails</p>
+            <h2 className="text-3xl font-semibold tracking-tight text-slate-950">
+              Cross-link into the adjacent route surfaces without leaving the
+              navigator context.
+            </h2>
+          </div>
+
+          <div className="mt-6 grid gap-4">
+            {interventionRails.map((rail) => (
+              <article
+                key={rail.title}
+                className="navigator-shell-card rounded-[1.5rem] border border-slate-200 bg-white/85 p-5 shadow-[0_12px_30px_rgba(15,23,42,0.06)]"
+              >
+                <p className="text-sm font-semibold text-slate-950">
+                  {rail.title}
+                </p>
+                <p className="mt-2 text-sm leading-7 text-slate-600">
+                  {rail.detail}
+                </p>
+                <Link
+                  href={rail.href}
+                  className="navigator-shell-link mt-4 inline-flex items-center text-sm font-semibold text-cyan-700 transition hover:text-cyan-800"
+                >
+                  {rail.action}
+                </Link>
+              </article>
+            ))}
+          </div>
+        </div>
+
+        <aside className="rounded-[2rem] border border-[var(--line)] bg-[linear-gradient(180deg,rgba(240,249,255,0.92),rgba(255,251,235,0.92))] p-6 shadow-[0_20px_90px_rgba(15,23,42,0.06)] sm:p-8">
+          <div className="space-y-2">
+            <p className="section-label text-slate-500">Cadence</p>
+            <h2 className="text-3xl font-semibold tracking-tight text-slate-950">
+              Keep the overlap release moving in a predictable rhythm.
+            </h2>
+          </div>
+
+          <ol className="mt-6 space-y-4">
+            {cadenceSteps.map((step) => (
+              <li
+                key={step.time}
+                className="rounded-[1.4rem] border border-white/70 bg-white/80 px-4 py-4 shadow-[0_10px_28px_rgba(15,23,42,0.05)]"
+              >
+                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-cyan-700">
+                  {step.time}
+                </p>
+                <p className="mt-2 text-base font-semibold text-slate-950">
+                  {step.title}
+                </p>
+                <p className="mt-2 text-sm leading-7 text-slate-600">
+                  {step.summary}
+                </p>
+              </li>
+            ))}
+          </ol>
+        </aside>
+      </section>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,10 @@
 import Link from "next/link";
 import { teamGroups, getDirectoryMetrics } from "@/data/team-directory";
 
-const launchChecks = [
-  "Five mock archive snapshots with visible preservation metadata",
-  "A route-driven detail panel keyed off the snapshot query string",
-  "Render-state coverage for default, targeted, and fallback selections",
+const navigatorHubHighlights = [
+  "New navigator hub route with linked intervention rails across queue, parcel, and command views",
+  "Shared landing-page overlap that rewrites the featured hero around the new route",
+  "Global shell styling updates that intentionally modify the common app nav, footer, and theme tokens",
 ];
 
 const notebookHighlights = [
@@ -73,28 +73,36 @@ export default function Home() {
       <section className="overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.08)]">
         <div className="grid gap-10 px-6 py-10 sm:px-10 lg:grid-cols-[minmax(0,1.2fr)_minmax(260px,0.8fr)] lg:px-12 lg:py-14">
           <div className="space-y-6">
-            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-amber-700">
-              Issue 90 / Archive Route
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-cyan-700">
+              Issue 216 / Navigator Hub
             </p>
             <div className="space-y-4">
               <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-                Controlled conflict drill B landing page headline.
+                Coordinate shared app-shell handoffs from a dedicated navigator
+                hub.
               </h1>
               <p className="max-w-2xl text-lg leading-8 text-slate-600">
-                The new archive browser route focuses on quick inspection:
-                snapshot cards on the left, full metadata detail on the right,
-                and server-rendered selection via the query string.
+                The navigator hub is the new conflict surface for issue 216:
+                one route that pulls together lane pressure, handoff timing,
+                and shared-shell entry points while also rewriting common
+                landing and global presentation files.
               </p>
             </div>
             <div className="flex flex-col gap-4 sm:flex-row">
               <Link
-                href="/archive-browser"
-                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-amber-50 transition hover:bg-slate-800"
+                href="/navigator-hub"
+                className="inline-flex items-center justify-center rounded-full bg-cyan-700 px-6 py-3 text-sm font-semibold text-cyan-50 transition hover:bg-cyan-800"
               >
-                Open archive browser
+                Open navigator hub
+              </Link>
+              <Link
+                href="/operations-center"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+              >
+                Open ops center
               </Link>
               <a
-                href="https://github.com/iamasx/api-test/issues/90"
+                href="https://github.com/iamasx/api-test/issues/216"
                 className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
                 target="_blank"
                 rel="noreferrer"
@@ -106,10 +114,10 @@ export default function Home() {
 
           <div className="rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
             <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
-              Delivery checks
+              Conflict checks
             </p>
             <ul className="mt-5 space-y-4">
-              {launchChecks.map((item) => (
+              {navigatorHubHighlights.map((item) => (
                 <li
                   key={item}
                   className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"


### PR DESCRIPTION
## Summary
- add a new `/navigator-hub` route with corridor handoff and intervention rail content
- rewrite the landing page hero to feature Navigator Hub and link into the new route
- update the shared layout chrome and global styles to widen the shared app-shell conflict surface

## Testing
- `npm run build`
- `npm test` *(currently fails in unrelated existing route tests, including `scenario-explorer`, `mission-planner`, `mission-briefing`, `scenario-board`, `route-planner`, `checkpoint-grid`, `field-guide`, `command-log`, `queue-board`, and `asset-inventory`)*

Closes #216