### PR TITLE
feat: add intake-desk route with triage cards (#242)

### DIFF
--- a/src/app/intake-desk/_components/assignment-panel.tsx
+++ b/src/app/intake-desk/_components/assignment-panel.tsx
@@ -1,0 +1,68 @@
+import type { AssignmentEntry } from "../_data/intake-desk-data";
+import styles from "../intake-desk.module.css";
+
+const statusLabels: Record<AssignmentEntry["status"], string> = {
+  unassigned: "Unassigned",
+  "in-progress": "In Progress",
+  completed: "Completed",
+};
+
+const statusBadgeStyles: Record<AssignmentEntry["status"], string> = {
+  unassigned: "border-slate-300/20 bg-slate-300/10 text-slate-50",
+  "in-progress": "border-amber-300/20 bg-amber-300/10 text-amber-50",
+  completed: "border-emerald-300/20 bg-emerald-300/10 text-emerald-50",
+};
+
+type AssignmentPanelProps = {
+  entries: AssignmentEntry[];
+};
+
+export function AssignmentPanel({ entries }: AssignmentPanelProps) {
+  return (
+    <section aria-label="Assignment summary" className="space-y-5">
+      <div className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+          Assignments
+        </p>
+        <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+          Assignment summary
+        </h2>
+        <p className="max-w-2xl text-sm leading-6 text-slate-300">
+          Current assignment status for triaged requests. Track who owns each
+          item and its progress toward completion.
+        </p>
+      </div>
+
+      <div
+        className={`${styles.assignmentPanel} rounded-[1.5rem] border border-white/10 p-5`}
+      >
+        <div className="space-y-3" role="list" aria-label="Assignment entries">
+          {entries.map((entry) => (
+            <article
+              key={entry.id}
+              className={`${styles.assignmentRow} rounded-2xl border border-white/8 px-5 py-4`}
+              role="listitem"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="space-y-1">
+                  <p className="text-sm font-semibold text-white">
+                    {entry.requestTitle}
+                  </p>
+                  <p className="text-xs text-slate-400">{entry.assignee}</p>
+                </div>
+                <span
+                  className={`${styles.statusBadge} inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${statusBadgeStyles[entry.status]}`}
+                >
+                  {statusLabels[entry.status]}
+                </span>
+              </div>
+              <p className="mt-2 text-xs text-slate-400">
+                Due: {entry.dueDate}
+              </p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/intake-desk/_components/request-card.tsx
+++ b/src/app/intake-desk/_components/request-card.tsx
@@ -1,0 +1,71 @@
+import type { IncomingRequest } from "../_data/intake-desk-data";
+import styles from "../intake-desk.module.css";
+
+const urgencyLabels: Record<IncomingRequest["urgency"], string> = {
+  low: "Low",
+  normal: "Normal",
+  high: "High",
+  critical: "Critical",
+};
+
+const urgencyBadgeStyles: Record<IncomingRequest["urgency"], string> = {
+  low: "border-emerald-300/20 bg-emerald-300/10 text-emerald-50",
+  normal: "border-cyan-300/20 bg-cyan-300/10 text-cyan-50",
+  high: "border-amber-300/20 bg-amber-300/10 text-amber-50",
+  critical: "border-rose-300/20 bg-rose-300/10 text-rose-50",
+};
+
+const urgencySurfaceStyles: Record<IncomingRequest["urgency"], string> = {
+  low: styles.urgencyLow,
+  normal: styles.urgencyNormal,
+  high: styles.urgencyHigh,
+  critical: styles.urgencyCritical,
+};
+
+type RequestCardProps = {
+  request: IncomingRequest;
+};
+
+export function RequestCard({ request }: RequestCardProps) {
+  return (
+    <article
+      className={`${styles.requestCard} ${urgencySurfaceStyles[request.urgency]} rounded-[1.7rem] border p-6`}
+      role="listitem"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold tracking-tight text-white">
+            {request.title}
+          </h3>
+          <p className="text-sm text-slate-300">{request.requester}</p>
+        </div>
+        <span
+          className={`${styles.statusBadge} inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${urgencyBadgeStyles[request.urgency]}`}
+        >
+          {urgencyLabels[request.urgency]}
+        </span>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        <div className="rounded-2xl border border-white/8 bg-white/5 px-4 py-3">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+            Category
+          </p>
+          <p className="mt-1 text-sm font-medium text-slate-100">
+            {request.category}
+          </p>
+        </div>
+        <div className="rounded-2xl border border-white/8 bg-white/5 px-4 py-3">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+            Received
+          </p>
+          <p className="mt-1 text-sm font-medium text-slate-100">
+            {request.receivedAt}
+          </p>
+        </div>
+      </div>
+
+      <p className="mt-4 text-sm leading-6 text-slate-300">{request.summary}</p>
+    </article>
+  );
+}

--- a/src/app/intake-desk/_components/triage-card.tsx
+++ b/src/app/intake-desk/_components/triage-card.tsx
@@ -1,0 +1,52 @@
+import type { TriageCard } from "../_data/intake-desk-data";
+import styles from "../intake-desk.module.css";
+
+const outcomeLabels: Record<TriageCard["outcome"], string> = {
+  accepted: "Accepted",
+  deferred: "Deferred",
+  escalated: "Escalated",
+  rejected: "Rejected",
+};
+
+const outcomeBadgeStyles: Record<TriageCard["outcome"], string> = {
+  accepted: "border-emerald-300/20 bg-emerald-300/10 text-emerald-50",
+  deferred: "border-cyan-300/20 bg-cyan-300/10 text-cyan-50",
+  escalated: "border-amber-300/20 bg-amber-300/10 text-amber-50",
+  rejected: "border-rose-300/20 bg-rose-300/10 text-rose-50",
+};
+
+const outcomeSurfaceStyles: Record<TriageCard["outcome"], string> = {
+  accepted: styles.outcomeAccepted,
+  deferred: styles.outcomeDeferred,
+  escalated: styles.outcomeEscalated,
+  rejected: styles.outcomeRejected,
+};
+
+type TriageCardItemProps = {
+  card: TriageCard;
+};
+
+export function TriageCardItem({ card }: TriageCardItemProps) {
+  return (
+    <article
+      className={`${styles.triageCard} ${outcomeSurfaceStyles[card.outcome]} rounded-[1.7rem] border p-6`}
+      role="listitem"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold tracking-tight text-white">
+            {card.reviewer}
+          </h3>
+          <p className="text-sm text-slate-300">{card.reviewedAt}</p>
+        </div>
+        <span
+          className={`${styles.statusBadge} inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${outcomeBadgeStyles[card.outcome]}`}
+        >
+          {outcomeLabels[card.outcome]}
+        </span>
+      </div>
+
+      <p className="mt-4 text-sm leading-6 text-slate-300">{card.notes}</p>
+    </article>
+  );
+}

--- a/src/app/intake-desk/_data/intake-desk-data.ts
+++ b/src/app/intake-desk/_data/intake-desk-data.ts
@@ -1,0 +1,211 @@
+export type RequestUrgency = "low" | "normal" | "high" | "critical";
+export type TriageOutcome = "accepted" | "deferred" | "escalated" | "rejected";
+export type AssignmentStatus = "unassigned" | "in-progress" | "completed";
+
+export interface IncomingRequest {
+  id: string;
+  title: string;
+  requester: string;
+  urgency: RequestUrgency;
+  receivedAt: string;
+  summary: string;
+  category: string;
+}
+
+export interface TriageCard {
+  id: string;
+  requestId: string;
+  reviewer: string;
+  outcome: TriageOutcome;
+  reviewedAt: string;
+  notes: string;
+}
+
+export interface AssignmentEntry {
+  id: string;
+  requestTitle: string;
+  assignee: string;
+  status: AssignmentStatus;
+  dueDate: string;
+}
+
+export interface IntakeDeskOverview {
+  eyebrow: string;
+  title: string;
+  description: string;
+  shiftWindow: string;
+  queue: string;
+}
+
+export interface IntakeStat {
+  label: string;
+  value: string;
+  detail: string;
+}
+
+export const intakeDeskOverview: IntakeDeskOverview = {
+  eyebrow: "Intake Desk",
+  title: "Triage incoming requests, review urgency, and track assignment progress.",
+  description:
+    "A centralized intake view for reviewing new requests, performing triage, and monitoring how work is distributed across the team.",
+  shiftWindow: "2026-04-25 — Morning shift",
+  queue: "Engineering support / Tier 2",
+};
+
+export const intakeStats: IntakeStat[] = [
+  {
+    label: "Pending requests",
+    value: "6",
+    detail: "Six incoming requests awaiting initial triage and assignment",
+  },
+  {
+    label: "Triaged today",
+    value: "4",
+    detail: "Four requests reviewed and categorized during the current shift",
+  },
+  {
+    label: "Active assignments",
+    value: "5",
+    detail: "Five work items currently assigned and in various stages of progress",
+  },
+];
+
+export const incomingRequests: IncomingRequest[] = [
+  {
+    id: "req-001",
+    title: "Database connection pool exhaustion",
+    requester: "L. Nakamura",
+    urgency: "critical",
+    receivedAt: "2026-04-25 08:12 PDT",
+    summary:
+      "Production database connections are being exhausted during peak traffic. Connection pool size may need to be increased or leak investigation is required.",
+    category: "Infrastructure",
+  },
+  {
+    id: "req-002",
+    title: "OAuth token refresh failing for SSO users",
+    requester: "D. Okonkwo",
+    urgency: "high",
+    receivedAt: "2026-04-25 08:34 PDT",
+    summary:
+      "SSO users are being logged out every 15 minutes because token refresh is returning 401. Likely a misconfigured redirect URI after the last IdP rotation.",
+    category: "Authentication",
+  },
+  {
+    id: "req-003",
+    title: "Add CSV export to analytics dashboard",
+    requester: "M. Rivera",
+    urgency: "normal",
+    receivedAt: "2026-04-25 09:01 PDT",
+    summary:
+      "Product team needs the ability to export filtered analytics data as CSV for quarterly reviews. No current workaround available.",
+    category: "Feature request",
+  },
+  {
+    id: "req-004",
+    title: "Staging environment SSL certificate expiring",
+    requester: "K. Andersen",
+    urgency: "high",
+    receivedAt: "2026-04-25 09:15 PDT",
+    summary:
+      "The staging environment SSL certificate expires in 48 hours. Auto-renewal failed due to a DNS validation issue that needs manual intervention.",
+    category: "Infrastructure",
+  },
+  {
+    id: "req-005",
+    title: "Onboarding docs link to deprecated API endpoints",
+    requester: "T. Pham",
+    urgency: "low",
+    receivedAt: "2026-04-25 09:28 PDT",
+    summary:
+      "Several links in the developer onboarding guide point to v1 API endpoints that were retired last quarter. Needs a documentation sweep.",
+    category: "Documentation",
+  },
+  {
+    id: "req-006",
+    title: "Webhook delivery retries not respecting backoff",
+    requester: "R. Gupta",
+    urgency: "normal",
+    receivedAt: "2026-04-25 09:45 PDT",
+    summary:
+      "Webhook retries are firing at a fixed 1-second interval instead of using exponential backoff, causing downstream rate limiting for some integrators.",
+    category: "Bug",
+  },
+];
+
+export const triageCards: TriageCard[] = [
+  {
+    id: "triage-001",
+    requestId: "req-001",
+    reviewer: "S. Petrov",
+    outcome: "escalated",
+    reviewedAt: "2026-04-25 08:20 PDT",
+    notes:
+      "Connection pool exhaustion confirmed via metrics. Escalated to on-call SRE for immediate investigation. Temporary mitigation: restart affected pods.",
+  },
+  {
+    id: "triage-002",
+    requestId: "req-002",
+    reviewer: "A. Reyes",
+    outcome: "accepted",
+    reviewedAt: "2026-04-25 08:50 PDT",
+    notes:
+      "Reproduced the token refresh failure in staging. Root cause is the redirect URI mismatch introduced in last week's IdP config update. Fix is straightforward.",
+  },
+  {
+    id: "triage-003",
+    requestId: "req-005",
+    reviewer: "J. Okafor",
+    outcome: "deferred",
+    reviewedAt: "2026-04-25 09:40 PDT",
+    notes:
+      "Documentation updates are low urgency. Deferred to next sprint's documentation sweep. Added to the docs backlog tracker.",
+  },
+  {
+    id: "triage-004",
+    requestId: "req-003",
+    reviewer: "S. Petrov",
+    outcome: "accepted",
+    reviewedAt: "2026-04-25 09:55 PDT",
+    notes:
+      "CSV export is a reasonable ask with clear business value. Scoped to filtered data only — full dataset export will need a separate background job.",
+  },
+];
+
+export const assignmentEntries: AssignmentEntry[] = [
+  {
+    id: "assign-001",
+    requestTitle: "Database connection pool exhaustion",
+    assignee: "M. Chen",
+    status: "in-progress",
+    dueDate: "2026-04-25",
+  },
+  {
+    id: "assign-002",
+    requestTitle: "OAuth token refresh fix",
+    assignee: "A. Reyes",
+    status: "in-progress",
+    dueDate: "2026-04-25",
+  },
+  {
+    id: "assign-003",
+    requestTitle: "CSV export — analytics dashboard",
+    assignee: "T. Pham",
+    status: "unassigned",
+    dueDate: "2026-04-28",
+  },
+  {
+    id: "assign-004",
+    requestTitle: "Staging SSL certificate renewal",
+    assignee: "K. Andersen",
+    status: "completed",
+    dueDate: "2026-04-25",
+  },
+  {
+    id: "assign-005",
+    requestTitle: "Webhook backoff implementation",
+    assignee: "R. Gupta",
+    status: "unassigned",
+    dueDate: "2026-04-29",
+  },
+];

--- a/src/app/intake-desk/intake-desk.module.css
+++ b/src/app/intake-desk/intake-desk.module.css
@@ -1,0 +1,130 @@
+.shell {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 20% 12%, rgba(99, 102, 241, 0.14), transparent 22%),
+    radial-gradient(circle at 78% 20%, rgba(52, 211, 153, 0.14), transparent 24%),
+    radial-gradient(circle at 50% 94%, rgba(251, 191, 36, 0.12), transparent 28%),
+    linear-gradient(180deg, #08111f 0%, #0e1c34 44%, #030712 100%);
+}
+
+.shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(125deg, rgba(255, 255, 255, 0.03), transparent 45%),
+    repeating-linear-gradient(
+      90deg,
+      rgba(148, 163, 184, 0.06) 0,
+      rgba(148, 163, 184, 0.06) 1px,
+      transparent 1px,
+      transparent 72px
+    );
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.95), transparent 96%);
+}
+
+.heroPanel {
+  position: relative;
+  background:
+    linear-gradient(140deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.58)),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(15, 23, 42, 0.12));
+  box-shadow: 0 38px 120px rgba(2, 6, 23, 0.42);
+}
+
+.heroPanel::after {
+  content: "";
+  position: absolute;
+  right: -5rem;
+  top: -4rem;
+  width: 18rem;
+  height: 18rem;
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgba(99, 102, 241, 0.22), transparent 66%);
+  filter: blur(20px);
+  pointer-events: none;
+}
+
+.statCard {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(15, 23, 42, 0.28));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.requestCard {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.82), rgba(6, 11, 24, 0.94));
+  box-shadow: 0 26px 70px rgba(2, 6, 23, 0.26);
+}
+
+.urgencyLow {
+  border-color: rgba(52, 211, 153, 0.22);
+}
+
+.urgencyNormal {
+  border-color: rgba(34, 211, 238, 0.22);
+}
+
+.urgencyHigh {
+  border-color: rgba(251, 191, 36, 0.24);
+}
+
+.urgencyCritical {
+  border-color: rgba(251, 113, 133, 0.28);
+}
+
+.triageCard {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.82), rgba(6, 11, 24, 0.94));
+  box-shadow: 0 26px 70px rgba(2, 6, 23, 0.26);
+}
+
+.outcomeAccepted {
+  border-color: rgba(52, 211, 153, 0.22);
+}
+
+.outcomeDeferred {
+  border-color: rgba(34, 211, 238, 0.22);
+}
+
+.outcomeEscalated {
+  border-color: rgba(251, 191, 36, 0.24);
+}
+
+.outcomeRejected {
+  border-color: rgba(251, 113, 133, 0.28);
+}
+
+.assignmentPanel {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(15, 23, 42, 0.32));
+}
+
+.assignmentRow {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(15, 23, 42, 0.18));
+}
+
+.statusBadge {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.floatingInfo {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(15, 23, 42, 0.26));
+}
+
+@media (max-width: 640px) {
+  .heroPanel,
+  .requestCard,
+  .triageCard,
+  .assignmentPanel,
+  .statCard {
+    border-radius: 1.5rem;
+  }
+}

--- a/src/app/intake-desk/page.test.tsx
+++ b/src/app/intake-desk/page.test.tsx
@@ -1,0 +1,89 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  assignmentEntries,
+  incomingRequests,
+  intakeDeskOverview,
+  intakeStats,
+  triageCards,
+} from "./_data/intake-desk-data";
+import IntakeDeskPage from "./page";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("IntakeDeskPage", () => {
+  it("renders the hero with primary heading, overview metadata, and back link", () => {
+    render(<IntakeDeskPage />);
+
+    expect(
+      screen.getByText(intakeDeskOverview.title, { selector: "h1" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(intakeDeskOverview.shiftWindow)).toBeInTheDocument();
+    expect(screen.getByText(intakeDeskOverview.queue)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /back to overview/i }),
+    ).toHaveAttribute("href", "/");
+  });
+
+  it("renders summary stats for intake desk", () => {
+    render(<IntakeDeskPage />);
+
+    const summarySection = screen.getByLabelText(/intake desk summary/i);
+
+    for (const stat of intakeStats) {
+      const statEl = within(summarySection).getByText(stat.label).closest("article");
+
+      expect(statEl).toBeTruthy();
+      expect(within(statEl as HTMLElement).getByText(stat.value)).toBeInTheDocument();
+    }
+  });
+
+  it("renders all incoming requests with titles, requesters, and urgency badges", () => {
+    render(<IntakeDeskPage />);
+
+    const requestList = screen.getByRole("list", { name: /incoming requests/i });
+    const requestItems = within(requestList).getAllByRole("listitem");
+
+    expect(requestItems).toHaveLength(incomingRequests.length);
+
+    for (const request of incomingRequests) {
+      expect(within(requestList).getByText(request.title)).toBeInTheDocument();
+      expect(within(requestList).getByText(request.requester)).toBeInTheDocument();
+      expect(within(requestList).getByText(request.category)).toBeInTheDocument();
+    }
+  });
+
+  it("renders all triage cards with reviewers, outcomes, and notes", () => {
+    render(<IntakeDeskPage />);
+
+    const triageList = screen.getByRole("list", { name: /triage cards/i });
+    const triageItems = within(triageList).getAllByRole("listitem");
+
+    expect(triageItems).toHaveLength(triageCards.length);
+
+    for (const card of triageCards) {
+      expect(within(triageList).getByText(card.reviewer)).toBeInTheDocument();
+      expect(within(triageList).getByText(card.notes)).toBeInTheDocument();
+    }
+  });
+
+  it("renders the assignment summary panel with all entries", () => {
+    render(<IntakeDeskPage />);
+
+    const assignmentSection = screen.getByLabelText(/assignment summary/i);
+    const assignmentList = within(assignmentSection).getByRole("list", {
+      name: /assignment entries/i,
+    });
+    const assignmentItems = within(assignmentList).getAllByRole("listitem");
+
+    expect(assignmentItems).toHaveLength(assignmentEntries.length);
+
+    for (const entry of assignmentEntries) {
+      expect(within(assignmentList).getByText(entry.requestTitle)).toBeInTheDocument();
+      expect(within(assignmentList).getByText(entry.assignee)).toBeInTheDocument();
+    }
+  });
+});

--- a/src/app/intake-desk/page.tsx
+++ b/src/app/intake-desk/page.tsx
@@ -1,0 +1,139 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { AssignmentPanel } from "./_components/assignment-panel";
+import { RequestCard } from "./_components/request-card";
+import { TriageCardItem } from "./_components/triage-card";
+import styles from "./intake-desk.module.css";
+import {
+  assignmentEntries,
+  incomingRequests,
+  intakeDeskOverview,
+  intakeStats,
+  triageCards,
+} from "./_data/intake-desk-data";
+
+export const metadata: Metadata = {
+  title: "Intake Desk",
+  description:
+    "Incoming request triage cards, assignment tracking, and intake queue management.",
+};
+
+export default function IntakeDeskPage() {
+  return (
+    <main className={`${styles.shell} px-6 py-12 text-slate-50 sm:px-10 lg:px-16`}>
+      <div className="relative mx-auto flex w-full max-w-7xl flex-col gap-8">
+        {/* Hero */}
+        <header
+          className={`${styles.heroPanel} overflow-hidden rounded-[2rem] border border-white/10 p-8 backdrop-blur sm:p-10`}
+        >
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+            <div className="max-w-3xl space-y-4">
+              <span className="inline-flex w-fit rounded-full border border-indigo-300/35 bg-indigo-300/12 px-4 py-1 text-sm font-medium uppercase tracking-[0.2em] text-indigo-100">
+                {intakeDeskOverview.eyebrow}
+              </span>
+              <h1 className="text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
+                {intakeDeskOverview.title}
+              </h1>
+              <p className="max-w-2xl text-base leading-7 text-slate-300 sm:text-lg">
+                {intakeDeskOverview.description}
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-3 sm:items-end">
+              <div
+                className={`${styles.floatingInfo} rounded-[1.4rem] border border-white/10 px-4 py-4 text-sm text-slate-200`}
+              >
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                  Shift window
+                </p>
+                <p className="mt-2 text-lg font-semibold text-white">
+                  {intakeDeskOverview.shiftWindow}
+                </p>
+                <p className="mt-2 text-sm text-slate-300">
+                  {intakeDeskOverview.queue}
+                </p>
+              </div>
+
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-full border border-white/15 bg-slate-950/40 px-5 py-3 text-sm font-semibold text-slate-100 transition hover:border-indigo-300/45 hover:bg-slate-900"
+              >
+                Back to overview
+              </Link>
+            </div>
+          </div>
+        </header>
+
+        {/* Stats */}
+        <section aria-label="Intake desk summary" className="grid gap-4 md:grid-cols-3">
+          {intakeStats.map((stat) => (
+            <article
+              key={stat.label}
+              className={`${styles.statCard} rounded-[1.5rem] border border-white/10 px-5 py-5`}
+            >
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+                {stat.label}
+              </p>
+              <p className="mt-3 text-3xl font-semibold tracking-tight text-white">
+                {stat.value}
+              </p>
+              <p className="mt-2 text-sm leading-6 text-slate-300">{stat.detail}</p>
+            </article>
+          ))}
+        </section>
+
+        {/* Incoming requests */}
+        <section className="space-y-5">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+                Incoming
+              </p>
+              <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+                Incoming requests
+              </h2>
+            </div>
+            <p className="max-w-2xl text-sm leading-6 text-slate-300">
+              New requests awaiting triage. Each card shows the requester,
+              urgency level, category, and a brief summary.
+            </p>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2" role="list" aria-label="Incoming requests">
+            {incomingRequests.map((request) => (
+              <RequestCard key={request.id} request={request} />
+            ))}
+          </div>
+        </section>
+
+        {/* Triage cards */}
+        <section className="space-y-5">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+                Triage
+              </p>
+              <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+                Triage summaries
+              </h2>
+            </div>
+            <p className="max-w-2xl text-sm leading-6 text-slate-300">
+              Completed triage reviews with outcomes and reviewer notes.
+              Each entry is linked to an incoming request.
+            </p>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2" role="list" aria-label="Triage cards">
+            {triageCards.map((card) => (
+              <TriageCardItem key={card.id} card={card} />
+            ))}
+          </div>
+        </section>
+
+        {/* Assignment summary */}
+        <AssignmentPanel entries={assignmentEntries} />
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `intake-desk` route with incoming request cards, triage summary cards, and a compact assignment summary panel
- Include mock data for 6 incoming requests, 4 triage reviews, and 5 assignment entries
- Follow existing route conventions (CSS modules, component structure, responsive layout)
- Add tests covering hero, stats, request list, triage list, and assignment panel rendering

Closes #242

## Test plan
- [ ] Verify route renders at `/intake-desk` with all sections visible
- [ ] Check mobile and desktop layouts are readable
- [ ] Confirm tests pass (currently blocked by rolldown native binding issue affecting all tests in CI)

Generated with [Claude Code](https://claude.com/claude-code)