### PR TITLE
feat: add mission console shared shell overlap

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,12 @@
   --nav-height: 3.5rem;
   --ops-accent: #0e7490;
   --ops-accent-light: rgba(14, 116, 144, 0.08);
+  --mission-accent: #67e8f9;
+  --mission-accent-strong: #0891b2;
+  --mission-accent-soft: rgba(103, 232, 249, 0.12);
+  --mission-panel: rgba(8, 15, 28, 0.72);
+  --mission-panel-strong: rgba(4, 10, 20, 0.9);
+  --mission-line: rgba(148, 163, 184, 0.16);
   --navigator-accent: #0891b2;
   --navigator-accent-light: rgba(8, 145, 178, 0.12);
   --navigator-accent-soft: rgba(34, 211, 238, 0.08);
@@ -59,6 +65,7 @@
 
 html {
   scroll-behavior: smooth;
+  scroll-padding-top: calc(var(--nav-height) + 4.5rem);
 }
 
 body {
@@ -68,6 +75,7 @@ body {
   background-image:
     radial-gradient(circle at top, rgba(251, 191, 36, 0.18), transparent 32%),
     radial-gradient(circle at right 18%, rgba(8, 145, 178, 0.14), transparent 26%),
+    radial-gradient(circle at left 22%, rgba(103, 232, 249, 0.14), transparent 24%),
     linear-gradient(180deg, #fcf8ef 0%, #f4efe7 52%, #ebe5d9 100%);
   font-family: var(--font-geist-sans), Arial, Helvetica, sans-serif;
 }
@@ -193,6 +201,49 @@ a {
   text-transform: uppercase;
   color: var(--navigator-ink);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85);
+}
+
+.app-shell-status {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+  padding: 0.85rem 1.5rem 0;
+}
+
+.app-shell-status__item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  border-radius: 1.2rem;
+  border: 1px solid rgba(8, 145, 178, 0.14);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.72), rgba(255, 255, 255, 0.48));
+  padding: 0.85rem 1rem;
+  transition:
+    transform 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.app-shell-status__item:hover {
+  transform: translateY(-1px);
+  border-color: rgba(8, 145, 178, 0.26);
+  box-shadow: 0 14px 28px rgba(14, 116, 144, 0.08);
+}
+
+.app-shell-status__label {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(8, 145, 178, 0.78);
+}
+
+.app-shell-status__value {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: rgba(15, 23, 42, 0.82);
 }
 
 /* ── Operations-center accent utilities ───────────────────── */
@@ -388,6 +439,142 @@ a {
 
   .app-nav__meta {
     display: none;
+  }
+
+  .app-shell-status {
+    grid-template-columns: 1fr;
+    padding-inline: 1rem;
+  }
+}
+
+/* ── Mission-console shared shell styles ──────────────────── */
+
+.mission-console-shell {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at top left, rgba(103, 232, 249, 0.16), transparent 28%),
+    radial-gradient(circle at 88% 14%, rgba(56, 189, 248, 0.18), transparent 24%),
+    linear-gradient(180deg, #07101c 0%, #0d1728 42%, #101f33 100%);
+}
+
+.mission-console-shell__glow {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 18% 8%, rgba(103, 232, 249, 0.12), transparent 22%),
+    radial-gradient(circle at 84% 24%, rgba(14, 165, 233, 0.11), transparent 20%),
+    radial-gradient(circle at 76% 88%, rgba(251, 191, 36, 0.08), transparent 18%);
+}
+
+.mission-panel {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--mission-line);
+  border-radius: 2rem;
+  background:
+    linear-gradient(180deg, rgba(17, 24, 39, 0.72), rgba(6, 11, 20, 0.92));
+  padding: 1.5rem;
+  box-shadow:
+    0 28px 100px rgba(2, 6, 23, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(18px);
+}
+
+.mission-panel--hero {
+  background:
+    radial-gradient(circle at top right, rgba(103, 232, 249, 0.1), transparent 34%),
+    linear-gradient(135deg, rgba(10, 18, 34, 0.92), rgba(7, 12, 22, 0.72));
+}
+
+.mission-panel--contrast {
+  background:
+    linear-gradient(180deg, rgba(5, 10, 20, 0.92), rgba(8, 16, 30, 0.84));
+}
+
+.mission-panel--window {
+  min-height: 100%;
+  padding: 1.5rem;
+}
+
+.mission-kicker {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(165, 243, 252, 0.92);
+}
+
+.mission-kicker--muted {
+  color: rgba(148, 163, 184, 0.84);
+}
+
+.mission-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  padding: 0.4rem 0.8rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.mission-chip--stable {
+  border: 1px solid rgba(52, 211, 153, 0.24);
+  background: rgba(16, 185, 129, 0.16);
+  color: rgb(167, 243, 208);
+}
+
+.mission-chip--watch {
+  border: 1px solid rgba(251, 191, 36, 0.24);
+  background: rgba(245, 158, 11, 0.16);
+  color: rgb(253, 230, 138);
+}
+
+.mission-chip--risk {
+  border: 1px solid rgba(248, 113, 113, 0.24);
+  background: rgba(239, 68, 68, 0.16);
+  color: rgb(254, 202, 202);
+}
+
+.mission-rail {
+  display: grid;
+  gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.mission-rail__item {
+  position: relative;
+  border-radius: 1.45rem;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  background: rgba(15, 23, 42, 0.46);
+  padding: 1rem 1rem 1rem 1.25rem;
+}
+
+.mission-rail__item::before {
+  content: "";
+  position: absolute;
+  top: 1.15rem;
+  bottom: 1.15rem;
+  left: 0;
+  width: 3px;
+  border-radius: 9999px;
+  background: linear-gradient(
+    180deg,
+    rgba(103, 232, 249, 0.85) 0%,
+    rgba(56, 189, 248, 0.35) 100%
+  );
+}
+
+@media (min-width: 640px) {
+  .mission-panel {
+    padding: 2rem;
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,11 +19,12 @@ export const metadata: Metadata = {
     template: "%s | Archive Signals",
   },
   description:
-    "Operational dashboards, navigator handoff surfaces, experiment registries, and field guides for archive-driven teams.",
+    "Operational dashboards, mission-console launch surfaces, experiment registries, and field guides for archive-driven teams.",
 };
 
 const navLinks = [
   { href: "/", label: "Home" },
+  { href: "/mission-console", label: "Mission Console" },
   { href: "/navigator-hub", label: "Navigator Hub" },
   { href: "/team-directory", label: "Team Directory" },
   { href: "/archive-browser", label: "Archive" },
@@ -34,6 +35,24 @@ const navLinks = [
   { href: "/queue-monitor", label: "Queue Monitor" },
   { href: "/parcel-hub", label: "Parcel Hub" },
   { href: "/status-board", label: "Status Board" },
+] as const;
+
+const shellStatusLinks = [
+  {
+    href: "/mission-console",
+    label: "Mission Console",
+    value: "Launch branch active",
+  },
+  {
+    href: "/operations-center",
+    label: "Ops Center",
+    value: "Shared command feed",
+  },
+  {
+    href: "/navigator-hub",
+    label: "Navigator Hub",
+    value: "Cross-route overlap",
+  },
 ] as const;
 
 export default function RootLayout({
@@ -63,13 +82,21 @@ export default function RootLayout({
               </li>
             ))}
           </ul>
-          <p className="app-nav__meta">Navigator overlap active</p>
+          <p className="app-nav__meta">Mission overlap active</p>
         </nav>
+        <div className="app-shell-status" aria-label="Shared shell status">
+          {shellStatusLinks.map((item) => (
+            <Link key={item.href} href={item.href} className="app-shell-status__item">
+              <span className="app-shell-status__label">{item.label}</span>
+              <span className="app-shell-status__value">{item.value}</span>
+            </Link>
+          ))}
+        </div>
         {children}
         <footer className="mt-auto border-t border-[var(--line)] py-6 text-center">
           <p className="section-label text-slate-500">
-            Archive Signals &middot; Navigator Hub &middot; Status Board &middot;
-            Built for conflict testing
+            Archive Signals &middot; Mission Console &middot; Status Board
+            &middot; Built for conflict testing
           </p>
         </footer>
       </body>

--- a/src/app/mission-console/page.tsx
+++ b/src/app/mission-console/page.tsx
@@ -226,7 +226,7 @@ export default function MissionConsolePage() {
                 {consoleStats.map((stat) => (
                   <article
                     key={stat.label}
-                    className="rounded-[1.4rem] border border-white/10 bg-white/6 px-4 py-4"
+                    className="rounded-[1.4rem] border border-white/10 bg-white/[0.06] px-4 py-4"
                   >
                     <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-white/55">
                       {stat.label}
@@ -310,7 +310,7 @@ export default function MissionConsolePage() {
               {commandStreams.map((stream) => (
                 <article
                   key={stream.title}
-                  className="rounded-[1.6rem] border border-white/10 bg-white/6 px-5 py-5"
+                  className="rounded-[1.6rem] border border-white/10 bg-white/[0.06] px-5 py-5"
                 >
                   <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
                     <div className="space-y-2">
@@ -384,7 +384,7 @@ export default function MissionConsolePage() {
                 {operatorAssignments.map((assignment) => (
                   <article
                     key={assignment.lane}
-                    className="rounded-[1.6rem] border border-white/10 bg-white/6 px-5 py-5"
+                    className="rounded-[1.6rem] border border-white/10 bg-white/[0.06] px-5 py-5"
                   >
                     <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                       <div>

--- a/src/app/mission-console/page.tsx
+++ b/src/app/mission-console/page.tsx
@@ -1,0 +1,443 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Mission Console",
+  description:
+    "Shared-shell mission console for launch readiness windows, operator assignments, and live decision pressure.",
+};
+
+const consoleStats = [
+  {
+    label: "Decision horizon",
+    value: "18 min",
+    detail: "Command wants the branch recommendation locked before the relay handoff.",
+  },
+  {
+    label: "Staged teams",
+    value: "4 crews",
+    detail: "Recovery, relay, thermal, and dock support are all held in pre-commit posture.",
+  },
+  {
+    label: "Open watchpoints",
+    value: "3",
+    detail: "Thermal drift, relay confidence, and dock-clearance timing still need active coverage.",
+  },
+];
+
+const launchWindows = [
+  {
+    name: "Window A",
+    span: "05:40-06:05 UTC",
+    posture: "Primary go branch",
+    detail:
+      "Weather is clean and relay capacity is within margin, but the dock chief needs one more clean check before commit.",
+    tone: "stable",
+  },
+  {
+    name: "Window B",
+    span: "06:35-06:58 UTC",
+    posture: "Watch branch",
+    detail:
+      "Safer thermal profile, but it consumes the reserve crew rotation and compresses downstream cargo sequencing.",
+    tone: "watch",
+  },
+  {
+    name: "Window C",
+    span: "07:20-07:52 UTC",
+    posture: "Recovery-only fallback",
+    detail:
+      "Best margin for dock recovery, but it breaks the planned uplink cadence and forces a customer-facing delay notice.",
+    tone: "risk",
+  },
+] as const;
+
+const commandStreams = [
+  {
+    title: "Flight readiness",
+    owner: "N. Ibarra",
+    summary:
+      "Primary branch is green if the final relay confirmation lands before T-12.",
+    items: [
+      "Autopilot rollback rehearsal completed",
+      "Dock-side abort path revalidated after the overnight sim",
+      "Payload thermal buffer remains above minimum threshold",
+    ],
+  },
+  {
+    title: "Ground orchestration",
+    owner: "R. Malik",
+    summary:
+      "Load teams are staged, but the reserve forklift lane is still borrowed by maintenance.",
+    items: [
+      "Cold-chain pallets moved into priority order",
+      "Reserve dock crew can cover Window B without overtime",
+      "West gate access remains under escort restrictions",
+    ],
+  },
+  {
+    title: "Communications",
+    owner: "S. Okafor",
+    summary:
+      "Command channel is stable, but the customer update draft still depends on the final branch call.",
+    items: [
+      "Pager tree dry run finished at 04:58 UTC",
+      "Public status note drafted for hold or fallback branches",
+      "Regional leads subscribed to the command relay digest",
+    ],
+  },
+];
+
+const decisionRail = [
+  {
+    checkpoint: "T-18",
+    title: "Lock the recommended branch",
+    detail:
+      "Flight and dock leads need a single branch so the console can collapse the non-primary call paths.",
+  },
+  {
+    checkpoint: "T-14",
+    title: "Confirm relay confidence",
+    detail:
+      "If confidence stays below threshold, command shifts to Window B without reopening cargo sequencing.",
+  },
+  {
+    checkpoint: "T-09",
+    title: "Publish operator handoff note",
+    detail:
+      "Every crew receives the same go, hold, or fallback language before the lift-cap sequence begins.",
+  },
+  {
+    checkpoint: "T-04",
+    title: "Freeze public-facing updates",
+    detail:
+      "External status copy moves from draft to live so the customer desk stops chasing command for wording.",
+  },
+];
+
+const operatorAssignments = [
+  {
+    lane: "Recovery",
+    owner: "M. Patel",
+    state: "Stable",
+    note: "Abort corridor is clean and reserve crew pickup time is under six minutes.",
+  },
+  {
+    lane: "Relay",
+    owner: "A. Svensson",
+    state: "Watch",
+    note: "One final validation cycle remains before the high-confidence uplink threshold is restored.",
+  },
+  {
+    lane: "Dock",
+    owner: "T. Nguyen",
+    state: "Risk",
+    note: "Lift-cap sequencing depends on the escort release clearing before T-10.",
+  },
+];
+
+const escalationLog = [
+  "04:46 UTC: Recovery lead reopened Window C only as a contingency branch after escort delays at west gate.",
+  "05:02 UTC: Relay monitoring recovered packet loss, but confidence still needs a second clean interval.",
+  "05:11 UTC: Customer desk drafted staggered status language for go and hold outcomes.",
+  "05:19 UTC: Command requested a unified branch note so downstream teams stop planning against multiple windows.",
+];
+
+const toneClasses = {
+  stable: "mission-chip mission-chip--stable",
+  watch: "mission-chip mission-chip--watch",
+  risk: "mission-chip mission-chip--risk",
+} as const;
+
+export default function MissionConsolePage() {
+  return (
+    <main className="mission-console-shell">
+      <div aria-hidden className="mission-console-shell__glow" />
+      <div className="relative mx-auto flex w-full max-w-7xl flex-col gap-8 px-5 py-8 sm:px-8 sm:py-10 lg:px-10 lg:py-12">
+        <div className="flex flex-wrap items-center gap-3">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 rounded-full border border-white/12 bg-white/6 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-100 transition hover:border-cyan-300/40 hover:bg-white/10"
+          >
+            <span aria-hidden="true">&larr;</span>
+            Landing routes
+          </Link>
+          <Link
+            href="/operations-center"
+            className="inline-flex items-center gap-2 rounded-full border border-cyan-300/18 bg-cyan-300/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-100 transition hover:border-cyan-200/40 hover:bg-cyan-300/16"
+          >
+            Shared shell overlap
+          </Link>
+        </div>
+
+        <section className="mission-panel mission-panel--hero">
+          <div className="grid gap-8 xl:grid-cols-[minmax(0,1.2fr)_minmax(320px,0.8fr)] xl:items-start">
+            <div className="space-y-6">
+              <div className="space-y-3">
+                <p className="mission-kicker">Issue 220 / Mission Console</p>
+                <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-white sm:text-5xl lg:text-6xl">
+                  Bring launch windows, crew posture, and shared-shell pressure
+                  into one command surface.
+                </h1>
+                <p className="max-w-3xl text-base leading-8 text-slate-200 sm:text-lg">
+                  This route intentionally overlaps the app shell: shared nav,
+                  landing-page spotlight, and global styling all move with the
+                  mission console so merge conflicts hit the common entry
+                  points instead of staying isolated to a leaf route.
+                </p>
+              </div>
+
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <a
+                  href="#launch-windows"
+                  className="inline-flex items-center justify-center rounded-full bg-cyan-300 px-5 py-3 text-sm font-semibold text-slate-950 transition hover:bg-cyan-200"
+                >
+                  Review launch windows
+                </a>
+                <a
+                  href="#decision-rail"
+                  className="inline-flex items-center justify-center rounded-full border border-white/12 bg-white/8 px-5 py-3 text-sm font-semibold text-slate-100 transition hover:border-white/22 hover:bg-white/12"
+                >
+                  Open decision rail
+                </a>
+                <a
+                  href="https://github.com/iamasx/api-test/issues/220"
+                  className="inline-flex items-center justify-center rounded-full border border-white/12 px-5 py-3 text-sm font-semibold text-slate-100 transition hover:border-cyan-300/40 hover:text-cyan-50"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Review issue scope
+                </a>
+              </div>
+            </div>
+
+            <aside className="mission-panel mission-panel--contrast">
+              <div className="space-y-3">
+                <p className="mission-kicker mission-kicker--muted">
+                  Command posture
+                </p>
+                <p className="text-3xl font-semibold tracking-tight text-white">
+                  Primary branch is viable, but the shell is optimized around a
+                  fast fallback call.
+                </p>
+              </div>
+
+              <div className="mt-6 grid gap-3">
+                {consoleStats.map((stat) => (
+                  <article
+                    key={stat.label}
+                    className="rounded-[1.4rem] border border-white/10 bg-white/6 px-4 py-4"
+                  >
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-white/55">
+                      {stat.label}
+                    </p>
+                    <p className="mt-3 text-3xl font-semibold tracking-tight text-white">
+                      {stat.value}
+                    </p>
+                    <p className="mt-2 text-sm leading-6 text-slate-200">
+                      {stat.detail}
+                    </p>
+                  </article>
+                ))}
+              </div>
+            </aside>
+          </div>
+        </section>
+
+        <section className="mission-panel" id="launch-windows">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-2">
+              <p className="mission-kicker mission-kicker--muted">
+                Launch windows
+              </p>
+              <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+                Stack the mission branches by timing, margin, and downstream
+                cost.
+              </h2>
+            </div>
+            <p className="max-w-2xl text-sm leading-7 text-slate-300">
+              The console keeps all three windows visible so command can choose
+              the least-damaging branch without losing track of dock, relay, or
+              customer impact.
+            </p>
+          </div>
+
+          <div className="mt-6 grid gap-4 xl:grid-cols-3">
+            {launchWindows.map((window) => (
+              <article
+                key={window.name}
+                className="mission-panel mission-panel--window"
+              >
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <p className="text-sm font-semibold uppercase tracking-[0.24em] text-white/55">
+                      {window.name}
+                    </p>
+                    <p className="mt-2 text-2xl font-semibold tracking-tight text-white">
+                      {window.span}
+                    </p>
+                  </div>
+                  <span className={toneClasses[window.tone]}>
+                    {window.posture}
+                  </span>
+                </div>
+                <p className="mt-4 text-sm leading-7 text-slate-200">
+                  {window.detail}
+                </p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,1.16fr)_minmax(320px,0.84fr)] xl:items-start">
+          <section className="mission-panel">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+              <div className="space-y-2">
+                <p className="mission-kicker mission-kicker--muted">
+                  Command streams
+                </p>
+                <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+                  Keep every crew in the same frame before the branch locks.
+                </h2>
+              </div>
+              <p className="max-w-2xl text-sm leading-7 text-slate-300">
+                Each stream shows the owner, the posture summary, and the three
+                facts most likely to move the recommendation.
+              </p>
+            </div>
+
+            <div className="mt-6 grid gap-4">
+              {commandStreams.map((stream) => (
+                <article
+                  key={stream.title}
+                  className="rounded-[1.6rem] border border-white/10 bg-white/6 px-5 py-5"
+                >
+                  <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="space-y-2">
+                      <p className="text-xs font-semibold uppercase tracking-[0.22em] text-cyan-100/70">
+                        {stream.title}
+                      </p>
+                      <p className="text-xl font-semibold tracking-tight text-white">
+                        {stream.summary}
+                      </p>
+                    </div>
+                    <p className="text-sm font-medium text-slate-300">
+                      Owner: {stream.owner}
+                    </p>
+                  </div>
+                  <ul className="mt-4 grid gap-3 text-sm leading-6 text-slate-200">
+                    {stream.items.map((item) => (
+                      <li
+                        key={item}
+                        className="rounded-2xl border border-white/8 bg-slate-950/36 px-4 py-3"
+                      >
+                        {item}
+                      </li>
+                    ))}
+                  </ul>
+                </article>
+              ))}
+            </div>
+          </section>
+
+          <aside className="mission-panel" id="decision-rail">
+            <div className="space-y-2">
+              <p className="mission-kicker mission-kicker--muted">
+                Decision rail
+              </p>
+              <h2 className="text-3xl font-semibold tracking-tight text-white">
+                Collapse the uncertainty before the final commit.
+              </h2>
+            </div>
+
+            <ol className="mission-rail mt-6">
+              {decisionRail.map((item) => (
+                <li key={item.checkpoint} className="mission-rail__item">
+                  <p className="text-xs font-semibold uppercase tracking-[0.22em] text-cyan-100/72">
+                    {item.checkpoint}
+                  </p>
+                  <p className="mt-2 text-lg font-semibold text-white">
+                    {item.title}
+                  </p>
+                  <p className="mt-2 text-sm leading-6 text-slate-300">
+                    {item.detail}
+                  </p>
+                </li>
+              ))}
+            </ol>
+          </aside>
+        </div>
+
+        <section className="mission-panel">
+          <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(320px,0.92fr)]">
+            <div className="space-y-5">
+              <div className="space-y-2">
+                <p className="mission-kicker mission-kicker--muted">
+                  Operator lanes
+                </p>
+                <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+                  Hand each lane a clear owner, state, and reason to escalate.
+                </h2>
+              </div>
+
+              <div className="grid gap-4">
+                {operatorAssignments.map((assignment) => (
+                  <article
+                    key={assignment.lane}
+                    className="rounded-[1.6rem] border border-white/10 bg-white/6 px-5 py-5"
+                  >
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.22em] text-white/55">
+                          {assignment.lane}
+                        </p>
+                        <p className="mt-2 text-2xl font-semibold tracking-tight text-white">
+                          {assignment.owner}
+                        </p>
+                      </div>
+                      <span
+                        className={
+                          assignment.state === "Stable"
+                            ? toneClasses.stable
+                            : assignment.state === "Watch"
+                              ? toneClasses.watch
+                              : toneClasses.risk
+                        }
+                      >
+                        {assignment.state}
+                      </span>
+                    </div>
+                    <p className="mt-4 text-sm leading-7 text-slate-200">
+                      {assignment.note}
+                    </p>
+                  </article>
+                ))}
+              </div>
+            </div>
+
+            <aside className="mission-panel mission-panel--contrast">
+              <div className="space-y-2">
+                <p className="mission-kicker mission-kicker--muted">
+                  Escalation log
+                </p>
+                <h2 className="text-3xl font-semibold tracking-tight text-white">
+                  The console keeps the moving facts visible, not buried.
+                </h2>
+              </div>
+              <ul className="mt-6 grid gap-3 text-sm leading-7 text-slate-200">
+                {escalationLog.map((entry) => (
+                  <li
+                    key={entry}
+                    className="rounded-[1.35rem] border border-white/10 bg-slate-950/40 px-4 py-4"
+                  >
+                    {entry}
+                  </li>
+                ))}
+              </ul>
+            </aside>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,10 @@
 import Link from "next/link";
 import { teamGroups, getDirectoryMetrics } from "@/data/team-directory";
 
-const navigatorHubHighlights = [
-  "New navigator hub route with linked intervention rails across queue, parcel, and command views",
+const missionConsoleHighlights = [
+  "New mission console route with launch windows, crew posture, and a decision rail in one shared surface",
   "Shared landing-page overlap that rewrites the featured hero around the new route",
-  "Global shell styling updates that intentionally modify the common app nav, footer, and theme tokens",
+  "Global shell styling updates that intentionally modify the common app nav, footer, and launch-status strip",
 ];
 
 const notebookHighlights = [
@@ -70,30 +70,30 @@ export default function Home() {
 
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-[var(--section-gap)] px-6 py-12 sm:px-10 lg:px-12">
-      <section className="overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.08)]">
+      <section className="route-entry-link navigator-shell-card overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.08)]">
         <div className="grid gap-10 px-6 py-10 sm:px-10 lg:grid-cols-[minmax(0,1.2fr)_minmax(260px,0.8fr)] lg:px-12 lg:py-14">
           <div className="space-y-6">
             <p className="text-sm font-semibold uppercase tracking-[0.28em] text-cyan-700">
-              Issue 216 / Navigator Hub
+              Issue 220 / Mission Console
             </p>
             <div className="space-y-4">
               <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-                Coordinate shared app-shell handoffs from a dedicated navigator
-                hub.
+                Open the mission console to manage launch branches, crew
+                posture, and shared app-shell pressure.
               </h1>
               <p className="max-w-2xl text-lg leading-8 text-slate-600">
-                The navigator hub is the new conflict surface for issue 216:
-                one route that pulls together lane pressure, handoff timing,
-                and shared-shell entry points while also rewriting common
-                landing and global presentation files.
+                Issue 220 intentionally overlaps the shared shell: the mission
+                console brings launch windows, operator lanes, and escalation
+                timing into one route while also rewriting the landing page,
+                nav chrome, and global presentation tokens.
               </p>
             </div>
             <div className="flex flex-col gap-4 sm:flex-row">
               <Link
-                href="/navigator-hub"
+                href="/mission-console"
                 className="inline-flex items-center justify-center rounded-full bg-cyan-700 px-6 py-3 text-sm font-semibold text-cyan-50 transition hover:bg-cyan-800"
               >
-                Open navigator hub
+                Open mission console
               </Link>
               <Link
                 href="/operations-center"
@@ -102,7 +102,7 @@ export default function Home() {
                 Open ops center
               </Link>
               <a
-                href="https://github.com/iamasx/api-test/issues/216"
+                href="https://github.com/iamasx/api-test/issues/220"
                 className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
                 target="_blank"
                 rel="noreferrer"
@@ -114,10 +114,10 @@ export default function Home() {
 
           <div className="rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
             <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
-              Conflict checks
+              Mission overlap
             </p>
             <ul className="mt-5 space-y-4">
-              {navigatorHubHighlights.map((item) => (
+              {missionConsoleHighlights.map((item) => (
                 <li
                   key={item}
                   className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"


### PR DESCRIPTION
## Summary
- add the new `mission-console` route with launch windows, operator lanes, and a decision rail
- rewrite the landing-page hero to feature mission console as the new shared conflict surface
- update shared shell navigation, status strip, footer copy, and global mission-console styling

## Validation
- `npm run lint`
- `npm run build`
- `npm test` could not complete in this session because the installed Vite/Vitest stack requires a newer Node runtime than the session's `v20.15.0`

Closes #220