### PR TITLE
feat: add reserve-bay route with allocation summary

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,6 +33,7 @@ const navLinks = [
   { href: "/queue-monitor", label: "Queue Monitor" },
   { href: "/parcel-hub", label: "Parcel Hub" },
   { href: "/status-board", label: "Status Board" },
+  { href: "/reserve-bay", label: "Reserve Bay" },
 ] as const;
 
 export default function RootLayout({

--- a/src/app/reserve-bay/_components/allocation-summary.tsx
+++ b/src/app/reserve-bay/_components/allocation-summary.tsx
@@ -1,0 +1,83 @@
+import type {
+  AllocationCategory,
+  AllocationEntry,
+} from "../_data/reserve-bay-data";
+import styles from "../reserve-bay.module.css";
+
+const categoryToneClasses: Record<AllocationCategory, string> = {
+  inbound: "border-sky-200 bg-sky-50/80 text-sky-800",
+  outbound: "border-emerald-200 bg-emerald-50/80 text-emerald-800",
+  overflow: "border-amber-200 bg-amber-50/90 text-amber-800",
+  maintenance: "border-slate-200 bg-slate-100/90 text-slate-700",
+};
+
+const categoryFillClasses: Record<AllocationCategory, string> = {
+  inbound: styles.fillInbound,
+  outbound: styles.fillHigh,
+  overflow: styles.fillModerate,
+  maintenance: styles.fillMaintenance,
+};
+
+export function AllocationSummary({
+  allocations,
+}: {
+  allocations: AllocationEntry[];
+}) {
+  const totalAllocated = allocations.reduce(
+    (sum, a) => sum + a.baysAllocated,
+    0,
+  );
+  const totalUsed = allocations.reduce((sum, a) => sum + a.baysUsed, 0);
+
+  return (
+    <div className={`${styles.surfaceCard} space-y-6 p-6 sm:p-8`}>
+      <div className="space-y-3">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-500">
+          Facility summary
+        </p>
+        <div className="flex items-baseline gap-3">
+          <p className="text-3xl font-semibold tracking-tight text-slate-950">
+            {totalUsed}/{totalAllocated}
+          </p>
+          <p className="text-sm text-slate-500">bays in use</p>
+        </div>
+      </div>
+
+      <div aria-label="Allocation breakdown" className="space-y-4" role="list">
+        {allocations.map((alloc) => (
+          <div
+            key={alloc.id}
+            role="listitem"
+            className="space-y-3 rounded-2xl bg-white/80 px-4 py-4 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.14)]"
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <span
+                  className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold ${categoryToneClasses[alloc.category]}`}
+                >
+                  {alloc.label}
+                </span>
+              </div>
+              <span className="text-sm font-semibold text-slate-700">
+                {alloc.baysUsed}/{alloc.baysAllocated}
+              </span>
+            </div>
+
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+                <span>Utilization</span>
+                <span>{alloc.utilization}%</span>
+              </div>
+              <div className={styles.progressRail}>
+                <span
+                  className={`${styles.progressFill} ${categoryFillClasses[alloc.category]}`}
+                  style={{ width: `${alloc.utilization}%` }}
+                />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/reserve-bay/_components/availability-snapshot.tsx
+++ b/src/app/reserve-bay/_components/availability-snapshot.tsx
@@ -1,0 +1,85 @@
+import type {
+  AvailabilityLevel,
+  AvailabilitySnapshot,
+} from "../_data/reserve-bay-data";
+import styles from "../reserve-bay.module.css";
+
+const levelToneClasses: Record<AvailabilityLevel, string> = {
+  high: "border-emerald-200 bg-emerald-50/80 text-emerald-800",
+  moderate: "border-amber-200 bg-amber-50/90 text-amber-800",
+  low: "border-rose-200 bg-rose-50 text-rose-800",
+};
+
+const levelFillClasses: Record<AvailabilityLevel, string> = {
+  high: styles.fillHigh,
+  moderate: styles.fillModerate,
+  low: styles.fillLow,
+};
+
+export function AvailabilitySnapshotCard({
+  snapshot,
+}: {
+  snapshot: AvailabilitySnapshot;
+}) {
+  const occupancyPct = Math.round(
+    (snapshot.occupiedBays / snapshot.totalBays) * 100,
+  );
+  const freeBays = snapshot.totalBays - snapshot.occupiedBays;
+
+  return (
+    <article
+      role="listitem"
+      className={`${styles.surfaceCard} flex h-full flex-col gap-5 p-6`}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+            {snapshot.zone}
+          </p>
+          <p className="text-4xl font-semibold tracking-tight text-slate-950">
+            {freeBays} <span className="text-lg text-slate-500">free</span>
+          </p>
+        </div>
+        <span
+          className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold ${levelToneClasses[snapshot.level]}`}
+        >
+          {snapshot.level} availability
+        </span>
+      </div>
+
+      <div className="grid gap-3 text-sm sm:grid-cols-2">
+        <div className="rounded-2xl bg-white/80 px-4 py-3 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.14)]">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Next free at
+          </p>
+          <p className="mt-2 font-medium text-slate-700">
+            {snapshot.nextFreeAt}
+          </p>
+        </div>
+        <div className="rounded-2xl bg-white/80 px-4 py-3 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.14)]">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Peak window
+          </p>
+          <p className="mt-2 font-medium text-slate-700">
+            {snapshot.peakWindow}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-auto space-y-3">
+        <div className="flex items-center justify-between text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+          <span>Occupancy</span>
+          <span>
+            {snapshot.occupiedBays}/{snapshot.totalBays} bays · {occupancyPct}%
+          </span>
+        </div>
+        <div className={styles.progressRail}>
+          <span
+            className={`${styles.progressFill} ${levelFillClasses[snapshot.level]}`}
+            style={{ width: `${occupancyPct}%` }}
+          />
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/app/reserve-bay/_components/reservation-card.tsx
+++ b/src/app/reserve-bay/_components/reservation-card.tsx
@@ -1,0 +1,66 @@
+import type { Reservation, ReservationStatus } from "../_data/reserve-bay-data";
+import styles from "../reserve-bay.module.css";
+
+const statusToneClasses: Record<ReservationStatus, string> = {
+  confirmed: "border-emerald-200 bg-emerald-50 text-emerald-800",
+  pending: "border-amber-200 bg-amber-50 text-amber-800",
+  expired: "border-slate-200 bg-slate-100 text-slate-600",
+};
+
+const statusLabel: Record<ReservationStatus, string> = {
+  confirmed: "Confirmed",
+  pending: "Pending",
+  expired: "Expired",
+};
+
+export function ReservationCard({ reservation }: { reservation: Reservation }) {
+  return (
+    <article
+      role="listitem"
+      className={`${styles.surfaceCard} ${styles.reservationCard} p-5 sm:p-6`}
+    >
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-3">
+            <span
+              className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] ${statusToneClasses[reservation.status]}`}
+            >
+              {statusLabel[reservation.status]}
+            </span>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+              Bay {reservation.bayCode}
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <h3 className="text-xl font-semibold tracking-tight text-slate-950">
+              {reservation.carrier}
+            </h3>
+            <p className="max-w-2xl text-sm leading-6 text-slate-600">
+              {reservation.notes}
+            </p>
+          </div>
+        </div>
+
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500">
+          {reservation.windowStart}–{reservation.windowEnd}
+        </p>
+      </div>
+
+      <div className="mt-5 grid gap-3 text-sm text-slate-700 sm:grid-cols-[1fr_1fr]">
+        <div className="rounded-2xl bg-white/80 px-4 py-3 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.14)]">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Trailer
+          </p>
+          <p className="mt-2 font-medium">{reservation.trailerId}</p>
+        </div>
+        <div className="rounded-2xl bg-white/80 px-4 py-3 shadow-[inset_0_0_0_1px_rgba(148,163,184,0.14)]">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500">
+            Load type
+          </p>
+          <p className="mt-2 font-medium">{reservation.loadType}</p>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/app/reserve-bay/_data/reserve-bay-data.ts
+++ b/src/app/reserve-bay/_data/reserve-bay-data.ts
@@ -1,0 +1,195 @@
+export type ReservationStatus = "confirmed" | "pending" | "expired";
+export type AvailabilityLevel = "high" | "moderate" | "low";
+export type AllocationCategory = "inbound" | "outbound" | "overflow" | "maintenance";
+
+export interface Reservation {
+  id: string;
+  bayCode: string;
+  carrier: string;
+  status: ReservationStatus;
+  windowStart: string;
+  windowEnd: string;
+  trailerId: string;
+  loadType: string;
+  notes: string;
+}
+
+export interface AvailabilitySnapshot {
+  id: string;
+  zone: string;
+  totalBays: number;
+  occupiedBays: number;
+  level: AvailabilityLevel;
+  nextFreeAt: string;
+  peakWindow: string;
+}
+
+export interface AllocationEntry {
+  id: string;
+  category: AllocationCategory;
+  baysAllocated: number;
+  baysUsed: number;
+  utilization: number;
+  label: string;
+}
+
+export const reserveBaySummary = {
+  eyebrow: "Reserve Bay",
+  title: "Manage dock reservations and bay allocation across facilities.",
+  description:
+    "Track reservation status, monitor real-time availability by zone, and review how bays are allocated across inbound, outbound, overflow, and maintenance categories.",
+  stats: [
+    {
+      label: "Total bays",
+      value: "48",
+      tone: "high" as AvailabilityLevel,
+    },
+    {
+      label: "Currently occupied",
+      value: "31",
+      tone: "moderate" as AvailabilityLevel,
+    },
+    {
+      label: "Reservations today",
+      value: "22",
+      tone: "high" as AvailabilityLevel,
+    },
+    {
+      label: "Avg turnaround",
+      value: "38 min",
+      tone: "moderate" as AvailabilityLevel,
+    },
+  ],
+};
+
+export const reserveBayReservations: Reservation[] = [
+  {
+    id: "res-001",
+    bayCode: "B-12",
+    carrier: "Northline Freight",
+    status: "confirmed",
+    windowStart: "06:00",
+    windowEnd: "08:30",
+    trailerId: "NLF-4821",
+    loadType: "Dry goods",
+    notes: "Priority unload — perishable buffer required on adjacent bay.",
+  },
+  {
+    id: "res-002",
+    bayCode: "B-07",
+    carrier: "Summit Logistics",
+    status: "confirmed",
+    windowStart: "07:15",
+    windowEnd: "09:00",
+    trailerId: "SML-1193",
+    loadType: "Palletized electronics",
+    notes: "Requires forklift team Alpha on standby for high-value scan.",
+  },
+  {
+    id: "res-003",
+    bayCode: "B-22",
+    carrier: "Coastway Express",
+    status: "pending",
+    windowStart: "09:30",
+    windowEnd: "11:00",
+    trailerId: "CWE-3347",
+    loadType: "Refrigerated produce",
+    notes: "Awaiting cold-chain dock confirmation from facilities.",
+  },
+  {
+    id: "res-004",
+    bayCode: "B-03",
+    carrier: "Midland Carriers",
+    status: "expired",
+    windowStart: "04:00",
+    windowEnd: "05:30",
+    trailerId: "MLC-0782",
+    loadType: "Bulk industrial",
+    notes: "Carrier no-show — bay released back to overflow pool.",
+  },
+  {
+    id: "res-005",
+    bayCode: "B-18",
+    carrier: "Tristate Hauling",
+    status: "confirmed",
+    windowStart: "10:00",
+    windowEnd: "12:30",
+    trailerId: "TSH-5590",
+    loadType: "Mixed freight",
+    notes: "Double-door access needed for tandem unload sequence.",
+  },
+];
+
+export const reserveBayAvailability: AvailabilitySnapshot[] = [
+  {
+    id: "zone-a",
+    zone: "Zone A — Inbound dock",
+    totalBays: 12,
+    occupiedBays: 9,
+    level: "low",
+    nextFreeAt: "08:45",
+    peakWindow: "06:00–10:00",
+  },
+  {
+    id: "zone-b",
+    zone: "Zone B — Outbound staging",
+    totalBays: 16,
+    occupiedBays: 10,
+    level: "moderate",
+    nextFreeAt: "07:30",
+    peakWindow: "14:00–18:00",
+  },
+  {
+    id: "zone-c",
+    zone: "Zone C — Overflow / flex",
+    totalBays: 10,
+    occupiedBays: 5,
+    level: "high",
+    nextFreeAt: "Available now",
+    peakWindow: "11:00–15:00",
+  },
+  {
+    id: "zone-d",
+    zone: "Zone D — Maintenance reserve",
+    totalBays: 10,
+    occupiedBays: 7,
+    level: "moderate",
+    nextFreeAt: "09:15",
+    peakWindow: "08:00–12:00",
+  },
+];
+
+export const reserveBayAllocations: AllocationEntry[] = [
+  {
+    id: "alloc-inbound",
+    category: "inbound",
+    baysAllocated: 14,
+    baysUsed: 11,
+    utilization: 79,
+    label: "Inbound receiving",
+  },
+  {
+    id: "alloc-outbound",
+    category: "outbound",
+    baysAllocated: 16,
+    baysUsed: 12,
+    utilization: 75,
+    label: "Outbound dispatch",
+  },
+  {
+    id: "alloc-overflow",
+    category: "overflow",
+    baysAllocated: 10,
+    baysUsed: 4,
+    utilization: 40,
+    label: "Overflow staging",
+  },
+  {
+    id: "alloc-maintenance",
+    category: "maintenance",
+    baysAllocated: 8,
+    baysUsed: 4,
+    utilization: 50,
+    label: "Maintenance hold",
+  },
+];

--- a/src/app/reserve-bay/page.test.tsx
+++ b/src/app/reserve-bay/page.test.tsx
@@ -1,0 +1,80 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  reserveBayAllocations,
+  reserveBayAvailability,
+  reserveBayReservations,
+} from "./_data/reserve-bay-data";
+import ReserveBayPage from "./page";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ReserveBayPage", () => {
+  it("renders the reserve bay shell independently from the home page", () => {
+    render(<ReserveBayPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: /manage dock reservations and bay allocation across facilities\./i,
+      }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: /availability snapshot/i }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: /reservations/i }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: /allocation summary/i }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText(/to get started, edit the page\.tsx file\./i),
+    ).toBeNull();
+  });
+
+  it("renders each availability zone from mock content", () => {
+    render(<ReserveBayPage />);
+
+    const zoneList = screen.getByRole("list", {
+      name: /availability zones/i,
+    });
+    expect(within(zoneList).getAllByRole("listitem")).toHaveLength(
+      reserveBayAvailability.length,
+    );
+
+    for (const snapshot of reserveBayAvailability) {
+      expect(screen.getByText(snapshot.zone)).toBeTruthy();
+    }
+  });
+
+  it("renders reservation cards and allocation panel with responsive layout hooks", () => {
+    render(<ReserveBayPage />);
+
+    const reservationList = screen.getByRole("list", {
+      name: /reservations/i,
+    });
+    const allocationList = screen.getByRole("list", {
+      name: /allocation breakdown/i,
+    });
+    const panels = screen.getByTestId("reserve-bay-panels");
+
+    expect(within(reservationList).getAllByRole("listitem")).toHaveLength(
+      reserveBayReservations.length,
+    );
+    expect(within(allocationList).getAllByRole("listitem")).toHaveLength(
+      reserveBayAllocations.length,
+    );
+    expect(
+      screen.getByText(reserveBayReservations[0].carrier),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(reserveBayAllocations[0].label),
+    ).toBeTruthy();
+    expect(panels.className).toContain(
+      "xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.95fr)]",
+    );
+  });
+});

--- a/src/app/reserve-bay/page.tsx
+++ b/src/app/reserve-bay/page.tsx
@@ -1,0 +1,192 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { AllocationSummary } from "./_components/allocation-summary";
+import { AvailabilitySnapshotCard } from "./_components/availability-snapshot";
+import { ReservationCard } from "./_components/reservation-card";
+import {
+  reserveBayAllocations,
+  reserveBayAvailability,
+  reserveBayReservations,
+  reserveBaySummary,
+  type AvailabilityLevel,
+} from "./_data/reserve-bay-data";
+import styles from "./reserve-bay.module.css";
+
+export const metadata: Metadata = {
+  title: "Reserve Bay",
+  description:
+    "Dock reservation cards, real-time availability snapshots, and a compact bay allocation summary.",
+};
+
+const levelToneClasses: Record<AvailabilityLevel, string> = {
+  high: "border-emerald-300/30 bg-emerald-300/15 text-emerald-50",
+  moderate: "border-amber-300/30 bg-amber-300/15 text-amber-50",
+  low: "border-rose-300/30 bg-rose-300/15 text-rose-50",
+};
+
+export default function ReserveBayPage() {
+  return (
+    <main className={styles.shell}>
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 px-5 py-8 sm:px-8 sm:py-10 lg:px-10 lg:py-12">
+        <div className="flex items-center gap-4">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-1.5 rounded-full border border-slate-300 bg-white/60 px-4 py-1.5 text-xs font-semibold text-slate-600 transition hover:border-slate-400 hover:text-slate-900"
+          >
+            <span aria-hidden="true">&larr;</span> Home
+          </Link>
+          <span className="ops-badge">Dock management</span>
+        </div>
+
+        <section className={`${styles.surfaceCard} ${styles.heroPanel} p-6 sm:p-8 lg:p-10`}>
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,1.5fr)_minmax(280px,0.95fr)] lg:items-start">
+            <div className="space-y-6">
+              <div className="space-y-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-sky-100/75">
+                  {reserveBaySummary.eyebrow}
+                </p>
+                <div className="space-y-4">
+                  <h1 className="max-w-3xl text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
+                    {reserveBaySummary.title}
+                  </h1>
+                  <p className="max-w-2xl text-base leading-7 text-slate-100/78 sm:text-lg">
+                    {reserveBaySummary.description}
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex flex-wrap gap-3">
+                {reserveBaySummary.stats.map((stat) => (
+                  <div
+                    key={stat.label}
+                    className={`inline-flex min-w-[11rem] flex-col rounded-2xl border px-4 py-3 ${levelToneClasses[stat.tone]}`}
+                  >
+                    <span className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/72">
+                      {stat.label}
+                    </span>
+                    <span className="mt-2 text-2xl font-semibold text-white">
+                      {stat.value}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <aside className={`${styles.surfaceCard} rounded-[1.5rem] bg-white/12 p-5 sm:p-6`}>
+              <div className="space-y-5">
+                <div>
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-white/65">
+                    Current shift
+                  </p>
+                  <p className="mt-3 text-3xl font-semibold tracking-tight text-white">
+                    Morning dock operations
+                  </p>
+                </div>
+
+                <div className="space-y-3 text-sm leading-6 text-slate-100/78">
+                  <p>Shift A · Dock supervisor on call</p>
+                  <p>Updated 5 minutes ago</p>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
+                  <div className="rounded-2xl bg-white/10 px-4 py-3">
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/60">
+                      Immediate focus
+                    </p>
+                    <p className="mt-2 text-sm font-medium text-white">
+                      Clear Zone A congestion before the 09:00 inbound surge window opens.
+                    </p>
+                  </div>
+                  <div className="rounded-2xl bg-white/10 px-4 py-3">
+                    <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/60">
+                      Overflow note
+                    </p>
+                    <p className="mt-2 text-sm font-medium text-white">
+                      Zone C flex bays are available for spillover if inbound volume exceeds forecast.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </aside>
+          </div>
+        </section>
+
+        <section aria-labelledby="reserve-bay-availability" className="space-y-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                Zone overview
+              </p>
+              <h2
+                id="reserve-bay-availability"
+                className="text-3xl font-semibold tracking-tight text-slate-950"
+              >
+                Availability snapshot
+              </h2>
+            </div>
+            <p className="max-w-2xl text-sm leading-6 text-slate-600">
+              Real-time bay occupancy across all facility zones with peak window indicators.
+            </p>
+          </div>
+
+          <div
+            aria-label="Availability zones"
+            className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4"
+            role="list"
+          >
+            {reserveBayAvailability.map((snapshot) => (
+              <AvailabilitySnapshotCard key={snapshot.id} snapshot={snapshot} />
+            ))}
+          </div>
+        </section>
+
+        <div
+          className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.95fr)]"
+          data-testid="reserve-bay-panels"
+        >
+          <section aria-labelledby="reserve-bay-reservations" className="space-y-5">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                  Dock schedule
+                </p>
+                <h2
+                  id="reserve-bay-reservations"
+                  className="text-3xl font-semibold tracking-tight text-slate-950"
+                >
+                  Reservations
+                </h2>
+              </div>
+              <p className="text-sm leading-6 text-slate-600">
+                Active and upcoming bay reservations ordered by time window.
+              </p>
+            </div>
+            <ul aria-label="Reservations" className="space-y-4">
+              {reserveBayReservations.map((reservation) => (
+                <li key={reservation.id}>
+                  <ReservationCard reservation={reservation} />
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section aria-labelledby="reserve-bay-allocation" className="space-y-5">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-500">
+                Capacity planning
+              </p>
+              <h2
+                id="reserve-bay-allocation"
+                className="text-3xl font-semibold tracking-tight text-slate-950"
+              >
+                Allocation summary
+              </h2>
+            </div>
+            <AllocationSummary allocations={reserveBayAllocations} />
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/reserve-bay/reserve-bay.module.css
+++ b/src/app/reserve-bay/reserve-bay.module.css
@@ -1,0 +1,112 @@
+.shell {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  min-height: 100vh;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(240, 242, 248, 0.98)),
+    linear-gradient(135deg, rgba(99, 102, 241, 0.1), transparent 38%),
+    linear-gradient(215deg, rgba(14, 165, 233, 0.08), transparent 42%);
+}
+
+.shell::before {
+  content: "";
+  position: absolute;
+  inset: -10% -30% auto auto;
+  width: 34rem;
+  height: 34rem;
+  border-radius: 9999px;
+  background:
+    radial-gradient(circle, rgba(99, 102, 241, 0.15), transparent 58%);
+  filter: blur(12px);
+  z-index: -2;
+}
+
+.shell::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(148, 163, 184, 0.12) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.12) 1px, transparent 1px);
+  background-position: center;
+  background-size: 4.75rem 4.75rem;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.5), transparent 85%);
+  z-index: -1;
+}
+
+.surfaceCard {
+  border: 1px solid rgba(255, 255, 255, 0.78);
+  background: rgba(255, 255, 255, 0.8);
+  box-shadow:
+    0 20px 60px rgba(15, 23, 42, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.65);
+  backdrop-filter: blur(14px);
+  border-radius: 1.75rem;
+}
+
+.heroPanel {
+  background:
+    linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(49, 46, 129, 0.88)),
+    radial-gradient(circle at top right, rgba(99, 102, 241, 0.3), transparent 40%);
+  color: #f8fafc;
+}
+
+.heroPanel .surfaceCard {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.reservationCard {
+  position: relative;
+}
+
+.reservationCard::before {
+  content: "";
+  position: absolute;
+  inset: 1.1rem auto 1.1rem 1.1rem;
+  width: 0.35rem;
+  border-radius: 9999px;
+  background: linear-gradient(180deg, #818cf8, #4f46e5);
+  opacity: 0.95;
+}
+
+.progressRail {
+  height: 0.7rem;
+  overflow: hidden;
+  border-radius: 9999px;
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.progressFill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+}
+
+.fillHigh {
+  background: linear-gradient(90deg, #10b981, #0f766e);
+}
+
+.fillModerate {
+  background: linear-gradient(90deg, #f59e0b, #ea580c);
+}
+
+.fillLow {
+  background: linear-gradient(90deg, #fb7185, #be123c);
+}
+
+.fillInbound {
+  background: linear-gradient(90deg, #38bdf8, #0284c7);
+}
+
+.fillMaintenance {
+  background: linear-gradient(90deg, #64748b, #334155);
+}
+
+@media (max-width: 640px) {
+  .shell::before {
+    inset: -15% -40% auto auto;
+    width: 24rem;
+    height: 24rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a new `reserve-bay` route under the app router with reservation cards, availability snapshots by zone, and a compact allocation summary panel.
- Creates mock data for reservations (5 entries), availability zones (4 zones), and allocation categories (4 categories) with typed interfaces.
- Builds three components: `ReservationCard`, `AvailabilitySnapshotCard`, and `AllocationSummary` following existing codebase patterns (CSS modules + Tailwind, role/aria attributes, tone-mapped styling).
- Adds the route to the global navigation in `layout.tsx`.
- Includes test coverage for main route headings, availability zone rendering, reservation/allocation counts, and responsive layout grid classes.

Closes #208

## Test plan
- [x] Production build passes (`npm run build`)
- [x] ESLint passes (`npm run lint`)
- [ ] Route renders reservation cards with status badges (confirmed/pending/expired)
- [ ] Availability snapshot cards show zone occupancy with progress bars
- [ ] Allocation summary panel displays utilization per category
- [ ] Layout is usable on narrow and wide viewports
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)