### PR TITLE
feat: add policy-board route with compliance notes

### DIFF
--- a/src/app/policy-board/_components/compliance-notes.tsx
+++ b/src/app/policy-board/_components/compliance-notes.tsx
@@ -1,0 +1,60 @@
+import type { ComplianceNote } from "../_data/policy-board-data";
+import styles from "../policy-board.module.css";
+
+const priorityLabels: Record<ComplianceNote["priority"], string> = {
+  info: "Info",
+  action: "Action",
+  warning: "Warning",
+};
+
+const priorityBadgeStyles: Record<ComplianceNote["priority"], string> = {
+  info: "border-cyan-300/20 bg-cyan-300/10 text-cyan-50",
+  action: "border-emerald-300/20 bg-emerald-300/10 text-emerald-50",
+  warning: "border-amber-300/20 bg-amber-300/10 text-amber-50",
+};
+
+type ComplianceNotesProps = {
+  notes: ComplianceNote[];
+};
+
+export function ComplianceNotes({ notes }: ComplianceNotesProps) {
+  return (
+    <section aria-label="Compliance notes" className="space-y-5">
+      <div className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+          Audit trail
+        </p>
+        <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+          Compliance notes from reviewers
+        </h2>
+        <p className="max-w-2xl text-sm leading-6 text-slate-300">
+          Notes, action items, and warnings captured during the current review
+          cycle. Each note is tied to a reviewer and timestamped.
+        </p>
+      </div>
+
+      <div className="space-y-4" role="list" aria-label="Compliance notes list">
+        {notes.map((note) => (
+          <article
+            key={note.id}
+            className={`${styles.noteCard} rounded-[1.5rem] border border-white/10 p-5`}
+            role="listitem"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="space-y-1">
+                <p className="text-sm font-semibold text-white">{note.author}</p>
+                <p className="text-xs text-slate-400">{note.timestamp}</p>
+              </div>
+              <span
+                className={`${styles.statusBadge} inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${priorityBadgeStyles[note.priority]}`}
+              >
+                {priorityLabels[note.priority]}
+              </span>
+            </div>
+            <p className="mt-3 text-sm leading-6 text-slate-300">{note.body}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/app/policy-board/_components/policy-card.tsx
+++ b/src/app/policy-board/_components/policy-card.tsx
@@ -1,0 +1,68 @@
+import type { Policy } from "../_data/policy-board-data";
+import styles from "../policy-board.module.css";
+
+const statusLabels: Record<Policy["status"], string> = {
+  active: "Active",
+  "under-review": "Under review",
+  deprecated: "Deprecated",
+};
+
+const statusBadgeStyles: Record<Policy["status"], string> = {
+  active: "border-emerald-300/20 bg-emerald-300/10 text-emerald-50",
+  "under-review": "border-amber-300/20 bg-amber-300/10 text-amber-50",
+  deprecated: "border-slate-300/20 bg-slate-300/10 text-slate-300",
+};
+
+const statusSurfaceStyles: Record<Policy["status"], string> = {
+  active: styles.policyActive,
+  "under-review": styles.policyUnderReview,
+  deprecated: styles.policyDeprecated,
+};
+
+type PolicyCardProps = {
+  policy: Policy;
+};
+
+export function PolicyCard({ policy }: PolicyCardProps) {
+  return (
+    <article
+      className={`${styles.policyCard} ${statusSurfaceStyles[policy.status]} rounded-[1.7rem] border p-6`}
+      role="listitem"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h3 className="text-lg font-semibold tracking-tight text-white">
+            {policy.name}
+          </h3>
+          <p className="text-sm text-slate-300">{policy.category}</p>
+        </div>
+        <span
+          className={`${styles.statusBadge} inline-flex rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] ${statusBadgeStyles[policy.status]}`}
+        >
+          {statusLabels[policy.status]}
+        </span>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        <div className="rounded-2xl border border-white/8 bg-white/5 px-4 py-3">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+            Effective date
+          </p>
+          <p className="mt-1 text-sm font-medium text-slate-100">
+            {policy.effectiveDate}
+          </p>
+        </div>
+        <div className="rounded-2xl border border-white/8 bg-white/5 px-4 py-3">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+            Owner
+          </p>
+          <p className="mt-1 text-sm font-medium text-slate-100">
+            {policy.owner}
+          </p>
+        </div>
+      </div>
+
+      <p className="mt-4 text-sm leading-6 text-slate-300">{policy.summary}</p>
+    </article>
+  );
+}

--- a/src/app/policy-board/_data/policy-board-data.ts
+++ b/src/app/policy-board/_data/policy-board-data.ts
@@ -1,0 +1,146 @@
+export type PolicyStatus = "active" | "under-review" | "deprecated";
+export type ComplianceLevel = "compliant" | "partial" | "non-compliant";
+export type NotePriority = "info" | "action" | "warning";
+
+export interface Policy {
+  id: string;
+  name: string;
+  status: PolicyStatus;
+  category: string;
+  effectiveDate: string;
+  owner: string;
+  summary: string;
+}
+
+export interface ComplianceNote {
+  id: string;
+  author: string;
+  timestamp: string;
+  body: string;
+  priority: NotePriority;
+}
+
+export interface ReviewSummary {
+  label: string;
+  value: string;
+  detail: string;
+}
+
+export interface PolicyBoardOverview {
+  eyebrow: string;
+  title: string;
+  description: string;
+  reviewCycle: string;
+  scope: string;
+}
+
+export const policyBoardOverview: PolicyBoardOverview = {
+  eyebrow: "Policy Board",
+  title: "Track active policies, compliance status, and review summaries in one place.",
+  description:
+    "A centralized view of organizational policies, compliance notes from auditors and stakeholders, and a compact summary of the latest review cycle.",
+  reviewCycle: "Q2 2026 — Review 3",
+  scope: "Engineering & Data divisions",
+};
+
+export const reviewSummaries: ReviewSummary[] = [
+  {
+    label: "Active policies",
+    value: "5",
+    detail: "Covering data retention, access control, incident response, change management, and vendor risk",
+  },
+  {
+    label: "Compliance notes",
+    value: "4",
+    detail: "Two action items, one warning, and one informational note from the latest audit cycle",
+  },
+  {
+    label: "Next review deadline",
+    value: "May 12",
+    detail: "All policy owners must submit updated compliance evidence before the review window closes",
+  },
+];
+
+export const policies: Policy[] = [
+  {
+    id: "pol-data-retention",
+    name: "Data Retention Policy",
+    status: "active",
+    category: "Data governance",
+    effectiveDate: "2025-01-15",
+    owner: "Data Platform team",
+    summary:
+      "Defines retention periods for all data classes. Production logs are retained for 90 days, analytics data for 2 years, and PII is purged within 30 days of account closure.",
+  },
+  {
+    id: "pol-access-control",
+    name: "Access Control Policy",
+    status: "active",
+    category: "Security",
+    effectiveDate: "2024-11-01",
+    owner: "Security engineering",
+    summary:
+      "Enforces least-privilege access across all internal systems. Role-based access is reviewed quarterly, and elevated permissions require manager approval with a 72-hour expiry.",
+  },
+  {
+    id: "pol-incident-response",
+    name: "Incident Response Policy",
+    status: "under-review",
+    category: "Operations",
+    effectiveDate: "2025-03-10",
+    owner: "SRE team",
+    summary:
+      "Outlines escalation paths, severity classifications, and post-incident review timelines. Currently under review to add requirements for customer notification within 4 hours of SEV-1 incidents.",
+  },
+  {
+    id: "pol-change-mgmt",
+    name: "Change Management Policy",
+    status: "active",
+    category: "Operations",
+    effectiveDate: "2025-06-01",
+    owner: "Release engineering",
+    summary:
+      "Requires all production changes to pass through a staged rollout with automated canary analysis. Emergency hotfixes must be retroactively documented within 24 hours.",
+  },
+  {
+    id: "pol-vendor-risk",
+    name: "Vendor Risk Assessment Policy",
+    status: "deprecated",
+    category: "Compliance",
+    effectiveDate: "2023-08-20",
+    owner: "Legal & compliance",
+    summary:
+      "Legacy vendor evaluation framework. Replaced by the updated third-party risk management policy. Retained for reference on contracts signed before 2025.",
+  },
+];
+
+export const complianceNotes: ComplianceNote[] = [
+  {
+    id: "cn-001",
+    author: "R. Nakamura",
+    timestamp: "2026-04-25 10:30 PDT",
+    body: "Data retention evidence for Q1 has been uploaded. Two edge cases around ephemeral processing logs still need clarification from the data platform team.",
+    priority: "action",
+  },
+  {
+    id: "cn-002",
+    author: "L. Fernandez",
+    timestamp: "2026-04-25 09:15 PDT",
+    body: "Access control audit flagged three service accounts with elevated permissions that haven't been rotated in over 90 days. Escalating to security engineering.",
+    priority: "warning",
+  },
+  {
+    id: "cn-003",
+    author: "D. Kim",
+    timestamp: "2026-04-24 16:45 PDT",
+    body: "Incident response policy revision is on track. Draft includes the new customer notification SLA. Expecting final sign-off by May 5.",
+    priority: "info",
+  },
+  {
+    id: "cn-004",
+    author: "T. Okonkwo",
+    timestamp: "2026-04-24 14:20 PDT",
+    body: "Change management compliance check for April deployments is complete. All 23 production changes followed the staged rollout process with no exceptions.",
+    priority: "action",
+  },
+];

--- a/src/app/policy-board/page.test.tsx
+++ b/src/app/policy-board/page.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  complianceNotes,
+  policies,
+  policyBoardOverview,
+  reviewSummaries,
+} from "./_data/policy-board-data";
+import PolicyBoardPage from "./page";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("PolicyBoardPage", () => {
+  it("renders the hero with primary heading, overview metadata, and back link", () => {
+    render(<PolicyBoardPage />);
+
+    expect(
+      screen.getByText(policyBoardOverview.title, { selector: "h1" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(policyBoardOverview.reviewCycle)).toBeInTheDocument();
+    expect(screen.getByText(policyBoardOverview.scope)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /back to overview/i }),
+    ).toHaveAttribute("href", "/");
+  });
+
+  it("renders review summary stats", () => {
+    render(<PolicyBoardPage />);
+
+    const summarySection = screen.getByLabelText(/review summary/i);
+
+    for (const stat of reviewSummaries) {
+      const statEl = within(summarySection).getByText(stat.label).closest("article");
+
+      expect(statEl).toBeTruthy();
+      expect(within(statEl as HTMLElement).getByText(stat.value)).toBeInTheDocument();
+    }
+  });
+
+  it("renders all policy cards with names, categories, and status badges", () => {
+    render(<PolicyBoardPage />);
+
+    const policyList = screen.getByRole("list", { name: /policy cards/i });
+    const policyItems = within(policyList).getAllByRole("listitem");
+
+    expect(policyItems).toHaveLength(policies.length);
+
+    for (const policy of policies) {
+      expect(within(policyList).getByText(policy.name)).toBeInTheDocument();
+      expect(within(policyList).getByText(policy.category)).toBeInTheDocument();
+      expect(within(policyList).getByText(policy.owner)).toBeInTheDocument();
+    }
+  });
+
+  it("renders compliance notes with authors, timestamps, and priority badges", () => {
+    render(<PolicyBoardPage />);
+
+    const notesSection = screen.getByLabelText(/compliance notes$/i);
+    const notesList = within(notesSection).getByRole("list", { name: /compliance notes list/i });
+    const noteItems = within(notesList).getAllByRole("listitem");
+
+    expect(noteItems).toHaveLength(complianceNotes.length);
+
+    for (const note of complianceNotes) {
+      expect(within(notesList).getByText(note.author)).toBeInTheDocument();
+      expect(within(notesList).getByText(note.timestamp)).toBeInTheDocument();
+      expect(within(notesList).getByText(note.body)).toBeInTheDocument();
+    }
+  });
+});

--- a/src/app/policy-board/page.tsx
+++ b/src/app/policy-board/page.tsx
@@ -1,0 +1,113 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { ComplianceNotes } from "./_components/compliance-notes";
+import { PolicyCard } from "./_components/policy-card";
+import styles from "./policy-board.module.css";
+import {
+  complianceNotes,
+  policies,
+  policyBoardOverview,
+  reviewSummaries,
+} from "./_data/policy-board-data";
+
+export const metadata: Metadata = {
+  title: "Policy Board",
+  description:
+    "Policy cards, compliance notes, and review summaries for organizational governance and audit readiness.",
+};
+
+export default function PolicyBoardPage() {
+  return (
+    <main className={`${styles.shell} px-6 py-12 text-slate-50 sm:px-10 lg:px-16`}>
+      <div className="relative mx-auto flex w-full max-w-7xl flex-col gap-8">
+        {/* Hero */}
+        <header
+          className={`${styles.heroPanel} overflow-hidden rounded-[2rem] border border-white/10 p-8 backdrop-blur sm:p-10`}
+        >
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+            <div className="max-w-3xl space-y-4">
+              <span className="inline-flex w-fit rounded-full border border-indigo-300/35 bg-indigo-300/12 px-4 py-1 text-sm font-medium uppercase tracking-[0.2em] text-indigo-100">
+                {policyBoardOverview.eyebrow}
+              </span>
+              <h1 className="text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
+                {policyBoardOverview.title}
+              </h1>
+              <p className="max-w-2xl text-base leading-7 text-slate-300 sm:text-lg">
+                {policyBoardOverview.description}
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-3 sm:items-end">
+              <div
+                className={`${styles.floatingInfo} rounded-[1.4rem] border border-white/10 px-4 py-4 text-sm text-slate-200`}
+              >
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                  Review cycle
+                </p>
+                <p className="mt-2 text-lg font-semibold text-white">
+                  {policyBoardOverview.reviewCycle}
+                </p>
+                <p className="mt-2 text-sm text-slate-300">
+                  {policyBoardOverview.scope}
+                </p>
+              </div>
+
+              <Link
+                href="/"
+                className="inline-flex items-center justify-center rounded-full border border-white/15 bg-slate-950/40 px-5 py-3 text-sm font-semibold text-slate-100 transition hover:border-indigo-300/45 hover:bg-slate-900"
+              >
+                Back to overview
+              </Link>
+            </div>
+          </div>
+        </header>
+
+        {/* Review summary */}
+        <section aria-label="Review summary" className="grid gap-4 md:grid-cols-3">
+          {reviewSummaries.map((stat) => (
+            <article
+              key={stat.label}
+              className={`${styles.statCard} rounded-[1.5rem] border border-white/10 px-5 py-5`}
+            >
+              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-400">
+                {stat.label}
+              </p>
+              <p className="mt-3 text-3xl font-semibold tracking-tight text-white">
+                {stat.value}
+              </p>
+              <p className="mt-2 text-sm leading-6 text-slate-300">{stat.detail}</p>
+            </article>
+          ))}
+        </section>
+
+        {/* Policy cards */}
+        <section className="space-y-5">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">
+                Governance
+              </p>
+              <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+                Active and reviewed policies
+              </h2>
+            </div>
+            <p className="max-w-2xl text-sm leading-6 text-slate-300">
+              Each card represents an organizational policy with its current status,
+              ownership, and a brief summary of scope.
+            </p>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2" role="list" aria-label="Policy cards">
+            {policies.map((policy) => (
+              <PolicyCard key={policy.id} policy={policy} />
+            ))}
+          </div>
+        </section>
+
+        {/* Compliance notes */}
+        <ComplianceNotes notes={complianceNotes} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/policy-board/policy-board.module.css
+++ b/src/app/policy-board/policy-board.module.css
@@ -1,0 +1,96 @@
+.shell {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 18% 14%, rgba(99, 102, 241, 0.14), transparent 22%),
+    radial-gradient(circle at 82% 18%, rgba(34, 211, 238, 0.16), transparent 24%),
+    radial-gradient(circle at 50% 96%, rgba(168, 85, 247, 0.16), transparent 28%),
+    linear-gradient(180deg, #08111f 0%, #0e1c34 44%, #030712 100%);
+}
+
+.shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(125deg, rgba(255, 255, 255, 0.03), transparent 45%),
+    repeating-linear-gradient(
+      90deg,
+      rgba(148, 163, 184, 0.06) 0,
+      rgba(148, 163, 184, 0.06) 1px,
+      transparent 1px,
+      transparent 72px
+    );
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.95), transparent 96%);
+}
+
+.heroPanel {
+  position: relative;
+  background:
+    linear-gradient(140deg, rgba(15, 23, 42, 0.82), rgba(15, 23, 42, 0.58)),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(15, 23, 42, 0.12));
+  box-shadow: 0 38px 120px rgba(2, 6, 23, 0.42);
+}
+
+.heroPanel::after {
+  content: "";
+  position: absolute;
+  right: -5rem;
+  top: -4rem;
+  width: 18rem;
+  height: 18rem;
+  border-radius: 9999px;
+  background: radial-gradient(circle, rgba(99, 102, 241, 0.22), transparent 66%);
+  filter: blur(20px);
+  pointer-events: none;
+}
+
+.statCard {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(15, 23, 42, 0.28));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.policyCard {
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.82), rgba(6, 11, 24, 0.94));
+  box-shadow: 0 26px 70px rgba(2, 6, 23, 0.26);
+}
+
+.policyActive {
+  border-color: rgba(52, 211, 153, 0.22);
+}
+
+.policyUnderReview {
+  border-color: rgba(251, 191, 36, 0.24);
+}
+
+.policyDeprecated {
+  border-color: rgba(148, 163, 184, 0.18);
+}
+
+.noteCard {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(15, 23, 42, 0.32));
+}
+
+.statusBadge {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.floatingInfo {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(15, 23, 42, 0.26));
+}
+
+@media (max-width: 640px) {
+  .heroPanel,
+  .policyCard,
+  .noteCard,
+  .statCard {
+    border-radius: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a dedicated `policy-board` route with policy cards (active, under-review, deprecated statuses), compliance notes with priority badges, and a compact review summary section
- Create mock data for 5 policies, 4 compliance notes, and 3 review summary stats
- Include test coverage for all rendered content sections

Closes #246

## Test plan
- [ ] Verify policy cards render with correct names, categories, owners, and status badges
- [ ] Verify compliance notes display authors, timestamps, bodies, and priority badges
- [ ] Verify review summary stats section renders all metrics
- [ ] Verify responsive layout across common breakpoints
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)