### PR TITLE
feat: add readiness-grid route with progress strip

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,6 +35,7 @@ const navLinks = [
   { href: "/parcel-hub", label: "Parcel Hub" },
   { href: "/status-board", label: "Status Board" },
   { href: "/capacity-planner", label: "Capacity Planner" },
+  { href: "/readiness-grid", label: "Readiness Grid" },
 ] as const;
 
 export default function RootLayout({

--- a/src/app/readiness-grid/_components/dependency-notes.tsx
+++ b/src/app/readiness-grid/_components/dependency-notes.tsx
@@ -13,11 +13,13 @@ const statusBadgeStyles: Record<DependencyNote["status"], string> = {
   "at-risk": "border-rose-300/20 bg-rose-300/10 text-rose-50",
 };
 
+// Renders a list of cross-workstream dependency notes with status badges
 type DependencyNotesProps = {
   notes: DependencyNote[];
 };
 
 export function DependencyNotes({ notes }: DependencyNotesProps) {
+  console.log("DependencyNotes rendered with", notes.length, "notes");
   return (
     <section aria-label="Dependency notes" className="space-y-5">
       <div className="space-y-2">

--- a/src/app/readiness-grid/_components/dependency-notes.tsx
+++ b/src/app/readiness-grid/_components/dependency-notes.tsx
@@ -1,0 +1,61 @@
+import type { DependencyNote } from "../_data/readiness-grid-data";
+import styles from "../readiness-grid.module.css";
+
+const statusLabels: Record<DependencyNote["status"], string> = {
+  resolved: "Resolved",
+  pending: "Pending",
+  "at-risk": "At risk",
+};
+
+const statusBadgeStyles: Record<DependencyNote["status"], string> = {
+  resolved: "border-emerald-300/20 bg-emerald-300/10 text-emerald-50",
+  pending: "border-amber-300/20 bg-amber-300/10 text-amber-50",
+  "at-risk": "border-rose-300/20 bg-rose-300/10 text-rose-50",
+};
+
+type DependencyNotesProps = {
+  notes: DependencyNote[];
+};
+
+export function DependencyNotes({ notes }: DependencyNotesProps) {
+  return (
+    <section aria-label="Dependency notes" className="space-y-5">
+      <div className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+          Dependencies
+        </p>
+        <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+          Cross-workstream dependencies
+        </h2>
+        <p className="max-w-2xl text-sm leading-6 text-slate-300">
+          Key dependency links between workstreams. Each note captures the
+          relationship and current resolution status.
+        </p>
+      </div>
+
+      <div className="space-y-4" role="list" aria-label="Dependency notes list">
+        {notes.map((dep) => (
+          <article
+            key={dep.id}
+            className={`${styles.depCard} rounded-[1.5rem] border border-white/10 p-5`}
+            role="listitem"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="space-y-1">
+                <p className="text-sm font-semibold text-white">
+                  {dep.source} &rarr; {dep.target}
+                </p>
+              </div>
+              <span
+                className={`${styles.statusBadge} inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${statusBadgeStyles[dep.status]}`}
+              >
+                {statusLabels[dep.status]}
+              </span>
+            </div>
+            <p className="mt-3 text-sm leading-6 text-slate-300">{dep.note}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/readiness-grid/_components/progress-strip.tsx
+++ b/src/app/readiness-grid/_components/progress-strip.tsx
@@ -1,0 +1,65 @@
+import type { ProgressEntry } from "../_data/readiness-grid-data";
+import styles from "../readiness-grid.module.css";
+
+const fillColor = (pct: number): string => {
+  if (pct === 100) return "bg-emerald-400";
+  if (pct >= 60) return "bg-amber-400";
+  if (pct > 0) return "bg-rose-400";
+  return "bg-slate-500";
+};
+
+type ProgressStripProps = {
+  entries: ProgressEntry[];
+};
+
+export function ProgressStrip({ entries }: ProgressStripProps) {
+  return (
+    <section aria-label="Progress strip" className="space-y-5">
+      <div className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+          Progress
+        </p>
+        <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+          Completion across workstreams
+        </h2>
+        <p className="max-w-2xl text-sm leading-6 text-slate-300">
+          A compact progress strip showing check completion for each tracked
+          workstream at a glance.
+        </p>
+      </div>
+
+      <div
+        className={`${styles.progressStrip} rounded-[1.5rem] border border-white/10 p-6`}
+        role="list"
+        aria-label="Progress entries"
+      >
+        <div className="space-y-5">
+          {entries.map((entry) => {
+            const pct = entry.total > 0 ? Math.round((entry.current / entry.total) * 100) : 0;
+            return (
+              <div key={entry.id} className="space-y-2" role="listitem">
+                <div className="flex items-baseline justify-between gap-3">
+                  <p className="text-sm font-semibold text-white">{entry.label}</p>
+                  <p className="text-xs tabular-nums text-slate-400">
+                    {entry.current}/{entry.total}
+                  </p>
+                </div>
+                <div className={styles.progressBar}>
+                  <div
+                    className={`${styles.progressFill} ${fillColor(pct)} h-2`}
+                    style={{ width: `${pct}%` }}
+                    role="progressbar"
+                    aria-valuenow={entry.current}
+                    aria-valuemin={0}
+                    aria-valuemax={entry.total}
+                    aria-label={`${entry.label} progress`}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/readiness-grid/_components/readiness-tile.tsx
+++ b/src/app/readiness-grid/_components/readiness-tile.tsx
@@ -1,0 +1,61 @@
+import type { ReadinessTile } from "../_data/readiness-grid-data";
+import styles from "../readiness-grid.module.css";
+
+const levelLabels: Record<ReadinessTile["level"], string> = {
+  ready: "Ready",
+  partial: "Partial",
+  blocked: "Blocked",
+  "not-started": "Not started",
+};
+
+const levelBadgeStyles: Record<ReadinessTile["level"], string> = {
+  ready: "border-emerald-300/20 bg-emerald-300/10 text-emerald-50",
+  partial: "border-amber-300/20 bg-amber-300/10 text-amber-50",
+  blocked: "border-rose-300/20 bg-rose-300/10 text-rose-50",
+  "not-started": "border-slate-300/20 bg-slate-300/10 text-slate-200",
+};
+
+const levelSurfaceStyles: Record<ReadinessTile["level"], string> = {
+  ready: styles.tileReady,
+  partial: styles.tilePartial,
+  blocked: styles.tileBlocked,
+  "not-started": styles.tileNotStarted,
+};
+
+type ReadinessTileCardProps = {
+  tile: ReadinessTile;
+};
+
+export function ReadinessTileCard({ tile }: ReadinessTileCardProps) {
+  return (
+    <article
+      className={`${styles.tileCard} ${levelSurfaceStyles[tile.level]} rounded-[1.7rem] border p-6`}
+      role="listitem"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold tracking-tight text-white">
+            {tile.area}
+          </h3>
+          <p className="text-sm text-slate-300">{tile.owner}</p>
+        </div>
+        <span
+          className={`${styles.statusBadge} inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${levelBadgeStyles[tile.level]}`}
+        >
+          {levelLabels[tile.level]}
+        </span>
+      </div>
+
+      <div className="mt-4 rounded-2xl border border-white/8 bg-white/5 px-4 py-3">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+          Checks completed
+        </p>
+        <p className="mt-1 text-2xl font-semibold tracking-tight text-white">
+          {tile.completedChecks} / {tile.totalChecks}
+        </p>
+      </div>
+
+      <p className="mt-4 text-sm leading-6 text-slate-300">{tile.summary}</p>
+    </article>
+  );
+}

--- a/src/app/readiness-grid/_data/readiness-grid-data.ts
+++ b/src/app/readiness-grid/_data/readiness-grid-data.ts
@@ -1,0 +1,177 @@
+export type ReadinessLevel = "ready" | "partial" | "blocked" | "not-started";
+
+export interface ReadinessTile {
+  id: string;
+  area: string;
+  level: ReadinessLevel;
+  owner: string;
+  completedChecks: number;
+  totalChecks: number;
+  summary: string;
+}
+
+export interface DependencyNote {
+  id: string;
+  source: string;
+  target: string;
+  status: "resolved" | "pending" | "at-risk";
+  note: string;
+}
+
+export interface ProgressEntry {
+  id: string;
+  label: string;
+  current: number;
+  total: number;
+}
+
+export interface ReadinessGridOverview {
+  eyebrow: string;
+  title: string;
+  description: string;
+  reviewWindow: string;
+  scope: string;
+}
+
+export interface ReadinessStat {
+  label: string;
+  value: string;
+  detail: string;
+}
+
+export const readinessGridOverview: ReadinessGridOverview = {
+  eyebrow: "Readiness Grid",
+  title: "Track launch readiness across every workstream before the go-live window.",
+  description:
+    "A consolidated view of readiness tiles, dependency notes, and progress strips that helps teams identify blockers and confirm go/no-go status ahead of critical milestones.",
+  reviewWindow: "Q2 2026 — Launch gate 3",
+  scope: "Platform / all workstreams",
+};
+
+export const readinessStats: ReadinessStat[] = [
+  {
+    label: "Workstreams tracked",
+    value: "6",
+    detail: "Auth, payments, notifications, data pipeline, monitoring, and docs",
+  },
+  {
+    label: "Dependencies logged",
+    value: "5",
+    detail: "Three resolved, one pending, and one at-risk requiring escalation",
+  },
+  {
+    label: "Overall progress",
+    value: "68%",
+    detail: "Combined completion across all tracked workstreams and their check items",
+  },
+];
+
+export const readinessTiles: ReadinessTile[] = [
+  {
+    id: "tile-auth",
+    area: "Authentication",
+    level: "ready",
+    owner: "Identity team",
+    completedChecks: 8,
+    totalChecks: 8,
+    summary:
+      "OAuth2 flows verified, session handling audited, and SSO integration confirmed across all tenants.",
+  },
+  {
+    id: "tile-payments",
+    area: "Payment processing",
+    level: "partial",
+    owner: "Billing squad",
+    completedChecks: 5,
+    totalChecks: 7,
+    summary:
+      "Stripe integration live, webhook retries tested. Remaining: currency conversion edge cases and refund idempotency.",
+  },
+  {
+    id: "tile-notifications",
+    area: "Notifications",
+    level: "ready",
+    owner: "Comms platform",
+    completedChecks: 6,
+    totalChecks: 6,
+    summary:
+      "Email, push, and in-app channels verified. Rate limiting and preference center tested end-to-end.",
+  },
+  {
+    id: "tile-pipeline",
+    area: "Data pipeline",
+    level: "blocked",
+    owner: "Data engineering",
+    completedChecks: 3,
+    totalChecks: 9,
+    summary:
+      "Ingestion layer stable, but the transform stage is blocked on schema migration approval from the compliance team.",
+  },
+  {
+    id: "tile-monitoring",
+    area: "Monitoring",
+    level: "partial",
+    owner: "SRE team",
+    completedChecks: 4,
+    totalChecks: 6,
+    summary:
+      "Alerting rules deployed, dashboards built. Remaining: runbook reviews and on-call rotation confirmation.",
+  },
+  {
+    id: "tile-docs",
+    area: "Documentation",
+    level: "not-started",
+    owner: "Tech writing",
+    completedChecks: 0,
+    totalChecks: 5,
+    summary:
+      "API reference and migration guide are pending. Work is scheduled to begin once endpoint contracts are finalized.",
+  },
+];
+
+export const dependencyNotes: DependencyNote[] = [
+  {
+    id: "dep-001",
+    source: "Payment processing",
+    target: "Authentication",
+    status: "resolved",
+    note: "Payments now receives verified identity tokens after the SSO rollout completed last sprint.",
+  },
+  {
+    id: "dep-002",
+    source: "Data pipeline",
+    target: "Payment processing",
+    status: "at-risk",
+    note: "Transform stage needs finalized transaction schema from billing. Blocked until currency conversion is settled.",
+  },
+  {
+    id: "dep-003",
+    source: "Monitoring",
+    target: "Data pipeline",
+    status: "pending",
+    note: "Pipeline health metrics are instrumented but alerting thresholds await the new ingestion throughput baseline.",
+  },
+  {
+    id: "dep-004",
+    source: "Notifications",
+    target: "Authentication",
+    status: "resolved",
+    note: "Notification delivery now respects per-user auth scopes after the permission model update.",
+  },
+  {
+    id: "dep-005",
+    source: "Documentation",
+    target: "Payment processing",
+    status: "pending",
+    note: "API reference for billing endpoints cannot be finalized until refund idempotency contracts are locked.",
+  },
+];
+
+export const progressEntries: ProgressEntry[] = [
+  { id: "prog-auth", label: "Authentication", current: 8, total: 8 },
+  { id: "prog-payments", label: "Payment processing", current: 5, total: 7 },
+  { id: "prog-notifications", label: "Notifications", current: 6, total: 6 },
+  { id: "prog-pipeline", label: "Data pipeline", current: 3, total: 9 },
+  { id: "prog-monitoring", label: "Monitoring", current: 4, total: 6 },
+  { id: "prog-docs", label: "Documentation", current: 0, total: 5 },
+];

--- a/src/app/readiness-grid/_data/readiness-grid-data.ts
+++ b/src/app/readiness-grid/_data/readiness-grid-data.ts
@@ -10,6 +10,7 @@ export interface ReadinessTile {
   summary: string;
 }
 
+// Represents a dependency link between two workstreams with resolution status
 export interface DependencyNote {
   id: string;
   source: string;

--- a/src/app/readiness-grid/page.test.tsx
+++ b/src/app/readiness-grid/page.test.tsx
@@ -1,0 +1,85 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  dependencyNotes,
+  progressEntries,
+  readinessGridOverview,
+  readinessStats,
+  readinessTiles,
+} from "./_data/readiness-grid-data";
+import ReadinessGridPage from "./page";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ReadinessGridPage", () => {
+  it("renders the hero with primary heading, overview metadata, and back link", () => {
+    render(<ReadinessGridPage />);
+
+    expect(
+      screen.getByText(readinessGridOverview.title, { selector: "h1" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(readinessGridOverview.reviewWindow)).toBeInTheDocument();
+    expect(screen.getByText(readinessGridOverview.scope)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /back to overview/i }),
+    ).toHaveAttribute("href", "/");
+  });
+
+  it("renders summary stats for readiness grid", () => {
+    render(<ReadinessGridPage />);
+
+    const summarySection = screen.getByLabelText(/readiness grid summary/i);
+
+    for (const stat of readinessStats) {
+      const statEl = within(summarySection).getByText(stat.label).closest("article");
+
+      expect(statEl).toBeTruthy();
+      expect(within(statEl as HTMLElement).getByText(stat.value)).toBeInTheDocument();
+    }
+  });
+
+  it("renders all readiness tiles with areas, owners, and level badges", () => {
+    render(<ReadinessGridPage />);
+
+    const tileList = screen.getByRole("list", { name: /readiness tiles/i });
+    const tileItems = within(tileList).getAllByRole("listitem");
+
+    expect(tileItems).toHaveLength(readinessTiles.length);
+
+    for (const tile of readinessTiles) {
+      expect(within(tileList).getByText(tile.area)).toBeInTheDocument();
+      expect(within(tileList).getByText(tile.owner)).toBeInTheDocument();
+    }
+  });
+
+  it("renders dependency notes with source-target pairs and status badges", () => {
+    render(<ReadinessGridPage />);
+
+    const notesSection = screen.getByLabelText(/dependency notes$/i);
+    const notesList = within(notesSection).getByRole("list", { name: /dependency notes list/i });
+    const noteItems = within(notesList).getAllByRole("listitem");
+
+    expect(noteItems).toHaveLength(dependencyNotes.length);
+
+    for (const dep of dependencyNotes) {
+      expect(within(notesList).getByText(dep.note)).toBeInTheDocument();
+    }
+  });
+
+  it("renders the progress strip with all workstream entries", () => {
+    render(<ReadinessGridPage />);
+
+    const progressSection = screen.getByLabelText(/progress strip/i);
+    const progressList = within(progressSection).getByRole("list", { name: /progress entries/i });
+    const progressItems = within(progressList).getAllByRole("listitem");
+
+    expect(progressItems).toHaveLength(progressEntries.length);
+
+    for (const entry of progressEntries) {
+      expect(within(progressList).getByText(entry.label)).toBeInTheDocument();
+    }
+  });
+});

--- a/src/app/readiness-grid/page.tsx
+++ b/src/app/readiness-grid/page.tsx
@@ -1,0 +1,118 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { DependencyNotes } from "./_components/dependency-notes";
+import { ProgressStrip } from "./_components/progress-strip";
+import { ReadinessTileCard } from "./_components/readiness-tile";
+import styles from "./readiness-grid.module.css";
+import {
+  dependencyNotes,
+  progressEntries,
+  readinessGridOverview,
+  readinessStats,
+  readinessTiles,
+} from "./_data/readiness-grid-data";
+
+export const metadata: Metadata = {
+  title: "Readiness Grid",
+  description:
+    "Readiness tiles, dependency notes, and a compact progress strip for tracking launch readiness across workstreams.",
+};
+
+export default function ReadinessGridPage() {
+  return (
+    <main className={`${styles.shell} px-6 py-12 text-slate-50 sm:px-10 lg:px-16`}>
+      <div className="relative mx-auto flex w-full max-w-7xl flex-col gap-8">
+        {/* Hero */}
+        <header
+          className={`${styles.heroPanel} overflow-hidden rounded-[2rem] border border-white/10 p-8 backdrop-blur sm:p-10`}
+        >
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+            <div className="max-w-3xl space-y-4">
+              <span className="inline-flex w-fit rounded-full border border-emerald-300/35 bg-emerald-300/12 px-4 py-1 text-sm font-medium uppercase tracking-[0.2em] text-emerald-100">
+                {readinessGridOverview.eyebrow}
+              </span>
+              <h1 className="text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
+                {readinessGridOverview.title}
+              </h1>
+              <p className="max-w-2xl text-base leading-7 text-slate-300 sm:text-lg">
+                {readinessGridOverview.description}
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-3 sm:items-end">
+              <div
+                className={`${styles.floatingInfo} rounded-[1.4rem] border border-white/10 px-4 py-4 text-sm text-slate-200`}
+              >
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                  Review window
+                </p>
+                <p className="mt-2 text-lg font-semibold text-white">
+                  {readinessGridOverview.reviewWindow}
+                </p>
+                <p className="mt-2 text-sm text-slate-300">
+                  {readinessGridOverview.scope}
+                </p>
+              </div>
+
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-full border border-white/15 bg-slate-950/40 px-5 py-3 text-sm font-semibold text-slate-100 transition hover:border-emerald-300/45 hover:bg-slate-900"
+              >
+                Back to overview
+              </Link>
+            </div>
+          </div>
+        </header>
+
+        {/* Stats */}
+        <section aria-label="Readiness grid summary" className="grid gap-4 md:grid-cols-3">
+          {readinessStats.map((stat) => (
+            <article
+              key={stat.label}
+              className={`${styles.statCard} rounded-[1.5rem] border border-white/10 px-5 py-5`}
+            >
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+                {stat.label}
+              </p>
+              <p className="mt-3 text-3xl font-semibold tracking-tight text-white">
+                {stat.value}
+              </p>
+              <p className="mt-2 text-sm leading-6 text-slate-300">{stat.detail}</p>
+            </article>
+          ))}
+        </section>
+
+        {/* Readiness tiles */}
+        <section className="space-y-5">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+                Readiness
+              </p>
+              <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+                Workstream readiness tiles
+              </h2>
+            </div>
+            <p className="max-w-2xl text-sm leading-6 text-slate-300">
+              Each tile shows the current readiness level, completed checks, and a
+              brief status summary for the workstream.
+            </p>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3" role="list" aria-label="Readiness tiles">
+            {readinessTiles.map((tile) => (
+              <ReadinessTileCard key={tile.id} tile={tile} />
+            ))}
+          </div>
+        </section>
+
+        {/* Dependency notes */}
+        <DependencyNotes notes={dependencyNotes} />
+
+        {/* Progress strip */}
+        <ProgressStrip entries={progressEntries} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/readiness-grid/readiness-grid.module.css
+++ b/src/app/readiness-grid/readiness-grid.module.css
@@ -1,0 +1,117 @@
+.shell {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 20% 12%, rgba(52, 211, 153, 0.14), transparent 22%),
+    radial-gradient(circle at 80% 20%, rgba(56, 189, 248, 0.16), transparent 24%),
+    radial-gradient(circle at 50% 94%, rgba(168, 85, 247, 0.14), transparent 28%),
+    linear-gradient(180deg, #08111f 0%, #0e1c34 44%, #030712 100%);
+}
+
+.shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(125deg, rgba(255, 255, 255, 0.03), transparent 45%),
+    repeating-linear-gradient(
+      90deg,
+      rgba(148, 163, 184, 0.06) 0,
+      rgba(148, 163, 184, 0.06) 1px,
+      transparent 1px,
+      transparent 72px
+    );
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.95), transparent 96%);
+}
+
+.heroPanel {
+  position: relative;
+  background:
+    linear-gradient(140deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.58)),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(15, 23, 42, 0.12));
+  box-shadow: 0 38px 120px rgba(2, 6, 23, 0.42);
+}
+
+.heroPanel::after {
+  content: "";
+  position: absolute;
+  right: -5rem;
+  top: -4rem;
+  width: 18rem;
+  height: 18rem;
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgba(52, 211, 153, 0.22), transparent 66%);
+  filter: blur(20px);
+  pointer-events: none;
+}
+
+.statCard {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(15, 23, 42, 0.28));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.tileCard {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.82), rgba(6, 11, 24, 0.94));
+  box-shadow: 0 26px 70px rgba(2, 6, 23, 0.26);
+}
+
+.tileReady {
+  border-color: rgba(52, 211, 153, 0.22);
+}
+
+.tilePartial {
+  border-color: rgba(251, 191, 36, 0.24);
+}
+
+.tileBlocked {
+  border-color: rgba(251, 113, 133, 0.28);
+}
+
+.tileNotStarted {
+  border-color: rgba(148, 163, 184, 0.22);
+}
+
+.depCard {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(15, 23, 42, 0.32));
+}
+
+.statusBadge {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.floatingInfo {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(15, 23, 42, 0.26));
+}
+
+.progressStrip {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(15, 23, 42, 0.32));
+}
+
+.progressBar {
+  background: rgba(148, 163, 184, 0.18);
+  border-radius: 9999px;
+  overflow: hidden;
+}
+
+.progressFill {
+  border-radius: 9999px;
+  transition: width 0.3s ease;
+}
+
+@media (max-width: 640px) {
+  .heroPanel,
+  .tileCard,
+  .depCard,
+  .statCard,
+  .progressStrip {
+    border-radius: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a `readiness-grid` route with readiness tiles, dependency notes, and a compact progress strip
- Create mock data for 6 workstreams with readiness levels, 5 cross-workstream dependencies, and progress entries
- Build 3 components: `ReadinessTileCard`, `DependencyNotes`, and `ProgressStrip` with dark-themed styling
- Add the route to the global navigation in `layout.tsx`
- Include comprehensive tests covering hero, stats, tiles, dependency notes, and progress strip

Closes #244

## Test plan
- [ ] Verify the readiness-grid route renders at `/readiness-grid`
- [ ] Confirm all 6 readiness tiles display with correct levels and check counts
- [ ] Confirm all 5 dependency notes render with source/target pairs and status badges
- [ ] Confirm the progress strip shows bars for all workstreams
- [ ] Verify responsive layout across breakpoints
- [ ] Run `npm test` and confirm all readiness-grid tests pass

Generated with [Claude Code](https://claude.com/claude-code)