### PR TITLE
feat: add capacity board overlap route

### DIFF
--- a/src/app/capacity-board/page.tsx
+++ b/src/app/capacity-board/page.tsx
@@ -1,0 +1,384 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Capacity Board",
+  description:
+    "Shared capacity route for pod load, overflow coverage, and overlap-heavy shell updates.",
+};
+
+const capacityPods = [
+  {
+    name: "North Intake",
+    status: "critical",
+    occupancy: 94,
+    coverage: "11 analysts for 12 planned stations",
+    buffer: "1 flex analyst left",
+    focus: "Same-day medical intake",
+    window: "07:10-08:00",
+    note: "Navigator handoffs are landing early, so this pod is carrying the heaviest overlap load.",
+    route: "/navigator-hub",
+    action: "Open navigator hub",
+  },
+  {
+    name: "Relay Triage",
+    status: "watch",
+    occupancy: 86,
+    coverage: "8 coordinators with 2 shared backups",
+    buffer: "Escalation desk available",
+    focus: "Priority escalations and route exceptions",
+    window: "07:25-08:15",
+    note: "Command-review traffic is trending above plan, but the escalation desk can still absorb another burst.",
+    route: "/command-log",
+    action: "Open command log",
+  },
+  {
+    name: "South Dispatch",
+    status: "stable",
+    occupancy: 72,
+    coverage: "10 dispatchers across 3 lanes",
+    buffer: "2 surge slots open",
+    focus: "Final assignment and launch approvals",
+    window: "07:40-08:20",
+    note: "Dispatch is the healthiest pod and can take redirected work if intake crosses the hard redline.",
+    route: "/operations-center",
+    action: "Open ops center",
+  },
+  {
+    name: "Dock Recovery",
+    status: "watch",
+    occupancy: 81,
+    coverage: "7 operators plus 1 floating supervisor",
+    buffer: "Supervisor can cover dock lane B",
+    focus: "Late-arrival recovery and rebalancing",
+    window: "07:55-08:35",
+    note: "Recovery stays viable, but only if parcel volume remains close to the current hub forecast.",
+    route: "/parcel-hub",
+    action: "Open parcel hub",
+  },
+] as const;
+
+const linkedSurfaces = [
+  {
+    title: "Navigator handoff rail",
+    href: "/navigator-hub",
+    action: "Open navigator hub",
+    detail:
+      "Confirm which corridors are pushing extra load into intake before shifting more headcount.",
+  },
+  {
+    title: "Operational posture rail",
+    href: "/operations-center",
+    action: "Open ops center",
+    detail:
+      "Compare redline pods against the active alert queue so capacity changes match the broader shift posture.",
+  },
+  {
+    title: "Parcel balancing rail",
+    href: "/parcel-hub",
+    action: "Open parcel hub",
+    detail:
+      "Validate hub volume before the recovery pod absorbs another late-arrival cluster.",
+  },
+] as const;
+
+const releaseChecks = [
+  {
+    time: "07:12",
+    title: "Landing and nav alignment",
+    summary:
+      "Make sure the shared shell points operators to the new capacity board before the first morning surge.",
+  },
+  {
+    time: "07:28",
+    title: "Redline threshold review",
+    summary:
+      "If two pods stay above eighty-five percent, route the overflow briefing through navigator and dispatch together.",
+  },
+  {
+    time: "07:46",
+    title: "Recovery fallback decision",
+    summary:
+      "Use parcel and command surfaces to decide whether dock recovery keeps the shared supervisor or yields it to triage.",
+  },
+] as const;
+
+const overlapSignals = [
+  "The capacity board intentionally overlaps the landing page hero instead of shipping as an isolated route card.",
+  "Shared shell navigation and footer copy now advertise the route alongside existing common entry points.",
+  "Global tokens, shell accents, and shared route treatments were adjusted so the conflict surface reaches beyond one page.",
+];
+
+const statusClasses: Record<string, string> = {
+  stable: "border-emerald-200 bg-emerald-50 text-emerald-800",
+  watch: "border-amber-200 bg-amber-50 text-amber-800",
+  critical: "border-rose-200 bg-rose-50 text-rose-800",
+};
+
+export default function CapacityBoardPage() {
+  const redlinePods = capacityPods.filter((pod) => pod.occupancy >= 85).length;
+  const surgeSlots = capacityPods.filter((pod) => pod.status === "stable").length;
+  const averageOccupancy = Math.round(
+    capacityPods.reduce((total, pod) => total + pod.occupancy, 0) /
+      capacityPods.length,
+  );
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
+      <section className="capacity-shell-card overflow-hidden rounded-[2.4rem] border border-slate-200 bg-[linear-gradient(135deg,#eff6ff_0%,#ffffff_45%,#fff7ed_100%)] shadow-[0_30px_100px_rgba(15,23,42,0.1)]">
+        <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1.16fr)_minmax(300px,0.84fr)] lg:px-12 lg:py-12">
+          <div className="space-y-6">
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="capacity-board-chip">Capacity Board</span>
+              <span className="rounded-full border border-slate-200 bg-white/80 px-3 py-1 text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-slate-500">
+                Shared overlap route
+              </span>
+            </div>
+
+            <div className="space-y-4">
+              <h1 className="heading-tight max-w-4xl text-4xl text-slate-950 sm:text-5xl">
+                Stage team load, overflow coverage, and redline thresholds from
+                one capacity board.
+              </h1>
+              <p className="max-w-3xl text-base leading-8 text-slate-600 sm:text-lg">
+                Capacity Board is wired directly into the same shared files as
+                the landing page and app shell. It gives release operators a
+                single place to read pod occupancy, choose the safest overflow
+                target, and keep overlap-heavy changes visible across the common
+                interface.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
+              >
+                Back to overview
+              </Link>
+              <Link
+                href="/operations-center"
+                className="capacity-board-link inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+              >
+                Open ops center
+              </Link>
+              <a
+                href="https://github.com/iamasx/api-test/issues/218"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Review issue
+              </a>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-3">
+              <article className="rounded-[1.4rem] border border-white/70 bg-white/78 px-4 py-4 shadow-[0_12px_36px_rgba(15,23,42,0.08)]">
+                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  Redline pods
+                </p>
+                <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+                  {redlinePods}
+                </p>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  Pods already at or above the threshold for shared overflow
+                  intervention.
+                </p>
+              </article>
+              <article className="rounded-[1.4rem] border border-white/70 bg-white/78 px-4 py-4 shadow-[0_12px_36px_rgba(15,23,42,0.08)]">
+                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  Average load
+                </p>
+                <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+                  {averageOccupancy}%
+                </p>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  Occupancy across the four active pods in the current release
+                  window.
+                </p>
+              </article>
+              <article className="rounded-[1.4rem] border border-white/70 bg-white/78 px-4 py-4 shadow-[0_12px_36px_rgba(15,23,42,0.08)]">
+                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  Available fallback
+                </p>
+                <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+                  {surgeSlots}
+                </p>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  Stable pods that can still absorb secondary work before the
+                  next overlap check.
+                </p>
+              </article>
+            </div>
+          </div>
+
+          <aside className="capacity-board-panel rounded-[1.8rem] border border-slate-200/80 bg-white/82 p-6 shadow-[0_22px_70px_rgba(15,23,42,0.1)]">
+            <p className="section-label text-slate-500">Overlap signals</p>
+            <ul className="mt-5 space-y-4">
+              {overlapSignals.map((signal) => (
+                <li
+                  key={signal}
+                  className="capacity-board-note rounded-[1.4rem] border border-slate-200 bg-slate-50/90 px-4 py-4 text-sm leading-6 text-slate-600"
+                >
+                  {signal}
+                </li>
+              ))}
+            </ul>
+          </aside>
+        </div>
+      </section>
+
+      <section className="rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.08)]">
+        <div className="grid gap-6 px-6 py-8 sm:px-10 lg:px-12 lg:py-10">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-2">
+              <p className="section-label text-[var(--capacity-ink)]">
+                Pod capacity board
+              </p>
+              <h2 className="max-w-3xl text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                Review the live pod mix before shifting people into the next
+                shared release window.
+              </h2>
+            </div>
+            <p className="max-w-2xl text-sm leading-7 text-slate-600">
+              Each card keeps occupancy, coverage, and the recommended linked
+              route together so the same release call can decide load balancing
+              and follow-up context.
+            </p>
+          </div>
+
+          <div className="grid gap-4 lg:grid-cols-2">
+            {capacityPods.map((pod) => (
+              <article
+                key={pod.name}
+                className="capacity-board-track rounded-[1.6rem] border border-slate-200 bg-white/88 p-5 shadow-[0_12px_36px_rgba(15,23,42,0.06)]"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-lg font-semibold text-slate-950">
+                      {pod.name}
+                    </p>
+                    <p className="mt-1 text-sm text-slate-500">{pod.focus}</p>
+                  </div>
+                  <span
+                    className={`rounded-full border px-3 py-1 text-[0.6875rem] font-semibold uppercase tracking-[0.14em] ${statusClasses[pod.status]}`}
+                  >
+                    {pod.status}
+                  </span>
+                </div>
+
+                <div className="mt-5 grid gap-3 sm:grid-cols-2">
+                  <div className="rounded-[1.2rem] border border-slate-200 bg-slate-50/90 px-4 py-3">
+                    <p className="text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                      Coverage
+                    </p>
+                    <p className="mt-2 text-sm font-semibold text-slate-900">
+                      {pod.coverage}
+                    </p>
+                  </div>
+                  <div className="rounded-[1.2rem] border border-slate-200 bg-slate-50/90 px-4 py-3">
+                    <p className="text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                      Buffer
+                    </p>
+                    <p className="mt-2 text-sm font-semibold text-slate-900">
+                      {pod.buffer}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="mt-4 space-y-2">
+                  <div className="flex items-center justify-between gap-3 text-[0.72rem] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                    <span>Occupancy</span>
+                    <span>{pod.occupancy}%</span>
+                  </div>
+                  <div className="capacity-board-meter" aria-hidden="true">
+                    <div
+                      className="capacity-board-meter__fill"
+                      style={{ width: `${pod.occupancy}%` }}
+                    />
+                  </div>
+                </div>
+
+                <div className="mt-4 grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+                  <p className="text-sm leading-7 text-slate-600">{pod.note}</p>
+                  <div className="rounded-[1rem] border border-slate-200 bg-slate-50/90 px-4 py-3 text-sm font-semibold text-slate-700">
+                    {pod.window}
+                  </div>
+                </div>
+
+                <Link
+                  href={pod.route}
+                  className="capacity-board-link mt-5 inline-flex items-center text-sm font-semibold text-[var(--capacity-ink)] transition hover:text-blue-800"
+                >
+                  {pod.action}
+                </Link>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[minmax(0,1.04fr)_minmax(320px,0.96fr)]">
+        <div className="rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] p-6 shadow-[0_20px_90px_rgba(15,23,42,0.06)] sm:p-8">
+          <div className="space-y-2">
+            <p className="section-label text-slate-500">Linked surfaces</p>
+            <h2 className="text-3xl font-semibold tracking-tight text-slate-950">
+              Follow the adjacent route rails before committing a capacity
+              change.
+            </h2>
+          </div>
+
+          <div className="mt-6 grid gap-4">
+            {linkedSurfaces.map((surface) => (
+              <article
+                key={surface.title}
+                className="capacity-board-track rounded-[1.5rem] border border-slate-200 bg-white/88 p-5 shadow-[0_12px_30px_rgba(15,23,42,0.06)]"
+              >
+                <p className="text-sm font-semibold text-slate-950">
+                  {surface.title}
+                </p>
+                <p className="mt-2 text-sm leading-7 text-slate-600">
+                  {surface.detail}
+                </p>
+                <Link
+                  href={surface.href}
+                  className="capacity-board-link mt-4 inline-flex items-center text-sm font-semibold text-[var(--capacity-ink)] transition hover:text-blue-800"
+                >
+                  {surface.action}
+                </Link>
+              </article>
+            ))}
+          </div>
+        </div>
+
+        <aside className="rounded-[2rem] border border-[var(--line)] bg-[linear-gradient(180deg,rgba(239,246,255,0.92),rgba(255,251,235,0.92))] p-6 shadow-[0_20px_90px_rgba(15,23,42,0.06)] sm:p-8">
+          <div className="space-y-2">
+            <p className="section-label text-slate-500">Release checks</p>
+            <h2 className="text-3xl font-semibold tracking-tight text-slate-950">
+              Keep the capacity release moving in a predictable cadence.
+            </h2>
+          </div>
+
+          <ol className="mt-6 space-y-4">
+            {releaseChecks.map((step) => (
+              <li
+                key={step.time}
+                className="rounded-[1.4rem] border border-white/70 bg-white/82 px-4 py-4 shadow-[0_10px_28px_rgba(15,23,42,0.05)]"
+              >
+                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-[var(--capacity-ink)]">
+                  {step.time}
+                </p>
+                <p className="mt-2 text-base font-semibold text-slate-950">
+                  {step.title}
+                </p>
+                <p className="mt-2 text-sm leading-7 text-slate-600">
+                  {step.summary}
+                </p>
+              </li>
+            ))}
+          </ol>
+        </aside>
+      </section>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,6 +13,10 @@
   --navigator-accent-light: rgba(8, 145, 178, 0.12);
   --navigator-accent-soft: rgba(34, 211, 238, 0.08);
   --navigator-ink: #164e63;
+  --capacity-accent: #2563eb;
+  --capacity-accent-light: rgba(37, 99, 235, 0.12);
+  --capacity-accent-soft: rgba(219, 234, 254, 0.7);
+  --capacity-ink: #1d4ed8;
 
   /* Shared typography tokens */
   --heading-tracking-tight: -0.025em;
@@ -67,6 +71,7 @@ body {
   color: var(--foreground);
   background-image:
     radial-gradient(circle at top, rgba(251, 191, 36, 0.18), transparent 32%),
+    radial-gradient(circle at left 22%, rgba(37, 99, 235, 0.12), transparent 24%),
     radial-gradient(circle at right 18%, rgba(8, 145, 178, 0.14), transparent 26%),
     linear-gradient(180deg, #fcf8ef 0%, #f4efe7 52%, #ebe5d9 100%);
   font-family: var(--font-geist-sans), Arial, Helvetica, sans-serif;
@@ -118,6 +123,35 @@ a {
   color: var(--foreground);
 }
 
+.app-shell__signal {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.9rem;
+  border-bottom: 1px solid rgba(37, 99, 235, 0.1);
+  background:
+    linear-gradient(90deg, rgba(239, 246, 255, 0.9), rgba(255, 251, 235, 0.85));
+  padding: 0.75rem 1.5rem;
+}
+
+.app-shell__signal-label {
+  border-radius: 9999px;
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  background: rgba(255, 255, 255, 0.82);
+  padding: 0.35rem 0.8rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--capacity-ink);
+}
+
+.app-shell__signal-copy {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: rgba(15, 23, 42, 0.72);
+}
+
 /* ── Shared app chrome ─────────────────────────────────────── */
 
 .app-nav {
@@ -130,7 +164,8 @@ a {
   gap: 1rem;
   min-height: var(--nav-height);
   padding: 0.875rem 1.5rem;
-  background: rgba(255, 251, 240, 0.86);
+  background:
+    linear-gradient(90deg, rgba(255, 251, 240, 0.88), rgba(239, 246, 255, 0.72));
   backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--line);
 }
@@ -374,7 +409,120 @@ a {
   border-left: 3px solid rgba(8, 145, 178, 0.28);
 }
 
+/* ── Capacity-board shared shell styles ───────────────────── */
+
+.capacity-shell-card {
+  position: relative;
+  isolation: isolate;
+}
+
+.capacity-shell-card::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    rgba(37, 99, 235, 0.72) 0%,
+    rgba(59, 130, 246, 0.42) 50%,
+    rgba(251, 191, 36, 0.58) 100%
+  );
+  opacity: 0.82;
+}
+
+.capacity-board-panel {
+  position: relative;
+  overflow: hidden;
+}
+
+.capacity-board-panel::before {
+  content: "";
+  position: absolute;
+  inset: auto -12% -34% 42%;
+  height: 11rem;
+  background: radial-gradient(circle, rgba(37, 99, 235, 0.13), transparent 68%);
+  pointer-events: none;
+}
+
+.capacity-board-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  background: rgba(255, 255, 255, 0.76);
+  padding: 0.35rem 0.8rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--capacity-ink);
+}
+
+.capacity-board-chip::before {
+  content: "";
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 9999px;
+  background: var(--capacity-accent);
+  box-shadow: 0 0 0 0.25rem rgba(37, 99, 235, 0.12);
+}
+
+.capacity-board-note {
+  border-left: 3px solid rgba(37, 99, 235, 0.24);
+}
+
+.capacity-board-track {
+  transition:
+    transform 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.capacity-board-track:hover {
+  transform: translateY(-2px);
+  border-color: rgba(37, 99, 235, 0.22);
+  box-shadow: 0 18px 34px rgba(37, 99, 235, 0.09);
+}
+
+.capacity-board-link {
+  position: relative;
+}
+
+.capacity-board-link::after {
+  content: "\2192";
+  margin-left: 0.45rem;
+  transition: transform 0.15s ease;
+}
+
+.capacity-board-link:hover::after {
+  transform: translateX(2px);
+}
+
+.capacity-board-meter {
+  overflow: hidden;
+  height: 0.6rem;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.capacity-board-meter__fill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    rgba(37, 99, 235, 0.92) 0%,
+    rgba(96, 165, 250, 0.62) 100%
+  );
+}
+
 @media (max-width: 960px) {
+  .app-shell__signal {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
   .app-nav {
     align-items: flex-start;
     flex-wrap: wrap;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,12 +19,13 @@ export const metadata: Metadata = {
     template: "%s | Archive Signals",
   },
   description:
-    "Operational dashboards, navigator handoff surfaces, experiment registries, and field guides for archive-driven teams.",
+    "Operational dashboards, navigator handoff surfaces, capacity boards, experiment registries, and field guides for archive-driven teams.",
 };
 
 const navLinks = [
   { href: "/", label: "Home" },
   { href: "/navigator-hub", label: "Navigator Hub" },
+  { href: "/capacity-board", label: "Capacity Board" },
   { href: "/team-directory", label: "Team Directory" },
   { href: "/archive-browser", label: "Archive" },
   { href: "/research-notebook", label: "Notebook" },
@@ -47,9 +48,16 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="flex min-h-full flex-col bg-slate-50/40">
+        <div className="app-shell__signal">
+          <span className="app-shell__signal-label">Issue 218</span>
+          <p className="app-shell__signal-copy">
+            Capacity Board overlap is active across the landing page, shared
+            layout, and global shell.
+          </p>
+        </div>
         <nav className="app-nav" aria-label="Primary">
           <div className="app-nav__cluster">
-            <p className="app-nav__eyebrow">Conflict surface</p>
+            <p className="app-nav__eyebrow">Conflict surfaces</p>
             <Link href="/" className="app-nav__brand">
               Archive Signals
             </Link>
@@ -63,13 +71,13 @@ export default function RootLayout({
               </li>
             ))}
           </ul>
-          <p className="app-nav__meta">Navigator overlap active</p>
+          <p className="app-nav__meta">Navigator + capacity overlap</p>
         </nav>
         {children}
         <footer className="mt-auto border-t border-[var(--line)] py-6 text-center">
           <p className="section-label text-slate-500">
-            Archive Signals &middot; Navigator Hub &middot; Status Board &middot;
-            Built for conflict testing
+            Archive Signals &middot; Navigator Hub &middot; Capacity Board
+            &middot; Built for conflict testing
           </p>
         </footer>
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,10 @@
 import Link from "next/link";
 import { teamGroups, getDirectoryMetrics } from "@/data/team-directory";
 
-const navigatorHubHighlights = [
-  "New navigator hub route with linked intervention rails across queue, parcel, and command views",
-  "Shared landing-page overlap that rewrites the featured hero around the new route",
-  "Global shell styling updates that intentionally modify the common app nav, footer, and theme tokens",
+const capacityBoardHighlights = [
+  "New capacity board route with redline pod summaries, linked route rails, and shared overflow checks",
+  "Landing-page overlap that rewrites the featured hero around team load and release coverage",
+  "Global shell updates that intentionally touch the common nav, footer, body treatment, and shared style tokens",
 ];
 
 const notebookHighlights = [
@@ -70,39 +70,39 @@ export default function Home() {
 
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-[var(--section-gap)] px-6 py-12 sm:px-10 lg:px-12">
-      <section className="overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.08)]">
+      <section className="capacity-shell-card overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.08)]">
         <div className="grid gap-10 px-6 py-10 sm:px-10 lg:grid-cols-[minmax(0,1.2fr)_minmax(260px,0.8fr)] lg:px-12 lg:py-14">
           <div className="space-y-6">
-            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-cyan-700">
-              Issue 216 / Navigator Hub
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-blue-700">
+              Issue 218 / Capacity Board
             </p>
             <div className="space-y-4">
               <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-                Coordinate shared app-shell handoffs from a dedicated navigator
-                hub.
+                Stage team load, overflow coverage, and release thresholds from
+                a dedicated capacity board.
               </h1>
               <p className="max-w-2xl text-lg leading-8 text-slate-600">
-                The navigator hub is the new conflict surface for issue 216:
-                one route that pulls together lane pressure, handoff timing,
-                and shared-shell entry points while also rewriting common
-                landing and global presentation files.
+                Capacity Board is the new conflict surface for issue 218: one
+                route that concentrates pod occupancy, fallback coverage, and
+                linked escalation rails while intentionally rewriting the shared
+                landing, layout, and global presentation files.
               </p>
             </div>
             <div className="flex flex-col gap-4 sm:flex-row">
               <Link
+                href="/capacity-board"
+                className="inline-flex items-center justify-center rounded-full bg-blue-700 px-6 py-3 text-sm font-semibold text-blue-50 transition hover:bg-blue-800"
+              >
+                Open capacity board
+              </Link>
+              <Link
                 href="/navigator-hub"
-                className="inline-flex items-center justify-center rounded-full bg-cyan-700 px-6 py-3 text-sm font-semibold text-cyan-50 transition hover:bg-cyan-800"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
               >
                 Open navigator hub
               </Link>
-              <Link
-                href="/operations-center"
-                className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
-              >
-                Open ops center
-              </Link>
               <a
-                href="https://github.com/iamasx/api-test/issues/216"
+                href="https://github.com/iamasx/api-test/issues/218"
                 className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
                 target="_blank"
                 rel="noreferrer"
@@ -112,15 +112,15 @@ export default function Home() {
             </div>
           </div>
 
-          <div className="rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
+          <div className="capacity-board-panel rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
             <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
-              Conflict checks
+              Release checks
             </p>
             <ul className="mt-5 space-y-4">
-              {navigatorHubHighlights.map((item) => (
+              {capacityBoardHighlights.map((item) => (
                 <li
                   key={item}
-                  className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"
+                  className="capacity-board-note rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"
                 >
                   {item}
                 </li>


### PR DESCRIPTION
## Summary
- add a new `/capacity-board` route with pod load, overflow coverage, and linked route rails
- rewrite the landing page hero so the new route is linked from the main entry point
- update the shared layout shell and global styles to widen the intentional conflict surface

Closes #218

## Verification
- `npm run lint`
- `npm run build`
- `npm run test` *(fails in existing unrelated suites: `src/app/scenario-board/page.test.tsx` and `src/app/field-guide/page.test.tsx`)*