### PR TITLE
feat: add response-ledger route with action history and ownership rail

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,6 +33,7 @@ const navLinks = [
   { href: "/queue-monitor", label: "Queue Monitor" },
   { href: "/parcel-hub", label: "Parcel Hub" },
   { href: "/status-board", label: "Status Board" },
+  { href: "/response-ledger", label: "Response Ledger" },
 ] as const;
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,6 +59,12 @@ const statusBoardHighlights = [
   "Summary bar with service counts, operational ratio, and open incident totals",
 ];
 
+const responseLedgerHighlights = [
+  "Chronological action history with status badges and owner attribution",
+  "Outcome summary cards showing success, partial, and pending results",
+  "Compact ownership rail with per-owner action counts and resolution rates",
+];
+
 const teamDirectoryHighlights = [
   "Cross-functional directory with grouped profiles and availability states",
   "Spotlight panel featuring role highlights and shared skill breakdowns",
@@ -549,6 +555,59 @@ export default function Home() {
             </p>
             <ul className="mt-5 space-y-4">
               {statusBoardHighlights.map((item) => (
+                <li
+                  key={item}
+                  className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"
+                >
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-[2rem] border border-[var(--line)] bg-[var(--surface)] shadow-[0_20px_90px_rgba(15,23,42,0.06)]">
+        <div className="grid gap-8 px-6 py-8 sm:px-10 lg:grid-cols-[minmax(0,1fr)_minmax(260px,0.9fr)] lg:px-12 lg:py-10">
+          <div className="space-y-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-orange-700">
+              Issue 212 / Response Ledger
+            </p>
+            <div className="space-y-3">
+              <h2 className="max-w-2xl text-3xl font-semibold tracking-tight text-slate-950 sm:text-4xl">
+                Track response actions, outcomes, and ownership across active
+                incidents.
+              </h2>
+              <p className="max-w-2xl text-base leading-7 text-slate-600 sm:text-lg">
+                The response ledger collects action history, short outcome
+                summaries, and a compact ownership rail so operators can review
+                who did what and how each action resolved.
+              </p>
+            </div>
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href="/response-ledger"
+                className="inline-flex items-center justify-center rounded-full bg-orange-700 px-6 py-3 text-sm font-semibold text-orange-50 transition hover:bg-orange-800"
+              >
+                Open response ledger
+              </Link>
+              <a
+                href="https://github.com/iamasx/api-test/issues/212"
+                className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Review issue scope
+              </a>
+            </div>
+          </div>
+
+          <div className="rounded-[1.75rem] border border-slate-200/80 bg-[var(--surface-strong)] p-6 shadow-[inset_0_1px_0_rgba(255,255,255,0.8)]">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Ledger features
+            </p>
+            <ul className="mt-5 space-y-4">
+              {responseLedgerHighlights.map((item) => (
                 <li
                   key={item}
                   className="rounded-2xl border border-slate-200 bg-white/75 px-4 py-4 text-sm leading-6 text-slate-600"

--- a/src/app/response-ledger/_components/ledger-entry.tsx
+++ b/src/app/response-ledger/_components/ledger-entry.tsx
@@ -1,0 +1,76 @@
+import type { ActionEntry } from "../_data/response-ledger-data";
+
+type LedgerEntryProps = {
+  action: ActionEntry;
+};
+
+const statusStyles: Record<ActionEntry["status"], string> = {
+  completed: "border-l-emerald-500",
+  "in-progress": "border-l-sky-400",
+  escalated: "border-l-rose-500",
+  deferred: "border-l-slate-400",
+};
+
+const statusBadge: Record<ActionEntry["status"], string> = {
+  completed: "bg-emerald-100 text-emerald-700",
+  "in-progress": "bg-sky-100 text-sky-700",
+  escalated: "bg-rose-100 text-rose-700",
+  deferred: "bg-slate-100 text-slate-600",
+};
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+export function LedgerEntry({ action }: LedgerEntryProps) {
+  return (
+    <article
+      role="listitem"
+      className={`rounded-xl border-l-4 bg-white/90 px-5 py-4 shadow-sm transition-shadow hover:shadow-md ${statusStyles[action.status]}`}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-3">
+          <time
+            dateTime={action.timestamp}
+            className="shrink-0 font-mono text-xs tabular-nums text-slate-500"
+          >
+            {formatTimestamp(action.timestamp)}
+          </time>
+          <span
+            className={`rounded-md px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wider ${statusBadge[action.status]}`}
+          >
+            {action.status}
+          </span>
+          <h3 className="text-sm font-semibold text-slate-900">
+            {action.title}
+          </h3>
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {action.tags.map((tag) => (
+            <span
+              key={tag}
+              className="rounded-full bg-slate-100 px-2.5 py-0.5 text-[11px] font-medium text-slate-600"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <p className="mt-2 text-sm leading-6 text-slate-600">
+        {action.description}
+      </p>
+
+      <div className="mt-2 flex items-center gap-3 text-xs text-slate-400">
+        <span>{action.owner}</span>
+        <span>&middot;</span>
+        <span>{action.team}</span>
+      </div>
+    </article>
+  );
+}

--- a/src/app/response-ledger/_components/outcome-summary.tsx
+++ b/src/app/response-ledger/_components/outcome-summary.tsx
@@ -1,0 +1,26 @@
+import type { OutcomeSummary } from "../_data/response-ledger-data";
+
+type OutcomeSummaryCardProps = {
+  outcome: OutcomeSummary;
+};
+
+const resultStyles: Record<OutcomeSummary["result"], string> = {
+  success: "border-emerald-200 bg-emerald-50 text-emerald-700",
+  partial: "border-amber-200 bg-amber-50 text-amber-700",
+  failed: "border-rose-200 bg-rose-50 text-rose-700",
+  pending: "border-slate-200 bg-slate-50 text-slate-600",
+};
+
+export function OutcomeSummaryCard({ outcome }: OutcomeSummaryCardProps) {
+  return (
+    <div className={`rounded-2xl border px-5 py-4 ${resultStyles[outcome.result]}`}>
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-semibold">{outcome.label}</span>
+        <span className="rounded-full border border-current/20 px-2 py-0.5 text-[0.625rem] font-semibold uppercase tracking-wide">
+          {outcome.result}
+        </span>
+      </div>
+      <p className="mt-1.5 text-sm leading-snug opacity-80">{outcome.detail}</p>
+    </div>
+  );
+}

--- a/src/app/response-ledger/_components/ownership-rail.tsx
+++ b/src/app/response-ledger/_components/ownership-rail.tsx
@@ -1,0 +1,38 @@
+import type { OwnershipRecord } from "../_data/response-ledger-data";
+
+type OwnershipRailProps = {
+  records: OwnershipRecord[];
+};
+
+export function OwnershipRail({ records }: OwnershipRailProps) {
+  return (
+    <div className="rounded-[var(--card-radius)] border border-[var(--line)] bg-[var(--surface-strong)] p-5">
+      <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+        Ownership
+      </p>
+      <ul className="mt-4 space-y-3" aria-label="Ownership summary">
+        {records.map((record) => (
+          <li
+            key={record.owner}
+            className="flex items-center justify-between rounded-xl border border-slate-200 bg-white/75 px-4 py-3"
+          >
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-slate-900">
+                {record.owner}
+              </p>
+              <p className="mt-0.5 text-xs text-slate-500">{record.team}</p>
+            </div>
+            <div className="shrink-0 text-right">
+              <p className="text-sm font-semibold text-slate-900">
+                {record.actionCount}
+              </p>
+              <p className="mt-0.5 text-xs text-slate-500">
+                {record.resolvedCount} resolved
+              </p>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/response-ledger/_data/response-ledger-data.ts
+++ b/src/app/response-ledger/_data/response-ledger-data.ts
@@ -1,0 +1,227 @@
+export type ActionStatus = "completed" | "in-progress" | "escalated" | "deferred";
+
+export type ActionEntry = {
+  id: string;
+  timestamp: string;
+  title: string;
+  description: string;
+  status: ActionStatus;
+  owner: string;
+  team: string;
+  tags: string[];
+};
+
+export type OutcomeSummary = {
+  id: string;
+  actionId: string;
+  label: string;
+  result: "success" | "partial" | "failed" | "pending";
+  detail: string;
+};
+
+export type OwnershipRecord = {
+  owner: string;
+  team: string;
+  actionCount: number;
+  resolvedCount: number;
+};
+
+export const actionEntries: ActionEntry[] = [
+  {
+    id: "act-001",
+    timestamp: "2026-04-25T09:12:00Z",
+    title: "Reroute inbound traffic to secondary gateway",
+    description:
+      "Primary gateway hit capacity limits during the morning surge. Traffic was shifted to the secondary gateway within the SLA window.",
+    status: "completed",
+    owner: "Mara Chen",
+    team: "Network Ops",
+    tags: ["traffic", "gateway", "capacity"],
+  },
+  {
+    id: "act-002",
+    timestamp: "2026-04-25T08:47:00Z",
+    title: "Escalate database replication lag to DBA on-call",
+    description:
+      "Replica lag exceeded 30 seconds on the analytics cluster. Escalated to the DBA rotation after automated recovery stalled.",
+    status: "escalated",
+    owner: "Jonas Park",
+    team: "Data Platform",
+    tags: ["database", "replication", "escalation"],
+  },
+  {
+    id: "act-003",
+    timestamp: "2026-04-25T08:30:00Z",
+    title: "Deploy hotfix for auth token validation",
+    description:
+      "A regression in token validation caused intermittent 401 responses for federated users. Hotfix deployed and canary confirmed healthy.",
+    status: "completed",
+    owner: "Priya Gupta",
+    team: "Identity",
+    tags: ["auth", "hotfix", "deploy"],
+  },
+  {
+    id: "act-004",
+    timestamp: "2026-04-25T08:15:00Z",
+    title: "Investigate elevated error rate on /v2/search",
+    description:
+      "Error rate spiked to 4.2% on the search endpoint. Root cause traced to an upstream index rebuild that temporarily returned partial results.",
+    status: "in-progress",
+    owner: "Leo Tanaka",
+    team: "Search",
+    tags: ["search", "errors", "investigation"],
+  },
+  {
+    id: "act-005",
+    timestamp: "2026-04-25T07:58:00Z",
+    title: "Defer cache warming for low-priority tenants",
+    description:
+      "Cache warming for tier-3 tenants deferred to off-peak window to preserve bandwidth for critical path traffic during the incident.",
+    status: "deferred",
+    owner: "Mara Chen",
+    team: "Network Ops",
+    tags: ["cache", "deferral", "capacity"],
+  },
+  {
+    id: "act-006",
+    timestamp: "2026-04-25T07:40:00Z",
+    title: "Restart notification relay workers",
+    description:
+      "Three relay workers stopped processing after a connection pool timeout. Rolling restart restored delivery within two minutes.",
+    status: "completed",
+    owner: "Sam Okoro",
+    team: "Messaging",
+    tags: ["notifications", "restart", "workers"],
+  },
+  {
+    id: "act-007",
+    timestamp: "2026-04-25T07:22:00Z",
+    title: "Roll back config change on rate limiter",
+    description:
+      "A config push lowered the global rate limit by 40%, triggering throttle alerts across partner integrations. Config reverted to previous version.",
+    status: "completed",
+    owner: "Priya Gupta",
+    team: "Identity",
+    tags: ["config", "rollback", "rate-limit"],
+  },
+  {
+    id: "act-008",
+    timestamp: "2026-04-25T07:05:00Z",
+    title: "Scale up compute pool for batch processing",
+    description:
+      "Batch job queue depth exceeded threshold. Auto-scale triggered but was capped; manual override added four additional nodes.",
+    status: "in-progress",
+    owner: "Jonas Park",
+    team: "Data Platform",
+    tags: ["compute", "scaling", "batch"],
+  },
+];
+
+export const outcomeSummaries: OutcomeSummary[] = [
+  {
+    id: "out-001",
+    actionId: "act-001",
+    label: "Traffic reroute",
+    result: "success",
+    detail: "Secondary gateway absorbed 100% of overflow. No dropped requests detected.",
+  },
+  {
+    id: "out-002",
+    actionId: "act-002",
+    label: "Replication lag escalation",
+    result: "pending",
+    detail: "DBA on-call acknowledged. Investigating replica configuration drift.",
+  },
+  {
+    id: "out-003",
+    actionId: "act-003",
+    label: "Auth hotfix deployment",
+    result: "success",
+    detail: "401 rate returned to baseline within 3 minutes of canary promotion.",
+  },
+  {
+    id: "out-004",
+    actionId: "act-004",
+    label: "Search error investigation",
+    result: "partial",
+    detail: "Index rebuild identified as root cause. Monitoring for recurrence after rebuild completes.",
+  },
+  {
+    id: "out-005",
+    actionId: "act-005",
+    label: "Cache warming deferral",
+    result: "success",
+    detail: "Bandwidth freed for critical traffic. Tier-3 warming rescheduled for 02:00 UTC.",
+  },
+  {
+    id: "out-006",
+    actionId: "act-006",
+    label: "Relay worker restart",
+    result: "success",
+    detail: "All three workers healthy. Notification backlog cleared in 90 seconds.",
+  },
+  {
+    id: "out-007",
+    actionId: "act-007",
+    label: "Rate limiter rollback",
+    result: "success",
+    detail: "Partner throttle alerts resolved. No SLA breaches recorded.",
+  },
+  {
+    id: "out-008",
+    actionId: "act-008",
+    label: "Compute scale-up",
+    result: "partial",
+    detail: "Four nodes added. Queue depth dropping but not yet below threshold.",
+  },
+];
+
+export function getOwnershipRecords(): OwnershipRecord[] {
+  const map = new Map<string, OwnershipRecord>();
+
+  for (const action of actionEntries) {
+    const key = action.owner;
+    const existing = map.get(key);
+    if (existing) {
+      existing.actionCount += 1;
+      if (action.status === "completed") existing.resolvedCount += 1;
+    } else {
+      map.set(key, {
+        owner: action.owner,
+        team: action.team,
+        actionCount: 1,
+        resolvedCount: action.status === "completed" ? 1 : 0,
+      });
+    }
+  }
+
+  return Array.from(map.values()).sort((a, b) => b.actionCount - a.actionCount);
+}
+
+export type ResponseLedgerView = {
+  actions: ActionEntry[];
+  outcomes: OutcomeSummary[];
+  ownership: OwnershipRecord[];
+  summary: {
+    totalActions: number;
+    completedCount: number;
+    escalatedCount: number;
+    inProgressCount: number;
+  };
+};
+
+export function getResponseLedgerView(): ResponseLedgerView {
+  const ownership = getOwnershipRecords();
+
+  return {
+    actions: actionEntries,
+    outcomes: outcomeSummaries,
+    ownership,
+    summary: {
+      totalActions: actionEntries.length,
+      completedCount: actionEntries.filter((a) => a.status === "completed").length,
+      escalatedCount: actionEntries.filter((a) => a.status === "escalated").length,
+      inProgressCount: actionEntries.filter((a) => a.status === "in-progress").length,
+    },
+  };
+}

--- a/src/app/response-ledger/page.test.tsx
+++ b/src/app/response-ledger/page.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import ResponseLedgerPage from "./page";
+import {
+  actionEntries,
+  outcomeSummaries,
+  getOwnershipRecords,
+} from "./_data/response-ledger-data";
+
+describe("ResponseLedgerPage", () => {
+  it("renders the page heading and summary stats", () => {
+    render(<ResponseLedgerPage />);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: /response ledger/i }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText(String(actionEntries.length))).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        String(actionEntries.filter((a) => a.status === "completed").length),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders all action history entries", () => {
+    render(<ResponseLedgerPage />);
+
+    const actionList = screen.getByRole("list", {
+      name: /response ledger actions/i,
+    });
+    expect(within(actionList).getAllByRole("listitem")).toHaveLength(
+      actionEntries.length,
+    );
+
+    for (const action of actionEntries) {
+      expect(screen.getByText(action.title)).toBeInTheDocument();
+    }
+  });
+
+  it("renders outcome summaries", () => {
+    render(<ResponseLedgerPage />);
+
+    const outcomeList = screen.getByRole("list", {
+      name: /outcome summaries/i,
+    });
+    expect(within(outcomeList).getAllByRole("listitem")).toHaveLength(
+      outcomeSummaries.length,
+    );
+
+    for (const outcome of outcomeSummaries) {
+      expect(screen.getByText(outcome.label)).toBeInTheDocument();
+    }
+  });
+
+  it("renders the ownership rail with all owners", () => {
+    render(<ResponseLedgerPage />);
+
+    const ownershipList = screen.getByRole("list", {
+      name: /ownership summary/i,
+    });
+    const records = getOwnershipRecords();
+
+    expect(within(ownershipList).getAllByRole("listitem")).toHaveLength(
+      records.length,
+    );
+
+    for (const record of records) {
+      expect(screen.getByText(record.owner)).toBeInTheDocument();
+    }
+  });
+});

--- a/src/app/response-ledger/page.tsx
+++ b/src/app/response-ledger/page.tsx
@@ -1,0 +1,145 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { LedgerEntry } from "./_components/ledger-entry";
+import { OutcomeSummaryCard } from "./_components/outcome-summary";
+import { OwnershipRail } from "./_components/ownership-rail";
+import { getResponseLedgerView } from "./_data/response-ledger-data";
+
+export const metadata: Metadata = {
+  title: "Response Ledger",
+  description:
+    "Action history with outcome summaries and a compact ownership rail for operational triage.",
+};
+
+export default function ResponseLedgerPage() {
+  const { actions, outcomes, ownership, summary } = getResponseLedgerView();
+
+  return (
+    <main className="min-h-screen bg-[#f4efe7]">
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-6 py-10 sm:px-10 lg:px-12 lg:py-14">
+        {/* Hero */}
+        <section className="rounded-[2rem] bg-white/86 p-8 shadow-sm sm:p-10">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <p className="text-sm font-semibold uppercase tracking-[0.28em] text-slate-500">
+              Response Actions
+            </p>
+            <Link
+              href="/"
+              className="rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-950 hover:text-slate-950"
+            >
+              Back to overview
+            </Link>
+          </div>
+
+          <div className="mt-8 space-y-4">
+            <h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-slate-950 sm:text-5xl lg:text-6xl">
+              Response Ledger
+            </h1>
+            <p className="max-w-3xl text-base leading-8 text-slate-600 sm:text-lg">
+              A running log of response actions, their outcomes, and who owns
+              each thread — designed for fast situational awareness during
+              active incidents.
+            </p>
+          </div>
+
+          {/* Summary stats */}
+          <div className="mt-8 flex flex-wrap gap-6">
+            <div className="rounded-xl border border-slate-200 bg-slate-50/80 px-5 py-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+                Total
+              </p>
+              <p className="mt-1 text-2xl font-semibold text-slate-900">
+                {summary.totalActions}
+              </p>
+            </div>
+            <div className="rounded-xl border border-emerald-200 bg-emerald-50/80 px-5 py-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-500">
+                Completed
+              </p>
+              <p className="mt-1 text-2xl font-semibold text-emerald-700">
+                {summary.completedCount}
+              </p>
+            </div>
+            <div className="rounded-xl border border-rose-200 bg-rose-50/80 px-5 py-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-rose-400">
+                Escalated
+              </p>
+              <p className="mt-1 text-2xl font-semibold text-rose-700">
+                {summary.escalatedCount}
+              </p>
+            </div>
+            <div className="rounded-xl border border-sky-200 bg-sky-50/80 px-5 py-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-400">
+                In Progress
+              </p>
+              <p className="mt-1 text-2xl font-semibold text-sky-700">
+                {summary.inProgressCount}
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Main content grid: action log + ownership rail */}
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_300px]">
+          {/* Action history */}
+          <section aria-labelledby="action-history-heading" className="space-y-5">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                Chronological feed
+              </p>
+              <h2
+                id="action-history-heading"
+                className="text-3xl font-semibold tracking-tight text-slate-950"
+              >
+                Action history
+              </h2>
+            </div>
+
+            <div
+              aria-label="Response ledger actions"
+              className="flex flex-col gap-4"
+              role="list"
+            >
+              {actions.map((action) => (
+                <LedgerEntry key={action.id} action={action} />
+              ))}
+            </div>
+          </section>
+
+          {/* Ownership rail */}
+          <aside className="space-y-5 lg:sticky lg:top-24 lg:self-start">
+            <OwnershipRail records={ownership} />
+          </aside>
+        </div>
+
+        {/* Outcome summaries */}
+        <section aria-labelledby="outcomes-heading" className="space-y-5">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+              Results
+            </p>
+            <h2
+              id="outcomes-heading"
+              className="text-3xl font-semibold tracking-tight text-slate-950"
+            >
+              Outcome summaries
+            </h2>
+          </div>
+
+          <div
+            aria-label="Outcome summaries"
+            className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3"
+            role="list"
+          >
+            {outcomes.map((outcome) => (
+              <div key={outcome.id} role="listitem">
+                <OutcomeSummaryCard outcome={outcome} />
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a new `/response-ledger` route with mock action history, outcome summaries, and a compact ownership rail
- Includes 8 mock action entries with status badges (completed, in-progress, escalated, deferred), 8 outcome summary cards, and per-owner resolution tracking
- Adds nav link in layout and showcase section on the home page
- Includes test coverage for page rendering, action list, outcomes, and ownership rail

Closes #212

## Test plan
- [ ] Verify `/response-ledger` renders action history entries with status badges
- [ ] Verify outcome summary cards display with correct result indicators
- [ ] Verify ownership rail shows owner counts and resolution rates
- [ ] Verify responsive layout across common breakpoints
- [ ] Run `vitest run src/app/response-ledger/page.test.tsx` to confirm tests pass

Generated with [Claude Code](https://claude.com/claude-code)