### PR TITLE
feat: add review hub shared overlap

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,10 @@
   --nav-height: 3.5rem;
   --ops-accent: #0e7490;
   --ops-accent-light: rgba(14, 116, 144, 0.08);
+  --review-accent: #be123c;
+  --review-accent-light: rgba(190, 24, 93, 0.12);
+  --review-accent-soft: rgba(251, 113, 133, 0.1);
+  --review-ink: #881337;
   --navigator-accent: #0891b2;
   --navigator-accent-light: rgba(8, 145, 178, 0.12);
   --navigator-accent-soft: rgba(34, 211, 238, 0.08);
@@ -67,6 +71,7 @@ body {
   color: var(--foreground);
   background-image:
     radial-gradient(circle at top, rgba(251, 191, 36, 0.18), transparent 32%),
+    radial-gradient(circle at left 18%, rgba(251, 113, 133, 0.12), transparent 24%),
     radial-gradient(circle at right 18%, rgba(8, 145, 178, 0.14), transparent 26%),
     linear-gradient(180deg, #fcf8ef 0%, #f4efe7 52%, #ebe5d9 100%);
   font-family: var(--font-geist-sans), Arial, Helvetica, sans-serif;
@@ -147,7 +152,7 @@ a {
   font-weight: 700;
   letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: rgba(8, 145, 178, 0.75);
+  color: rgba(190, 24, 93, 0.76);
 }
 
 .app-nav__brand {
@@ -174,7 +179,7 @@ a {
 }
 
 .app-nav__link:hover {
-  color: var(--foreground);
+  color: var(--review-ink);
 }
 
 .app-nav__link--active {
@@ -184,14 +189,18 @@ a {
 
 .app-nav__meta {
   border-radius: 9999px;
-  border: 1px solid rgba(8, 145, 178, 0.18);
-  background: rgba(255, 255, 255, 0.58);
+  border: 1px solid rgba(190, 24, 93, 0.18);
+  background: linear-gradient(
+    135deg,
+    rgba(255, 241, 242, 0.9),
+    rgba(255, 255, 255, 0.7)
+  );
   padding: 0.4rem 0.8rem;
   font-size: 0.6875rem;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--navigator-ink);
+  color: var(--review-ink);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85);
 }
 
@@ -273,6 +282,139 @@ a {
 .route-entry-link:hover {
   transform: translateY(-2px);
   box-shadow: 0 8px 30px rgba(15, 23, 42, 0.12);
+}
+
+/* ── Review-hub shared shell styles ───────────────────────── */
+
+.review-hub-hero {
+  position: relative;
+  background-image: linear-gradient(
+    135deg,
+    rgba(255, 241, 242, 0.92) 0%,
+    rgba(255, 255, 255, 0.96) 44%,
+    rgba(255, 247, 237, 0.95) 100%
+  );
+}
+
+.review-hub-hero::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    rgba(190, 24, 93, 0.76) 0%,
+    rgba(251, 113, 133, 0.38) 48%,
+    rgba(245, 158, 11, 0.52) 100%
+  );
+  opacity: 0.82;
+}
+
+.review-shell-card {
+  position: relative;
+  isolation: isolate;
+}
+
+.review-shell-card::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    rgba(190, 24, 93, 0.72) 0%,
+    rgba(251, 113, 133, 0.36) 48%,
+    rgba(245, 158, 11, 0.5) 100%
+  );
+  opacity: 0.72;
+}
+
+.review-shell-link {
+  position: relative;
+}
+
+.review-shell-link::after {
+  content: "\2192";
+  margin-left: 0.45rem;
+  transition: transform 0.15s ease;
+}
+
+.review-shell-link:hover::after {
+  transform: translateX(2px);
+}
+
+.review-hub-orbit,
+.review-hub-section {
+  position: relative;
+}
+
+.review-hub-track,
+.review-hub-check {
+  transition:
+    transform 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.review-hub-track:hover,
+.review-hub-check:hover {
+  transform: translateY(-2px);
+  border-color: rgba(190, 24, 93, 0.2);
+  box-shadow: 0 18px 34px rgba(190, 24, 93, 0.08);
+}
+
+.review-hub-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(190, 24, 93, 0.18);
+  background: rgba(255, 255, 255, 0.76);
+  padding: 0.35rem 0.8rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--review-ink);
+}
+
+.review-hub-kicker::before {
+  content: "";
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 9999px;
+  background: var(--review-accent);
+  box-shadow: 0 0 0 0.25rem var(--review-accent-light);
+}
+
+.review-hub-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 9999px;
+  border: 1px solid rgba(190, 24, 93, 0.16);
+  background: rgba(255, 241, 242, 0.88);
+  padding: 0.35rem 0.75rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--review-ink);
+}
+
+.review-hub-note {
+  border-left: 3px solid rgba(190, 24, 93, 0.24);
+}
+
+.review-hub-chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 9999px;
+  border: 1px solid rgba(190, 24, 93, 0.14);
+  background: rgba(255, 241, 242, 0.8);
+  padding: 0.35rem 0.7rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--review-ink);
 }
 
 /* ── Navigator-hub shared shell styles ────────────────────── */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,11 +19,12 @@ export const metadata: Metadata = {
     template: "%s | Archive Signals",
   },
   description:
-    "Operational dashboards, navigator handoff surfaces, experiment registries, and field guides for archive-driven teams.",
+    "Operational dashboards, navigator and review handoff surfaces, experiment registries, and field guides for archive-driven teams.",
 };
 
 const navLinks = [
   { href: "/", label: "Home" },
+  { href: "/review-hub", label: "Review Hub" },
   { href: "/navigator-hub", label: "Navigator Hub" },
   { href: "/team-directory", label: "Team Directory" },
   { href: "/archive-browser", label: "Archive" },
@@ -49,7 +50,7 @@ export default function RootLayout({
       <body className="flex min-h-full flex-col bg-slate-50/40">
         <nav className="app-nav" aria-label="Primary">
           <div className="app-nav__cluster">
-            <p className="app-nav__eyebrow">Conflict surface</p>
+            <p className="app-nav__eyebrow">Shared review surface</p>
             <Link href="/" className="app-nav__brand">
               Archive Signals
             </Link>
@@ -63,12 +64,12 @@ export default function RootLayout({
               </li>
             ))}
           </ul>
-          <p className="app-nav__meta">Navigator overlap active</p>
+          <p className="app-nav__meta">Review overlap active</p>
         </nav>
         {children}
         <footer className="mt-auto border-t border-[var(--line)] py-6 text-center">
           <p className="section-label text-slate-500">
-            Archive Signals &middot; Navigator Hub &middot; Status Board &middot;
+            Archive Signals &middot; Review Hub &middot; Navigator Hub &middot;
             Built for conflict testing
           </p>
         </footer>

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import Home from "./page";
+
+describe("Home", () => {
+  it("features the review hub entry from the landing page", () => {
+    render(<Home />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /stage the shared landing-page overlap from the review hub\./i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /open review hub/i }),
+    ).toHaveAttribute("href", "/review-hub");
+    expect(
+      screen.queryByText(/issue 216 \/ navigator hub/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,10 @@
 import Link from "next/link";
 import { teamGroups, getDirectoryMetrics } from "@/data/team-directory";
 
-const navigatorHubHighlights = [
-  "New navigator hub route with linked intervention rails across queue, parcel, and command views",
-  "Shared landing-page overlap that rewrites the featured hero around the new route",
-  "Global shell styling updates that intentionally modify the common app nav, footer, and theme tokens",
+const reviewHubHighlights = [
+  "Dedicated review-hub route with file-by-file overlap targets and a release cadence for shared-shell changes",
+  "Featured landing-page hero rewritten so the common entry point routes directly into the review surface",
+  "Global shell copy and presentation updates intentionally widen the merge-conflict surface in shared files",
 ];
 
 const notebookHighlights = [
@@ -70,39 +70,41 @@ export default function Home() {
 
   return (
     <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-[var(--section-gap)] px-6 py-12 sm:px-10 lg:px-12">
-      <section className="overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.08)]">
+      <section className="review-hub-hero route-entry-link overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.08)]">
         <div className="grid gap-10 px-6 py-10 sm:px-10 lg:grid-cols-[minmax(0,1.2fr)_minmax(260px,0.8fr)] lg:px-12 lg:py-14">
           <div className="space-y-6">
-            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-cyan-700">
-              Issue 216 / Navigator Hub
-            </p>
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="review-hub-badge">Landing overlap route</span>
+              <p className="text-sm font-semibold uppercase tracking-[0.28em] text-rose-700">
+                Issue 217 / Review Hub
+              </p>
+            </div>
             <div className="space-y-4">
               <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl">
-                Coordinate shared app-shell handoffs from a dedicated navigator
-                hub.
+                Stage the shared landing-page overlap from the review hub.
               </h1>
               <p className="max-w-2xl text-lg leading-8 text-slate-600">
-                The navigator hub is the new conflict surface for issue 216:
-                one route that pulls together lane pressure, handoff timing,
-                and shared-shell entry points while also rewriting common
-                landing and global presentation files.
+                Review Hub is the new conflict surface for issue 217: one route
+                that inventories the shared files, tracks the active review
+                lanes, and keeps the landing page plus app shell intentionally
+                overlapped while adjacent PRs are still in flight.
               </p>
             </div>
             <div className="flex flex-col gap-4 sm:flex-row">
               <Link
+                href="/review-hub"
+                className="inline-flex items-center justify-center rounded-full bg-rose-700 px-6 py-3 text-sm font-semibold text-rose-50 transition hover:bg-rose-800"
+              >
+                Open review hub
+              </Link>
+              <Link
                 href="/navigator-hub"
-                className="inline-flex items-center justify-center rounded-full bg-cyan-700 px-6 py-3 text-sm font-semibold text-cyan-50 transition hover:bg-cyan-800"
+                className="review-shell-link inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
               >
                 Open navigator hub
               </Link>
-              <Link
-                href="/operations-center"
-                className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
-              >
-                Open ops center
-              </Link>
               <a
-                href="https://github.com/iamasx/api-test/issues/216"
+                href="https://github.com/iamasx/api-test/issues/217"
                 className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
                 target="_blank"
                 rel="noreferrer"
@@ -114,13 +116,13 @@ export default function Home() {
 
           <div className="rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
             <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
-              Conflict checks
+              Review checks
             </p>
             <ul className="mt-5 space-y-4">
-              {navigatorHubHighlights.map((item) => (
+              {reviewHubHighlights.map((item) => (
                 <li
                   key={item}
-                  className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"
+                  className="review-hub-note rounded-2xl border border-rose-100 bg-white/80 px-4 py-4 text-sm leading-6 text-slate-600"
                 >
                   {item}
                 </li>

--- a/src/app/review-hub/page.test.tsx
+++ b/src/app/review-hub/page.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import ReviewHubPage from "./page";
+
+describe("ReviewHubPage", () => {
+  it("renders the route hero and primary actions", () => {
+    render(<ReviewHubPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: /stage the shared landing-page overlap before the next merge lands\./i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /back to overview/i }),
+    ).toHaveAttribute("href", "/");
+    expect(
+      screen.getByRole("link", { name: /open navigator hub/i }),
+    ).toHaveAttribute("href", "/navigator-hub");
+    expect(screen.getByText("09:10-09:46")).toBeInTheDocument();
+  });
+
+  it("lists the shared file overlap targets and review lanes", () => {
+    render(<ReviewHubPage />);
+
+    const fileList = screen.getByRole("list", {
+      name: /shared file overlap targets/i,
+    });
+
+    expect(within(fileList).getAllByRole("listitem")).toHaveLength(4);
+    expect(within(fileList).getByText("src/app/page.tsx")).toBeInTheDocument();
+    expect(
+      within(fileList).getByText("src/app/review-hub/page.tsx"),
+    ).toBeInTheDocument();
+
+    const laneList = screen.getByRole("list", {
+      name: /review handoff lanes/i,
+    });
+
+    expect(within(laneList).getAllByRole("listitem")).toHaveLength(4);
+    expect(
+      within(laneList).getByRole("heading", { name: /landing hero rewrite/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(laneList).getByRole("heading", { name: /review route audit/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the release checks and cadence guidance", () => {
+    render(<ReviewHubPage />);
+
+    const releaseChecks = screen.getByRole("list", {
+      name: /review release checks/i,
+    });
+
+    expect(within(releaseChecks).getAllByRole("listitem")).toHaveLength(4);
+    expect(
+      within(releaseChecks).getByText(
+        /confirm the homepage now points at review hub/i,
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("heading", {
+        name: /keep the overlap audit moving on a timed cadence\./i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("09:24")).toBeInTheDocument();
+    expect(screen.getByText(/shell pass/i)).toBeInTheDocument();
+  });
+});

--- a/src/app/review-hub/page.tsx
+++ b/src/app/review-hub/page.tsx
@@ -1,0 +1,380 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Review Hub",
+  description:
+    "Shared landing-page overlap route for file-by-file review lanes, shell checks, and release cadence.",
+};
+
+type ReviewTrackStatus = "active" | "queued" | "ready";
+
+const sharedFiles = [
+  {
+    path: "src/app/page.tsx",
+    impact: "Homepage hero copy, primary CTA, and feature card now route into Review Hub.",
+    risk: "High overlap",
+    note: "This is the first file other landing-page issues are likely to touch when they replace the featured route.",
+  },
+  {
+    path: "src/app/layout.tsx",
+    impact: "Root navigation, shared eyebrow copy, and footer treatment all acknowledge the new review surface.",
+    risk: "High overlap",
+    note: "Any branch changing the app shell can collide here because the route list and shell messaging live together.",
+  },
+  {
+    path: "src/app/globals.css",
+    impact: "Theme accents, navigation chrome, and route-specific shell affordances shift to the review palette.",
+    risk: "High overlap",
+    note: "Global tokens and hover states are reused across the app, so palette changes widen the merge surface quickly.",
+  },
+  {
+    path: "src/app/review-hub/page.tsx",
+    impact: "Dedicated route content centralizes the overlap audit, release checks, and reviewer cadence.",
+    risk: "New route",
+    note: "This file stays isolated while the other shared files create the deliberate conflict pressure.",
+  },
+] as const;
+
+const reviewTracks: Array<{
+  title: string;
+  status: ReviewTrackStatus;
+  owner: string;
+  window: string;
+  summary: string;
+  files: readonly string[];
+}> = [
+  {
+    title: "Landing hero rewrite",
+    status: "active",
+    owner: "Homepage surface",
+    window: "09:10-09:18",
+    summary:
+      "Replace the featured landing block so the common entry point now introduces Review Hub instead of the previous spotlight route.",
+    files: ["src/app/page.tsx", "src/app/layout.tsx"],
+  },
+  {
+    title: "Shared shell copy sweep",
+    status: "active",
+    owner: "App chrome",
+    window: "09:18-09:28",
+    summary:
+      "Align the root nav, eyebrow, and footer so review-specific messaging shows up anywhere the shared shell is visible.",
+    files: ["src/app/layout.tsx", "src/app/globals.css"],
+  },
+  {
+    title: "Token and hover pass",
+    status: "queued",
+    owner: "Global styling",
+    window: "09:28-09:37",
+    summary:
+      "Update the shared palette and route-shell utilities so the review route and landing hero read as one coordinated surface.",
+    files: ["src/app/globals.css", "src/app/page.tsx"],
+  },
+  {
+    title: "Review route audit",
+    status: "ready",
+    owner: "Route owner",
+    window: "09:37-09:46",
+    summary:
+      "Capture the file-by-file overlap targets, the release checks, and the cadence reviewers should follow once adjacent PRs land.",
+    files: ["src/app/review-hub/page.tsx"],
+  },
+];
+
+const releaseChecks = [
+  {
+    title: "Confirm the homepage now points at Review Hub",
+    detail:
+      "The shared landing hero and CTA need to reference the new route directly so the conflict surface is visible from the first screen.",
+  },
+  {
+    title: "Re-read the shared shell copy in one pass",
+    detail:
+      "Navigation, eyebrow text, and footer wording should shift together so reviewers are not reconciling mixed route names.",
+  },
+  {
+    title: "Check the palette drift before merging",
+    detail:
+      "Body background, nav badge styling, and review-shell affordances should stay in the same family once the globals land.",
+  },
+  {
+    title: "Leave a handoff note for the next overlapping PR",
+    detail:
+      "Document which shared file is most likely to conflict so the follow-up branch can rebase with context instead of guesswork.",
+  },
+] as const;
+
+const reviewCadence = [
+  {
+    time: "09:10",
+    title: "Landing pass",
+    summary:
+      "Review the homepage hero and primary CTA before any route-specific content is assessed.",
+  },
+  {
+    time: "09:24",
+    title: "Shell pass",
+    summary:
+      "Open the shared navigation and footer together so copy drift is caught in the same read-through.",
+  },
+  {
+    time: "09:46",
+    title: "Conflict note",
+    summary:
+      "Record which shared file changed last and flag the probable merge hotspot for the next PR.",
+  },
+] as const;
+
+const statusClasses: Record<ReviewTrackStatus, string> = {
+  active: "border-rose-200 bg-rose-50 text-rose-800",
+  queued: "border-amber-200 bg-amber-50 text-amber-800",
+  ready: "border-emerald-200 bg-emerald-50 text-emerald-800",
+};
+
+export default function ReviewHubPage() {
+  const activeTracks = reviewTracks.filter((track) => track.status === "active").length;
+  const cadenceWindow = `${reviewCadence[0].time}-${reviewCadence[reviewCadence.length - 1].time}`;
+
+  return (
+    <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
+      <section className="review-hub-orbit review-shell-card overflow-hidden rounded-[2.4rem] border border-slate-200 bg-[linear-gradient(135deg,#fff1f2_0%,#ffffff_44%,#fff7ed_100%)] shadow-[0_30px_100px_rgba(15,23,42,0.1)]">
+        <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1.16fr)_minmax(300px,0.84fr)] lg:px-12 lg:py-12">
+          <div className="space-y-6">
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="ops-badge">Review Hub</span>
+              <span className="review-hub-badge">Landing overlap route</span>
+            </div>
+
+            <div className="space-y-4">
+              <h1 className="heading-tight max-w-4xl text-4xl text-slate-950 sm:text-5xl">
+                Stage the shared landing-page overlap before the next merge
+                lands.
+              </h1>
+              <p className="max-w-3xl text-base leading-8 text-slate-600 sm:text-lg">
+                Review Hub is the deliberate conflict surface for issue 217. It
+                inventories the shared files, lines up the review lanes, and
+                keeps the app-shell edits tied to one route so overlapping PRs
+                have a clear place to compare before rebasing.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-full bg-slate-950 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
+              >
+                Back to overview
+              </Link>
+              <Link
+                href="/navigator-hub"
+                className="review-shell-link inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+              >
+                Open navigator hub
+              </Link>
+              <a
+                href="https://github.com/iamasx/api-test/issues/217"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Review issue
+              </a>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-3">
+              <article className="rounded-[1.4rem] border border-white/70 bg-white/80 px-4 py-4 shadow-[0_12px_36px_rgba(15,23,42,0.08)]">
+                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  Shared files
+                </p>
+                <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+                  {sharedFiles.length}
+                </p>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  Direct overlap targets across the landing page, app shell, and
+                  globals.
+                </p>
+              </article>
+              <article className="rounded-[1.4rem] border border-white/70 bg-white/80 px-4 py-4 shadow-[0_12px_36px_rgba(15,23,42,0.08)]">
+                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  Active lanes
+                </p>
+                <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+                  {activeTracks}
+                </p>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  Review lanes still moving while the shared files remain open.
+                </p>
+              </article>
+              <article className="rounded-[1.4rem] border border-white/70 bg-white/80 px-4 py-4 shadow-[0_12px_36px_rgba(15,23,42,0.08)]">
+                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                  Cadence window
+                </p>
+                <p className="mt-3 text-3xl font-semibold tracking-tight text-slate-950">
+                  {cadenceWindow}
+                </p>
+                <p className="mt-2 text-sm leading-6 text-slate-600">
+                  Planned handoff window for the overlap audit before PR
+                  routing.
+                </p>
+              </article>
+            </div>
+          </div>
+
+          <aside className="review-shell-card rounded-[1.8rem] border border-slate-200/80 bg-white/80 p-6 shadow-[0_22px_70px_rgba(15,23,42,0.1)]">
+            <p className="section-label text-slate-500">Shared files in play</p>
+            <ul
+              className="mt-5 space-y-4"
+              role="list"
+              aria-label="shared file overlap targets"
+            >
+              {sharedFiles.map((file) => (
+                <li
+                  key={file.path}
+                  className="review-hub-note rounded-[1.4rem] border border-slate-200 bg-slate-50/90 px-4 py-4 text-sm leading-6 text-slate-600"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <code className="text-[0.72rem] font-semibold text-slate-950">
+                      {file.path}
+                    </code>
+                    <span className="rounded-full border border-rose-200 bg-rose-50 px-2.5 py-1 text-[0.625rem] font-semibold uppercase tracking-[0.12em] text-rose-700">
+                      {file.risk}
+                    </span>
+                  </div>
+                  <p className="mt-3 font-medium text-slate-900">{file.impact}</p>
+                  <p className="mt-2 text-slate-500">{file.note}</p>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        </div>
+      </section>
+
+      <section className="review-hub-section overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.08)]">
+        <div className="relative grid gap-6 px-6 py-8 sm:px-10 lg:px-12 lg:py-10">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-2">
+              <p className="review-hub-kicker">Review lanes</p>
+              <h2 className="max-w-3xl text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                Walk the shared edits in the same order reviewers will see them.
+              </h2>
+            </div>
+            <p className="max-w-2xl text-sm leading-7 text-slate-600">
+              Each lane calls out the owner, active window, and the exact files
+              the review pass is supposed to touch before the route goes up for
+              merge.
+            </p>
+          </div>
+
+          <div
+            className="grid gap-4 lg:grid-cols-2"
+            role="list"
+            aria-label="review handoff lanes"
+          >
+            {reviewTracks.map((track) => (
+              <article
+                key={track.title}
+                role="listitem"
+                className="review-hub-track rounded-[1.6rem] border border-slate-200 bg-white/85 p-5 shadow-[0_12px_36px_rgba(15,23,42,0.06)]"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <h3 className="text-lg font-semibold text-slate-950">
+                      {track.title}
+                    </h3>
+                    <p className="mt-1 text-sm text-slate-500">{track.owner}</p>
+                  </div>
+                  <span
+                    className={`rounded-full border px-3 py-1 text-[0.6875rem] font-semibold uppercase tracking-[0.14em] ${statusClasses[track.status]}`}
+                  >
+                    {track.status}
+                  </span>
+                </div>
+
+                <div className="mt-5 rounded-[1.2rem] border border-slate-200 bg-slate-50/90 px-4 py-3">
+                  <p className="text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                    Window
+                  </p>
+                  <p className="mt-2 text-sm font-semibold text-slate-900">
+                    {track.window}
+                  </p>
+                </div>
+
+                <p className="mt-4 text-sm leading-7 text-slate-600">
+                  {track.summary}
+                </p>
+
+                <ul className="mt-4 flex flex-wrap gap-2" aria-label={`${track.title} files`}>
+                  {track.files.map((file) => (
+                    <li key={file} className="review-hub-chip">
+                      {file}
+                    </li>
+                  ))}
+                </ul>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[minmax(0,1.04fr)_minmax(320px,0.96fr)]">
+        <div className="rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] p-6 shadow-[0_20px_90px_rgba(15,23,42,0.06)] sm:p-8">
+          <div className="space-y-2">
+            <p className="section-label text-slate-500">Release checks</p>
+            <h2 className="text-3xl font-semibold tracking-tight text-slate-950">
+              Clear the shared shell before review routing starts.
+            </h2>
+          </div>
+
+          <ol
+            className="mt-6 space-y-4"
+            role="list"
+            aria-label="review release checks"
+          >
+            {releaseChecks.map((check) => (
+              <li
+                key={check.title}
+                className="review-hub-check rounded-[1.5rem] border border-slate-200 bg-white/85 px-5 py-4 shadow-[0_12px_30px_rgba(15,23,42,0.06)]"
+              >
+                <p className="text-base font-semibold text-slate-950">
+                  {check.title}
+                </p>
+                <p className="mt-2 text-sm leading-7 text-slate-600">
+                  {check.detail}
+                </p>
+              </li>
+            ))}
+          </ol>
+        </div>
+
+        <aside className="rounded-[2rem] border border-[var(--line)] bg-[linear-gradient(180deg,rgba(255,241,242,0.92),rgba(255,247,237,0.92))] p-6 shadow-[0_20px_90px_rgba(15,23,42,0.06)] sm:p-8">
+          <div className="space-y-2">
+            <p className="section-label text-slate-500">Cadence</p>
+            <h2 className="text-3xl font-semibold tracking-tight text-slate-950">
+              Keep the overlap audit moving on a timed cadence.
+            </h2>
+          </div>
+
+          <ol className="mt-6 space-y-4">
+            {reviewCadence.map((step) => (
+              <li
+                key={step.time}
+                className="rounded-[1.4rem] border border-white/70 bg-white/80 px-4 py-4 shadow-[0_10px_28px_rgba(15,23,42,0.05)]"
+              >
+                <p className="text-[0.7rem] font-semibold uppercase tracking-[0.2em] text-rose-700">
+                  {step.time}
+                </p>
+                <p className="mt-2 text-base font-semibold text-slate-950">
+                  {step.title}
+                </p>
+                <p className="mt-2 text-sm leading-7 text-slate-600">
+                  {step.summary}
+                </p>
+              </li>
+            ))}
+          </ol>
+        </aside>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add a new `review-hub` route with shared-file audit content, release checks, and review cadence
- rewrite the landing-page hero to route into Review Hub and add focused route render coverage
- update the shared app shell and global styling so the nav, footer, and shell presentation overlap intentionally

Closes #217

## Testing
- not run (pushing current implementation immediately per orchestrator instruction)