### PR TITLE
feat: add manifest-room route with discrepancy panel

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,6 +30,7 @@ const navLinks = [
   { href: "/field-guide", label: "Field Guide" },
   { href: "/operations-center", label: "Ops Center" },
   { href: "/experiment-registry", label: "Experiments" },
+  { href: "/manifest-room", label: "Manifest Room" },
   { href: "/queue-monitor", label: "Queue Monitor" },
   { href: "/parcel-hub", label: "Parcel Hub" },
   { href: "/status-board", label: "Status Board" },

--- a/src/app/manifest-room/_data/manifest-room-data.ts
+++ b/src/app/manifest-room/_data/manifest-room-data.ts
@@ -1,0 +1,61 @@
+export const manifestRoomOverview = {
+  eyebrow: "Manifest Room / Dispatch Mock",
+  title: "Stage grouped manifests, package rollups, and discrepancy follow-up before dispatch.",
+  description:
+    "The manifest room keeps outbound groups, package summaries, and compact discrepancy triage on one route so the shift lead can clear exceptions before the next wave closes.",
+  primaryAction: "Review manifest groups",
+  secondaryAction: "Open discrepancy panel",
+};
+
+export const packageSummaries = [
+  { id: "cold-chain", label: "Cold-chain kits", manifested: "184 units", staged: "176 sealed", discrepancy: "2 temperature holds", note: "Split across docks D-14 and H-03 for staggered release." },
+  { id: "archive-canisters", label: "Archive canisters", manifested: "68 canisters", staged: "64 scanned", discrepancy: "1 seal mismatch", note: "Cross-border relay depends on the final seal reconciliation." },
+  { id: "specimen-sleeves", label: "Specimen sleeves", manifested: "420 sleeves", staged: "409 staged", discrepancy: "5 relabel checks", note: "Overflow volume is concentrated in the final-mile overflow group." },
+  { id: "field-repair-packs", label: "Field repair packs", manifested: "52 kits", staged: "52 ready", discrepancy: "No open issues", note: "Ready for immediate release when the relay window opens." },
+] as const;
+
+export const manifestGroups = [
+  {
+    id: "cold-chain-departures",
+    label: "Group 01",
+    title: "Cold-chain departures",
+    description: "Priority medical and preservation freight leaving on the first wave with temperature tracking attached to every manifest.",
+    dock: "Dock D-14",
+    cutoff: "18:20 local",
+    manifests: [
+      { id: "MN-2044", carrier: "Northline Air", lane: "Delta relay", departure: "18:05", status: "sealed", packages: [{ label: "Cryo cassettes", count: "24 cases", staging: "24 sealed" }, { label: "Gel stabilizers", count: "60 packs", staging: "58 staged" }] },
+      { id: "MN-2047", carrier: "Blue Summit Cargo", lane: "Harbor transfer", departure: "18:18", status: "review", packages: [{ label: "Specimen sleeves", count: "108 sleeves", staging: "103 staged" }, { label: "Chain-of-custody tags", count: "108 tags", staging: "108 ready" }] },
+    ],
+  },
+  {
+    id: "cross-border-relay",
+    label: "Group 02",
+    title: "Cross-border relay",
+    description: "Manifests that need customs-ready package labeling and seal confirmation before the relay truck clears the gate.",
+    dock: "Dock B-06",
+    cutoff: "19:05 local",
+    manifests: [
+      { id: "MN-2051", carrier: "Axis Freight", lane: "Northern border", departure: "18:50", status: "holding", packages: [{ label: "Archive canisters", count: "32 canisters", staging: "30 scanned" }, { label: "Repair packs", count: "18 kits", staging: "18 sealed" }] },
+      { id: "MN-2055", carrier: "Relay Eight", lane: "South corridor", departure: "19:02", status: "review", packages: [{ label: "Specimen sleeves", count: "122 sleeves", staging: "120 staged" }, { label: "Archive canisters", count: "18 canisters", staging: "18 sealed" }] },
+    ],
+  },
+  {
+    id: "final-mile-overflow",
+    label: "Group 03",
+    title: "Final-mile overflow",
+    description: "Overflow manifests held for same-day courier reassignment when the primary wave exceeds the planned package mix.",
+    dock: "Dock H-03",
+    cutoff: "20:10 local",
+    manifests: [
+      { id: "MN-2059", carrier: "Last Mile One", lane: "Metro west", departure: "19:40", status: "review", packages: [{ label: "Cold-chain kits", count: "36 units", staging: "34 sealed" }, { label: "Repair packs", count: "14 kits", staging: "14 ready" }] },
+      { id: "MN-2062", carrier: "Courier Atlas", lane: "Metro east", departure: "20:05", status: "sealed", packages: [{ label: "Specimen sleeves", count: "190 sleeves", staging: "186 staged" }, { label: "Cold-chain kits", count: "28 units", staging: "28 sealed" }] },
+    ],
+  },
+] as const;
+
+export const manifestDiscrepancies = [
+  { id: "disc-01", severity: "critical", title: "Seal count mismatch on archive canisters", manifestId: "MN-2051", packageLabel: "Archive canisters", detail: "Two canisters were scanned into staging without the second seal verification stamp.", action: "Hold border relay until seal audit clears.", owner: "J. Alvarez" },
+  { id: "disc-02", severity: "watch", title: "Temperature hold on cold-chain kits", manifestId: "MN-2059", packageLabel: "Cold-chain kits", detail: "Sensor log showed a five-minute warming spike during dock reassignment.", action: "Replace the affected kits before overflow release.", owner: "M. Patel" },
+  { id: "disc-03", severity: "watch", title: "Specimen sleeve relabel queue still open", manifestId: "MN-2047", packageLabel: "Specimen sleeves", detail: "Five sleeves still need destination relabeling after the harbor transfer lane changed.", action: "Close relabel task before final seal at 17:55.", owner: "R. Chen" },
+  { id: "disc-04", severity: "resolved", title: "Courier reassignment cleared for metro east", manifestId: "MN-2062", packageLabel: "Specimen sleeves", detail: "Dispatch confirmed the courier swap and reprinted the route inserts for metro east.", action: "No further action, keep the manifest in the sealed queue.", owner: "S. Monroe" },
+] as const;

--- a/src/app/manifest-room/page.test.tsx
+++ b/src/app/manifest-room/page.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  manifestDiscrepancies,
+  manifestGroups,
+  manifestRoomOverview,
+  packageSummaries,
+} from "./_data/manifest-room-data";
+import ManifestRoomPage from "./page";
+
+describe("ManifestRoomPage", () => {
+  it("renders the route shell with manifest room actions and package summaries", () => {
+    render(<ManifestRoomPage />);
+
+    expect(screen.getByRole("heading", { level: 1, name: new RegExp(manifestRoomOverview.title, "i") })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /review manifest groups/i })).toHaveAttribute("href", "#manifest-groups");
+    expect(screen.getByRole("link", { name: /open discrepancy panel/i })).toHaveAttribute("href", "#manifest-discrepancies");
+    expect(screen.getByRole("link", { name: /back to route index/i })).toHaveAttribute("href", "/");
+
+    const summaryList = screen.getByRole("list", { name: /package summaries/i });
+    expect(within(summaryList).getAllByRole("listitem")).toHaveLength(packageSummaries.length);
+    expect(summaryList).toHaveTextContent("Archive canisters");
+    expect(summaryList).toHaveTextContent("1 seal mismatch");
+  }, 15000);
+
+  it("renders every manifest group with manifest cards and package details", () => {
+    render(<ManifestRoomPage />);
+
+    for (const group of manifestGroups) {
+      const region = screen.getByRole("region", { name: group.title });
+
+      expect(within(region).getByText(group.description)).toBeInTheDocument();
+      expect(within(region).getByText(group.dock, { exact: false })).toBeInTheDocument();
+      expect(within(region).getByText(group.cutoff, { exact: false })).toBeInTheDocument();
+      const manifestList = within(region).getByRole("list", { name: `${group.title} manifests` });
+      expect(manifestList.querySelectorAll(':scope > [role="listitem"]')).toHaveLength(
+        group.manifests.length,
+      );
+      for (const manifest of group.manifests) {
+        const manifestCard = within(manifestList).getByRole("heading", { name: manifest.carrier }).closest('[role="listitem"]');
+
+        expect(manifestCard).toBeInTheDocument();
+        expect(manifestCard).toHaveTextContent(manifest.id);
+        expect(manifestCard).toHaveTextContent(manifest.lane);
+        expect(manifestCard).toHaveTextContent(manifest.departure);
+        expect(manifestCard).toHaveTextContent(manifest.packages[0].label);
+      }
+    }
+  }, 15000);
+
+  it("shows the discrepancy panel counts and issue details", () => {
+    render(<ManifestRoomPage />);
+
+    const discrepancyPanel = screen.getByLabelText(/manifest discrepancy panel/i);
+    const discrepancyList = within(discrepancyPanel).getByRole("list", { name: /manifest discrepancies/i });
+    expect(within(discrepancyList).getAllByRole("listitem")).toHaveLength(manifestDiscrepancies.length);
+    expect(discrepancyPanel).toHaveTextContent("Critical");
+    expect(discrepancyPanel).toHaveTextContent("Watch");
+    expect(discrepancyPanel).toHaveTextContent("Resolved");
+
+    const criticalIssue = within(discrepancyPanel).getByRole("heading", { name: /seal count mismatch on archive canisters/i }).closest('[role="listitem"]');
+
+    expect(criticalIssue).toBeInTheDocument();
+    expect(criticalIssue).toHaveTextContent("MN-2051");
+    expect(criticalIssue).toHaveTextContent("Hold border relay until seal audit clears.");
+    expect(criticalIssue).toHaveTextContent("J. Alvarez");
+  }, 15000);
+});

--- a/src/app/manifest-room/page.tsx
+++ b/src/app/manifest-room/page.tsx
@@ -1,0 +1,216 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import {
+  manifestDiscrepancies,
+  manifestGroups,
+  manifestRoomOverview,
+  packageSummaries,
+} from "./_data/manifest-room-data";
+
+export const metadata: Metadata = {
+  title: "Manifest Room",
+  description:
+    "Grouped manifests, package summaries, and a compact discrepancy panel for dispatch review.",
+};
+
+const manifestStatusStyles = {
+  sealed: "border-emerald-300/30 bg-emerald-300/12 text-emerald-100",
+  review: "border-amber-300/30 bg-amber-300/12 text-amber-100",
+  holding: "border-rose-300/30 bg-rose-300/12 text-rose-100",
+} as const;
+
+const discrepancySeverityStyles = {
+  critical: "border-rose-300/30 bg-rose-300/10 text-rose-100",
+  watch: "border-amber-300/30 bg-amber-300/10 text-amber-100",
+  resolved: "border-emerald-300/30 bg-emerald-300/10 text-emerald-100",
+} as const;
+
+export default function ManifestRoomPage() {
+  const manifestCount = manifestGroups.reduce((count, group) => count + group.manifests.length, 0);
+  const packageLineCount = manifestGroups.reduce(
+    (count, group) => count + group.manifests.reduce((sum, manifest) => sum + manifest.packages.length, 0),
+    0,
+  );
+  const criticalCount = manifestDiscrepancies.filter((item) => item.severity === "critical").length;
+  const watchCount = manifestDiscrepancies.filter((item) => item.severity === "watch").length;
+
+  return (
+    <main className="relative min-h-screen overflow-hidden bg-[radial-gradient(circle_at_top_left,rgba(251,191,36,0.18),transparent_28%),radial-gradient(circle_at_bottom_right,rgba(34,211,238,0.18),transparent_30%),linear-gradient(180deg,#111827_0%,#172033_52%,#0f172a_100%)] px-6 py-12 text-slate-50 sm:px-10 lg:px-14">
+      <div aria-hidden className="pointer-events-none absolute inset-x-0 top-0 h-72 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.12),transparent_52%)]" />
+      <div aria-hidden className="pointer-events-none absolute left-0 top-20 h-72 w-72 rounded-full bg-amber-300/10 blur-3xl" />
+      <div aria-hidden className="pointer-events-none absolute bottom-0 right-0 h-80 w-80 rounded-full bg-cyan-300/10 blur-3xl" />
+
+      <div className="relative mx-auto flex w-full max-w-7xl flex-col gap-8">
+        <header className="overflow-hidden rounded-[2.25rem] border border-white/10 bg-[linear-gradient(135deg,rgba(255,248,235,0.1),rgba(15,23,42,0.18))] p-8 shadow-[0_32px_120px_rgba(2,6,23,0.42)] backdrop-blur sm:p-10">
+          <div className="grid gap-8 xl:grid-cols-[minmax(0,1.15fr)_minmax(300px,0.85fr)]">
+            <div className="space-y-5">
+              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-amber-100/80">{manifestRoomOverview.eyebrow}</p>
+              <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-balance text-white sm:text-5xl lg:text-6xl">{manifestRoomOverview.title}</h1>
+              <p className="max-w-3xl text-base leading-8 text-slate-200 sm:text-lg">{manifestRoomOverview.description}</p>
+
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <a href="#manifest-groups" className="inline-flex items-center justify-center rounded-full bg-amber-300 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-amber-200">{manifestRoomOverview.primaryAction}</a>
+                <a href="#manifest-discrepancies" className="inline-flex items-center justify-center rounded-full border border-white/14 bg-white/8 px-5 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-300/35 hover:bg-white/12">{manifestRoomOverview.secondaryAction}</a>
+                <Link href="/" className="inline-flex items-center justify-center rounded-full border border-white/14 bg-slate-950/30 px-5 py-3 text-sm font-semibold text-slate-100 transition hover:border-white/30 hover:bg-slate-900/60">Back to route index</Link>
+              </div>
+            </div>
+
+            <aside className="rounded-[1.8rem] border border-white/10 bg-[linear-gradient(180deg,rgba(10,15,28,0.72),rgba(8,12,24,0.94))] p-6 shadow-[0_22px_70px_rgba(2,6,23,0.28)]">
+              <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Dispatch pulse</p>
+              <div className="mt-5 grid gap-3 sm:grid-cols-2">
+                <div className="rounded-[1.4rem] border border-cyan-300/16 bg-cyan-300/10 px-4 py-4">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-cyan-100/75">Manifest groups</p>
+                  <p className="mt-2 text-3xl font-semibold text-white">{manifestGroups.length}</p>
+                  <p className="mt-2 text-sm leading-6 text-slate-200">{manifestCount} manifests staged across the next dispatch wave.</p>
+                </div>
+                <div className="rounded-[1.4rem] border border-amber-300/16 bg-amber-300/10 px-4 py-4">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-100/75">Package lines</p>
+                  <p className="mt-2 text-3xl font-semibold text-white">{packageLineCount}</p>
+                  <p className="mt-2 text-sm leading-6 text-slate-200">Enough detail to reconcile staging without leaving the route.</p>
+                </div>
+                <div className="rounded-[1.4rem] border border-rose-300/16 bg-rose-300/10 px-4 py-4">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-100/75">Critical exceptions</p>
+                  <p className="mt-2 text-3xl font-semibold text-white">{criticalCount}</p>
+                  <p className="mt-2 text-sm leading-6 text-slate-200">Hold these before the cross-border relay closes.</p>
+                </div>
+                <div className="rounded-[1.4rem] border border-emerald-300/16 bg-emerald-300/10 px-4 py-4">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-100/75">Watch queue</p>
+                  <p className="mt-2 text-3xl font-semibold text-white">{watchCount}</p>
+                  <p className="mt-2 text-sm leading-6 text-slate-200">Follow-up items that can still clear without delaying release.</p>
+                </div>
+              </div>
+            </aside>
+          </div>
+        </header>
+
+        <section aria-labelledby="package-summaries-heading" className="space-y-5">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Package summaries</p>
+              <h2 id="package-summaries-heading" className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Summaries sized for a pre-dispatch scan</h2>
+            </div>
+            <p className="max-w-2xl text-sm leading-7 text-slate-300">These rollups give the shift lead a compact view of manifested, staged, and exception volume before they inspect group-level detail.</p>
+          </div>
+
+          <div aria-label="Package summaries" className="grid gap-4 md:grid-cols-2 xl:grid-cols-4" role="list">
+            {packageSummaries.map((summary) => (
+              <article key={summary.id} className="rounded-[1.6rem] border border-white/10 bg-white/8 p-5 shadow-[0_24px_70px_rgba(2,6,23,0.22)] backdrop-blur" role="listitem">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">{summary.label}</p>
+                <div className="mt-4 space-y-3 text-sm leading-6 text-slate-200">
+                  <p><span className="font-semibold text-white">Manifested:</span> {summary.manifested}</p>
+                  <p><span className="font-semibold text-white">Staged:</span> {summary.staged}</p>
+                  <p><span className="font-semibold text-white">Discrepancy:</span> {summary.discrepancy}</p>
+                </div>
+                <p className="mt-4 text-sm leading-6 text-slate-300">{summary.note}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.12fr)_minmax(320px,0.88fr)] xl:items-start">
+          <section id="manifest-groups" aria-labelledby="manifest-groups-heading" className="space-y-5">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Grouped manifests</p>
+                <h2 id="manifest-groups-heading" className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Work the dispatch wave by grouped manifest lanes</h2>
+              </div>
+              <p className="max-w-2xl text-sm leading-7 text-slate-300">Every group exposes the dock, cutoff, and manifest-level package mix so the room can clear release work in order.</p>
+            </div>
+
+            {manifestGroups.map((group) => (
+              <section key={group.id} aria-labelledby={`${group.id}-heading`} className="rounded-[2rem] border border-white/10 bg-[linear-gradient(180deg,rgba(15,23,42,0.74),rgba(8,12,24,0.92))] p-6 shadow-[0_28px_80px_rgba(3,7,18,0.26)]">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                  <div className="space-y-3">
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-400">{group.label}</p>
+                    <div>
+                      <h3 id={`${group.id}-heading`} className="text-2xl font-semibold tracking-tight text-white sm:text-3xl">{group.title}</h3>
+                      <p className="mt-3 max-w-3xl text-sm leading-7 text-slate-300">{group.description}</p>
+                    </div>
+                  </div>
+
+                  <div className="rounded-[1.4rem] border border-white/10 bg-white/6 px-4 py-4 text-sm leading-6 text-slate-200">
+                    <p><span className="font-semibold text-white">Dock:</span> {group.dock}</p>
+                    <p><span className="font-semibold text-white">Cutoff:</span> {group.cutoff}</p>
+                  </div>
+                </div>
+
+                <div aria-label={`${group.title} manifests`} className="mt-6 grid gap-4 lg:grid-cols-2" role="list">
+                  {group.manifests.map((manifest) => (
+                    <article key={manifest.id} className="rounded-[1.6rem] border border-white/10 bg-white/6 p-5" role="listitem">
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">{manifest.id}</p>
+                          <h4 className="mt-2 text-xl font-semibold text-white">{manifest.carrier}</h4>
+                          <p className="mt-1 text-sm text-slate-300">{manifest.lane} · Departs {manifest.departure}</p>
+                        </div>
+                        <span className={`rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${manifestStatusStyles[manifest.status]}`}>{manifest.status}</span>
+                      </div>
+
+                      <ul className="mt-5 space-y-3">
+                        {manifest.packages.map((item) => (
+                          <li key={item.label} className="rounded-[1.1rem] border border-white/8 bg-slate-950/30 px-4 py-3 text-sm leading-6 text-slate-200">
+                            <p className="font-semibold text-white">{item.label}</p>
+                            <p>{item.count}</p>
+                            <p className="text-slate-300">{item.staging}</p>
+                          </li>
+                        ))}
+                      </ul>
+                    </article>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </section>
+
+          <aside
+            id="manifest-discrepancies"
+            aria-label="Manifest discrepancy panel"
+            className="xl:sticky xl:top-6"
+          >
+            <div className="rounded-[2rem] border border-white/10 bg-[linear-gradient(180deg,rgba(10,15,28,0.88),rgba(8,12,24,0.98))] p-6 shadow-[0_28px_80px_rgba(3,7,18,0.3)]">
+              <div className="space-y-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Discrepancy panel</p>
+                <h2 className="text-3xl font-semibold tracking-tight text-white">Compact follow-up queue</h2>
+                <p className="text-sm leading-7 text-slate-300">Keep seal, relabel, and temperature issues visible beside the grouped manifests.</p>
+              </div>
+
+              <div className="mt-6 grid grid-cols-3 gap-3 text-center">
+                <div className="rounded-[1.25rem] border border-rose-300/16 bg-rose-300/10 px-3 py-3">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-100/75">Critical</p>
+                  <p className="mt-2 text-2xl font-semibold text-white">{criticalCount}</p>
+                </div>
+                <div className="rounded-[1.25rem] border border-amber-300/16 bg-amber-300/10 px-3 py-3">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-100/75">Watch</p>
+                  <p className="mt-2 text-2xl font-semibold text-white">{watchCount}</p>
+                </div>
+                <div className="rounded-[1.25rem] border border-emerald-300/16 bg-emerald-300/10 px-3 py-3">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-100/75">Resolved</p>
+                  <p className="mt-2 text-2xl font-semibold text-white">{manifestDiscrepancies.length - criticalCount - watchCount}</p>
+                </div>
+              </div>
+
+              <div aria-label="Manifest discrepancies" className="mt-6 space-y-3" role="list">
+                {manifestDiscrepancies.map((item) => (
+                  <article key={item.id} className={`rounded-[1.4rem] border p-4 ${discrepancySeverityStyles[item.severity]}`} role="listitem">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-300">{item.manifestId}</p>
+                        <h3 className="mt-2 text-base font-semibold text-white">{item.title}</h3>
+                      </div>
+                      <span className="rounded-full border border-current/25 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.18em]">{item.severity}</span>
+                    </div>
+                    <p className="mt-3 text-sm font-medium text-slate-100">{item.packageLabel}</p>
+                    <p className="mt-2 text-sm leading-6 text-slate-200">{item.detail}</p>
+                    <p className="mt-3 text-sm leading-6 text-slate-100">{item.action}</p>
+                    <p className="mt-3 text-xs font-semibold uppercase tracking-[0.18em] text-slate-300">Owner · {item.owner}</p>
+                  </article>
+                ))}
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,6 +59,13 @@ const statusBoardHighlights = [
   "Summary bar with service counts, operational ratio, and open incident totals",
 ];
 
+const manifestRoomHighlights = [
+  "Grouped outbound manifests with lane, carrier, dock, and cutoff context",
+  "Package rollups showing manifested, staged, and discrepancy volume together",
+  "Compact discrepancy queue with critical, watch, and resolved follow-up states",
+  "A dispatch-first layout that keeps grouped content and exception review side by side",
+];
+
 const teamDirectoryHighlights = [
   "Cross-functional directory with grouped profiles and availability states",
   "Spotlight panel featuring role highlights and shared skill breakdowns",
@@ -549,6 +556,56 @@ export default function Home() {
             </p>
             <ul className="mt-5 space-y-4">
               {statusBoardHighlights.map((item) => (
+                <li
+                  key={item}
+                  className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"
+                >
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="route-entry-link overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.06)]">
+        <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1fr)_minmax(260px,0.9fr)] lg:px-12 lg:py-10">
+          <div className="space-y-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-cyan-800">
+              Issue 210 / Manifest Room
+            </p>
+            <div className="space-y-3">
+              <h2 className="max-w-2xl text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                Review grouped manifests, package rollups, and discrepancies before the dispatch wave closes.
+              </h2>
+              <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
+                The manifest room stages outbound manifest groups with package summaries and a compact discrepancy panel so the shift lead can clear holds without switching between disconnected views.
+              </p>
+            </div>
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/manifest-room"
+                className="inline-flex items-center justify-center rounded-full bg-cyan-800 px-6 py-3 text-sm font-semibold text-cyan-50 transition hover:bg-cyan-900"
+              >
+                Open manifest room
+              </Link>
+              <a
+                href="https://github.com/iamasx/api-test/issues/210"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Review issue scope
+              </a>
+            </div>
+          </div>
+
+          <div className="rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Manifest room highlights
+            </p>
+            <ul className="mt-5 space-y-4">
+              {manifestRoomHighlights.map((item) => (
                 <li
                   key={item}
                   className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,30 @@
+import { createElement, forwardRef } from "react";
 import { cleanup } from "@testing-library/react";
-import "@testing-library/jest-dom/vitest";
-import { afterEach } from "vitest";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { afterEach, expect, vi } from "vitest";
+
+vi.mock("next/link", () => {
+  const MockLink = forwardRef<HTMLAnchorElement, any>(function MockLink(
+    { href, children, ...props },
+    ref,
+  ) {
+    const resolvedHref =
+      typeof href === "string"
+        ? href
+        : typeof href === "object" &&
+            href !== null &&
+            "pathname" in href &&
+            typeof href.pathname === "string"
+          ? href.pathname
+          : "#";
+
+    return createElement("a", { ...props, href: resolvedHref, ref }, children);
+  });
+
+  return { default: MockLink };
+});
+
+expect.extend(matchers);
 
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
## Summary
- add a dedicated `manifest-room` route with grouped manifests, package rollups, and a compact discrepancy panel
- add mock manifest, package, and discrepancy data plus a home-page entry for the route
- cover the new route in tests and mock `next/link` in Vitest setup so App Router pages render under Next 16

Closes #210